### PR TITLE
fix: model selector clipping on mobile

### DIFF
--- a/src/components/chat/model-selector.tsx
+++ b/src/components/chat/model-selector.tsx
@@ -38,6 +38,8 @@ export function ModelSelector({
     maxHeight: string
     bottom?: string
     top?: string
+    left?: string
+    right?: string
   }>({
     maxHeight: '400px',
     ...(preferredPosition === 'below' ? { top: '100%' } : { bottom: '100%' }),
@@ -91,11 +93,35 @@ export function ModelSelector({
       const isMobile = window.innerWidth < 768
       const maxHeightCap = isMobile ? 300 : window.innerHeight * 0.7
 
+      // Calculate horizontal positioning to prevent overflow
+      const menuWidth = 280 // Fixed width from className
+      const viewportWidth = window.innerWidth
+      const buttonLeft = buttonRect.left
+      const buttonRight = buttonRect.right
+
+      let horizontalStyles: { left?: string; right?: string } = {}
+
+      if (isMobile) {
+        // On mobile, check if dropdown would overflow right edge
+        if (buttonLeft + menuWidth > viewportWidth - 10) {
+          // Anchor to right edge of button, but ensure it doesn't overflow left
+          const rightOffset = viewportWidth - buttonRight
+          const dropdownLeft = viewportWidth - rightOffset - menuWidth
+          if (dropdownLeft < 10) {
+            // Would overflow left, center it in viewport instead
+            horizontalStyles = { left: `${-buttonLeft + 10}px` }
+          } else {
+            horizontalStyles = { right: '0' }
+          }
+        }
+      }
+
       if (useAbove) {
         setDynamicStyles({
           maxHeight: `${Math.min(Math.max(0, spaceAbove), maxHeightCap)}px`,
           bottom: '100%',
           top: undefined,
+          ...horizontalStyles,
         })
       } else {
         // Position below
@@ -103,6 +129,7 @@ export function ModelSelector({
           maxHeight: `${Math.min(Math.max(0, spaceBelow), maxHeightCap)}px`,
           top: '100%',
           bottom: undefined,
+          ...horizontalStyles,
         })
       }
     }
@@ -160,6 +187,8 @@ export function ModelSelector({
         maxHeight: dynamicStyles.maxHeight,
         ...(dynamicStyles.bottom && { bottom: dynamicStyles.bottom }),
         ...(dynamicStyles.top && { top: dynamicStyles.top }),
+        ...(dynamicStyles.left && { left: dynamicStyles.left }),
+        ...(dynamicStyles.right && { right: dynamicStyles.right }),
       }}
       onTouchStart={(e) => {
         e.stopPropagation()


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes mobile clipping in the model selector by adding horizontal positioning logic to prevent right-edge overflow. Applies dynamic left/right styles and caps the menu height on mobile to keep the dropdown fully visible above or below the button.

<sup>Written for commit ecc077eacb140598cd315f230fdfbc6ac16e8820. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

