### PR TITLE
fix: set trialing status as active subscription

### DIFF
--- a/src/app/api/billing/subscription-status/route.ts
+++ b/src/app/api/billing/subscription-status/route.ts
@@ -49,7 +49,7 @@ const hasActiveSubscription = (
     return false
   }
 
-  if (status === 'active') {
+  if (status === 'active' || status === 'trialing') {
     return true
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Treat trialing subscriptions as active so trial users get full access to paid features. Updates the subscription-status API to return active for both "active" and "trialing" states.

<!-- End of auto-generated description by cubic. -->

