### PR TITLE
refactor: use dynamic model selection

### DIFF
--- a/src/components/chat/constants.ts
+++ b/src/components/chat/constants.ts
@@ -1,10 +1,7 @@
-import type { AIModel } from './types'
-
 export const CONSTANTS = {
   LOADING_TIMEOUT: 500,
   MOBILE_BREAKPOINT: 768,
   SINGLE_SIDEBAR_BREAKPOINT: 1024, // Below this width, only one sidebar can be open at a time
-  DEFAULT_MODEL: 'llama-free' as AIModel,
   MAX_MESSAGES: 100,
   MAX_MESSAGE_LENGTH: 4000,
   MAX_DOCUMENT_SIZE_MB: 10,

--- a/src/components/chat/hooks/use-chat-messaging.ts
+++ b/src/components/chat/hooks/use-chat-messaging.ts
@@ -140,8 +140,8 @@ export function useChatMessaging({
             model.paid === false,
         )
 
-        // Use first free model if found, otherwise fallback to default
-        return firstFreeModel?.modelName || CONSTANTS.DEFAULT_MODEL
+        // Use first free model if found, otherwise fallback to selected model as last resort
+        return firstFreeModel?.modelName || selectedModel
       })()
     : selectedModel
 

--- a/src/components/chat/hooks/use-model-management.ts
+++ b/src/components/chat/hooks/use-model-management.ts
@@ -2,7 +2,6 @@ import { isModelNameAvailable, type BaseModel } from '@/app/config/models'
 import { DEV_SIMULATOR_MODEL } from '@/utils/dev-simulator'
 import { logWarning } from '@/utils/error-handling'
 import { useCallback, useEffect, useState } from 'react'
-import { CONSTANTS } from '../constants'
 import type { AIModel, LabelType } from '../types'
 
 interface UseModelManagementProps {
@@ -35,7 +34,7 @@ export function useModelManagement({
   storeHistory,
   subscriptionLoading = false,
 }: UseModelManagementProps): UseModelManagementReturn {
-  // Model state - initialize with saved model or temporary default
+  // Model state - initialize with saved model or empty string as placeholder
   const [selectedModel, setSelectedModel] = useState<AIModel>(() => {
     if (typeof window !== 'undefined') {
       const saved = localStorage.getItem('selectedModel')
@@ -43,9 +42,8 @@ export function useModelManagement({
         return saved as AIModel
       }
     }
-    // Use DEFAULT_MODEL only as a temporary placeholder
-    // It will be replaced with the first available model from config
-    return CONSTANTS.DEFAULT_MODEL
+    // Empty string will be replaced with first available model from config
+    return ''
   })
 
   // Track if we've validated against the loaded models
@@ -95,7 +93,8 @@ export function useModelManagement({
       }
 
       // Determine the best model for this user
-      let targetModel: AIModel = selectedModel
+      let targetModel: AIModel =
+        selectedModel || (availableChatModels[0].modelName as AIModel)
 
       // For premium users, always prefer premium models
       if (isPremium) {
@@ -138,7 +137,10 @@ export function useModelManagement({
         }
       } else {
         // For free users, validate current model or use first available
-        if (!isModelNameAvailable(selectedModel, models, isPremium)) {
+        if (
+          !selectedModel ||
+          !isModelNameAvailable(selectedModel, models, isPremium)
+        ) {
           targetModel = availableChatModels[0].modelName as AIModel
         }
       }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switches chat model selection to be dynamic based on available models and user status, removing the hard-coded default. This prevents invalid defaults and improves fallback behavior when availability changes.

- **Refactors**
  - Removed DEFAULT_MODEL and related usage.
  - Initialize selectedModel from localStorage or empty string; resolve to first available model after config loads.
  - For free users, choose the first free model if none is selected or available; premium users keep existing preference logic.
  - In messaging, when a paid model is gated, fall back to the selected model if no free model is found.

<sup>Written for commit 94fb920c42897bc5b574e4c86b091995572d0146. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

