### PR TITLE
docs: add security architecture section

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,34 @@
 - **[Tailwind CSS](https://tailwindcss.com/)** - Styling
 - **[Radix UI](https://www.radix-ui.com/)** - Accessible components
 
+## Security Architecture
+
+Tinfoil Chat ensures your messages reach a verified Trusted Execution Environment (TEE) through a multi-layered security approach:
+
+### Browser-to-TEE Communication
+
+Since browsers cannot perform TLS certificate pinning or inspect certificate chains, we use **EHBP (Encrypted HTTP Body Protocol)** with **HPKE encryption** (RFC 9180):
+
+1. **Attestation Verification**: Before sending any data, the client verifies the remote enclave using WebAssembly-based attestation
+2. **Key Binding**: The verifier returns the enclave's expected HPKE public key after successful attestation
+3. **End-to-End Encryption**: Messages are encrypted directly to the verified enclave's public key before transmission
+4. **Hardware Validation**: The enclave runs in a secure TEE with cryptographically verified code integrity
+
+This approach provides security guarantees equivalent to TLS pinning while working within browser constraints. Only the attested enclave possessing the corresponding private key can decrypt your messages.
+
+### Verification Steps
+
+The chat interface shows real-time verification status for:
+
+- **Hardware Attestation**: Confirms the model runs in a genuine secure enclave
+- **Code Integrity**: Verifies the enclave is running unmodified, audited code
+- **Chat Security**: Validates measurements match expected values
+
+Learn more about the security model:
+
+- [Tinfoil Node SDK Documentation](https://docs.tinfoil.sh/sdk/node-sdk)
+- [EHBP Protocol Details](https://docs.tinfoil.sh/resources/ehbp)
+
 ## Reporting Vulnerabilities
 
 Please report security vulnerabilities by either:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added a Security Architecture section to the README explaining how browser-to-TEE communication is secured with EHBP (HPKE), including attestation, key binding, and end-to-end encryption. Documented the chat UI’s verification steps and linked to relevant SDK and protocol docs.

<sup>Written for commit df9297f90c5cf15c1eb420c6fda6582e62ed47e3. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

