### PR TITLE
fix: prevent deleted chats from reappearing during sync

### DIFF
--- a/src/services/storage/chat-storage.ts
+++ b/src/services/storage/chat-storage.ts
@@ -4,6 +4,7 @@ import { cloudSync } from '../cloud/cloud-sync'
 import { r2Storage } from '../cloud/r2-storage'
 import { streamingTracker } from '../cloud/streaming-tracker'
 import { encryptionService } from '../encryption/encryption-service'
+import { deletedChatsTracker } from './deleted-chats-tracker'
 import { indexedDBStorage, type Chat as StorageChat } from './indexed-db'
 import { storageMigration } from './migration'
 import { migrationEvents } from './migration-events'
@@ -216,6 +217,10 @@ export class ChatStorageService {
 
   async deleteChat(id: string): Promise<void> {
     await this.initialize()
+
+    // Mark as deleted to prevent re-sync
+    deletedChatsTracker.markAsDeleted(id)
+
     await indexedDBStorage.deleteChat(id)
 
     // Also delete from cloud storage (non-blocking)

--- a/src/services/storage/deleted-chats-tracker.ts
+++ b/src/services/storage/deleted-chats-tracker.ts
@@ -109,12 +109,21 @@ class DeletedChatsTracker {
   getDeletedIds(): string[] {
     const now = Date.now()
     const validIds: string[] = []
+    const expiredIds: string[] = []
 
     this.deletedChats.forEach((deletedAt, chatId) => {
       if (now - deletedAt < EXPIRY_TIME) {
         validIds.push(chatId)
+      } else {
+        expiredIds.push(chatId)
       }
     })
+
+    // Remove expired entries from memory
+    if (expiredIds.length > 0) {
+      expiredIds.forEach((id) => this.deletedChats.delete(id))
+      this.saveToStorage()
+    }
 
     return validIds
   }

--- a/src/services/storage/deleted-chats-tracker.ts
+++ b/src/services/storage/deleted-chats-tracker.ts
@@ -52,10 +52,14 @@ class DeletedChatsTracker {
       }
     })
 
-    if (entries.length > 0) {
-      sessionStorage.setItem(DELETED_CHATS_KEY, JSON.stringify(entries))
-    } else {
-      sessionStorage.removeItem(DELETED_CHATS_KEY)
+    try {
+      if (entries.length > 0) {
+        sessionStorage.setItem(DELETED_CHATS_KEY, JSON.stringify(entries))
+      } else {
+        sessionStorage.removeItem(DELETED_CHATS_KEY)
+      }
+    } catch (error) {
+      // Silently fail - storage may be unavailable or full
     }
   }
 

--- a/src/services/storage/deleted-chats-tracker.ts
+++ b/src/services/storage/deleted-chats-tracker.ts
@@ -1,0 +1,123 @@
+import { logInfo } from '@/utils/error-handling'
+
+const DELETED_CHATS_KEY = 'tinfoil-deleted-chats'
+const EXPIRY_TIME = 5 * 60 * 1000 // 5 minutes
+
+interface DeletedChatEntry {
+  chatId: string
+  deletedAt: number
+}
+
+class DeletedChatsTracker {
+  private deletedChats: Map<string, number> = new Map()
+
+  constructor() {
+    this.loadFromStorage()
+  }
+
+  private loadFromStorage(): void {
+    if (typeof window === 'undefined') return
+
+    try {
+      const stored = sessionStorage.getItem(DELETED_CHATS_KEY)
+      if (stored) {
+        const entries: DeletedChatEntry[] = JSON.parse(stored)
+        const now = Date.now()
+
+        // Only keep entries that aren't expired
+        entries.forEach((entry) => {
+          if (now - entry.deletedAt < EXPIRY_TIME) {
+            this.deletedChats.set(entry.chatId, entry.deletedAt)
+          }
+        })
+
+        // Update storage to remove expired entries
+        this.saveToStorage()
+      }
+    } catch (error) {
+      // Ignore errors loading from storage
+    }
+  }
+
+  private saveToStorage(): void {
+    if (typeof window === 'undefined') return
+
+    const now = Date.now()
+    const entries: DeletedChatEntry[] = []
+
+    // Only save non-expired entries
+    this.deletedChats.forEach((deletedAt, chatId) => {
+      if (now - deletedAt < EXPIRY_TIME) {
+        entries.push({ chatId, deletedAt })
+      }
+    })
+
+    if (entries.length > 0) {
+      sessionStorage.setItem(DELETED_CHATS_KEY, JSON.stringify(entries))
+    } else {
+      sessionStorage.removeItem(DELETED_CHATS_KEY)
+    }
+  }
+
+  markAsDeleted(chatId: string): void {
+    this.deletedChats.set(chatId, Date.now())
+    this.saveToStorage()
+
+    logInfo('Marked chat as deleted', {
+      component: 'DeletedChatsTracker',
+      action: 'markAsDeleted',
+      metadata: { chatId },
+    })
+  }
+
+  isDeleted(chatId: string): boolean {
+    const deletedAt = this.deletedChats.get(chatId)
+    if (!deletedAt) return false
+
+    const now = Date.now()
+    const isExpired = now - deletedAt > EXPIRY_TIME
+
+    if (isExpired) {
+      // Remove expired entry
+      this.deletedChats.delete(chatId)
+      this.saveToStorage()
+      return false
+    }
+
+    return true
+  }
+
+  removeFromDeleted(chatId: string): void {
+    if (this.deletedChats.delete(chatId)) {
+      this.saveToStorage()
+
+      logInfo('Removed chat from deleted tracker', {
+        component: 'DeletedChatsTracker',
+        action: 'removeFromDeleted',
+        metadata: { chatId },
+      })
+    }
+  }
+
+  clear(): void {
+    this.deletedChats.clear()
+    if (typeof window !== 'undefined') {
+      sessionStorage.removeItem(DELETED_CHATS_KEY)
+    }
+  }
+
+  getDeletedIds(): string[] {
+    const now = Date.now()
+    const validIds: string[] = []
+
+    this.deletedChats.forEach((deletedAt, chatId) => {
+      if (now - deletedAt < EXPIRY_TIME) {
+        validIds.push(chatId)
+      }
+    })
+
+    return validIds
+  }
+}
+
+export const deletedChatsTracker = new DeletedChatsTracker()

--- a/src/utils/signout-cleanup.ts
+++ b/src/utils/signout-cleanup.ts
@@ -1,4 +1,5 @@
 import { profileSync } from '@/services/cloud/profile-sync'
+import { deletedChatsTracker } from '@/services/storage/deleted-chats-tracker'
 import { indexedDBStorage } from '@/services/storage/indexed-db'
 import { logError, logInfo } from '@/utils/error-handling'
 
@@ -31,6 +32,13 @@ export async function performSignoutCleanup(): Promise<void> {
     logInfo('Cleared profile sync cache', {
       component: 'signoutCleanup',
       action: 'clearProfileCache',
+    })
+
+    // Clear deleted chats tracker
+    deletedChatsTracker.clear()
+    logInfo('Cleared deleted chats tracker', {
+      component: 'signoutCleanup',
+      action: 'clearDeletedChatsTracker',
     })
 
     // Clear specific localStorage items first


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Prevents deleted chats from reappearing by tracking recently deleted IDs and skipping them during local merges and cloud sync. Adds a 5-minute guard window to cover eventual consistency and pagination.

- **Bug Fixes**
  - Added DeletedChatsTracker (sessionStorage, 5-minute TTL) with mark/isDeleted/remove APIs.
  - useChatStorage: filter out deleted IDs when merging/reading saved chats; mark on delete.
  - CloudSyncService: skip sync/load for deleted IDs; clear from tracker after successful cloud delete; add logs.
  - ChatStorageService.deleteChat: mark as deleted before local/cloud deletion.

<!-- End of auto-generated description by cubic. -->

