### PR TITLE
Feat: ability to inject chat messages 

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import { AuthCleanupHandler } from '@/components/auth-cleanup-handler'
+import { IframeMessageHandler } from '@/components/iframe-message-handler'
 import { Toaster } from '@/components/ui/toaster'
 import '@/styles/tailwind.css'
 import { ClerkProvider } from '@clerk/nextjs'
@@ -91,6 +92,7 @@ export default function RootLayout({
         </head>
         <body className="bg-gray-900 text-gray-100 antialiased">
           <AuthCleanupHandler />
+          <IframeMessageHandler />
           {children}
           <Toaster />
         </body>

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -294,6 +294,18 @@ export function ChatInterface({
     selectedModelDetails,
   )
 
+  // Check for injected text from iframe on mount
+  useEffect(() => {
+    const injectedText = localStorage.getItem('injected_text')
+    if (injectedText) {
+      // Clear it immediately to prevent re-sending on refresh
+      localStorage.removeItem('injected_text')
+
+      // Send as first user message
+      handleQuery(injectedText)
+    }
+  }, []) // Only run once on mount
+
   // Sync chats and profile when user signs in and periodically
   useEffect(() => {
     if (!isSignedIn) return

--- a/src/components/iframe-message-handler.tsx
+++ b/src/components/iframe-message-handler.tsx
@@ -1,0 +1,74 @@
+'use client'
+
+import { logError, logInfo } from '@/utils/error-handling'
+import { useEffect } from 'react'
+
+interface IframeMessage {
+  type: string
+  text?: string
+  key?: string
+}
+
+export function IframeMessageHandler() {
+  useEffect(() => {
+    const handleMessage = (event: MessageEvent) => {
+      try {
+        // Parse the message
+        const data = event.data as IframeMessage
+
+        // Only handle text injection - no retrieval for security
+        if (data.type === 'INJECT_TEXT') {
+          if (data.text) {
+            // Save to localStorage with optional key
+            const storageKey = data.key || 'injected_text'
+            localStorage.setItem(storageKey, data.text)
+
+            // Send confirmation back to parent
+            event.source?.postMessage(
+              {
+                type: 'TEXT_INJECTED',
+                success: true,
+                key: storageKey,
+              },
+              { targetOrigin: event.origin },
+            )
+
+            logInfo('Text injected via iframe', {
+              component: 'IframeMessageHandler',
+              key: storageKey,
+              origin: event.origin,
+            })
+          }
+        }
+      } catch (error) {
+        logError('Failed to handle iframe message', error, {
+          component: 'IframeMessageHandler',
+          origin: event.origin,
+        })
+
+        // Send error response
+        event.source?.postMessage(
+          {
+            type: 'ERROR',
+            error: 'Failed to process message',
+          },
+          { targetOrigin: event.origin },
+        )
+      }
+    }
+
+    // Add event listener
+    window.addEventListener('message', handleMessage)
+
+    // Send ready signal to parent
+    if (window.parent !== window) {
+      window.parent.postMessage({ type: 'IFRAME_READY' }, '*')
+    }
+
+    return () => {
+      window.removeEventListener('message', handleMessage)
+    }
+  }, [])
+
+  return null
+}

--- a/src/components/iframe-message-handler.tsx
+++ b/src/components/iframe-message-handler.tsx
@@ -35,15 +35,17 @@ export function IframeMessageHandler() {
 
             logInfo('Text injected via iframe', {
               component: 'IframeMessageHandler',
-              key: storageKey,
-              origin: event.origin,
+              metadata: {
+                key: storageKey,
+                origin: event.origin,
+              },
             })
           }
         }
       } catch (error) {
         logError('Failed to handle iframe message', error, {
           component: 'IframeMessageHandler',
-          origin: event.origin,
+          metadata: { origin: event.origin },
         })
 
         // Send error response


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added support for injecting chat messages from an iframe, allowing external sources to send text directly into the chat interface.

- **New Features**
 - Listens for postMessage events to receive injected text.
 - Stores injected text in localStorage and sends it as the first user message on chat load.
 - Sends confirmation or error responses back to the parent iframe.

<!-- End of auto-generated description by cubic. -->

