### PR TITLE
chore: remove test env files from tracking

### DIFF
--- a/.clerk/.tmp/README.md
+++ b/.clerk/.tmp/README.md
@@ -1,4 +1,0 @@
-
-## DO NOT COMMIT
-This directory is auto-generated from `@clerk/nextjs` because you are running in Keyless mode. Avoid committing the `.clerk/` directory as it includes the secret key of the unclaimed instance.
-  

--- a/.clerk/.tmp/keyless.json
+++ b/.clerk/.tmp/keyless.json
@@ -1,1 +1,0 @@
-{"publishableKey":"pk_test_d2l0dHktb3lzdGVyLTk3LmNsZXJrLmFjY291bnRzLmRldiQ","secretKey":"sk_test_PM1GtgSXvRFlN8r7zWbkNy63RfsDf2vo0ePyG9cfRA","claimUrl":"https://dashboard.clerk.com/apps/claim?token=n2kzq7opq88o05x1vsoqhhxa7j1fyhafpxvrxopq","apiKeysUrl":"https://dashboard.clerk.com/apps/app_339DnzymCLnwYvBrrocAt1MUAKa/instances/ins_339Dnuhficwlo3yElQhyeZrXiJO/api-keys"}

--- a/.env
+++ b/.env
@@ -1,8 +1,0 @@
-# Clerk Authentication
-NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_cnVsaW5nLWxhZHlidWctNjguY2xlcmsuYWNjb3VudHMuZGV2JA
-CLERK_SECRET_KEY=sk_test_5Z1NffPJYwt4AsGHjbuNaHF1oQT9AFP5PrLxs5naSU
-
-# API Base URL
-# NEXT_PUBLIC_API_BASE_URL=https://api.tinfoil.sh
-NEXT_PUBLIC_API_BASE_URL=https://dev-api.tinfoil.sh
-NEXT_PUBLIC_CLERK_AFTER_SIGN_OUT_URL=/

--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,11 @@ yarn-debug.log*
 yarn-error.log*
 
 # local env files
+.env
 .env*.local
+
+# clerk
+.clerk/
 
 # vercel
 .vercel


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed committed env and Clerk keyless files, and updated .gitignore to ignore .env and the .clerk/ directory. This prevents accidental commits of secrets and cleans up the repo.

<sup>Written for commit 0eef2adfec88f358538d10f3506b81b43b544ddc. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

