### PR TITLE
fix: remove rehype-sanitize package breaking latex rendering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,6 @@
         "react-syntax-highlighter": "^16.1.0",
         "rehype-katex": "^7.0.1",
         "rehype-raw": "^7.0.0",
-        "rehype-sanitize": "^6.0.0",
         "remark-breaks": "^4.0.0",
         "remark-gfm": "^4.0.1",
         "remark-math": "^6.0.0",
@@ -7981,21 +7980,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/hast-util-sanitize": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/hast-util-sanitize/-/hast-util-sanitize-5.0.2.tgz",
-      "integrity": "sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "@ungap/structured-clone": "^1.0.0",
-        "unist-util-position": "^5.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/hast-util-to-jsx-runtime": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
@@ -11929,20 +11913,6 @@
         "@types/hast": "^3.0.0",
         "hast-util-raw": "^9.0.0",
         "vfile": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/rehype-sanitize": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/rehype-sanitize/-/rehype-sanitize-6.0.0.tgz",
-      "integrity": "sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "hast-util-sanitize": "^5.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "react-syntax-highlighter": "^16.1.0",
     "rehype-katex": "^7.0.1",
     "rehype-raw": "^7.0.0",
-    "rehype-sanitize": "^6.0.0",
     "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1",
     "remark-math": "^6.0.0",

--- a/src/components/chat/renderers/components/use-math-plugins.ts
+++ b/src/components/chat/renderers/components/use-math-plugins.ts
@@ -31,58 +31,30 @@ async function loadPlugins(): Promise<PluginState> {
     import('rehype-katex'),
     import('remark-breaks'),
     import('rehype-raw'),
-    import('rehype-sanitize'),
   ])
-    .then(
-      ([
-        remarkMathMod,
-        rehypeKatexMod,
-        remarkBreaksMod,
-        rehypeRawMod,
-        rehypeSanitizeMod,
-      ]) => {
-        cachedPlugins = {
-          remarkPlugins: [
-            [remarkMathMod.default, { singleDollarTextMath: false }],
-            remarkGfm,
-            remarkBreaksMod.default,
+    .then(([remarkMathMod, rehypeKatexMod, remarkBreaksMod, rehypeRawMod]) => {
+      cachedPlugins = {
+        remarkPlugins: [
+          [remarkMathMod.default, { singleDollarTextMath: false }],
+          remarkGfm,
+          remarkBreaksMod.default,
+        ],
+        rehypePlugins: [
+          rehypeRawMod.default,
+          [
+            rehypeKatexMod.default,
+            {
+              throwOnError: false,
+              strict: false,
+              output: 'htmlAndMathml',
+              errorColor: TINFOIL_COLORS.utility.destructive,
+              trust: false,
+            },
           ],
-          rehypePlugins: [
-            rehypeRawMod.default,
-            [
-              rehypeSanitizeMod.default,
-              {
-                ...rehypeSanitizeMod.defaultSchema,
-                tagNames: [
-                  ...(rehypeSanitizeMod.defaultSchema.tagNames || []),
-                  'br',
-                  'span',
-                  'div',
-                  'sup',
-                  'sub',
-                  'mark',
-                ],
-                attributes: {
-                  ...rehypeSanitizeMod.defaultSchema.attributes,
-                  '*': ['className'],
-                },
-              },
-            ],
-            [
-              rehypeKatexMod.default,
-              {
-                throwOnError: false,
-                strict: false,
-                output: 'htmlAndMathml',
-                errorColor: TINFOIL_COLORS.utility.destructive,
-                trust: false,
-              },
-            ],
-          ],
-        }
-        return cachedPlugins
-      },
-    )
+        ],
+      }
+      return cachedPlugins
+    })
     .catch((error) => {
       logError('Failed to load markdown plugins', error, {
         component: 'useMathPlugins',


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed rehype-sanitize from the markdown pipeline to fix broken LaTeX rendering in chat messages. Updated dependencies and math plugin setup to restore reliable KaTeX output.

- **Bug Fixes**
  - Removed rehype-sanitize from package.json and use-math-plugins.
  - Kept rehype-raw and rehype-katex (trust: false, throwOnError: false) to render HTML+MathML safely.

<sup>Written for commit 9f8289990ee6dc412eb9a6054b13022132403cff. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

