### PR TITLE
fix: update csp to include sigstore

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -40,7 +40,7 @@ const nextConfig = {
               "style-src 'self' 'unsafe-inline'",
               "font-src 'self' data:",
               "img-src 'self' data: blob: https:",
-              "connect-src 'self' data: https://*.tinfoil.sh https://tinfoilsh.github.io https://plausible.io https://vitals.vercel-insights.com https://clerk.accounts.dev https://*.clerk.accounts.dev wss://*.clerk.accounts.dev",
+              "connect-src 'self' data: https://*.tinfoil.sh https://tinfoilsh.github.io https://tuf-repo-cdn.sigstore.dev https://plausible.io https://vitals.vercel-insights.com https://clerk.accounts.dev https://*.clerk.accounts.dev wss://*.clerk.accounts.dev",
               "frame-src 'self' https://vercel.live https://clerk.accounts.dev https://*.clerk.accounts.dev https://verification-center.tinfoil.sh",
               "frame-ancestors 'none'",
               "base-uri 'self'",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update Content Security Policy to allow connections to https://tuf-repo-cdn.sigstore.dev via connect-src. This unblocks Sigstore verification (TUF metadata fetch) and resolves related CSP errors.

<sup>Written for commit 5d6131310b11c7bbc5c6e5413900ecd6a78abb10. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

