### PR TITLE
chore: bump wasm verifier

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "remark-math": "^6.0.0",
         "tailwind-merge": "^2.6.0",
         "tailwindcss-animate": "^1.0.7",
-        "tinfoil": "^0.10.0",
+        "tinfoil": "^0.10.9",
         "uuid": "^11.0.3"
       },
       "devDependencies": {
@@ -4091,9 +4091,9 @@
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
     },
     "node_modules/ehbp": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/ehbp/-/ehbp-0.0.4.tgz",
-      "integrity": "sha512-kbqQ74hFeyV8+2xy8ELqU1H/DGayBVsgUmm1JkBCht9V4beJ9vHeY5rx93KoApnyj05cAp8cfcpgU0Ywq2ULAA==",
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/ehbp/-/ehbp-0.0.5.tgz",
+      "integrity": "sha512-WI/y9Objv17a7g11gWAeEb/GaPzAYPjxwxfmssm0cERseMkFENo+VF0x3sJB572xA6n0uhQIv/KzIOqbTyuXvQ==",
       "license": "MIT",
       "dependencies": {
         "@hpke/core": "^1.7.4",
@@ -9945,15 +9945,15 @@
       }
     },
     "node_modules/tinfoil": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/tinfoil/-/tinfoil-0.10.0.tgz",
-      "integrity": "sha512-jOvYrsM0zvbh1w7BBfwZleoGEkAyisxjVtKBGnaAvhka3NYZCabH/Z3+pdmMSYvKJPzKSmlUfPA31JAMtroJQg==",
+      "version": "0.10.9",
+      "resolved": "https://registry.npmjs.org/tinfoil/-/tinfoil-0.10.9.tgz",
+      "integrity": "sha512-SDP7PoORSufZED4gw72AX8K83xIZer175mE6cqP3xwYOxDo2rvHXMW7Al7BwWnDk952YsEaaouSqJJ91TWiC7g==",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@ai-sdk/openai-compatible": "^1.0.10",
         "ai": "^5.0.19",
         "dotenv": "^17.2.1",
-        "ehbp": "^0.0.4",
+        "ehbp": "^0.0.5",
         "openai": "^5.13.1",
         "ts-node": "^10.9.2"
       },

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "remark-math": "^6.0.0",
     "tailwind-merge": "^2.6.0",
     "tailwindcss-animate": "^1.0.7",
-    "tinfoil": "^0.10.0",
+    "tinfoil": "^0.10.9",
     "uuid": "^11.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Upgrade tinfoil to 0.10.9, which updates the WASM verifier via ehbp 0.0.5. Pulls in recent fixes and keeps the verification path up to date.

<!-- End of auto-generated description by cubic. -->

