### PR TITLE
feat: make verification sidebar wider

### DIFF
--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -973,10 +973,12 @@ export function ChatInterface({
       ) && (
         <div
           className={`fixed top-4 z-50 flex gap-2 transition-all duration-300 ${
-            isVerifierSidebarOpen || isSettingsSidebarOpen
-              ? windowWidth >= CONSTANTS.MOBILE_BREAKPOINT
-                ? 'right-[369px]'
-                : 'right-4'
+            windowWidth >= CONSTANTS.MOBILE_BREAKPOINT
+              ? isVerifierSidebarOpen
+                ? 'right-[444px]'
+                : isSettingsSidebarOpen
+                  ? 'right-[369px]'
+                  : 'right-4'
               : 'right-4'
           }`}
         >
@@ -1130,9 +1132,12 @@ export function ChatInterface({
         className="fixed inset-0 overflow-hidden transition-all duration-200"
         style={{
           right:
-            (isVerifierSidebarOpen || isSettingsSidebarOpen) &&
             windowWidth >= CONSTANTS.MOBILE_BREAKPOINT
-              ? `${CONSTANTS.SETTINGS_SIDEBAR_WIDTH_PX}px`
+              ? isVerifierSidebarOpen
+                ? `${CONSTANTS.VERIFIER_SIDEBAR_WIDTH_PX}px`
+                : isSettingsSidebarOpen
+                  ? `${CONSTANTS.SETTINGS_SIDEBAR_WIDTH_PX}px`
+                  : '0'
               : '0',
           bottom: 0,
           left:

--- a/src/components/chat/constants.ts
+++ b/src/components/chat/constants.ts
@@ -22,7 +22,7 @@ export const CONSTANTS = {
   // Sidebar widths
   CHAT_SIDEBAR_WIDTH_PX: 300,
   SETTINGS_SIDEBAR_WIDTH_PX: 345,
-  VERIFIER_SIDEBAR_WIDTH_PX: 345,
+  VERIFIER_SIDEBAR_WIDTH_PX: 420,
   // Long text paste threshold (characters) - texts longer than this will be converted to .txt file
   LONG_PASTE_THRESHOLD: 3000,
   // System prompt for AI title generation


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Widened the verification sidebar to 420px for better readability. Updated layout offsets so floating actions and the chat overlay align correctly depending on which sidebar is open.

- **New Features**
  - Increased VERIFIER_SIDEBAR_WIDTH_PX from 345 to 420 when above the mobile breakpoint.
  - Dynamic right offset for top actions: 444px (verifier), 369px (settings), 4px otherwise.
  - Chat overlay now offsets by the active sidebar’s width; 0 when no sidebar is open.

<!-- End of auto-generated description by cubic. -->

