### PR TITLE
fix: update prompt and cleanup for thought summary

### DIFF
--- a/src/components/chat/constants.ts
+++ b/src/components/chat/constants.ts
@@ -26,5 +26,5 @@ export const CONSTANTS = {
   // Title generation settings
   TITLE_GENERATION_WORD_THRESHOLD: 100, // Words needed to trigger early title generation during streaming
   TITLE_GENERATION_PROMPT: `You are a title generator. Generate a concise, descriptive title or headline (max 5 words) for the following text blob. Output ONLY the title in plain text. NEVER output markdown.`,
-  THOUGHT_SUMMARY_GENERATION_PROMPT: `You are a thoughts summarizer. Generate a headline (max 10 words) summarizing the following thought process from a first person perspective prefixed by "I am thinking about". Output ONLY the headline in plain text. NEVER output markdown.`,
+  THOUGHT_SUMMARY_GENERATION_PROMPT: `You are a thoughts summarizer. Generate a title or headline (max 5 words) summarizing the following thought process using a few words only. Output ONLY the headline in plain text. NEVER output markdown.`,
 } as const

--- a/src/components/chat/renderers/components/ThoughtProcess.tsx
+++ b/src/components/chat/renderers/components/ThoughtProcess.tsx
@@ -90,10 +90,19 @@ export const ThoughtProcess = memo(function ThoughtProcess({
           max_tokens: 50,
         })
 
-        const summary = completion.choices?.[0]?.message?.content?.trim() || ''
-        const cleanSummary = summary.replace(/^["']|["']$/g, '').trim()
-        if (isMountedRef.current && cleanSummary) {
-          setThoughtSummary(cleanSummary)
+        const generatedSummary =
+          completion.choices?.[0]?.message?.content?.trim() || ''
+        const cleaned = generatedSummary
+          .toLowerCase()
+          .replace(/[".]/g, '')
+          .replace(
+            /\b(my|your|yours|mine|our|ours|their|theirs|his|her|hers)\b/g,
+            '',
+          )
+          .replace(/\s+/g, ' ')
+          .trim()
+        if (isMountedRef.current && cleaned) {
+          setThoughtSummary(cleaned)
         }
       } catch (error) {
         logError('Failed to generate thought summary', error, {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make thought summaries shorter and cleaner to improve the chat UI and reduce noisy titles.

- **Bug Fixes**
  - Update THOUGHT_SUMMARY_GENERATION_PROMPT to a concise, 5-word headline in plain text.
  - Sanitize output: lowercase, remove quotes/periods, drop possessive pronouns, collapse whitespace.
  - Only set the summary when the component is still mounted.

<sup>Written for commit 9baf734358d564a081e03d1ff029e0710ad136eb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

