### PR TITLE
Fix: duplicate first token in ui

### DIFF
--- a/src/components/chat/hooks/streaming-processor.ts
+++ b/src/components/chat/hooks/streaming-processor.ts
@@ -459,6 +459,18 @@ export async function processStreamingResponse(
                       )
                     }
                   }
+                } else {
+                  // Non-thinking content in first chunk - add it to the message
+                  if (content) {
+                    assistantMessage = {
+                      ...assistantMessage,
+                      content: (assistantMessage.content || '') + content,
+                      isThinking: false,
+                    }
+                    if (isSameChat()) {
+                      scheduleStreamingUpdate()
+                    }
+                  }
                 }
                 if (
                   typeof window !== 'undefined' &&
@@ -472,6 +484,7 @@ export async function processStreamingResponse(
                     ctx.setIsWaitingForResponse(false)
                   }, 16)
                 }
+                continue // Prevent falling through to duplicate content processing
               } else {
                 continue
               }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes duplicated first token in the chat UI by correctly handling the first non-thinking chunk and preventing duplicate processing.

- **Bug Fixes**
  - Append the first non-thinking chunk to assistantMessage, set isThinking to false, and schedule an update for the same chat.
  - Add a continue to skip the duplicate-content path for the initial chunk.

<sup>Written for commit 7f5c9e2118b0d7b636ca31a727e065e234fe6151. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

