### PR TITLE
refactor: less hacky model image selector

### DIFF
--- a/src/components/chat/WelcomeScreen.tsx
+++ b/src/components/chat/WelcomeScreen.tsx
@@ -196,16 +196,11 @@ export const WelcomeScreen = memo(function WelcomeScreen({
                               <>
                                 <img
                                   src={
-                                    model.modelName
-                                      .toLowerCase()
-                                      .includes('openai') ||
-                                    model.modelName
-                                      .toLowerCase()
-                                      .includes('gpt')
-                                      ? isDarkMode
-                                        ? '/model-icons/openai-dark.png'
-                                        : '/model-icons/openai-light.png'
-                                      : `/model-icons/${model.image}`
+                                    model.image === 'openai.png'
+                                      ? `/model-icons/openai-${isDarkMode ? 'dark' : 'light'}.png`
+                                      : model.image === 'moonshot.png'
+                                        ? `/model-icons/moonshot-${isDarkMode ? 'dark' : 'light'}.png`
+                                        : `/model-icons/${model.image}`
                                   }
                                   alt={model.name}
                                   className="h-4 w-4"

--- a/src/components/chat/chat-controls.tsx
+++ b/src/components/chat/chat-controls.tsx
@@ -96,12 +96,11 @@ export function ChatControls({
           >
             <img
               src={
-                model.modelName.toLowerCase().includes('openai') ||
-                model.modelName.toLowerCase().includes('gpt')
-                  ? isDarkMode
-                    ? '/model-icons/openai-dark.png'
-                    : '/model-icons/openai-light.png'
-                  : `/model-icons/${model.image}`
+                model.image === 'openai.png'
+                  ? `/model-icons/openai-${isDarkMode ? 'dark' : 'light'}.png`
+                  : model.image === 'moonshot.png'
+                    ? `/model-icons/moonshot-${isDarkMode ? 'dark' : 'light'}.png`
+                    : `/model-icons/${model.image}`
               }
               alt={model.name}
               className="h-5 w-5"

--- a/src/components/chat/model-selector.tsx
+++ b/src/components/chat/model-selector.tsx
@@ -209,12 +209,11 @@ export function ModelSelector({
                 src={
                   failedImages[model.modelName]
                     ? '/icon.png'
-                    : model.modelName.toLowerCase().includes('openai') ||
-                        model.modelName.toLowerCase().includes('gpt')
-                      ? isDarkMode
-                        ? '/model-icons/openai-dark.png'
-                        : '/model-icons/openai-light.png'
-                      : `/model-icons/${model.image}`
+                    : model.image === 'openai.png'
+                      ? `/model-icons/openai-${isDarkMode ? 'dark' : 'light'}.png`
+                      : model.image === 'moonshot.png'
+                        ? `/model-icons/moonshot-${isDarkMode ? 'dark' : 'light'}.png`
+                        : `/model-icons/${model.image}`
                 }
                 alt={model.name}
                 className={`h-5 w-5 ${!isAvailable ? 'opacity-70 grayscale' : ''}`}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Refactored model icon selection to use explicit image names with dark/light variants instead of name-based string checks. Icons are now consistent across WelcomeScreen, ChatControls, and ModelSelector, with correct theming and fewer mislabels.

- **Refactors**
  - Use model.image ('openai.png'/'moonshot.png') to map to `/model-icons/<provider>-<theme>.png`.
  - Default to `/model-icons/${model.image}`; keep fallback to `/icon.png` when loading fails.
  - Removed brittle checks like `includes('openai'|'gpt')`.

<sup>Written for commit cebf50cc5e4fff82ca0678ba3b7ea0a2d6d1185a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

