### PR TITLE
Refactor: separate and clean up cloud sync logic 

### DIFF
--- a/src/app/api/billing/subscription-status/route.ts
+++ b/src/app/api/billing/subscription-status/route.ts
@@ -77,7 +77,10 @@ export async function GET() {
       return NextResponse.json({ error: 'User not found' }, { status: 404 })
     }
 
-    const publicMetadata = (user.publicMetadata ?? {}) as Record<string, unknown>
+    const publicMetadata = (user.publicMetadata ?? {}) as Record<
+      string,
+      unknown
+    >
 
     const rawChatStatus = publicMetadata['chat_subscription_status']
     const chatStatus = isValidStatus(rawChatStatus) ? rawChatStatus : null

--- a/src/config.ts
+++ b/src/config.ts
@@ -26,10 +26,13 @@ export const PAGINATION = {
 // Cloud sync settings
 export const CLOUD_SYNC = {
   RETRY_DELAY: 100, // milliseconds
-  SYNC_INTERVAL: 5000, // 5 seconds - frequency for syncing chats and profile
+  SYNC_INTERVAL: 15000, // 15 seconds - frequency for syncing chats and profile
   // Grace period to avoid deleting chats that were just uploaded but may not yet
   // appear in eventually-consistent remote listings
   DELETION_GRACE_MS: 120000, // 2 minutes
+  // Additional safety: if a chat remains missing from remote listings beyond this TTL
+  // (across sync cycles), it can be considered deleted remotely.
+  DELETION_TTL_MS: 600000, // 10 minutes
 } as const
 
 // UI settings

--- a/src/hooks/use-cloud-pagination.ts
+++ b/src/hooks/use-cloud-pagination.ts
@@ -1,0 +1,192 @@
+import { CLOUD_SYNC, PAGINATION } from '@/config'
+import { cloudSync } from '@/services/cloud/cloud-sync'
+import { r2Storage } from '@/services/cloud/r2-storage'
+import { indexedDBStorage } from '@/services/storage/indexed-db'
+import { logError } from '@/utils/error-handling'
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+interface UseCloudPaginationOptions {
+  isSignedIn: boolean
+  userId?: string
+  pageSize?: number
+}
+
+interface UseCloudPaginationReturn {
+  hasMore: boolean
+  isLoading: boolean
+  hasAttempted: boolean
+  initialize: () => Promise<
+    | {
+        hasMore: boolean
+        nextToken?: string
+        deletedIds: string[]
+      }
+    | undefined
+  >
+  loadMore: () => Promise<
+    | {
+        hasMore: boolean
+        nextToken?: string
+        saved: number
+      }
+    | undefined
+  >
+  reset: () => Promise<
+    | {
+        hasMore: boolean
+        nextToken?: string
+        deletedIds: string[]
+      }
+    | undefined
+  >
+}
+
+export function useCloudPagination(
+  options: UseCloudPaginationOptions,
+): UseCloudPaginationReturn {
+  const { isSignedIn, userId, pageSize = PAGINATION.CHATS_PER_PAGE } = options
+
+  const [nextToken, setNextToken] = useState<string | undefined>(undefined)
+  const [hasMore, setHasMore] = useState(false)
+  const [isLoading, setIsLoading] = useState(false)
+  const [hasAttempted, setHasAttempted] = useState(false)
+  const initializedRef = useRef(false)
+
+  const initialize = useCallback(async () => {
+    if (!isSignedIn || !userId) return
+
+    try {
+      const allChats = await indexedDBStorage.getAllChats()
+      const syncedChats = allChats
+        .filter(
+          (chat) =>
+            chat.syncedAt &&
+            !(chat as any).isBlankChat &&
+            !(chat as any).hasTemporaryId,
+        )
+        .sort((a, b) => {
+          const timeA = new Date(a.createdAt).getTime()
+          const timeB = new Date(b.createdAt).getTime()
+          return timeB - timeA
+        })
+
+      const deletedIds: string[] = []
+      if (syncedChats.length > pageSize) {
+        const chatsToDelete = syncedChats.slice(pageSize)
+        for (const chat of chatsToDelete) {
+          // Skip deletion for chats that were recently synced
+          // Remote listings might not include them yet due to eventual consistency
+          const recentlySynced =
+            typeof chat.syncedAt === 'number' &&
+            Date.now() - chat.syncedAt < CLOUD_SYNC.DELETION_GRACE_MS
+          if (recentlySynced) {
+            continue
+          }
+
+          try {
+            await indexedDBStorage.deleteChat(chat.id)
+            deletedIds.push(chat.id)
+          } catch (deleteError) {
+            logError('Failed to prune paginated chat', deleteError, {
+              component: 'useCloudPagination',
+              action: 'initialize_delete',
+              metadata: { chatId: chat.id },
+            })
+          }
+        }
+      }
+
+      const result = await r2Storage.listChats({ limit: pageSize })
+      setNextToken(result.nextContinuationToken)
+      setHasMore(!!result.nextContinuationToken)
+      setHasAttempted(false)
+      initializedRef.current = true
+      return {
+        hasMore: !!result.nextContinuationToken,
+        nextToken: result.nextContinuationToken,
+        deletedIds,
+      }
+    } catch (error) {
+      logError('Failed to initialize pagination', error, {
+        component: 'useCloudPagination',
+        action: 'initialize',
+      })
+      return undefined
+    }
+  }, [isSignedIn, userId, pageSize])
+
+  const loadMore = useCallback(async () => {
+    if (!isSignedIn || !userId || isLoading) return
+
+    // Save current state in case we need to rollback
+    const previousToken = nextToken
+    const previousHasMore = hasMore
+
+    setIsLoading(true)
+    setHasAttempted(true)
+
+    try {
+      let tokenToUse = nextToken
+      if (!tokenToUse && !initializedRef.current) {
+        const init = await r2Storage.listChats({ limit: pageSize })
+        tokenToUse = init.nextContinuationToken
+      }
+
+      if (!tokenToUse) {
+        setHasMore(false)
+        return
+      }
+
+      const result = await cloudSync.fetchAndStorePage({
+        limit: pageSize,
+        continuationToken: tokenToUse,
+      })
+
+      setNextToken(result.nextToken)
+      setHasMore(!!result.nextToken)
+      return result
+    } catch (error) {
+      // Rollback state on error
+      setNextToken(previousToken)
+      setHasMore(previousHasMore)
+
+      // If this was the first attempt and we have no token,
+      // we should allow retry on next attempt
+      if (!previousToken && !initializedRef.current) {
+        setHasAttempted(false)
+      }
+
+      logError('Failed to load more chats', error, {
+        component: 'useCloudPagination',
+        action: 'loadMore',
+        metadata: {
+          hadToken: !!previousToken,
+          wasInitialized: initializedRef.current,
+        },
+      })
+      return undefined
+    } finally {
+      setIsLoading(false)
+    }
+  }, [isSignedIn, userId, isLoading, nextToken, pageSize, hasMore])
+
+  const reset = useCallback(async () => {
+    setHasAttempted(false)
+    initializedRef.current = false
+    return initialize()
+  }, [initialize])
+
+  // Initialize when user changes
+  useEffect(() => {
+    if (isSignedIn && userId) {
+      void initialize()
+    } else {
+      setNextToken(undefined)
+      setHasMore(false)
+      setHasAttempted(false)
+      initializedRef.current = false
+    }
+  }, [isSignedIn, userId, initialize])
+
+  return { hasMore, isLoading, hasAttempted, initialize, loadMore, reset }
+}

--- a/src/services/storage/chat-events.ts
+++ b/src/services/storage/chat-events.ts
@@ -1,0 +1,52 @@
+import { logError } from '@/utils/error-handling'
+
+export type ChatChangeReason = 'save' | 'delete' | 'sync' | 'pagination'
+
+export interface ChatChangedEvent {
+  reason: ChatChangeReason
+  ids?: string[]
+}
+
+type Listener = (event: ChatChangedEvent) => void
+
+class ChatEvents {
+  private listeners: Set<Listener> = new Set()
+  private listenerCleanupMap = new WeakMap<Listener, () => void>()
+
+  on(listener: Listener): () => void {
+    this.listeners.add(listener)
+
+    // Create and store the cleanup function
+    const cleanup = () => this.off(listener)
+    this.listenerCleanupMap.set(listener, cleanup)
+
+    return cleanup
+  }
+
+  off(listener: Listener): void {
+    this.listeners.delete(listener)
+    this.listenerCleanupMap.delete(listener)
+  }
+
+  emit(event: ChatChangedEvent): void {
+    for (const listener of this.listeners) {
+      try {
+        listener(event)
+      } catch (error) {
+        logError('Chat event listener error', error, {
+          component: 'ChatEvents',
+          action: 'emit',
+          metadata: { reason: event.reason, idsCount: event.ids?.length ?? 0 },
+        })
+      }
+    }
+  }
+
+  // Clean up all listeners (useful for testing or shutdown)
+  clear(): void {
+    this.listeners.clear()
+    // WeakMap will automatically clean up when listeners are garbage collected
+  }
+}
+
+export const chatEvents = new ChatEvents()


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Separated cloud sync and pagination into dedicated modules to simplify ChatSidebar and make sync safer and more reliable. Also hardened subscription status parsing and added safeguards against premature local deletions.

- **Refactors**
  - Moved cloud pagination into useCloudPagination hook; ChatSidebar now delegates init/load/reset and no longer touches cloud sync directly.
  - Added cloudSync.fetchAndStorePage to fetch, decrypt, and persist paginated chats.
  - Introduced chatEvents bus; emits on save/delete/sync/pagination so views can react to changes.
  - Tuned cloud sync settings: SYNC_INTERVAL 15s, DELETION_GRACE_MS 2m, DELETION_TTL_MS 10m.

- **Bug Fixes**
  - Prevented accidental local deletions when remote listings lag by tracking “missing remotely” chats and applying grace/TTL before deletion.
  - Made subscription status check robust: strict status validation, safe expiration parsing, and correct active/canceled-within-period logic.

<!-- End of auto-generated description by cubic. -->

