### PR TITLE
Revert "fix: update csp to include sigstore"

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -40,7 +40,7 @@ const nextConfig = {
               "style-src 'self' 'unsafe-inline'",
               "font-src 'self' data:",
               "img-src 'self' data: blob: https:",
-              "connect-src 'self' data: https://*.tinfoil.sh https://tinfoilsh.github.io https://tuf-repo-cdn.sigstore.dev https://plausible.io https://vitals.vercel-insights.com https://clerk.accounts.dev https://*.clerk.accounts.dev wss://*.clerk.accounts.dev",
+              "connect-src 'self' data: https://*.tinfoil.sh https://tinfoilsh.github.io https://plausible.io https://vitals.vercel-insights.com https://clerk.accounts.dev https://*.clerk.accounts.dev wss://*.clerk.accounts.dev",
               "frame-src 'self' https://vercel.live https://clerk.accounts.dev https://*.clerk.accounts.dev https://verification-center.tinfoil.sh",
               "frame-ancestors 'none'",
               "base-uri 'self'",


### PR DESCRIPTION
Reverts tinfoilsh/tinfoil-chat#179

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the CSP change that added Sigstore. Removes https://tuf-repo-cdn.sigstore.dev from connect-src to restore the previous policy and block those requests.

<sup>Written for commit 4bf8a71643aa82b482f285f82b49dab8b0673128. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

