### PR TITLE
feat: render citation markers from web search sources

### DIFF
--- a/src/components/chat/renderers/components/ThoughtProcess.tsx
+++ b/src/components/chat/renderers/components/ThoughtProcess.tsx
@@ -355,6 +355,16 @@ export const ThoughtProcess = memo(function ThoughtProcess({
                     {children}
                   </code>
                 ),
+              a: ({ children, href }: any) => (
+                <a
+                  href={href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-blue-500 underline hover:text-blue-600"
+                >
+                  {children}
+                </a>
+              ),
             }}
           >
             {sanitizedThoughts}

--- a/src/components/chat/renderers/default/DefaultMessageRenderer.tsx
+++ b/src/components/chat/renderers/default/DefaultMessageRenderer.tsx
@@ -273,7 +273,7 @@ const DefaultMessageComponent = ({
                   className={cn(
                     'prose w-full max-w-none overflow-x-auto text-lg prose-pre:bg-transparent prose-pre:p-0',
                     'text-content-primary prose-headings:text-content-primary prose-strong:text-content-primary prose-code:text-content-primary',
-                    'prose-a:text-accent hover:prose-a:text-accent/80',
+                    'prose-a:text-blue-500 hover:prose-a:text-blue-600',
                   )}
                 >
                   {!isUser && isStreaming && isLastMessage ? (


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Render citation markers from web search in assistant messages as clickable source pills, visible during streaming and after completion. Also standardize link styling and improve source handling in the web search UI.

- **New Features**
  - Convert markers like 【1】 into markdown links using #cite-N~url with safe URL encoding.
  - Render #cite-* links as CitationPill with favicon, domain, and tooltip.
  - Show citations during streaming and in the final message.
  - Deduplicate web search sources by URL for display, while keeping original order for marker indices.
  - Use consistent blue link styling in messages and thought process.

- **Refactors**
  - Centralize citation parsing in processCitationMarkers and replace the pipe delimiter with a tilde to avoid conflicts.

<sup>Written for commit dca575065eb04d60d8420fceb776967c2d16c94b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

