### PR TITLE
feat: add /chat/local/[chatId] URL pattern for local-only chats

### DIFF
--- a/src/components/chat/hooks/use-chat-state.ts
+++ b/src/components/chat/hooks/use-chat-state.ts
@@ -64,6 +64,7 @@ interface UseChatStateReturn {
   regenerateMessage: (messageIndex: number) => void
   initialChatDecryptionFailed: boolean
   clearInitialChatDecryptionFailed: () => void
+  localChatNotFound: boolean
 }
 
 export function useChatState({
@@ -76,6 +77,7 @@ export function useChatState({
   scrollToBottom,
   reasoningEffort,
   initialChatId,
+  isLocalChatUrl = false,
 }: {
   systemPrompt: string
   rules?: string
@@ -86,6 +88,7 @@ export function useChatState({
   scrollToBottom?: () => void
   reasoningEffort?: ReasoningEffort
   initialChatId?: string | null
+  isLocalChatUrl?: boolean
 }): UseChatStateReturn {
   const hasCreatedInitialChatRef = useRef(false)
 
@@ -117,6 +120,7 @@ export function useChatState({
     reloadChats,
     initialChatDecryptionFailed,
     clearInitialChatDecryptionFailed,
+    localChatNotFound,
   } = useChatStorage({
     storeHistory,
     scrollToBottom,
@@ -127,6 +131,7 @@ export function useChatState({
       }
     },
     initialChatId,
+    isLocalChatUrl,
   })
 
   // Create ref to store cancelGeneration function
@@ -296,5 +301,6 @@ export function useChatState({
     regenerateMessage,
     initialChatDecryptionFailed,
     clearInitialChatDecryptionFailed,
+    localChatNotFound,
   }
 }

--- a/src/hooks/use-chat-router.ts
+++ b/src/hooks/use-chat-router.ts
@@ -4,8 +4,10 @@ import { useCallback, useEffect, useState } from 'react'
 interface UseChatRouterReturn {
   initialChatId: string | null
   initialProjectId: string | null
+  isLocalChatUrl: boolean
   isRouterReady: boolean
   updateUrlForChat: (chatId: string, projectId?: string) => void
+  updateUrlForLocalChat: (chatId: string) => void
   updateUrlForProject: (projectId: string) => void
   clearUrl: () => void
 }
@@ -23,6 +25,10 @@ export function useChatRouter(): UseChatRouterReturn {
     router.isReady && typeof router.query.projectId === 'string'
       ? router.query.projectId
       : null
+
+  // Detect if current URL is a local chat URL
+  const isLocalChatUrl =
+    router.isReady && router.pathname === '/chat/local/[chatId]'
 
   // Mark router as ready
   useEffect(() => {
@@ -42,6 +48,21 @@ export function useChatRouter(): UseChatRouterReturn {
       : `/chat/${chatId}`
 
     // Only update if path actually changed
+    if (window.location.pathname !== newPath) {
+      window.history.replaceState(
+        { ...window.history.state, as: newPath, url: newPath },
+        '',
+        newPath,
+      )
+    }
+  }, [])
+
+  // Update URL for local-only chats
+  const updateUrlForLocalChat = useCallback((chatId: string) => {
+    if (typeof window === 'undefined') return
+
+    const newPath = `/chat/local/${chatId}`
+
     if (window.location.pathname !== newPath) {
       window.history.replaceState(
         { ...window.history.state, as: newPath, url: newPath },
@@ -82,8 +103,10 @@ export function useChatRouter(): UseChatRouterReturn {
   return {
     initialChatId,
     initialProjectId,
+    isLocalChatUrl,
     isRouterReady,
     updateUrlForChat,
+    updateUrlForLocalChat,
     updateUrlForProject,
     clearUrl,
   }

--- a/src/pages/chat/local/[chatId].tsx
+++ b/src/pages/chat/local/[chatId].tsx
@@ -1,0 +1,19 @@
+'use client'
+
+import { ChatInterface } from '@/components/chat'
+import { ProjectProvider } from '@/components/project'
+import { useRouter } from 'next/router'
+
+export default function LocalChatPage() {
+  const router = useRouter()
+  const chatId =
+    typeof router.query.chatId === 'string' ? router.query.chatId : null
+
+  return (
+    <div className="h-screen font-aeonik">
+      <ProjectProvider>
+        <ChatInterface initialChatId={chatId} isLocalChatUrl={true} />
+      </ProjectProvider>
+    </div>
+  )
+}


### PR DESCRIPTION
Local-only chats (stored in IndexedDB with isLocalOnly=true) now get distinct URLs that persist across page refreshes. Previously, these chats used /chat/[chatId] which would fail on refresh as the app tried to load them from the cloud.

- Add new route /chat/local/[chatId] for local chat URLs
- Update useChatRouter with isLocalChatUrl detection and updateUrlForLocalChat
- Update URL sync logic to use /chat/local/ for local-only chats
- Add chat not found error screen for missing local chats

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Local-only chats now use /chat/local/[chatId] URLs that persist across refresh and avoid cloud-loading errors.

- **New Features**
  - Added /chat/local/[chatId] route and router helpers (isLocalChatUrl, updateUrlForLocalChat).
  - Synced URL to /chat/local when a chat has isLocalOnly=true.
  - Added a “Chat not found” screen when a local chat was deleted from IndexedDB.

<sup>Written for commit 9ff4600218f93c97e94e3ac9e637f529a9c320c2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

