### PR TITLE
Revert "Feat: improve message passing via iframe"

### DIFF
--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -295,25 +295,16 @@ export function ChatInterface({
   )
 
   // Check for injected text from iframe on mount
-  const hasProcessedInjectedText = useRef(false)
   useEffect(() => {
-    // Only process if we're NOT in an iframe (i.e., we're the main page after redirect)
-    // and we haven't already processed an injected message
-    if (window.parent === window && !hasProcessedInjectedText.current) {
-      const injectedText = localStorage.getItem('injected_text')
-      if (injectedText && currentChat && !subscriptionLoading) {
-        hasProcessedInjectedText.current = true
+    const injectedText = localStorage.getItem('injected_text')
+    if (injectedText) {
+      // Clear it immediately to prevent re-sending on refresh
+      localStorage.removeItem('injected_text')
 
-        // Clear it immediately to prevent re-sending on refresh
-        localStorage.removeItem('injected_text')
-
-        // Small delay to ensure everything is fully initialized
-        setTimeout(() => {
-          handleQuery(injectedText)
-        }, 100)
-      }
+      // Send as first user message
+      handleQuery(injectedText)
     }
-  }, [currentChat, subscriptionLoading, handleQuery])
+  }, []) // Only run once on mount
 
   // Sync chats and profile when user signs in and periodically
   useEffect(() => {


### PR DESCRIPTION
Reverts tinfoilsh/tinfoil-chat#68
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Reverted recent changes to message passing via iframe to restore previous chat initialization behavior. The chat interface now processes injected text from localStorage on mount as before.

<!-- End of auto-generated description by cubic. -->

