### PR TITLE
feat: retry client on error

### DIFF
--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -657,15 +657,11 @@ export function ChatInterface({
   useEffect(() => {
     const initTinfoil = async () => {
       try {
-        const { initializeTinfoilClient, getTinfoilClient } = await import(
+        const { getReadyClient } = await import(
           '@/services/inference/tinfoil-client'
         )
-        // Initialize in background - will use placeholder key if not signed in
-        await initializeTinfoilClient()
-
-        // Fetch the verification document after initialization
-        const client = await getTinfoilClient()
-        const doc = await (client as any).getVerificationDocument?.()
+        const client = await getReadyClient()
+        const doc = await client.getVerificationDocument()
         if (doc) {
           setVerificationDocument(doc)
           // Set verification status based on document

--- a/src/components/chat/document-uploader.tsx
+++ b/src/components/chat/document-uploader.tsx
@@ -1,5 +1,5 @@
 import { getAIModels } from '@/config/models'
-import { getTinfoilClient } from '@/services/inference/tinfoil-client'
+import { getReadyClient } from '@/services/inference/tinfoil-client'
 import { logError } from '@/utils/error-handling'
 import {
   getDocumentFormat,
@@ -103,8 +103,7 @@ export const useDocumentUploader = (
       throw new Error('No multimodal model available')
     }
 
-    const client = await getTinfoilClient()
-    await client.ready()
+    const client = await getReadyClient()
 
     const response = await client.chat.completions.create({
       model: multimodalModel.modelName,
@@ -251,8 +250,7 @@ export const useDocumentUploader = (
           return
         }
 
-        const client = await getTinfoilClient()
-        await client.ready()
+        const client = await getReadyClient()
         const transcription = await client.audio.transcriptions.create({
           file,
           model: audioModel,

--- a/src/services/inference/inference-client.ts
+++ b/src/services/inference/inference-client.ts
@@ -8,8 +8,9 @@ import type { Message } from '@/components/chat/types'
 import type { BaseModel } from '@/config/models'
 import { shouldRetryTestFail } from '@/utils/dev-simulator'
 import { logError, logInfo } from '@/utils/error-handling'
+import { AttestationError, ConfigurationError, FetchError } from 'tinfoil'
 import { ChatQueryBuilder } from './chat-query-builder'
-import { getTinfoilClient } from './tinfoil-client'
+import { getReadyClient } from './tinfoil-client'
 
 function isOnline(): boolean {
   return typeof navigator !== 'undefined' ? navigator.onLine : true
@@ -20,6 +21,10 @@ function delay(ms: number): Promise<void> {
 }
 
 function isRetryableError(error: unknown): boolean {
+  if (error instanceof ConfigurationError) return false
+  if (error instanceof FetchError || error instanceof AttestationError)
+    return true
+
   const anyErr = error as any
 
   // Don't retry user-initiated aborts
@@ -243,8 +248,7 @@ export async function sendChatStream(
     }
 
     try {
-      const client = await getTinfoilClient()
-      await client.ready()
+      const client = await getReadyClient()
 
       // Build request body
       const requestBody: Record<string, unknown> = {
@@ -369,8 +373,7 @@ export async function sendStructuredCompletion<T>(
 ): Promise<T> {
   const { model, messages, jsonSchema, signal } = params
 
-  const client = await getTinfoilClient()
-  await client.ready()
+  const client = await getReadyClient()
 
   const response = await client.chat.completions.create(
     {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds automatic client retry and reinit on verification errors, and makes configuration errors fail fast. Improves reliability for chat, document uploads, and audio transcription.

- **New Features**
  - Introduced getReadyClient: verifies ready(), resets on FetchError/AttestationError, throws on ConfigurationError.
  - Replaced initializeTinfoilClient and manual ready() with getReadyClient in chat-interface and document-uploader.
  - Marked FetchError and AttestationError as retryable; ConfigurationError as non-retryable in inference-client.

<sup>Written for commit bfbcda94e6a1ee59b18c03ccea3fb4f7fc1b32ef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

