### PR TITLE
feat: add support for audio uploads

### DIFF
--- a/src/components/chat/chat-input.tsx
+++ b/src/components/chat/chat-input.tsx
@@ -405,7 +405,7 @@ export function ChatInput({
             multiple
             accept={
               isPremium
-                ? '.pdf,.docx,.xlsx,.pptx,.md,.html,.xhtml,.csv,.png,.jpg,.jpeg,.tiff,.bmp,.webp,.txt'
+                ? '.pdf,.docx,.xlsx,.pptx,.md,.html,.xhtml,.csv,.png,.jpg,.jpeg,.tiff,.bmp,.webp,.txt,.mp3,.wav,.ogg,.m4a,.aac,.flac,.webm,.wma'
                 : '.pdf,.docx,.xlsx,.pptx,.md,.html,.xhtml,.csv,.txt'
             }
           />

--- a/src/utils/file-types.ts
+++ b/src/utils/file-types.ts
@@ -25,7 +25,7 @@ const DOCUMENT_EXTENSIONS = {
 
 // Supported media extensions
 const MEDIA_EXTENSIONS = {
-  audio: ['.mp3', '.wav', '.ogg'],
+  audio: ['.mp3', '.wav', '.ogg', '.m4a', '.aac', '.flac', '.webm', '.wma'],
   video: ['.mp4', '.mov', '.avi'],
 }
 

--- a/src/utils/preprocessing/index.ts
+++ b/src/utils/preprocessing/index.ts
@@ -2,4 +2,4 @@
  * Preprocessing utilities for various input types
  */
 
-export * from './image'
+export * from './media'

--- a/src/utils/preprocessing/media.ts
+++ b/src/utils/preprocessing/media.ts
@@ -1,5 +1,5 @@
 /**
- * Image preprocessing utilities for document upload
+ * Media preprocessing utilities for document upload
  */
 
 interface ImageScaleOptions {
@@ -90,6 +90,15 @@ export async function scaleImage(
  */
 export function isImageFile(file: File): boolean {
   return file.type.startsWith('image/')
+}
+
+/**
+ * Checks if a file is an audio file based on its MIME type
+ * @param file - The file to check
+ * @returns true if the file is an audio file, false otherwise
+ */
+export function isAudioFile(file: File): boolean {
+  return file.type.startsWith('audio/')
 }
 
 /**


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add audio upload support with automatic transcription for premium users. Expands accepted file types and routes audio files to the audio model.

- **New Features**
  - Accepts audio files: .mp3, .wav, .ogg, .m4a, .aac, .flac, .webm, .wma.
  - Auto-transcribes on upload using DEFAULT_AUDIO_MODEL or any available audio model.
  - Shows clear errors for non-premium uploads or when no audio model is available.
  - Updates chat input accept list for premium users to include audio types.

- **Refactors**
  - Renamed preprocessing utilities from image to media and added isAudioFile().
  - Extended MEDIA_EXTENSIONS.audio and updated index re-exports.

<sup>Written for commit 6d896c2f2159e52336147f86b9171b12e6f4bd99. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

