### PR TITLE
feat: add vercel speed insights package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@types/jszip": "^3.4.1",
         "@types/pako": "^2.0.3",
         "@types/uuid": "^10.0.0",
+        "@vercel/speed-insights": "^1.2.0",
         "@xyflow/react": "^12.6.0",
         "audiobuffer-to-wav": "^1.0.0",
         "autoprefixer": "^10.4.21",
@@ -2700,6 +2701,40 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@vercel/speed-insights": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/speed-insights/-/speed-insights-1.2.0.tgz",
+      "integrity": "sha512-y9GVzrUJ2xmgtQlzFP2KhVRoCglwfRQgjyfY607aU0hh0Un6d0OUyrJkjuAlsV18qR4zfoFPs/BiIj9YDS6Wzw==",
+      "hasInstallScript": true,
+      "peerDependencies": {
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@xyflow/react": {
       "version": "12.8.3",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@types/jszip": "^3.4.1",
     "@types/pako": "^2.0.3",
     "@types/uuid": "^10.0.0",
+    "@vercel/speed-insights": "^1.2.0",
     "@xyflow/react": "^12.6.0",
     "audiobuffer-to-wav": "^1.0.0",
     "autoprefixer": "^10.4.21",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import { AuthCleanupHandler } from '@/components/auth-cleanup-handler'
 import { Toaster } from '@/components/ui/toaster'
 import '@/styles/tailwind.css'
 import { ClerkProvider } from '@clerk/nextjs'
+import { SpeedInsights } from '@vercel/speed-insights/next'
 import type { Metadata } from 'next'
 import { Inter } from 'next/font/google'
 import Script from 'next/script'
@@ -103,6 +104,7 @@ export default function RootLayout({
           <AuthCleanupHandler />
           {children}
           <Toaster />
+          <SpeedInsights />
         </ClerkProvider>
       </body>
     </html>


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Integrates Vercel Speed Insights to capture web performance metrics across the app. Adds the @vercel/speed-insights package and renders SpeedInsights in RootLayout for automatic reporting in Vercel.

<!-- End of auto-generated description by cubic. -->

