### PR TITLE
fix: align inline markdown elements to baseline

### DIFF
--- a/src/components/chat/renderers/components/MessageContent.tsx
+++ b/src/components/chat/renderers/components/MessageContent.tsx
@@ -165,7 +165,7 @@ export const MessageContent = memo(function MessageContent({
           if (props.inline) {
             return (
               <code
-                className={`${className || ''} bg-surface-secondary break-words rounded px-1.5 py-0.5 font-mono text-sm text-content-primary`}
+                className={`${className || ''} bg-surface-secondary inline break-words rounded px-1.5 py-0.5 align-baseline font-mono text-sm text-content-primary`}
                 {...props}
               >
                 {children}
@@ -286,7 +286,7 @@ export const MessageContent = memo(function MessageContent({
               href={sanitizedHref}
               target="_blank"
               rel="noopener noreferrer"
-              className="text-blue-500 underline hover:text-blue-600"
+              className="inline align-baseline text-blue-500 underline hover:text-blue-600"
             >
               {children}
             </a>
@@ -294,14 +294,14 @@ export const MessageContent = memo(function MessageContent({
         },
         strong({ children, ...props }: any) {
           return (
-            <strong {...props} className="font-semibold">
+            <strong {...props} className="inline align-baseline font-semibold">
               {children}
             </strong>
           )
         },
         b({ children, ...props }: any) {
           return (
-            <b {...props} className="font-semibold">
+            <b {...props} className="inline align-baseline font-semibold">
               {children}
             </b>
           )

--- a/src/components/chat/renderers/components/ThoughtProcess.tsx
+++ b/src/components/chat/renderers/components/ThoughtProcess.tsx
@@ -300,7 +300,7 @@ export const ThoughtProcess = memo(function ThoughtProcess({
                 children?: React.ReactNode
               }) =>
                 inline ? (
-                  <code className="break-words rounded border border-border-subtle bg-surface-chat px-1 py-0.5 font-mono text-xs text-content-primary">
+                  <code className="inline break-words rounded border border-border-subtle bg-surface-chat px-1 py-0.5 align-baseline font-mono text-xs text-content-primary">
                     {children}
                   </code>
                 ) : (


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Align inline markdown elements (code, links, bold/strong) to the text baseline to fix vertical misalignment and improve readability in chat and thought process views. Implemented by rendering these elements as inline with align-baseline in MessageContent and ThoughtProcess.

<sup>Written for commit f5c3c171d4614cf9599da3f85f29bcd63d425d1b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

