### PR TITLE
fix: make the verification sidebar shorter

### DIFF
--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -972,15 +972,17 @@ export function ChatInterface({
         (isSidebarOpen || isVerifierSidebarOpen || isSettingsSidebarOpen)
       ) && (
         <div
-          className={`fixed top-4 z-50 flex gap-2 transition-all duration-300 ${
-            windowWidth >= CONSTANTS.MOBILE_BREAKPOINT
-              ? isVerifierSidebarOpen
-                ? 'right-[444px]'
-                : isSettingsSidebarOpen
-                  ? 'right-[369px]'
-                  : 'right-4'
-              : 'right-4'
-          }`}
+          className="fixed top-4 z-50 flex gap-2 transition-all duration-300"
+          style={{
+            right:
+              windowWidth >= CONSTANTS.MOBILE_BREAKPOINT
+                ? isVerifierSidebarOpen
+                  ? `${CONSTANTS.VERIFIER_SIDEBAR_WIDTH_PX + 24}px`
+                  : isSettingsSidebarOpen
+                    ? `${CONSTANTS.SETTINGS_SIDEBAR_WIDTH_PX + 24}px`
+                    : '16px'
+                : '16px',
+          }}
         >
           {/* New chat button */}
           <div className="group relative">

--- a/src/components/chat/constants.ts
+++ b/src/components/chat/constants.ts
@@ -22,7 +22,7 @@ export const CONSTANTS = {
   // Sidebar widths
   CHAT_SIDEBAR_WIDTH_PX: 300,
   SETTINGS_SIDEBAR_WIDTH_PX: 345,
-  VERIFIER_SIDEBAR_WIDTH_PX: 420,
+  VERIFIER_SIDEBAR_WIDTH_PX: 345,
   // Long text paste threshold (characters) - texts longer than this will be converted to .txt file
   LONG_PASTE_THRESHOLD: 3000,
   // System prompt for AI title generation


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Shortened the verification sidebar to 345px to match the settings sidebar and free up space. Updated the top-right action buttons to position based on sidebar widths, fixing misalignment when a sidebar is open.

<!-- End of auto-generated description by cubic. -->

