### PR TITLE
fix: update tinfoil-js and its dependencies 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@braintree/sanitize-url": "^7.1.1",
         "@clerk/nextjs": "^6.21.0",
+        "@freedomofpress/sigstore-browser": "^0.1.11",
         "@headlessui/react": "^2.1.1",
         "@heroicons/react": "^2.1.4",
         "@radix-ui/react-alert-dialog": "^1.1.4",
@@ -51,7 +52,7 @@
         "remark-math": "^6.0.0",
         "tailwind-merge": "^2.6.0",
         "tailwindcss-animate": "^1.0.7",
-        "tinfoil": "^0.11.0",
+        "tinfoil": "^0.11.4",
         "uuid": "^11.0.3"
       },
       "devDependencies": {
@@ -461,13 +462,13 @@
       }
     },
     "node_modules/@freedomofpress/sigstore-browser": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/@freedomofpress/sigstore-browser/-/sigstore-browser-0.1.10.tgz",
-      "integrity": "sha512-siqF2EnmtPskpvaDYRe7luiOA48z/h8JBX9qQJrT9k6bWDmg47h4Fx/qzu3fkvcoDf1wC9+hxvKIVQO77Ady5A==",
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@freedomofpress/sigstore-browser/-/sigstore-browser-0.1.11.tgz",
+      "integrity": "sha512-woXCq/mY+vdldq8wm8JYdbaGcEWEB/oaS6c/eaJYfIb036Z/+HQ4D6/sSk7hK67nBzFLFYPzxwSb2FR+mzmidg==",
       "license": "MIT",
       "dependencies": {
         "@freedomofpress/crypto-browser": "^0.1.4",
-        "@freedomofpress/tuf-browser": "^0.1.7",
+        "@freedomofpress/tuf-browser": "^0.1.8",
         "@noble/curves": "^2.0.1"
       }
     },
@@ -499,9 +500,9 @@
       }
     },
     "node_modules/@freedomofpress/tuf-browser": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/@freedomofpress/tuf-browser/-/tuf-browser-0.1.7.tgz",
-      "integrity": "sha512-fly3ke6Y//vjWSP5GaRLNN+Vq6pcE07tDaRECGibHEcH4AdRl2ocRqCLpiAZ9Hpsp5n2yIFZFZBiIt/o/IyCmA==",
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@freedomofpress/tuf-browser/-/tuf-browser-0.1.8.tgz",
+      "integrity": "sha512-NdungNe3/rf10EO7LdsHS8GHhL6k2epfeTlf1lLRdw58gSxxNVpWOJIvPc+9qSNoelNN+OIPCSHgVALhI1Yvcg==",
       "license": "MIT",
       "dependencies": {
         "@freedomofpress/crypto-browser": "^0.1.3"
@@ -2328,7 +2329,7 @@
       "version": "20.19.11",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.11.tgz",
       "integrity": "sha512-uug3FEEGv0r+jrecvUUpbY8lLisvIjg6AAic6a2bSP5OEOLeJsDSnvhCDov7ipFFMXS3orMpzlmi0ZcuGkBbow==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2982,7 +2983,7 @@
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-      "devOptional": true,
+      "dev": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -9770,12 +9771,13 @@
       }
     },
     "node_modules/tinfoil": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/tinfoil/-/tinfoil-0.11.0.tgz",
-      "integrity": "sha512-IEPyEkVyopXdWQ5jdI6oAaQnUFAka8yvmlz7bUJOjwqyp4zGn/BoOsuvM5YN1J2HPYODQMaCdhXLNLZgTZDHkg==",
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/tinfoil/-/tinfoil-0.11.4.tgz",
+      "integrity": "sha512-D1Pon/txryguV3i+7DY6UT6ueHRBuuPN+OeRhhDAGkhf29W5ZQ9PSbHzN1MeB3KSsb7MpbMyNn27xANj1vg88w==",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@ai-sdk/openai-compatible": "^1.0.10",
+        "@freedomofpress/sigstore-browser": "^0.1.11",
         "@tinfoilsh/verifier": "*",
         "ehbp": "^0.1.1",
         "openai": "^5.13.1"
@@ -10026,7 +10028,7 @@
       "version": "5.9.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
-      "devOptional": true,
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10057,7 +10059,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/unified": {
       "version": "11.0.5",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@braintree/sanitize-url": "^7.1.1",
     "@clerk/nextjs": "^6.21.0",
+    "@freedomofpress/sigstore-browser": "^0.1.11",
     "@headlessui/react": "^2.1.1",
     "@heroicons/react": "^2.1.4",
     "@radix-ui/react-alert-dialog": "^1.1.4",
@@ -54,7 +55,7 @@
     "remark-math": "^6.0.0",
     "tailwind-merge": "^2.6.0",
     "tailwindcss-animate": "^1.0.7",
-    "tinfoil": "^0.11.0",
+    "tinfoil": "^0.11.4",
     "uuid": "^11.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION












<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated tinfoil from 0.11.0 to 0.11.4 and added @freedomofpress/sigstore-browser to fix browser build compatibility.

<sup>Written for commit 6a4c38fca20434f4399a29c8eab14d3c69d593cd. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->











