### PR TITLE
Fix: save chat after title gen

### DIFF
--- a/src/components/chat/hooks/use-chat-messaging.ts
+++ b/src/components/chat/hooks/use-chat-messaging.ts
@@ -660,6 +660,18 @@ export function useChatMessaging({
                     title: generatedTitle,
                     id: chatId,
                   }
+
+                  // Update state immediately with the new title
+                  setCurrentChat((prev) =>
+                    prev.id === chatId
+                      ? { ...prev, title: generatedTitle }
+                      : prev,
+                  )
+                  setChats((prevChats) =>
+                    prevChats.map((c) =>
+                      c.id === chatId ? { ...c, title: generatedTitle } : c,
+                    ),
+                  )
                 }
               } else {
                 logWarning('No free model found for title generation', {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Save and display the generated chat title immediately by updating both current chat and chat list state when the title is created. This prevents stale titles and ensures the UI shows the new title right away.

<sup>Written for commit 624b6671a3b505261cd9271e442e1a7b701cb028. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

