### PR TITLE
fix: trim whitespace inside markdown formatting markers

### DIFF
--- a/src/components/chat/renderers/components/MessageContent.tsx
+++ b/src/components/chat/renderers/components/MessageContent.tsx
@@ -5,64 +5,11 @@ import {
   processLatexTags,
   sanitizeUnsupportedMathBlocks,
 } from '@/utils/latex-processing'
+import { preprocessMarkdown } from '@/utils/markdown-preprocessing'
 import { sanitizeUrl } from '@braintree/sanitize-url'
 import { memo, useEffect, useState } from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
-
-/**
- * Converts HTML tags to markdown equivalents for safe rendering
- * Preserves code blocks and inline code to avoid breaking HTML examples
- */
-function preprocessHtmlToMarkdown(content: string): string {
-  // Extract code blocks and inline code to protect them
-  const codeBlocks: string[] = []
-  const inlineCode: string[] = []
-
-  // Protect fenced code blocks (```...```)
-  let processed = content.replace(/```[\s\S]*?```/g, (match) => {
-    codeBlocks.push(match)
-    return `__CODE_BLOCK_${codeBlocks.length - 1}__`
-  })
-
-  // Protect inline code (`...`)
-  processed = processed.replace(/`[^`]+`/g, (match) => {
-    inlineCode.push(match)
-    return `__INLINE_CODE_${inlineCode.length - 1}__`
-  })
-
-  // Now safely convert HTML to markdown in non-code content
-  // Convert <a href="url">text</a> to [text](url)
-  processed = processed.replace(
-    /<a\s+(?:[^>]*?\s+)?href=["']([^"']+)["'][^>]*>([^<]*)<\/a>/gi,
-    (match, url, text) => {
-      const linkText = text.trim() || url
-      return `[${linkText}](${url})`
-    },
-  )
-
-  // Convert <b>text</b> and <strong>text</strong> to **text**
-  processed = processed.replace(/<b>([^<]*)<\/b>/gi, '**$1**')
-  processed = processed.replace(/<strong>([^<]*)<\/strong>/gi, '**$1**')
-
-  // Convert <br>, <br/>, and </br> to markdown line breaks
-  processed = processed.replace(/<br\s*\/?>/gi, '  \n')
-  processed = processed.replace(/<\/br>/gi, '  \n')
-
-  // Restore inline code first (they might be inside code blocks)
-  processed = processed.replace(
-    /__INLINE_CODE_(\d+)__/g,
-    (_, index) => inlineCode[parseInt(index)],
-  )
-
-  // Restore code blocks
-  processed = processed.replace(
-    /__CODE_BLOCK_(\d+)__/g,
-    (_, index) => codeBlocks[parseInt(index)],
-  )
-
-  return processed
-}
 
 interface MessageContentProps {
   content: string
@@ -133,8 +80,8 @@ export const MessageContent = memo(function MessageContent({
   isUser = false,
 }: MessageContentProps) {
   const { remarkPlugins, rehypePlugins } = useMathPlugins()
-  const htmlToMarkdown = preprocessHtmlToMarkdown(content)
-  const processedContent = processLatexTags(htmlToMarkdown)
+  const preprocessed = preprocessMarkdown(content)
+  const processedContent = processLatexTags(preprocessed)
   const sanitizedContent = sanitizeUnsupportedMathBlocks(processedContent)
 
   // For user messages, render as plain text without markdown processing

--- a/src/components/chat/renderers/components/ThoughtProcess.tsx
+++ b/src/components/chat/renderers/components/ThoughtProcess.tsx
@@ -6,6 +6,7 @@ import {
   processLatexTags,
   sanitizeUnsupportedMathBlocks,
 } from '@/utils/latex-processing'
+import { preprocessMarkdown } from '@/utils/markdown-preprocessing'
 import { TfTin } from '@tinfoilsh/tinfoil-icons'
 import { memo, useCallback, useEffect, useRef, useState } from 'react'
 import ReactMarkdown from 'react-markdown'
@@ -309,7 +310,8 @@ export const ThoughtProcess = memo(function ThoughtProcess({
   }, [thoughts, isThinking])
 
   const { remarkPlugins, rehypePlugins } = useMathPlugins()
-  const processedThoughts = processLatexTags(thoughts)
+  const preprocessed = preprocessMarkdown(thoughts)
+  const processedThoughts = processLatexTags(preprocessed)
   const sanitizedThoughts = sanitizeUnsupportedMathBlocks(processedThoughts)
 
   if (shouldDiscard || (!thoughts.trim() && !isThinking)) {

--- a/src/utils/markdown-preprocessing.ts
+++ b/src/utils/markdown-preprocessing.ts
@@ -1,0 +1,92 @@
+/**
+ * Preprocesses markdown content to fix common formatting issues
+ * and convert HTML tags to markdown equivalents.
+ * Preserves code blocks and inline code to avoid breaking examples.
+ */
+export function preprocessMarkdown(content: string): string {
+  // Extract code blocks and inline code to protect them
+  const codeBlocks: string[] = []
+  const inlineCode: string[] = []
+
+  // Protect fenced code blocks (```...```)
+  let processed = content.replace(/```[\s\S]*?```/g, (match) => {
+    codeBlocks.push(match)
+    return `__CODE_BLOCK_${codeBlocks.length - 1}__`
+  })
+
+  // Protect inline code (`...`)
+  processed = processed.replace(/`[^`]+`/g, (match) => {
+    inlineCode.push(match)
+    return `__INLINE_CODE_${inlineCode.length - 1}__`
+  })
+
+  // Convert <a href="url">text</a> to [text](url)
+  processed = processed.replace(
+    /<a\s+(?:[^>]*?\s+)?href=["']([^"']+)["'][^>]*>([^<]*)<\/a>/gi,
+    (match, url, text) => {
+      const linkText = text.trim() || url
+      return `[${linkText}](${url})`
+    },
+  )
+
+  // Convert <b>text</b> and <strong>text</strong> to **text**
+  processed = processed.replace(/<b>([^<]*)<\/b>/gi, '**$1**')
+  processed = processed.replace(/<strong>([^<]*)<\/strong>/gi, '**$1**')
+
+  // Convert <br>, <br/>, and </br> to markdown line breaks
+  processed = processed.replace(/<br\s*\/?>/gi, '  \n')
+  processed = processed.replace(/<\/br>/gi, '  \n')
+
+  // Fix bold markers with internal whitespace: **text ** or ** text** -> **text**
+  // Markdown requires no space immediately after opening ** or before closing **
+  processed = processed.replace(/\*\*(.+?)\*\*/g, (match, content) => {
+    const trimmed = content.trim()
+    return trimmed ? `**${trimmed}**` : match
+  })
+
+  // Fix underscore bold: __text __ or __ text__ -> __text__
+  processed = processed.replace(/__(.+?)__/g, (match, content) => {
+    const trimmed = content.trim()
+    return trimmed ? `__${trimmed}__` : match
+  })
+
+  // Fix italic with asterisk: *text * or * text* -> *text*
+  // Use negative lookbehind/lookahead to avoid matching ** markers
+  processed = processed.replace(
+    /(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)/g,
+    (match, content) => {
+      const trimmed = content.trim()
+      return trimmed ? `*${trimmed}*` : match
+    },
+  )
+
+  // Fix italic with underscore: _text _ or _ text_ -> _text_
+  // Use negative lookbehind/lookahead to avoid matching __ markers
+  processed = processed.replace(
+    /(?<!_)_(?!_)(.+?)(?<!_)_(?!_)/g,
+    (match, content) => {
+      const trimmed = content.trim()
+      return trimmed ? `_${trimmed}_` : match
+    },
+  )
+
+  // Fix strikethrough: ~~text ~~ or ~~ text~~ -> ~~text~~
+  processed = processed.replace(/~~(.+?)~~/g, (match, content) => {
+    const trimmed = content.trim()
+    return trimmed ? `~~${trimmed}~~` : match
+  })
+
+  // Restore inline code first (they might be inside code blocks)
+  processed = processed.replace(
+    /__INLINE_CODE_(\d+)__/g,
+    (_, index) => inlineCode[parseInt(index)],
+  )
+
+  // Restore code blocks
+  processed = processed.replace(
+    /__CODE_BLOCK_(\d+)__/g,
+    (_, index) => codeBlocks[parseInt(index)],
+  )
+
+  return processed
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Trims whitespace inside markdown markers so bold/italic/strikethrough render correctly, without touching code blocks. Also centralizes basic HTML-to-markdown conversion and applies it across chat renderers.

- Bug Fixes
  - Trim spaces inside **, __, *, _, and ~~ markers; preserve code blocks and inline code.
  - Convert <a>, <b>/<strong>, and <br> tags to markdown.

- Refactors
  - Add utils/preprocessMarkdown and use it in MessageContent and ThoughtProcess.
  - Remove component-level HTML-to-markdown preprocessing.

<sup>Written for commit 254373beaae300c5f493ba8c3f09f4ab53f6b5ab. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

