### PR TITLE
Fix: handle reasoning_content null in stream

### DIFF
--- a/src/components/chat/hooks/streaming-processor.ts
+++ b/src/components/chat/hooks/streaming-processor.ts
@@ -329,20 +329,23 @@ export async function processStreamingResponse(
                 isThinking: false,
                 thinkingDuration,
               }
+              if (ctx.currentChatIdRef.current === ctx.updatedChat.id) {
+                scheduleStreamingUpdate()
+              }
+              continue
             } else if (reasoningContent) {
               assistantMessage = {
                 ...assistantMessage,
                 thoughts: thoughtsBuffer,
                 isThinking: isInThinkingMode,
               }
+              if (ctx.currentChatIdRef.current === ctx.updatedChat.id) {
+                scheduleStreamingUpdate()
+              }
+              continue
             }
-            if (
-              (reasoningContent || content) &&
-              ctx.currentChatIdRef.current === ctx.updatedChat.id
-            ) {
-              scheduleStreamingUpdate()
-            }
-            if (!content) continue
+            // If we have content but no reasoningContent and not in thinking mode,
+            // fall through to the content handling block below
           }
 
           if (isUsingReasoningFormat && content) {
@@ -459,18 +462,6 @@ export async function processStreamingResponse(
                       )
                     }
                   }
-                } else {
-                  // Non-thinking content in first chunk - add it to the message
-                  if (content) {
-                    assistantMessage = {
-                      ...assistantMessage,
-                      content: (assistantMessage.content || '') + content,
-                      isThinking: false,
-                    }
-                    if (isSameChat()) {
-                      scheduleStreamingUpdate()
-                    }
-                  }
                 }
                 if (
                   typeof window !== 'undefined' &&
@@ -484,7 +475,6 @@ export async function processStreamingResponse(
                     ctx.setIsWaitingForResponse(false)
                   }, 16)
                 }
-                continue // Prevent falling through to duplicate content processing
               } else {
                 continue
               }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes streaming when reasoning_content is null so content still renders and the UI updates correctly for the active chat. Also removes duplicate processing to prevent double updates and flicker.

- **Bug Fixes**
  - Fall through to content handling when reasoning_content is missing.
  - Schedule updates when thinking ends or reasoning chunks arrive, gated to the current chat.
  - Remove duplicate early content handling to avoid double processing.

<sup>Written for commit bb72aeaf89a863f81315eb852028d6b8c0d22b3f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

