### PR TITLE
refactor: use new websearch tool format

### DIFF
--- a/src/components/chat/hooks/streaming-processor.ts
+++ b/src/components/chat/hooks/streaming-processor.ts
@@ -392,23 +392,18 @@ export async function processStreamingResponse(
                 annotation.type === 'url_citation' &&
                 annotation.url_citation
               ) {
-                const { title, url, content, published_date } =
-                  annotation.url_citation
+                const { title, url } = annotation.url_citation
                 if (url) {
                   // Add to collectedSources without deduplication to preserve citation index mapping
                   collectedSources.push({
                     title: title || url,
                     url,
-                    text: content,
-                    publishedDate: published_date,
                   })
                   collectedAnnotations.push({
                     type: 'url_citation',
                     url_citation: {
                       title: title || url,
                       url,
-                      content,
-                      published_date,
                     },
                   })
                 }

--- a/src/components/chat/renderers/components/WebSearchProcess.tsx
+++ b/src/components/chat/renderers/components/WebSearchProcess.tsx
@@ -33,20 +33,6 @@ function getDomainName(url: string): string {
   }
 }
 
-function formatPublishedDate(dateString: string): string {
-  try {
-    const date = new Date(dateString)
-    if (isNaN(date.getTime())) return ''
-    return date.toLocaleDateString(undefined, {
-      year: 'numeric',
-      month: 'short',
-      day: 'numeric',
-    })
-  } catch {
-    return ''
-  }
-}
-
 function BouncingPlaceholder({
   index,
   style,
@@ -290,22 +276,10 @@ export const WebSearchProcess = memo(function WebSearchProcess({
                     className="mt-0.5 h-4 w-4 shrink-0 rounded-full"
                   />
                   <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-                    <div className="flex items-center gap-2">
-                      <span className="text-xs opacity-50">
-                        {getDomainName(source.url)}
-                      </span>
-                      {source.publishedDate && (
-                        <span className="text-xs opacity-50">
-                          {formatPublishedDate(source.publishedDate)}
-                        </span>
-                      )}
-                    </div>
+                    <span className="text-xs opacity-50">
+                      {getDomainName(source.url)}
+                    </span>
                     <span className="truncate font-medium">{source.title}</span>
-                    {source.text && (
-                      <p className="line-clamp-2 text-xs opacity-70">
-                        {source.text}
-                      </p>
-                    )}
                   </div>
                 </a>
               ))}

--- a/src/components/chat/types.ts
+++ b/src/components/chat/types.ts
@@ -1,8 +1,8 @@
 export type URLCitation = {
   title: string
   url: string
-  content?: string
-  published_date?: string
+  start_index?: number
+  end_index?: number
 }
 
 export type Annotation = {
@@ -13,8 +13,6 @@ export type Annotation = {
 export type WebSearchSource = {
   title: string
   url: string
-  text?: string
-  publishedDate?: string
 }
 
 export type WebSearchState = {

--- a/src/services/inference/inference-client.ts
+++ b/src/services/inference/inference-client.ts
@@ -246,7 +246,7 @@ export async function sendChatStream(
       const client = await getTinfoilClient()
       await client.ready()
 
-      // Build request body - tools is a custom extension for our web search proxy
+      // Build request body
       const requestBody: Record<string, unknown> = {
         model: model.modelName,
         messages,
@@ -256,11 +256,10 @@ export async function sendChatStream(
         requestBody.reasoning_effort = reasoningEffort
       }
       if (webSearchEnabled) {
-        const tools: Array<{ type: string }> = [{ type: 'web_search' }]
-        if (piiCheckEnabled) {
-          tools.push({ type: 'pii_check' })
-        }
-        requestBody.tools = tools
+        requestBody.web_search_options = {}
+      }
+      if (piiCheckEnabled) {
+        requestBody.pii_check_options = {}
       }
 
       const stream = await (client.chat.completions.create as Function)(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adopt the new web search/PII tool options format and align citation types and UI with the backend. Citations now include only title and URL, with optional start/end indices; the search card no longer shows snippet or publish date.

- **Refactors**
  - inference-client: replace tools array with web_search_options and pii_check_options.
  - streaming: remove content and published_date from URL citations and collected sources.
  - types: URLCitation now has start_index/end_index; WebSearchSource drops text/publishedDate.
  - UI: WebSearchProcess removes snippet and published date; shows domain and title only.

<sup>Written for commit 34a17968e041ee07a76c30df4b7e170964ce91fe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

