### PR TITLE
fix: errors when model switching with image upload

### DIFF
--- a/src/components/chat/document-uploader.tsx
+++ b/src/components/chat/document-uploader.tsx
@@ -267,8 +267,9 @@ export const useDocumentUploader = (
       if (processingResult.document && processingResult.document.md_content) {
         // Pass the content and image data if it's an image
         onSuccess(processingResult.document.md_content, documentId, imageData)
-      } else if (isImage && imageData) {
+      } else if (isImage) {
         // For images with no text content, still pass the image data with empty content
+        // (imageData might be undefined if the model doesn't support multimodal)
         onSuccess('', documentId, imageData)
       } else {
         throw new Error('No document content received')

--- a/src/components/chat/hooks/use-chat-messaging.ts
+++ b/src/components/chat/hooks/use-chat-messaging.ts
@@ -295,8 +295,12 @@ export function useChatMessaging({
               },
               // Include message history with a limit
               ...updatedMessages.slice(-maxMessages).map((msg) => {
-                // Check if this message has image data
-                if (msg.imageData && msg.imageData.length > 0) {
+                // Check if this message has image data AND the current model supports multimodal
+                if (
+                  msg.imageData &&
+                  msg.imageData.length > 0 &&
+                  model.multimodal
+                ) {
                   // Create multimodal content array
                   const content = [
                     {
@@ -319,7 +323,7 @@ export function useChatMessaging({
                     content,
                   }
                 } else {
-                  // Standard text message
+                  // Standard text message (or image data stripped for non-multimodal models)
                   return {
                     role: msg.role,
                     content: msg.documentContent


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixed errors when switching models after uploading images by ensuring image data is only sent to models that support multimodal input.

<!-- End of auto-generated description by cubic. -->

