### PR TITLE
fix: validate clerk tokens before making requests

### DIFF
--- a/src/services/cloud/profile-sync.ts
+++ b/src/services/cloud/profile-sync.ts
@@ -1,4 +1,5 @@
 import { logError, logInfo } from '@/utils/error-handling'
+import { isTokenValid } from '@/utils/token-validation'
 import { encryptionService } from '../encryption/encryption-service'
 
 const API_BASE_URL =
@@ -47,6 +48,10 @@ export class ProfileSyncService {
       throw new Error('Authentication token not set')
     }
 
+    if (!isTokenValid(token)) {
+      throw new Error('Token is expired')
+    }
+
     return {
       Authorization: `Bearer ${token}`,
       'Content-Type': 'application/json',
@@ -56,7 +61,7 @@ export class ProfileSyncService {
   async isAuthenticated(): Promise<boolean> {
     if (!this.getToken) return false
     const token = await this.getToken()
-    return token !== null && token !== ''
+    return isTokenValid(token)
   }
 
   // Get profile from cloud

--- a/src/services/cloud/r2-storage.ts
+++ b/src/services/cloud/r2-storage.ts
@@ -1,5 +1,6 @@
 import { ensureValidISODate } from '@/utils/chat-timestamps'
 import { logError } from '@/utils/error-handling'
+import { isTokenValid } from '@/utils/token-validation'
 import { encryptionService } from '../encryption/encryption-service'
 import { DB_VERSION, type StoredChat } from '../storage/indexed-db'
 
@@ -58,6 +59,10 @@ export class R2StorageService {
       throw new Error('Failed to get authentication token')
     }
 
+    if (!isTokenValid(token)) {
+      throw new Error('Token is expired')
+    }
+
     return {
       Authorization: `Bearer ${token}`,
       'Content-Type': 'application/json',
@@ -67,7 +72,7 @@ export class R2StorageService {
   async isAuthenticated(): Promise<boolean> {
     if (!this.getToken) return false
     const token = await this.getToken()
-    return token !== null && token !== ''
+    return isTokenValid(token)
   }
 
   async uploadChat(chat: StoredChat): Promise<void> {

--- a/src/services/inference/tinfoil-client.ts
+++ b/src/services/inference/tinfoil-client.ts
@@ -1,5 +1,6 @@
 import { API_BASE_URL } from '@/config'
 import { logError } from '@/utils/error-handling'
+import { isTokenValid } from '@/utils/token-validation'
 import { TinfoilAI } from 'tinfoil'
 
 const PLACEHOLDER_API_KEY = 'tinfoil-placeholder-api-key'
@@ -39,7 +40,7 @@ async function fetchApiKey(): Promise<string> {
 
   try {
     const token = await getTokenFn()
-    if (!token) {
+    if (!token || !isTokenValid(token)) {
       return PLACEHOLDER_API_KEY
     }
 

--- a/src/utils/token-validation.ts
+++ b/src/utils/token-validation.ts
@@ -1,0 +1,43 @@
+/**
+ * Validates a JWT token by checking its expiration time and not-before time.
+ * Returns true if the token is valid and not expired.
+ *
+ * Clerk JWTs include:
+ * - exp (expiration time): seconds since epoch when token expires
+ * - nbf (not before): seconds since epoch when token becomes valid
+ * - iat (issued at): seconds since epoch when token was issued
+ */
+export function isTokenValid(token: string | null): boolean {
+  if (!token) return false
+
+  try {
+    // JWT tokens have 3 parts separated by dots: header.payload.signature
+    const parts = token.split('.')
+    if (parts.length !== 3) return false
+
+    // Decode the payload (second part) - it's base64url encoded
+    const payload = parts[1]
+    const decoded = JSON.parse(
+      atob(payload.replace(/-/g, '+').replace(/_/g, '/')),
+    )
+
+    const nowSeconds = Math.floor(Date.now() / 1000)
+    // Add a 30-second buffer before expiration to avoid race conditions
+    const bufferSeconds = 30
+
+    // Check expiration (exp claim) - token must not be expired
+    if (decoded.exp && decoded.exp < nowSeconds + bufferSeconds) {
+      return false
+    }
+
+    // Check not-before (nbf claim) - token must be valid now
+    if (decoded.nbf && decoded.nbf > nowSeconds) {
+      return false
+    }
+
+    return true
+  } catch {
+    // If we can't decode the token, assume it's invalid
+    return false
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Validate Clerk JWTs before cloud and inference requests to prevent expired tokens from being used. Improves auth checks and avoids unnecessary 401s.

- **Bug Fixes**
  - Added isTokenValid utility that checks exp/nbf with a 30s buffer.
  - ProfileSyncService and R2StorageService now validate tokens before building headers; isAuthenticated uses isTokenValid; throws “Token is expired” on invalid tokens.
  - Tinfoil client returns a placeholder API key when the token is missing or invalid.

<sup>Written for commit 8c36bbe5871be8537be1f2384513cc31c7ad6c6a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

