### PR TITLE
fix: scroll textarea to bottom when adding new lines

### DIFF
--- a/src/components/chat/chat-input.tsx
+++ b/src/components/chat/chat-input.tsx
@@ -555,7 +555,13 @@ export function ChatInput({
                 /^(\s*)(\s*\u2022\s+|[-*+]|\s*\d+\.)\s+/,
               )
 
-              if (listMarkerMatch) {
+              if (!listMarkerMatch) {
+                setTimeout(() => {
+                  textarea.style.height = inputMinHeight
+                  textarea.style.height = `${Math.min(textarea.scrollHeight, 240)}px`
+                  textarea.scrollTop = textarea.scrollHeight
+                }, 0)
+              } else if (listMarkerMatch) {
                 e.preventDefault()
                 const [fullMatch, indent, marker] = listMarkerMatch
 
@@ -606,6 +612,7 @@ export function ChatInput({
                     textarea.style.height = `${Math.min(textarea.scrollHeight, 240)}px`
                     textarea.selectionStart = textarea.selectionEnd =
                       newCursorPos
+                    textarea.scrollTop = textarea.scrollHeight
                   }, 0)
                 }
               }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes chat input auto-resize and scroll so the textarea moves to the bottom when you add new lines. Works for normal Enter and list auto-formatting, keeping the caret and latest text visible.

<sup>Written for commit 81663f3f2680b1f66445795ef1d98cc9526b3a7d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

