### PR TITLE
feat: add support for printing chats

### DIFF
--- a/src/components/chat/PrintableChat.tsx
+++ b/src/components/chat/PrintableChat.tsx
@@ -1,0 +1,260 @@
+import { CodeBlock } from '@/components/code-block'
+import {
+  processLatexTags,
+  sanitizeUnsupportedMathBlocks,
+} from '@/utils/latex-processing'
+import { preprocessMarkdown } from '@/utils/markdown-preprocessing'
+import { sanitizeUrl } from '@braintree/sanitize-url'
+import { memo } from 'react'
+import ReactMarkdown from 'react-markdown'
+import { useMathPlugins } from './renderers/components/use-math-plugins'
+import type { Message } from './types'
+
+interface PrintableChatProps {
+  messages: Message[]
+  printRef: React.RefObject<HTMLDivElement>
+}
+
+const formatTimestamp = (timestamp: Date): string => {
+  const date = timestamp instanceof Date ? timestamp : new Date(timestamp)
+  return date.toLocaleString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+const PrintableMessage = memo(function PrintableMessage({
+  message,
+}: {
+  message: Message
+}) {
+  const { remarkPlugins, rehypePlugins } = useMathPlugins()
+
+  const renderContent = (content: string, isUser: boolean) => {
+    if (isUser) {
+      return <div className="whitespace-pre-wrap break-words">{content}</div>
+    }
+
+    const preprocessed = preprocessMarkdown(content)
+    const processedContent = processLatexTags(preprocessed)
+    const sanitizedContent = sanitizeUnsupportedMathBlocks(processedContent)
+
+    return (
+      <ReactMarkdown
+        remarkPlugins={remarkPlugins}
+        rehypePlugins={rehypePlugins}
+        components={{
+          hr: () => null,
+          code({
+            className,
+            children,
+            ...props
+          }: {
+            className?: string
+            children?: React.ReactNode
+            inline?: boolean
+          } & React.HTMLAttributes<HTMLElement>) {
+            if (props.inline) {
+              return (
+                <code
+                  className={`${className || ''} inline break-words rounded bg-gray-100 px-1.5 py-0.5 align-baseline font-mono text-sm`}
+                  {...props}
+                >
+                  {children}
+                </code>
+              )
+            }
+            return (
+              <code className={className} {...props}>
+                {children}
+              </code>
+            )
+          },
+          pre({ children }: { children?: React.ReactNode }) {
+            if (
+              children &&
+              typeof children === 'object' &&
+              'props' in (children as any)
+            ) {
+              const codeProps = (children as any).props
+              const className = codeProps?.className || ''
+              const match = /language-([\w+#-]+)/.exec(className)
+              const language = match ? match[1] : 'text'
+              const code = String(codeProps?.children || '').replace(/\n$/, '')
+
+              return (
+                <CodeBlock
+                  code={code}
+                  language={language}
+                  isDarkMode={false}
+                  isStreaming={false}
+                />
+              )
+            }
+            return <pre>{children}</pre>
+          },
+          table({ children, node, ...props }: any) {
+            return (
+              <div className="my-4 w-full overflow-x-auto">
+                <table
+                  {...props}
+                  className="divide-y divide-gray-200"
+                  style={{ minWidth: 'max-content' }}
+                >
+                  {children}
+                </table>
+              </div>
+            )
+          },
+          thead({ children, node, ...props }: any) {
+            return (
+              <thead {...props} className="bg-gray-50">
+                {children}
+              </thead>
+            )
+          },
+          tbody({ children, node, ...props }: any) {
+            return (
+              <tbody {...props} className="divide-y divide-gray-200 bg-white">
+                {children}
+              </tbody>
+            )
+          },
+          tr({ children, node, ...props }: any) {
+            return <tr {...props}>{children}</tr>
+          },
+          th({ children, node, ...props }: any) {
+            return (
+              <th
+                {...props}
+                className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-700"
+                style={{
+                  maxWidth: '300px',
+                  wordWrap: 'break-word',
+                  whiteSpace: 'normal',
+                }}
+              >
+                {children}
+              </th>
+            )
+          },
+          td({ children, node, ...props }: any) {
+            return (
+              <td
+                {...props}
+                className="px-4 py-3 text-sm text-gray-900"
+                style={{
+                  maxWidth: '300px',
+                  wordWrap: 'break-word',
+                  whiteSpace: 'normal',
+                }}
+              >
+                {children}
+              </td>
+            )
+          },
+          blockquote({ children, node, ...props }: any) {
+            return (
+              <blockquote
+                {...props}
+                className="my-4 border-l-4 border-gray-300 pl-4 text-gray-700"
+              >
+                {children}
+              </blockquote>
+            )
+          },
+          a({ children, href, node, ...props }: any) {
+            const sanitizedHref = sanitizeUrl(href)
+            return (
+              <a
+                {...props}
+                href={sanitizedHref}
+                className="inline align-baseline text-blue-600 underline"
+              >
+                {children}
+              </a>
+            )
+          },
+          strong({ children, node, ...props }: any) {
+            return (
+              <strong
+                {...props}
+                className="inline align-baseline font-semibold"
+              >
+                {children}
+              </strong>
+            )
+          },
+          b({ children, node, ...props }: any) {
+            return (
+              <b {...props} className="inline align-baseline font-semibold">
+                {children}
+              </b>
+            )
+          },
+          br({ node, ...props }: any) {
+            return <br {...props} />
+          },
+        }}
+      >
+        {sanitizedContent}
+      </ReactMarkdown>
+    )
+  }
+
+  const isUser = message.role === 'user'
+
+  return (
+    <div className="printable-message">
+      <div className="printable-role-header">
+        <span className="printable-role">{isUser ? 'User' : 'Assistant'}</span>
+        <span className="printable-timestamp">
+          {formatTimestamp(message.timestamp)}
+        </span>
+      </div>
+
+      {message.documents && message.documents.length > 0 && (
+        <div className="printable-documents">
+          <span className="printable-documents-label">Attachments:</span>
+          <ul>
+            {message.documents.map((doc, i) => (
+              <li key={i}>{doc.name}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {message.thoughts && (
+        <div className="printable-thinking">
+          <div className="printable-thinking-label">Thinking</div>
+          <div className="whitespace-pre-wrap text-sm">{message.thoughts}</div>
+        </div>
+      )}
+
+      {message.content && (
+        <div className="printable-content prose prose-sm max-w-none">
+          {renderContent(message.content, isUser)}
+        </div>
+      )}
+    </div>
+  )
+})
+
+export const PrintableChat = memo(function PrintableChat({
+  messages,
+  printRef,
+}: PrintableChatProps) {
+  return (
+    <div ref={printRef} className="printable-chat hidden" aria-hidden="true">
+      {messages.map((message, index) => (
+        <PrintableMessage
+          key={`print-${message.role}-${message.timestamp instanceof Date ? message.timestamp.getTime() : index}`}
+          message={message}
+        />
+      ))}
+    </div>
+  )
+})

--- a/src/components/chat/chat-messages.tsx
+++ b/src/components/chat/chat-messages.tsx
@@ -1,8 +1,17 @@
 import { type BaseModel } from '@/config/models'
+import { useChatPrint } from '@/hooks/use-chat-print'
 import 'katex/dist/katex.min.css'
-import React, { memo, useCallback, useEffect, useMemo, useState } from 'react'
+import React, {
+  memo,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
 import { LoadingDots } from '../loading-dots'
 import { useMaxMessages } from './hooks/use-max-messages'
+import { PrintableChat } from './PrintableChat'
 import { getRendererRegistry } from './renderers/client'
 import type { LabelType, Message } from './types'
 import { WelcomeScreen } from './WelcomeScreen'
@@ -260,6 +269,12 @@ export function ChatMessages({
   const prevMessageCountRef = React.useRef(messages.length)
   const prevShowScrollButtonRef = React.useRef(showScrollButton)
   const messageCountWhenSpacerSetRef = React.useRef<number | null>(null)
+  const printRef = useRef<HTMLDivElement>(null)
+
+  useChatPrint({
+    printRef,
+    enabled: messages.length > 0,
+  })
 
   // Show spacer when user sends a new message
   React.useEffect(() => {
@@ -437,6 +452,7 @@ export function ChatMessages({
           aria-hidden="true"
         />
       )}
+      <PrintableChat messages={messages} printRef={printRef} />
     </div>
   )
 }

--- a/src/hooks/use-chat-print.ts
+++ b/src/hooks/use-chat-print.ts
@@ -1,0 +1,76 @@
+import { toast } from '@/hooks/use-toast'
+import { useCallback, useEffect, useState } from 'react'
+
+interface UseChatPrintOptions {
+  printRef: React.RefObject<HTMLDivElement>
+  enabled?: boolean
+}
+
+interface UseChatPrintReturn {
+  isGeneratingPdf: boolean
+  triggerPrint: () => Promise<void>
+}
+
+export function useChatPrint({
+  printRef,
+  enabled = true,
+}: UseChatPrintOptions): UseChatPrintReturn {
+  const [isGeneratingPdf, setIsGeneratingPdf] = useState(false)
+
+  const triggerPrint = useCallback(async () => {
+    if (!printRef.current || isGeneratingPdf) return
+
+    setIsGeneratingPdf(true)
+    const element = printRef.current
+    try {
+      element.classList.remove('hidden')
+
+      const html2pdf = (await import('html2pdf.js')).default
+      const blob = await html2pdf()
+        .set({
+          margin: [15, 15, 15, 15],
+          filename: 'chat.pdf',
+          image: { type: 'jpeg', quality: 0.98 },
+          html2canvas: { scale: 2, useCORS: true },
+          jsPDF: { unit: 'mm', format: 'a4', orientation: 'portrait' },
+        })
+        .from(element)
+        .outputPdf('blob')
+
+      const pdfUrl = URL.createObjectURL(blob)
+      const printWindow = window.open(pdfUrl, '_blank')
+
+      if (printWindow) {
+        printWindow.onload = () => {
+          printWindow.print()
+        }
+      }
+
+      setTimeout(() => URL.revokeObjectURL(pdfUrl), 60000)
+    } catch {
+      toast({ title: 'Failed to generate PDF', variant: 'destructive' })
+    } finally {
+      element.classList.add('hidden')
+      setIsGeneratingPdf(false)
+    }
+  }, [printRef, isGeneratingPdf])
+
+  useEffect(() => {
+    if (!enabled) return
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key === 'p') {
+        e.preventDefault()
+        triggerPrint()
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [enabled, triggerPrint])
+
+  return {
+    isGeneratingPdf,
+    triggerPrint,
+  }
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -361,3 +361,126 @@
 .no-scroll-anchoring {
   overflow-anchor: none;
 }
+
+/* Printable chat styles */
+.printable-chat {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    'Segoe UI',
+    Roboto,
+    sans-serif;
+  color: #000;
+  background: #fff;
+  padding: 2rem;
+  max-width: 800px;
+}
+
+.printable-message {
+  page-break-inside: avoid;
+  margin-bottom: 1.5rem;
+  padding-bottom: 1.5rem;
+  border-bottom: 1px solid #e5e5e5;
+}
+
+.printable-message:last-child {
+  border-bottom: none;
+}
+
+.printable-role-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.printable-role {
+  font-weight: 600;
+  font-size: 0.875rem;
+  text-transform: uppercase;
+  letter-spacing: 0.025em;
+}
+
+.printable-timestamp {
+  color: #666;
+  font-size: 0.75rem;
+}
+
+.printable-documents {
+  margin-bottom: 0.75rem;
+  padding: 0.5rem 0.75rem;
+  background: #f9f9f9;
+  border-radius: 0.375rem;
+  font-size: 0.875rem;
+}
+
+.printable-documents-label {
+  font-weight: 500;
+  margin-right: 0.5rem;
+}
+
+.printable-documents ul {
+  margin: 0.25rem 0 0 1rem;
+  padding: 0;
+}
+
+.printable-documents li {
+  margin: 0.125rem 0;
+}
+
+.printable-thinking {
+  background: #f5f5f5;
+  padding: 0.75rem 1rem;
+  border-radius: 0.5rem;
+  margin-bottom: 0.75rem;
+  border-left: 3px solid #d1d5db;
+}
+
+.printable-thinking-label {
+  font-weight: 600;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #666;
+  margin-bottom: 0.5rem;
+}
+
+.printable-content {
+  line-height: 1.6;
+}
+
+.printable-chat pre {
+  background: #f8f8f8 !important;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  overflow-x: auto;
+  font-size: 0.8125rem;
+  border: 1px solid #e5e5e5;
+}
+
+.printable-chat code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+}
+
+.printable-chat table {
+  border-collapse: collapse;
+  width: 100%;
+  margin: 1rem 0;
+  table-layout: fixed;
+}
+
+.printable-chat th,
+.printable-chat td {
+  border: 1px solid #e5e5e5;
+  padding: 0.5rem 0.75rem;
+  text-align: left;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+  hyphens: auto;
+}
+
+.printable-chat th {
+  background: #f5f5f5;
+  font-weight: 600;
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a print-ready view for chats. Users can press Ctrl/Cmd+P to generate a clean PDF and print it.

- **New Features**
  - Added PrintableChat component that renders a hidden, print-only version of messages with role headers, timestamps, attachments, and “Thinking”.
  - Introduced useChatPrint hook to intercept Ctrl/Cmd+P and create an A4 PDF via html2pdf.js, then open and trigger native print.
  - Markdown, math, code blocks, tables, and links are preprocessed and sanitized for safe, readable output.
  - Added print-focused CSS for layout, pagination, and styling of code and tables.

<sup>Written for commit 35b4f7b65dde1596b588041d7423d335c9b70462. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

