### PR TITLE
feat: persist sidebar state in session storage

### DIFF
--- a/src/components/chat/chat-sidebar.tsx
+++ b/src/components/chat/chat-sidebar.tsx
@@ -198,6 +198,10 @@ export function ChatSidebar({
       if (expandSection === 'projects') {
         return true
       }
+      const stored = sessionStorage.getItem('sidebarProjectsExpanded')
+      if (stored !== null) {
+        return stored === 'true'
+      }
     }
     return false
   })
@@ -214,6 +218,10 @@ export function ChatSidebar({
       const expandSection = sessionStorage.getItem('sidebarExpandSection')
       if (expandSection === 'projects') {
         return false
+      }
+      const stored = sessionStorage.getItem('sidebarChatHistoryExpanded')
+      if (stored !== null) {
+        return stored === 'true'
       }
     }
     return true
@@ -286,6 +294,22 @@ export function ChatSidebar({
   useEffect(() => {
     sessionStorage.setItem('chatSidebarActiveTab', activeTab)
   }, [activeTab])
+
+  // Persist projects expanded state to sessionStorage
+  useEffect(() => {
+    sessionStorage.setItem(
+      'sidebarProjectsExpanded',
+      isProjectsExpanded ? 'true' : 'false',
+    )
+  }, [isProjectsExpanded])
+
+  // Persist chat history expanded state to sessionStorage
+  useEffect(() => {
+    sessionStorage.setItem(
+      'sidebarChatHistoryExpanded',
+      isChatHistoryExpanded ? 'true' : 'false',
+    )
+  }, [isChatHistoryExpanded])
 
   // Listen for cloud sync setting changes
   useEffect(() => {

--- a/src/components/chat/hooks/use-ui-state.ts
+++ b/src/components/chat/hooks/use-ui-state.ts
@@ -21,9 +21,16 @@ interface UseUIStateReturn {
 const useIsomorphicLayoutEffect =
   typeof window !== 'undefined' ? useLayoutEffect : useEffect
 
+const SIDEBAR_OPEN_KEY = 'sidebarOpen'
+
 export function useUIState(): UseUIStateReturn {
   const [isClient, setIsClient] = useState(false)
-  const [isSidebarOpen, setIsSidebarOpen] = useState(false)
+  const [isSidebarOpen, setIsSidebarOpen] = useState(() => {
+    if (typeof window !== 'undefined') {
+      return sessionStorage.getItem(SIDEBAR_OPEN_KEY) === 'true'
+    }
+    return false
+  })
   const [isDarkMode, setIsDarkMode] = useState(false)
   const [windowWidth, setWindowWidth] = useState(
     typeof window !== 'undefined' ? window.innerWidth : 0,
@@ -100,6 +107,11 @@ export function useUIState(): UseUIStateReturn {
       }
     }
   }, [isClient])
+
+  // Persist sidebar open state to sessionStorage
+  useEffect(() => {
+    sessionStorage.setItem(SIDEBAR_OPEN_KEY, isSidebarOpen ? 'true' : 'false')
+  }, [isSidebarOpen])
 
   // Toggle dark mode
   const toggleTheme = useCallback(() => {


### PR DESCRIPTION
- Store sidebar open/close state in sessionStorage
- Persist projects and chat history expanded states
- States are restored on page refresh within the same session

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist the chat sidebar open/close state and the projects/chat history expansion states in sessionStorage. On refresh within the same session, the sidebar and sections restore to their previous state.

<sup>Written for commit c8d22d638be6bc5b436c23c8df9fa276a4fd7b45. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

