### PR TITLE
refactor: remove automatic browser language detection

### DIFF
--- a/src/components/chat/settings-sidebar.tsx
+++ b/src/components/chat/settings-sidebar.tsx
@@ -195,14 +195,8 @@ export function SettingsSidebar({
       // Set default language if not already set
       const savedLanguage = localStorage.getItem('userLanguage')
       if (!savedLanguage) {
-        // Get user's locale and set as default
-        const userLocale = navigator.language || 'en-US'
-        const languageName =
-          new Intl.DisplayNames([userLocale], { type: 'language' }).of(
-            userLocale.split('-')[0],
-          ) || 'English'
-        setLanguage(languageName)
-        localStorage.setItem('userLanguage', languageName)
+        setLanguage('English')
+        localStorage.setItem('userLanguage', 'English')
       }
     }
   }, [isClient, loadSettingsFromStorage])
@@ -378,21 +372,15 @@ export function SettingsSidebar({
     setProfession('')
     setSelectedTraits([])
     setAdditionalContext('')
-    // Reset language to user's locale
-    const userLocale = navigator.language || 'en-US'
-    const languageName =
-      new Intl.DisplayNames([userLocale], { type: 'language' }).of(
-        userLocale.split('-')[0],
-      ) || 'English'
-    setLanguage(languageName)
+    setLanguage('English')
 
     if (isClient) {
       localStorage.removeItem('userNickname')
       localStorage.removeItem('userProfession')
       localStorage.removeItem('userTraits')
       localStorage.removeItem('userAdditionalContext')
-      localStorage.setItem('userLanguage', languageName)
-      saveLanguageSetting(languageName)
+      localStorage.setItem('userLanguage', 'English')
+      saveLanguageSetting('English')
       savePersonalizationSettings({
         nickname: '',
         profession: '',


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed automatic browser language detection in the chat settings sidebar. Language now defaults to English when not set or after reset, for consistent and predictable behavior.

<sup>Written for commit 1c1165e7c6e42501ad7034a0f5d6a05148763c42. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

