### PR TITLE
dev

### DIFF
--- a/.clerk/.tmp/README.md
+++ b/.clerk/.tmp/README.md
@@ -1,0 +1,4 @@
+
+## DO NOT COMMIT
+This directory is auto-generated from `@clerk/nextjs` because you are running in Keyless mode. Avoid committing the `.clerk/` directory as it includes the secret key of the unclaimed instance.
+  

--- a/.clerk/.tmp/keyless.json
+++ b/.clerk/.tmp/keyless.json
@@ -1,0 +1,1 @@
+{"publishableKey":"pk_test_d2l0dHktb3lzdGVyLTk3LmNsZXJrLmFjY291bnRzLmRldiQ","secretKey":"sk_test_PM1GtgSXvRFlN8r7zWbkNy63RfsDf2vo0ePyG9cfRA","claimUrl":"https://dashboard.clerk.com/apps/claim?token=n2kzq7opq88o05x1vsoqhhxa7j1fyhafpxvrxopq","apiKeysUrl":"https://dashboard.clerk.com/apps/app_339DnzymCLnwYvBrrocAt1MUAKa/instances/ins_339Dnuhficwlo3yElQhyeZrXiJO/api-keys"}

--- a/.env
+++ b/.env
@@ -1,0 +1,8 @@
+# Clerk Authentication
+NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_cnVsaW5nLWxhZHlidWctNjguY2xlcmsuYWNjb3VudHMuZGV2JA
+CLERK_SECRET_KEY=sk_test_5Z1NffPJYwt4AsGHjbuNaHF1oQT9AFP5PrLxs5naSU
+
+# API Base URL
+# NEXT_PUBLIC_API_BASE_URL=https://api.tinfoil.sh
+NEXT_PUBLIC_API_BASE_URL=https://dev-api.tinfoil.sh
+NEXT_PUBLIC_CLERK_AFTER_SIGN_OUT_URL=/

--- a/src/components/verifier/constants.ts
+++ b/src/components/verifier/constants.ts
@@ -1,4 +1,4 @@
-export const VERIFIER_VERSION = 'v0.1.0'
+export const VERIFIER_VERSION = 'v0.10.1'
 
 export const VERIFIER_CONSTANTS = {
   VERSION: VERIFIER_VERSION,


### PR DESCRIPTION
from dev
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Bump verifier to v0.10.1 and set up Clerk Keyless auth for dev. Adds .env with Clerk keys and points the app to https://dev-api.tinfoil.sh.

- **Dependencies**
  - Update VERIFIER_VERSION to v0.10.1.

- **Migration**
  - Do not commit .clerk/ or .env; add both to .gitignore.
  - Rotate the committed Clerk keys and remove .clerk/.tmp from the repo.

<!-- End of auto-generated description by cubic. -->

