### PR TITLE
fix: render inline markdown code elements correctly 

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,18 +1,16 @@
-@layer base {
-  /* Use dynamic viewport units for better mobile handling */
-  .h-dvh {
-    height: 100dvh;
-  }
+/* Use dynamic viewport units for better mobile handling */
+.h-dvh {
+  height: 100dvh;
+}
 
-  /* Safe area padding for mobile browsers */
+/* Safe area padding for mobile browsers */
+.pb-safe {
+  padding-bottom: max(0.75rem, env(safe-area-inset-bottom, 0.75rem));
+}
+
+@media (min-width: 768px) {
   .pb-safe {
-    padding-bottom: max(0.75rem, env(safe-area-inset-bottom, 0.75rem));
-  }
-
-  @media (min-width: 768px) {
-    .pb-safe {
-      padding-bottom: 0;
-    }
+    padding-bottom: 0;
   }
 }
 
@@ -91,16 +89,44 @@
   white-space: pre;
 }
 
-/* Ensure inline code wraps and has consistent color */
-.prose code {
+/* Inline code styling - override typography plugin defaults */
+/* Only target inline code, not code blocks (which are inside <pre>) */
+.prose :not(pre) > code {
   word-break: break-word;
   color: hsl(var(--content-primary)) !important;
   vertical-align: baseline !important;
+  background-color: hsl(var(--muted)) !important;
+  padding: 0.25rem 0.375rem !important;
+  border-radius: 0.375rem !important;
+  font-size: 0.875rem !important;
+  font-family:
+    'Aeonik Fono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+    monospace !important;
 }
 
-.dark .prose code {
+/* Remove decorative backticks added by typography plugin */
+.prose :not(pre) > code::before,
+.prose :not(pre) > code::after {
+  content: '' !important;
+  display: none !important;
+}
+
+.dark .prose :not(pre) > code {
   color: hsl(var(--content-primary)) !important;
   vertical-align: baseline !important;
+  background-color: hsl(var(--muted)) !important;
+  padding: 0.25rem 0.375rem !important;
+  border-radius: 0.375rem !important;
+  font-size: 0.875rem !important;
+  font-family:
+    'Aeonik Fono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+    monospace !important;
+}
+
+.dark .prose :not(pre) > code::before,
+.dark .prose :not(pre) > code::after {
+  content: '' !important;
+  display: none !important;
 }
 
 /* Tables should scroll horizontally when needed */

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,3 +1,4 @@
+import '@/app/globals.css'
 import { AuthCleanupHandler } from '@/components/auth-cleanup-handler'
 import { Toaster } from '@/components/ui/toaster'
 import '@/styles/tailwind.css'


### PR DESCRIPTION
The @tailwindcss/typography plugin was adding decorative backticks to inline code via ::before and ::after pseudo-elements. This caused inline code to render as `code` instead of just code with styling.

Changes:
- Import globals.css in layout.tsx (was missing)
- Remove @layer base wrapper from globals.css (incompatible without @tailwind directives)
- Add CSS to remove ::before and ::after content from code elements
- Add proper inline code styling (background, padding, rounded corners, monospace font)

The root cause was that globals.css contained overrides but was never imported, so the typography plugin's default styles were applied.





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed decorative backticks on inline code and applied clean, consistent styling. Inline code now renders with proper background and padding, not as `code`.

- **Bug Fixes**
  - Import globals.css in layout.tsx so overrides load.
  - Remove @layer base wrapper in globals.css to work without @tailwind directives.
  - Override typography for inline code (:not(pre) > code): strip ::before/::after backticks and add background, padding, rounded corners, monospace font.

<sup>Written for commit 34ba8d99ba78bec8001fc2e35b69ed2c25e5e8f3. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





