### PR TITLE
fix: prevent welcome view during hash message processing

### DIFF
--- a/src/components/chat/chat-messages.tsx
+++ b/src/components/chat/chat-messages.tsx
@@ -269,7 +269,7 @@ export function ChatMessages({
     return <div className="h-full"></div>
   }
 
-  if (messages.length === 0) {
+  if (messages.length === 0 && !isWaitingForResponse) {
     return (
       <div className="flex w-full flex-1 items-center justify-center">
         <div className="w-full max-w-4xl px-8">


### PR DESCRIPTION












<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevent the welcome view while a hash-triggered message is being processed to avoid flicker on initial load. Preserve URL hash messages during chat reload so the in-progress chat isn't replaced.

- **Bug Fixes**
  - Update ChatMessages: show welcome view only when messages.length === 0 and not waiting for response.
  - Update useChatStorage: preserve the current chat if it has messages (including URL-hash). Otherwise switch to the mode’s blank chat; same rule on initial load.

<sup>Written for commit be8e1139679b7f4c94c4d870ec38f3fdc9800fc4. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->











