### PR TITLE
Feat: color consistency in UI and markdown rendering

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -91,9 +91,14 @@
   white-space: pre;
 }
 
-/* Ensure inline code wraps */
+/* Ensure inline code wraps and has consistent color */
 .prose code {
   word-break: break-word;
+  color: hsl(var(--content-primary)) !important;
+}
+
+.dark .prose code {
+  color: hsl(var(--content-primary)) !important;
 }
 
 /* Tables should scroll horizontally when needed */
@@ -114,15 +119,149 @@
   height: auto;
 }
 
-/* Fix blockquotes */
-.prose blockquote {
-  word-wrap: break-word;
+/* Comprehensive prose color overrides for consistent text colors */
+.prose {
   color: hsl(var(--content-primary)) !important;
 }
 
-/* Override prose-invert for blockquotes to ensure consistent text color */
+.prose blockquote {
+  word-wrap: break-word;
+  color: hsl(var(--content-primary)) !important;
+  border-left-color: hsl(var(--border-subtle)) !important;
+}
+
+.prose blockquote p {
+  color: hsl(var(--content-primary)) !important;
+}
+
+.prose h1,
+.prose h2,
+.prose h3,
+.prose h4,
+.prose h5,
+.prose h6 {
+  color: hsl(var(--content-primary)) !important;
+}
+
+.prose p {
+  color: hsl(var(--content-primary)) !important;
+}
+
+.prose ul,
+.prose ol {
+  color: hsl(var(--content-primary)) !important;
+}
+
+.prose li {
+  color: hsl(var(--content-primary)) !important;
+}
+
+.prose li::marker {
+  color: hsl(var(--content-primary)) !important;
+}
+
+.prose strong {
+  color: hsl(var(--content-primary)) !important;
+}
+
+.prose em {
+  color: hsl(var(--content-primary)) !important;
+}
+
+.prose table {
+  color: hsl(var(--content-primary)) !important;
+}
+
+.prose thead {
+  color: hsl(var(--content-primary)) !important;
+}
+
+.prose tbody {
+  color: hsl(var(--content-primary)) !important;
+}
+
+.prose th {
+  color: hsl(var(--content-primary)) !important;
+}
+
+.prose td {
+  color: hsl(var(--content-primary)) !important;
+}
+
+.prose hr {
+  border-color: hsl(var(--border-subtle)) !important;
+}
+
+/* Dark mode specific overrides to prevent any prose-invert remnants */
+.dark .prose {
+  color: hsl(var(--content-primary)) !important;
+}
+
 .dark .prose blockquote {
   color: hsl(var(--content-primary)) !important;
+  border-left-color: hsl(var(--border-subtle)) !important;
+}
+
+.dark .prose blockquote p {
+  color: hsl(var(--content-primary)) !important;
+}
+
+.dark .prose h1,
+.dark .prose h2,
+.dark .prose h3,
+.dark .prose h4,
+.dark .prose h5,
+.dark .prose h6 {
+  color: hsl(var(--content-primary)) !important;
+}
+
+.dark .prose p {
+  color: hsl(var(--content-primary)) !important;
+}
+
+.dark .prose ul,
+.dark .prose ol {
+  color: hsl(var(--content-primary)) !important;
+}
+
+.dark .prose li {
+  color: hsl(var(--content-primary)) !important;
+}
+
+.dark .prose li::marker {
+  color: hsl(var(--content-primary)) !important;
+}
+
+.dark .prose strong {
+  color: hsl(var(--content-primary)) !important;
+}
+
+.dark .prose em {
+  color: hsl(var(--content-primary)) !important;
+}
+
+.dark .prose table {
+  color: hsl(var(--content-primary)) !important;
+}
+
+.dark .prose thead {
+  color: hsl(var(--content-primary)) !important;
+}
+
+.dark .prose tbody {
+  color: hsl(var(--content-primary)) !important;
+}
+
+.dark .prose th {
+  color: hsl(var(--content-primary)) !important;
+}
+
+.dark .prose td {
+  color: hsl(var(--content-primary)) !important;
+}
+
+.dark .prose hr {
+  border-color: hsl(var(--border-subtle)) !important;
 }
 
 /* Responsive adjustments for narrow screens */

--- a/src/components/chat/chat-sidebar.tsx
+++ b/src/components/chat/chat-sidebar.tsx
@@ -703,11 +703,7 @@ export function ChatSidebar({
                     )}
                   </button>
                   {upgradeError && (
-                    <p
-                      className={`mt-2 text-xs ${
-                        isDarkMode ? 'text-red-400' : 'text-red-600'
-                      }`}
-                    >
+                    <p className="mt-2 text-xs text-destructive">
                       {upgradeError}
                     </p>
                   )}
@@ -718,11 +714,7 @@ export function ChatSidebar({
 
           {/* Divider after boxes */}
           {(!isSignedIn || (isSignedIn && !isPremium)) && (
-            <div
-              className={`border-b ${
-                isDarkMode ? 'border-gray-800' : 'border-gray-200'
-              }`}
-            />
+            <div className="border-b border-border-subtle" />
           )}
 
           {/* New Chat button */}
@@ -752,17 +744,9 @@ export function ChatSidebar({
           </div>
 
           {/* Chat History Header */}
-          <div
-            className={`flex-none border-b ${
-              isDarkMode ? 'border-gray-800' : 'border-gray-200'
-            } px-3 py-2 sm:px-4 sm:py-3`}
-          >
+          <div className="flex-none border-b border-border-subtle px-3 py-2 sm:px-4 sm:py-3">
             <div className="flex items-center justify-between">
-              <h3
-                className={`truncate font-aeonik-fono text-sm font-medium ${
-                  isDarkMode ? 'text-content-secondary' : 'text-content-primary'
-                }`}
-              >
+              <h3 className="truncate font-aeonik-fono text-sm font-medium text-content-primary">
                 Chat History
               </h3>
               <div className="flex items-center gap-1">
@@ -794,11 +778,7 @@ export function ChatSidebar({
                 )}
               </div>
             </div>
-            <div
-              className={`font-base mt-1 font-aeonik-fono text-xs ${
-                isDarkMode ? 'text-content-muted' : 'text-content-muted'
-              }`}
-            >
+            <div className="font-base mt-1 font-aeonik-fono text-xs text-content-muted">
               {isSignedIn ? (
                 <>
                   Your chats are encrypted and synced to the cloud. The
@@ -898,11 +878,7 @@ export function ChatSidebar({
                 !shouldShowLoadMore &&
                 !hasMoreRemote &&
                 hasAttemptedLoadMore && (
-                  <div
-                    className={`w-full rounded-lg p-3 text-center text-sm ${
-                      isDarkMode ? 'text-content-muted' : 'text-content-muted'
-                    }`}
-                  >
+                  <div className="w-full rounded-lg p-3 text-center text-sm text-content-muted">
                     No more chats
                   </div>
                 )}
@@ -911,11 +887,7 @@ export function ChatSidebar({
 
           {/* App Store button for iOS users */}
           {isClient && isIOS && (
-            <div
-              className={`flex-none border-t ${
-                isDarkMode ? 'border-gray-800' : 'border-gray-200'
-              } p-3`}
-            >
+            <div className="flex-none border-t border-border-subtle p-3">
               <div className="text-center">
                 <p
                   className={`mb-2 text-sm font-medium ${'text-content-secondary'}`}
@@ -942,11 +914,7 @@ export function ChatSidebar({
 
           {/* Terms and privacy policy */}
           <div className="flex h-[56px] flex-none items-center justify-center border-t border-border-subtle bg-surface-sidebar p-3">
-            <p
-              className={`text-center text-xs leading-relaxed ${
-                isDarkMode ? 'text-content-secondary' : 'text-content-primary'
-              }`}
-            >
+            <p className="text-center text-xs leading-relaxed text-content-secondary">
               By using this service, you agree to Tinfoil&apos;s{' '}
               <Link
                 href="https://tinfoil.sh/terms"
@@ -1052,9 +1020,7 @@ function TypingAnimation({
     <span className="inline-flex items-baseline">
       <span>{currentText}</span>
       <span
-        className={`ml-0.5 inline-block w-0.5 ${
-          isDarkMode ? 'bg-gray-300' : 'bg-gray-700'
-        } ${showCursor ? 'opacity-100' : 'opacity-0'}`}
+        className={`ml-0.5 inline-block w-0.5 bg-content-primary ${showCursor ? 'opacity-100' : 'opacity-0'}`}
         style={{ height: '1.1em', transform: 'translateY(0.05em)' }}
       />
     </span>
@@ -1308,9 +1274,7 @@ function DeleteConfirmation({
           duration: 0.15,
         },
       }}
-      className={`absolute inset-x-0 top-0 z-50 flex gap-2 rounded-md ${
-        isDarkMode ? 'bg-surface-chat' : 'bg-surface-sidebar'
-      } p-2 shadow-lg`}
+      className="absolute inset-x-0 top-0 z-50 flex gap-2 rounded-md bg-surface-sidebar p-2 shadow-lg"
     >
       <button
         className={`flex-1 rounded-md p-2 text-sm font-medium transition-colors ${

--- a/src/components/chat/renderers/components/MessageContent.tsx
+++ b/src/components/chat/renderers/components/MessageContent.tsx
@@ -104,11 +104,7 @@ export const MessageContent = memo(function MessageContent({
           if (props.inline) {
             return (
               <code
-                className={`${className || ''} break-words rounded px-1.5 py-0.5 font-mono text-sm ${
-                  isDarkMode
-                    ? 'bg-gray-700 text-gray-200'
-                    : 'bg-gray-100 text-gray-800'
-                }`}
+                className={`${className || ''} bg-surface-secondary break-words rounded px-1.5 py-0.5 font-mono text-sm text-content-primary`}
                 {...props}
               >
                 {children}
@@ -153,7 +149,7 @@ export const MessageContent = memo(function MessageContent({
             <div className="my-4 w-full overflow-x-auto">
               <table
                 {...props}
-                className={`divide-y ${isDarkMode ? 'divide-gray-600' : 'divide-gray-200'}`}
+                className="divide-y divide-border-subtle"
                 style={{ minWidth: 'max-content' }}
               >
                 {children}
@@ -163,10 +159,7 @@ export const MessageContent = memo(function MessageContent({
         },
         thead({ children, node, ...props }: any) {
           return (
-            <thead
-              {...props}
-              className={isDarkMode ? 'bg-gray-700' : 'bg-gray-100'}
-            >
+            <thead {...props} className="bg-surface-secondary">
               {children}
             </thead>
           )
@@ -175,7 +168,7 @@ export const MessageContent = memo(function MessageContent({
           return (
             <tbody
               {...props}
-              className={`divide-y ${isDarkMode ? 'divide-gray-700 bg-gray-800' : 'divide-gray-200 bg-gray-50'}`}
+              className="bg-surface-primary divide-y divide-border-subtle"
             >
               {children}
             </tbody>
@@ -188,7 +181,7 @@ export const MessageContent = memo(function MessageContent({
           return (
             <th
               {...props}
-              className={`whitespace-nowrap px-4 py-3 text-left text-xs font-medium uppercase tracking-wider ${isDarkMode ? 'text-gray-300' : 'text-gray-600'}`}
+              className="whitespace-nowrap px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-content-primary"
             >
               {children}
             </th>
@@ -198,10 +191,20 @@ export const MessageContent = memo(function MessageContent({
           return (
             <td
               {...props}
-              className={`px-4 py-3 text-sm ${isDarkMode ? 'text-gray-200' : 'text-gray-700'} whitespace-nowrap`}
+              className="whitespace-nowrap px-4 py-3 text-sm text-content-primary"
             >
               {children}
             </td>
+          )
+        },
+        blockquote({ children, ...props }: any) {
+          return (
+            <blockquote
+              {...props}
+              className="my-4 border-l-4 border-border-subtle pl-4 text-content-primary"
+            >
+              {children}
+            </blockquote>
           )
         },
       }}

--- a/src/components/chat/renderers/default/DefaultMessageRenderer.tsx
+++ b/src/components/chat/renderers/default/DefaultMessageRenderer.tsx
@@ -152,7 +152,6 @@ const DefaultMessageComponent = ({
                   'prose w-full max-w-none overflow-x-auto text-base prose-pre:bg-transparent prose-pre:p-0',
                   'text-content-primary prose-headings:text-content-primary prose-strong:text-content-primary prose-code:text-content-primary',
                   'prose-a:text-accent hover:prose-a:text-accent/80',
-                  'dark:prose-invert',
                 )}
               >
                 {!isUser && isStreaming && isLastMessage ? (


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Unifies markdown and chat UI colors with design tokens across light and dark modes. Fixes inconsistent text and borders in prose content and removes reliance on prose-invert.

- **Bug Fixes**
  - Applies consistent .prose styles (code, headings, lists, tables, blockquotes, hr) using content-primary and border-subtle in both modes.
  - Replaces isDarkMode-specific classes in ChatSidebar with semantic tokens for text and dividers.
  - Standardizes MessageContent: inline code, tables, and blockquotes use surface/content/border tokens; removes dark:prose-invert in DefaultMessageRenderer.

<!-- End of auto-generated description by cubic. -->

