### PR TITLE
feat: add chat key ttl and auto-retry on 401 errors

### DIFF
--- a/src/services/inference/inference-client.ts
+++ b/src/services/inference/inference-client.ts
@@ -8,8 +8,9 @@ import type { Message } from '@/components/chat/types'
 import type { BaseModel } from '@/config/models'
 import { shouldRetryTestFail } from '@/utils/dev-simulator'
 import { logError, logInfo } from '@/utils/error-handling'
+import { AuthenticationError } from 'openai'
 import { ChatQueryBuilder } from './chat-query-builder'
-import { getTinfoilClient } from './tinfoil-client'
+import { clearCachedApiKey, getTinfoilClient } from './tinfoil-client'
 
 function isOnline(): boolean {
   return typeof navigator !== 'undefined' ? navigator.onLine : true
@@ -243,8 +244,6 @@ export async function sendChatStream(
     }
 
     try {
-      const client = await getTinfoilClient()
-
       // Build request body
       const requestBody: Record<string, unknown> = {
         model: model.modelName,
@@ -261,10 +260,25 @@ export async function sendChatStream(
         requestBody.pii_check_options = {}
       }
 
-      const stream = await (client.chat.completions.create as Function)(
-        requestBody,
-        { signal },
-      )
+      const createStream = async () => {
+        const client = await getTinfoilClient()
+        return (client.chat.completions.create as Function)(
+          requestBody,
+          { signal },
+        )
+      }
+
+      let stream
+      try {
+        stream = await createStream()
+      } catch (err) {
+        if (err instanceof AuthenticationError) {
+          clearCachedApiKey()
+          stream = await createStream()
+        } else {
+          throw err
+        }
+      }
 
       const encoder = new TextEncoder()
       const readableStream = new ReadableStream({

--- a/src/services/inference/title.ts
+++ b/src/services/inference/title.ts
@@ -1,6 +1,7 @@
 import { CONSTANTS } from '@/components/chat/constants'
 import { logError } from '@/utils/error-handling'
-import { getTinfoilClient } from './tinfoil-client'
+import { AuthenticationError } from 'openai'
+import { clearCachedApiKey, getTinfoilClient } from './tinfoil-client'
 
 export async function generateTitle(
   messages: Array<{ role: string; content: string }>,
@@ -18,20 +19,33 @@ export async function generateTitle(
       .slice(0, CONSTANTS.TITLE_GENERATION_WORD_THRESHOLD)
       .join(' ')
 
-    const client = await getTinfoilClient()
+    const createCompletion = async () => {
+      const client = await getTinfoilClient()
+      return client.chat.completions.create({
+        model: titleModelName,
+        messages: [
+          { role: 'system', content: CONSTANTS.TITLE_GENERATION_PROMPT },
+          {
+            role: 'user',
+            content: truncatedContent,
+          },
+        ],
+        stream: false,
+        max_tokens: 50,
+      })
+    }
 
-    const completion = await client.chat.completions.create({
-      model: titleModelName,
-      messages: [
-        { role: 'system', content: CONSTANTS.TITLE_GENERATION_PROMPT },
-        {
-          role: 'user',
-          content: truncatedContent,
-        },
-      ],
-      stream: false,
-      max_tokens: 50,
-    })
+    let completion
+    try {
+      completion = await createCompletion()
+    } catch (err) {
+      if (err instanceof AuthenticationError) {
+        clearCachedApiKey()
+        completion = await createCompletion()
+      } else {
+        throw err
+      }
+    }
 
     const title = completion.choices?.[0]?.message?.content?.trim() || ''
     const cleanTitle = title.replace(/^["']|["']$/g, '').trim()


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a 5-minute TTL for the cached Tinfoil API key and auto-retry chat/title requests on 401 by refreshing the key. This prevents failed chats and title generation when keys expire.

- **New Features**
  - Cache API key with a 5-minute TTL and timestamp; clear on reset and on 401.
  - On AuthenticationError (401), clear cached key and retry the request once.
  - Applied to sendChatStream and title generation.

<sup>Written for commit ebeca191b0c217bf1dc5c362e909ba97fbba64f2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

