### PR TITLE
refactor: remove app-level SDK recovery

### DIFF
--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -657,10 +657,10 @@ export function ChatInterface({
   useEffect(() => {
     const initTinfoil = async () => {
       try {
-        const { getReadyClient } = await import(
+        const { getTinfoilClient } = await import(
           '@/services/inference/tinfoil-client'
         )
-        const client = await getReadyClient()
+        const client = await getTinfoilClient()
         const doc = await client.getVerificationDocument()
         if (doc) {
           setVerificationDocument(doc)

--- a/src/components/chat/document-uploader.tsx
+++ b/src/components/chat/document-uploader.tsx
@@ -1,5 +1,5 @@
 import { getAIModels } from '@/config/models'
-import { getReadyClient } from '@/services/inference/tinfoil-client'
+import { getTinfoilClient } from '@/services/inference/tinfoil-client'
 import { logError } from '@/utils/error-handling'
 import {
   getDocumentFormat,
@@ -103,8 +103,7 @@ export const useDocumentUploader = (
       throw new Error('No multimodal model available')
     }
 
-    const client = await getReadyClient()
-
+    const client = await getTinfoilClient()
     const response = await client.chat.completions.create({
       model: multimodalModel.modelName,
       messages: [
@@ -250,7 +249,7 @@ export const useDocumentUploader = (
           return
         }
 
-        const client = await getReadyClient()
+        const client = await getTinfoilClient()
         const transcription = await client.audio.transcriptions.create({
           file,
           model: audioModel,

--- a/src/services/inference/inference-client.ts
+++ b/src/services/inference/inference-client.ts
@@ -8,9 +8,8 @@ import type { Message } from '@/components/chat/types'
 import type { BaseModel } from '@/config/models'
 import { shouldRetryTestFail } from '@/utils/dev-simulator'
 import { logError, logInfo } from '@/utils/error-handling'
-import { AttestationError, ConfigurationError, FetchError } from 'tinfoil'
 import { ChatQueryBuilder } from './chat-query-builder'
-import { getReadyClient } from './tinfoil-client'
+import { getTinfoilClient } from './tinfoil-client'
 
 function isOnline(): boolean {
   return typeof navigator !== 'undefined' ? navigator.onLine : true
@@ -21,10 +20,6 @@ function delay(ms: number): Promise<void> {
 }
 
 function isRetryableError(error: unknown): boolean {
-  if (error instanceof ConfigurationError) return false
-  if (error instanceof FetchError || error instanceof AttestationError)
-    return true
-
   const anyErr = error as any
 
   // Don't retry user-initiated aborts
@@ -248,7 +243,7 @@ export async function sendChatStream(
     }
 
     try {
-      const client = await getReadyClient()
+      const client = await getTinfoilClient()
 
       // Build request body
       const requestBody: Record<string, unknown> = {
@@ -373,8 +368,7 @@ export async function sendStructuredCompletion<T>(
 ): Promise<T> {
   const { model, messages, jsonSchema, signal } = params
 
-  const client = await getReadyClient()
-
+  const client = await getTinfoilClient()
   const response = await client.chat.completions.create(
     {
       model: model.modelName,

--- a/src/services/inference/tinfoil-client.ts
+++ b/src/services/inference/tinfoil-client.ts
@@ -1,6 +1,6 @@
 import { API_BASE_URL } from '@/config'
 import { logError } from '@/utils/error-handling'
-import { ConfigurationError, FetchError, TinfoilAI } from 'tinfoil'
+import { TinfoilAI } from 'tinfoil'
 import { authTokenManager } from '../auth'
 
 const PLACEHOLDER_API_KEY = 'tinfoil-placeholder-api-key'
@@ -101,28 +101,3 @@ export async function getTinfoilClient(): Promise<TinfoilAI> {
   return clientInstance!
 }
 
-export async function getReadyClient(): Promise<TinfoilAI> {
-  const client = await getTinfoilClient()
-  try {
-    await client.ready()
-    return client
-  } catch (error) {
-    if (error instanceof ConfigurationError) {
-      throw error
-    }
-
-    logError('Client verification failed, resetting', error, {
-      component: 'tinfoil-client',
-      action: 'getReadyClient',
-      metadata: {
-        errorType:
-          error instanceof FetchError ? 'FetchError' : 'AttestationError',
-      },
-    })
-
-    resetTinfoilClient()
-    const freshClient = await getTinfoilClient()
-    await freshClient.ready()
-    return freshClient
-  }
-}


### PR DESCRIPTION
This reverts the manual retry/error-handling from 25e1866 and deletes initializeTinfoilClient, getReadyClient, explicit ready() calls, and SDK error imports. The SDK's internal recovery makes all of it unnecessary.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed app-level SDK recovery and ready() calls; recovery is now handled by SecureClient in the Tinfoil SDK. This simplifies client initialization and removes redundant retry logic across chat and uploads.

- **Refactors**
  - Replaced getReadyClient with getTinfoilClient and removed all client.ready() calls in chat-interface, document-uploader, and inference-client.
  - Deleted app-level recovery helpers and SDK error imports; simplified retry checks in inference-client to rely on SDK recovery.

- **Migration**
  - If any external code imports getReadyClient or calls client.ready(), switch to getTinfoilClient and remove ready() calls.

<sup>Written for commit 565b4c91edeee8a73b604df80e15dd24950a2cf0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

