### PR TITLE
feat: add URL hash message injection

### DIFF
--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -28,6 +28,7 @@ import ScrollableFeed from 'react-scrollable-feed'
 import { CloudSyncIntroModal } from '../modals/cloud-sync-intro-modal'
 import { EncryptionKeyModal } from '../modals/encryption-key-modal'
 import { FirstLoginKeyModal } from '../modals/first-login-key-modal'
+import { UrlHashMessageHandler } from '../url-hash-message-handler'
 import { VerifierSidebar } from '../verifier/verifier-sidebar'
 import { ChatInput } from './chat-input'
 import { ChatLabels } from './chat-labels'
@@ -637,6 +638,14 @@ export function ChatInterface({
         overscrollBehavior: 'none',
       }}
     >
+      {/* URL Hash Message Handler */}
+      <UrlHashMessageHandler
+        isReady={!isLoadingConfig && isClient && !!currentChat}
+        onMessageReady={(message) => {
+          handleQuery(message)
+        }}
+      />
+
       {/* Sidebar toggle button - visible when left sidebar is closed, hidden when open */}
       {!isSidebarOpen &&
         !(

--- a/src/components/url-hash-message-handler.tsx
+++ b/src/components/url-hash-message-handler.tsx
@@ -1,0 +1,73 @@
+'use client'
+
+import { logError, logInfo, logWarning } from '@/utils/error-handling'
+import { useEffect, useRef } from 'react'
+
+interface UrlHashMessageHandlerProps {
+  onMessageReady: (message: string) => void
+  isReady: boolean
+}
+
+export function UrlHashMessageHandler({
+  onMessageReady,
+  isReady,
+}: UrlHashMessageHandlerProps) {
+  const hasProcessed = useRef(false)
+
+  useEffect(() => {
+    if (!isReady || hasProcessed.current) {
+      return
+    }
+
+    const processHashMessage = () => {
+      try {
+        const hash = window.location.hash
+
+        if (!hash || hash.length <= 1) {
+          return
+        }
+
+        const encodedMessage = hash.slice(1)
+
+        try {
+          const decodedMessage = atob(encodedMessage)
+
+          if (decodedMessage) {
+            logInfo('Processing message from URL hash', {
+              component: 'UrlHashMessageHandler',
+              metadata: { messageLength: decodedMessage.length },
+            })
+
+            hasProcessed.current = true
+
+            onMessageReady(decodedMessage)
+
+            window.history.replaceState(
+              null,
+              '',
+              window.location.pathname + window.location.search,
+            )
+          }
+        } catch (decodeError) {
+          logWarning('Invalid base64 encoding in URL hash', {
+            component: 'UrlHashMessageHandler',
+            metadata: {
+              error:
+                decodeError instanceof Error
+                  ? decodeError.message
+                  : 'Unknown error',
+            },
+          })
+        }
+      } catch (error) {
+        logError('Failed to process URL hash message', error, {
+          component: 'UrlHashMessageHandler',
+        })
+      }
+    }
+
+    processHashMessage()
+  }, [isReady, onMessageReady])
+
+  return null
+}


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added support for injecting a chat message from the URL hash, allowing users to pre-fill the chat with a base64-encoded message.

- **New Features**
 - Decodes and processes a message from the URL hash when the chat is ready.
 - Removes the hash from the URL after processing to keep the address clean.

<!-- End of auto-generated description by cubic. -->

