### PR TITLE
fix: markdown quote rendering issues

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -155,7 +155,18 @@
 .prose blockquote {
   word-wrap: break-word;
   color: hsl(var(--content-primary)) !important;
-  border-left-color: hsl(var(--border-subtle)) !important;
+  border-left: none !important;
+  padding-left: 1.5rem !important;
+  font-style: normal !important;
+  quotes: none !important;
+}
+
+.prose blockquote::before,
+.prose blockquote::after,
+.prose blockquote p::before,
+.prose blockquote p::after {
+  content: '' !important;
+  display: none !important;
 }
 
 .prose blockquote p {
@@ -233,7 +244,18 @@
 
 .dark .prose blockquote {
   color: hsl(var(--content-primary)) !important;
-  border-left-color: hsl(var(--border-subtle)) !important;
+  border-left: none !important;
+  padding-left: 1.5rem !important;
+  font-style: normal !important;
+  quotes: none !important;
+}
+
+.dark .prose blockquote::before,
+.dark .prose blockquote::after,
+.dark .prose blockquote p::before,
+.dark .prose blockquote p::after {
+  content: '' !important;
+  display: none !important;
 }
 
 .dark .prose blockquote p {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes Markdown blockquote rendering by removing the left border and auto-added quote marks, and adding consistent padding. Normalizes font style and disables pseudo-elements so quotes display cleanly in light and dark modes.

<sup>Written for commit 2b1262aca278f1cb460dd47a470a5fcefb579b6d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

