### PR TITLE
fix: prevent react reconciliation errors by waiting for markdown plugins

### DIFF
--- a/src/components/chat/renderers/components/MessageContent.tsx
+++ b/src/components/chat/renderers/components/MessageContent.tsx
@@ -20,7 +20,7 @@ export const MessageContent = memo(function MessageContent({
   isDarkMode,
   isUser = false,
 }: MessageContentProps) {
-  const { remarkPlugins, rehypePlugins } = useMathPlugins()
+  const plugins = useMathPlugins()
   const preprocessed = preprocessMarkdown(content)
   const processedContent = processLatexTags(preprocessed)
   const sanitizedContent = sanitizeUnsupportedMathBlocks(processedContent)
@@ -32,8 +32,8 @@ export const MessageContent = memo(function MessageContent({
 
   return (
     <ReactMarkdown
-      remarkPlugins={remarkPlugins}
-      rehypePlugins={rehypePlugins}
+      remarkPlugins={plugins.remarkPlugins}
+      rehypePlugins={plugins.rehypePlugins}
       components={{
         hr: () => null, // Don't render horizontal rules
         code({

--- a/src/components/chat/renderers/components/ThoughtProcess.tsx
+++ b/src/components/chat/renderers/components/ThoughtProcess.tsx
@@ -251,7 +251,7 @@ export const ThoughtProcess = memo(function ThoughtProcess({
     }
   }, [thoughts, isThinking])
 
-  const { remarkPlugins, rehypePlugins } = useMathPlugins()
+  const plugins = useMathPlugins()
   const preprocessed = preprocessMarkdown(thoughts)
   const processedThoughts = processLatexTags(preprocessed)
   const sanitizedThoughts = sanitizeUnsupportedMathBlocks(processedThoughts)
@@ -324,8 +324,8 @@ export const ThoughtProcess = memo(function ThoughtProcess({
           className="px-4 py-3 font-aeonik-fono text-sm text-content-primary"
         >
           <ReactMarkdown
-            remarkPlugins={remarkPlugins}
-            rehypePlugins={rehypePlugins}
+            remarkPlugins={plugins?.remarkPlugins}
+            rehypePlugins={plugins?.rehypePlugins}
             components={{
               p: ({ children }: { children?: React.ReactNode }) => (
                 <p className="mb-2 break-words last:mb-0">{children}</p>

--- a/src/components/chat/renderers/components/use-math-plugins.ts
+++ b/src/components/chat/renderers/components/use-math-plugins.ts
@@ -84,12 +84,14 @@ if (typeof window !== 'undefined') {
   loadPlugins()
 }
 
-export function useMathPlugins() {
+export function useMathPlugins(): PluginState {
   const [plugins, setPlugins] = useState<PluginState>(() => {
     // If already loaded, use cached plugins immediately
     if (cachedPlugins) {
       return cachedPlugins
     }
+    // Return initial plugins while loading - this ensures ReactMarkdown
+    // always receives valid plugin arrays, avoiding component type changes
     return {
       remarkPlugins: INITIAL_REMARK_PLUGINS,
       rehypePlugins: INITIAL_REHYPE_PLUGINS,
@@ -106,7 +108,7 @@ export function useMathPlugins() {
     let mounted = true
 
     loadPlugins().then((loadedPlugins) => {
-      if (mounted && !plugins.loaded) {
+      if (mounted) {
         setPlugins(loadedPlugins)
       }
     })


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stabilized markdown plugin loading and streaming chunk keys to prevent ReactMarkdown reconciliation errors and render flicker during streaming.

- **Bug Fixes**
  - useMathPlugins returns initial plugin arrays and updates once loaded, keeping ReactMarkdown props stable.
  - MessageContent and ThoughtProcess use a unified plugins object for consistent plugin passing.
  - StreamingChunkedText uses position-based IDs and memoizes chunk splitting to keep keys stable while streaming.

<sup>Written for commit 77ea8a84262fd027f9d1f4df936d5f6cbe74fe80. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

