### PR TITLE
fix: drag-and-drop of chats

### DIFF
--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -1352,7 +1352,8 @@ export function ChatInterface({
     e.preventDefault()
     e.stopPropagation()
 
-    if (e.dataTransfer.items && e.dataTransfer.items.length > 0) {
+    const hasFiles = e.dataTransfer.types.includes('Files')
+    if (hasFiles && e.dataTransfer.items && e.dataTransfer.items.length > 0) {
       dragCounterRef.current += 1
       if (dragCounterRef.current === 1) {
         setIsGlobalDragActive(true)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes chat drag-and-drop by only activating the global drag state when files are dragged. Prevents chat/text drags from triggering the overlay and counters, reducing flicker.

<sup>Written for commit 79c123e5fef914bee55e4b7d993d5394fcb61d2f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

