### PR TITLE
fix: enforce baseline alignment for all inline markdown elements

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -95,10 +95,12 @@
 .prose code {
   word-break: break-word;
   color: hsl(var(--content-primary)) !important;
+  vertical-align: baseline !important;
 }
 
 .dark .prose code {
   color: hsl(var(--content-primary)) !important;
+  vertical-align: baseline !important;
 }
 
 /* Tables should scroll horizontally when needed */
@@ -162,10 +164,16 @@
 
 .prose strong {
   color: hsl(var(--content-primary)) !important;
+  vertical-align: baseline !important;
 }
 
 .prose em {
   color: hsl(var(--content-primary)) !important;
+  vertical-align: baseline !important;
+}
+
+.prose a {
+  vertical-align: baseline !important;
 }
 
 .prose table {
@@ -234,10 +242,16 @@
 
 .dark .prose strong {
   color: hsl(var(--content-primary)) !important;
+  vertical-align: baseline !important;
 }
 
 .dark .prose em {
   color: hsl(var(--content-primary)) !important;
+  vertical-align: baseline !important;
+}
+
+.dark .prose a {
+  vertical-align: baseline !important;
 }
 
 .dark .prose table {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enforced baseline alignment for inline markdown elements to fix text misalignment and keep lines even across light and dark themes. Applied vertical-align: baseline to code, strong, em, and links within .prose to improve readability and prevent wobble.

<sup>Written for commit 2f1ae18c54569c634fa5da70c8b10af89d16f1e5. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

