### PR TITLE
fix: change deprecated api endpoints

### DIFF
--- a/src/app/config/models.ts
+++ b/src/app/config/models.ts
@@ -40,14 +40,7 @@ export const getAvailableChatModels = (
   models: BaseModel[],
   isPremium: boolean,
 ): BaseModel[] => {
-  return models.filter(
-    (model) =>
-      // Must be a chat model
-      model.type === 'chat' &&
-      model.chat === true &&
-      // Show models that are available for the user's subscription level
-      isModelAvailable(model, isPremium),
-  )
+  return models.filter((model) => isModelAvailable(model, isPremium))
 }
 
 // Helper function to validate if a specific model name is available for a user
@@ -60,13 +53,7 @@ export const isModelNameAvailable = (
   if (!model) {
     return false
   }
-
-  return (
-    model.type === 'chat' &&
-    model.chat === true &&
-    // Use the standard availability check
-    isModelAvailable(model, isPremium)
-  )
+  return isModelAvailable(model, isPremium)
 }
 
 // Helper function to check if running in local development

--- a/src/components/chat/hooks/use-chat-messaging.ts
+++ b/src/components/chat/hooks/use-chat-messaging.ts
@@ -129,22 +129,12 @@ export function useChatMessaging({
         )
 
         // If selected model is free and available, use it
-        if (
-          selectedModelData &&
-          selectedModelData.type === 'chat' &&
-          selectedModelData.chat === true &&
-          selectedModelData.paid === false
-        ) {
+        if (selectedModelData && selectedModelData.paid === false) {
           return selectedModel
         }
 
         // Otherwise fall back to first free chat model
-        const firstFreeModel = models.find(
-          (model) =>
-            model.type === 'chat' &&
-            model.chat === true &&
-            model.paid === false,
-        )
+        const firstFreeModel = models.find((model) => model.paid === false)
 
         // Use first free model if found, otherwise fallback to selected model as last resort
         return firstFreeModel?.modelName || selectedModel

--- a/src/components/chat/hooks/use-model-management.ts
+++ b/src/components/chat/hooks/use-model-management.ts
@@ -76,11 +76,8 @@ export function useModelManagement({
       setLastKnownPremiumStatus(isPremium)
 
       // Get all available chat models for this user
-      const availableChatModels = models.filter(
-        (model) =>
-          model.type === 'chat' &&
-          model.chat === true &&
-          isModelNameAvailable(model.modelName as AIModel, models, isPremium),
+      const availableChatModels = models.filter((model) =>
+        isModelNameAvailable(model.modelName as AIModel, models, isPremium),
       )
 
       if (availableChatModels.length === 0) {


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Replace deprecated /api/app endpoints with /api/config and simplify chat model filtering to rely on availability checks. This fixes model fetching and improves default model selection.

- **Bug Fixes**
  - Use /api/config/models?paid=true&chat=true for model fetches.
  - Use /api/config/system-prompt for system prompt.

- **Refactors**
  - Removed `type === 'chat` and `chat === true` checks; use `isModelAvailable`/`isModelNameAvailable`.
  - Default selection now picks the first free model.

<sup>Written for commit 1fe2b2255d0605ea0194ba344b8248a632b7deb5. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



