### PR TITLE
Fix: allow data url in csp

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -40,7 +40,7 @@ const nextConfig = {
               "style-src 'self' 'unsafe-inline' https://api.fontshare.com",
               "font-src 'self' https://api.fontshare.com data:",
               "img-src 'self' data: blob: https:",
-              "connect-src 'self' https://*.tinfoil.sh https://tinfoilsh.github.io https://plausible.io https://clerk.accounts.dev https://*.clerk.accounts.dev wss://*.clerk.accounts.dev",
+              "connect-src 'self' data: https://*.tinfoil.sh https://tinfoilsh.github.io https://plausible.io https://clerk.accounts.dev https://*.clerk.accounts.dev wss://*.clerk.accounts.dev",
               "frame-src 'self' https://vercel.live https://challenges.cloudflare.com https://clerk.accounts.dev https://*.clerk.accounts.dev https://verification-center.tinfoil.sh",
               "frame-ancestors 'none'",
               "base-uri 'self'",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Allow data: URLs in the CSP connect-src directive to prevent blocked client connections that rely on data URIs. This resolves CSP violations causing errors during client-side operations that use data URLs.

<sup>Written for commit e71ff34e7f9171c3418b2080c9eff0d9b45ae0ea. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

