### PR TITLE
Support chat and project deep links on static deployments

### DIFF
--- a/src/pages/chat/[[...slug]].tsx
+++ b/src/pages/chat/[[...slug]].tsx
@@ -1,0 +1,26 @@
+'use client'
+
+import { ChatInterface } from '@/components/chat'
+import { ProjectProvider } from '@/components/project'
+import { useRouter } from 'next/router'
+
+export default function ChatCatchAllPage() {
+  const router = useRouter()
+  const slug = router.query.slug
+  const parts =
+    typeof slug === 'string' ? [slug] : Array.isArray(slug) ? slug : []
+
+  const isLocalChatUrl = parts[0] === 'local'
+  const chatId = isLocalChatUrl ? (parts[1] ?? null) : (parts[0] ?? null)
+
+  return (
+    <div className="h-screen font-aeonik">
+      <ProjectProvider>
+        <ChatInterface
+          initialChatId={typeof chatId === 'string' ? chatId : null}
+          isLocalChatUrl={isLocalChatUrl}
+        />
+      </ProjectProvider>
+    </div>
+  )
+}

--- a/src/pages/project/[[...slug]].tsx
+++ b/src/pages/project/[[...slug]].tsx
@@ -1,0 +1,29 @@
+'use client'
+
+import { ChatInterface } from '@/components/chat'
+import { ProjectProvider } from '@/components/project'
+import { useRouter } from 'next/router'
+
+export default function ProjectCatchAllPage() {
+  const router = useRouter()
+  const slug = router.query.slug
+  const parts =
+    typeof slug === 'string' ? [slug] : Array.isArray(slug) ? slug : []
+
+  const projectId = parts[0] ?? null
+  const isProjectChat = parts[1] === 'chat'
+  const chatId = isProjectChat ? (parts[2] ?? null) : null
+
+  return (
+    <div className="h-screen font-aeonik">
+      <ProjectProvider
+        initialProjectId={typeof projectId === 'string' ? projectId : null}
+      >
+        <ChatInterface
+          initialProjectId={typeof projectId === 'string' ? projectId : null}
+          initialChatId={typeof chatId === 'string' ? chatId : null}
+        />
+      </ProjectProvider>
+    </div>
+  )
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,34 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
+  "builds": [
+    {
+      "src": "package.json",
+      "use": "@vercel/static-build",
+      "config": {
+        "distDir": "out"
+      }
+    }
+  ],
+  "rewrites": [
+    { "source": "/chat", "destination": "/chat/%5B%5B...slug%5D%5D.html" },
+    { "source": "/chat/", "destination": "/chat/%5B%5B...slug%5D%5D.html" },
+    {
+      "source": "/chat/local",
+      "destination": "/chat/%5B%5B...slug%5D%5D.html"
+    },
+    {
+      "source": "/chat/local/",
+      "destination": "/chat/%5B%5B...slug%5D%5D.html"
+    },
+    {
+      "source": "/chat/:path*",
+      "destination": "/chat/%5B%5B...slug%5D%5D.html"
+    },
+    {
+      "source": "/project/:path*",
+      "destination": "/project/%5B%5B...slug%5D%5D.html"
+    }
+  ],
   "headers": [
     {
       "source": "/(.*)",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes chat page refresh issues for local-only chats and keeps deep links working after export. Local chat URLs now stay stable and load the right chat without flicker.

- **Bug Fixes**
  - Keep /chat/local/[id] URLs for local-only chats; blank new chats stay at /.
  - Don’t clear the URL while a local chat URL is still loading.
  - Load local chats directly from IndexedDB (chatStorage) to avoid race conditions.
  - Add catch-all pages + Vercel rewrites for chat/project deep links on static export.

<sup>Written for commit 78bba98cf2bad871f4f4d2a3ce57147e0e200b67. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

