### PR TITLE
fix: convert fenced code blocks to inline code in markdown tables

### DIFF
--- a/src/utils/markdown-preprocessing.ts
+++ b/src/utils/markdown-preprocessing.ts
@@ -1,21 +1,58 @@
 /**
+ * Wraps code in backticks using a delimiter longer than any backtick run in the content.
+ * Per CommonMark, if using multiple backticks, spaces separate content from delimiters.
+ */
+function wrapInlineCode(code: string): string {
+  const backtickRuns = code.match(/`+/g) || []
+  const maxRun = backtickRuns.reduce((max, run) => Math.max(max, run.length), 0)
+  const delimiter = '`'.repeat(maxRun + 1)
+
+  if (maxRun === 0) {
+    return `\`${code}\``
+  }
+  return `${delimiter} ${code} ${delimiter}`
+}
+
+/**
  * Preprocesses markdown content to fix common formatting issues
  * and convert HTML tags to markdown equivalents.
  * Preserves code blocks and inline code to avoid breaking examples.
  */
 export function preprocessMarkdown(content: string): string {
+  // First, fix inline fenced code blocks inside table rows.
+  // These look like ```lang\ncode``` on a single line (with literal \n, not newlines)
+  // and break table parsing. Convert them to inline code.
+  let processed = content.replace(
+    /^(\|.*?)```[^\s`]*\\n(.+?)```(.*\|)$/gm,
+    (_, before, code, after) => {
+      const cleanedCode = code.replace(/\\n/g, ' ').trim()
+      return `${before}${wrapInlineCode(cleanedCode)}${after}`
+    },
+  )
+
+  // Also handle cases where the code block spans multiple cells or has no \n
+  processed = processed.replace(
+    /^(\|.*?)```[^\s`]*\s*([^`\n]+?)```(.*\|)$/gm,
+    (_, before, code, after) => {
+      const cleanedCode = code.trim()
+      return `${before}${wrapInlineCode(cleanedCode)}${after}`
+    },
+  )
+
   // Extract code blocks and inline code to protect them
   const codeBlocks: string[] = []
   const inlineCode: string[] = []
 
   // Protect fenced code blocks (```...```)
-  let processed = content.replace(/```[\s\S]*?```/g, (match) => {
+  processed = processed.replace(/```[\s\S]*?```/g, (match) => {
     codeBlocks.push(match)
     return `__CODE_BLOCK_${codeBlocks.length - 1}__`
   })
 
-  // Protect inline code (`...`)
-  processed = processed.replace(/`[^`]+`/g, (match) => {
+  // Protect inline code - handles both single and multi-backtick delimiters
+  // Multi-backtick format from wrapInlineCode: `` content `` (with spaces)
+  // Single-backtick format: `content`
+  processed = processed.replace(/(`+) .+? \1|`[^`]+`/g, (match) => {
     inlineCode.push(match)
     return `__INLINE_CODE_${inlineCode.length - 1}__`
   })


### PR DESCRIPTION
Tables with  syntax break markdown parsing since fenced code blocks aren't supported inside table cells. Preprocess these into single-backtick inline code for proper rendering.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix markdown table parsing by converting fenced code blocks inside table cells to inline code using a safe backtick delimiter, so tables render correctly. Handles both literal \n cases and standard fenced blocks within rows.

- **Bug Fixes**
  - Detects fenced code blocks in table rows and wraps content with a delimiter longer than any backtick run, collapsing literal \n and trimming.
  - Converts before code-block protection; inline-code protection now supports multi-backtick delimiters.

<sup>Written for commit 618c4ce7932a129c0ce1260a52507991d50e0c96. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

