### PR TITLE
fix: better LaTeX rendering

### DIFF
--- a/src/components/chat/chat-messages.tsx
+++ b/src/components/chat/chat-messages.tsx
@@ -151,10 +151,8 @@ function convertTeXDelimitersToRemarkMath(text: string): string {
     // Inline math: \( ... \) → $ ... $
     s = s.replace(/\\\(([\s\S]*?)\\\)/g, (_, inner) => `$${inner}$`)
 
-    // Collapse accidental $$$$ from nested replacements
+    // Collapse accidental $$$$ from nested replacements (only 4+ dollars)
     s = s.replace(/\$\$\$\$/g, '$$')
-    // Also collapse triple dollars
-    s = s.replace(/\$\$\$/g, '$$')
     return s
   }
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Improves LaTeX rendering in chat messages by normalizing TeX delimiters and using remark-breaks for line breaks. Inline and display math now render reliably with KaTeX without touching code blocks.

- **Bug Fixes**
  - Convert \( … \), \[ … ], and equation/equation* to $…$ and $$…$$ for remark-math.
  - Skip all conversions inside fenced code blocks.
  - Add remark-breaks and remove manual newline replacement to avoid breaking math and preserve formatting.

<!-- End of auto-generated description by cubic. -->

