### PR TITLE
fix: latex rendering issues

### DIFF
--- a/src/components/chat/renderers/components/markdown-components.tsx
+++ b/src/components/chat/renderers/components/markdown-components.tsx
@@ -362,25 +362,25 @@ export function createMarkdownComponents({
     },
 
     // Generic container elements - pass through with text color
-    div({ children, ...props }: any) {
+    div({ children, className, ...props }: any) {
       return (
-        <div {...props} className="text-content-primary">
+        <div {...props} className={className || 'text-content-primary'}>
           {children}
         </div>
       )
     },
 
-    span({ children, ...props }: any) {
+    span({ children, className, ...props }: any) {
       return (
-        <span {...props} className="text-content-primary">
+        <span {...props} className={className || 'text-content-primary'}>
           {children}
         </span>
       )
     },
 
-    p({ children, ...props }: any) {
+    p({ children, className, ...props }: any) {
       return (
-        <p {...props} className="text-content-primary">
+        <p {...props} className={className || 'text-content-primary'}>
           {children}
         </p>
       )

--- a/src/components/chat/renderers/components/use-math-plugins.ts
+++ b/src/components/chat/renderers/components/use-math-plugins.ts
@@ -35,7 +35,7 @@ async function loadPlugins(): Promise<PluginState> {
     .then(([remarkMathMod, rehypeKatexMod, remarkBreaksMod, rehypeRawMod]) => {
       cachedPlugins = {
         remarkPlugins: [
-          [remarkMathMod.default, { singleDollarTextMath: false }],
+          [remarkMathMod.default, { singleDollarTextMath: true }],
           remarkGfm,
           remarkBreaksMod.default,
         ],
@@ -46,7 +46,7 @@ async function loadPlugins(): Promise<PluginState> {
             {
               throwOnError: false,
               strict: false,
-              output: 'htmlAndMathml',
+              output: 'html',
               errorColor: TINFOIL_COLORS.utility.destructive,
               trust: false,
             },


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes LaTeX rendering so inline $...$ math and KaTeX styling work correctly in chat markdown. Equations now display properly without duplicate MathML output.

- **Bug Fixes**
  - Enable single-dollar inline math parsing (singleDollarTextMath: true).
  - Output KaTeX as HTML only to prevent duplicate/garbled rendering.
  - Preserve provided className on div/span/p (default to text-content-primary) so KaTeX classes aren’t overridden.

<sup>Written for commit 11b52266e0dd88b3e2582769f5bfc3413413ba95. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

