### PR TITLE
chore: update tinfoil sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "remark-math": "^6.0.0",
         "tailwind-merge": "^2.6.0",
         "tailwindcss-animate": "^1.0.7",
-        "tinfoil": "^0.11.5",
+        "tinfoil": "^0.11.6",
         "uuid": "^11.0.3"
       },
       "devDependencies": {
@@ -2185,14 +2185,14 @@
       }
     },
     "node_modules/@tinfoilsh/verifier": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@tinfoilsh/verifier/-/verifier-0.1.0.tgz",
-      "integrity": "sha512-WzjqyplLf7YrixNPAkyJnSz5YO7CdZU5+vx196oX7m2DJY0viP7Z0Yie6uopEl9bR8tFSdax0b9EhEymx6v95w==",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@tinfoilsh/verifier/-/verifier-0.1.7.tgz",
+      "integrity": "sha512-8rE5pPhJi/VEcGhbS5b8ltYTyQHfSgpn4pmhGdJhCy+Oqsqnr8XybYCFa/o4Tro0o9yCLGzw+ZtZBtee8In/YA==",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
-        "@freedomofpress/crypto-browser": "^0.1.4",
-        "@freedomofpress/sigstore-browser": "^0.1.9",
-        "@freedomofpress/tuf-browser": "^0.1.5"
+        "@freedomofpress/crypto-browser": "^0.1.6",
+        "@freedomofpress/sigstore-browser": "^0.1.11",
+        "@freedomofpress/tuf-browser": "^0.1.8"
       },
       "engines": {
         "node": ">=20"
@@ -9771,14 +9771,14 @@
       }
     },
     "node_modules/tinfoil": {
-      "version": "0.11.5",
-      "resolved": "https://registry.npmjs.org/tinfoil/-/tinfoil-0.11.5.tgz",
-      "integrity": "sha512-gp6WgOToMMKEH8Ofx+Y08M8sStLYzbUSSuhv6b0S+rEoBq2WNoQo/W+x0kXQ885G5KM84mIJEnC4qHqcpVEg4g==",
+      "version": "0.11.6",
+      "resolved": "https://registry.npmjs.org/tinfoil/-/tinfoil-0.11.6.tgz",
+      "integrity": "sha512-DGBQ3hqDYuBmIai94sRmLkCjmeElZyawsUzyDCTThilLEKp+e7DVoUFwR7ugAfwTWuHN0TIFa8v2YH/YmIrcMg==",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@ai-sdk/openai-compatible": "^1.0.10",
         "@freedomofpress/sigstore-browser": "^0.1.11",
-        "@tinfoilsh/verifier": "*",
+        "@tinfoilsh/verifier": "^0.1.7",
         "ehbp": "^0.1.1",
         "openai": "^5.13.1"
       },

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "remark-math": "^6.0.0",
     "tailwind-merge": "^2.6.0",
     "tailwindcss-animate": "^1.0.7",
-    "tinfoil": "^0.11.5",
+    "tinfoil": "^0.11.6",
     "uuid": "^11.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bump Tinfoil SDK to 0.11.6 to pull in the latest verifier and related fixes. Improves compatibility and keeps dependencies current.

- **Dependencies**
  - tinfoil: ^0.11.5 → ^0.11.6
  - Transitive: @tinfoilsh/verifier → ^0.1.7 (with updated freedomofpress crypto/sigstore/tuf packages)

<sup>Written for commit 1a1fd643462f0c7b9e3e9994b628ce9f7299a960. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

