### PR TITLE
chore: update tinfoil package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
         "remark-math": "^6.0.0",
         "tailwind-merge": "^2.6.0",
         "tailwindcss-animate": "^1.0.7",
-        "tinfoil": "^1.0.5",
+        "tinfoil": "^1.1.0",
         "uuid": "^11.0.3"
       },
       "devDependencies": {
@@ -99,13 +99,13 @@
       "license": "MIT"
     },
     "node_modules/@ai-sdk/openai-compatible": {
-      "version": "1.0.22",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/openai-compatible/-/openai-compatible-1.0.22.tgz",
-      "integrity": "sha512-Q+lwBIeMprc/iM+vg1yGjvzRrp74l316wDpqWdbmd4VXXlllblzGsUgBLTeKvcEapFTgqk0FRETvSb58Y6dsfA==",
+      "version": "2.0.30",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai-compatible/-/openai-compatible-2.0.30.tgz",
+      "integrity": "sha512-iTjumHf1/u4NhjXYFn/aONM2GId3/o7J1Lp5ql8FCbgIMyRwrmanR5xy1S3aaVkfTscuDvLTzWiy1mAbGzK3nQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "2.0.0",
-        "@ai-sdk/provider-utils": "3.0.12"
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.15"
       },
       "engines": {
         "node": ">=18"
@@ -115,9 +115,9 @@
       }
     },
     "node_modules/@ai-sdk/provider": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-2.0.0.tgz",
-      "integrity": "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
+      "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "json-schema": "^0.4.0"
@@ -127,14 +127,14 @@
       }
     },
     "node_modules/@ai-sdk/provider-utils": {
-      "version": "3.0.12",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.12.tgz",
-      "integrity": "sha512-ZtbdvYxdMoria+2SlNarEk6Hlgyf+zzcznlD55EAl+7VZvJaSg2sqPvwArY7L6TfDEDJsnCq0fdhBSkYo0Xqdg==",
+      "version": "4.0.15",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.15.tgz",
+      "integrity": "sha512-8XiKWbemmCbvNN0CLR9u3PQiet4gtEVIrX4zzLxnCj06AwsEDJwJVBbKrEI4t6qE8XRSIvU2irka0dcpziKW6w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "2.0.0",
-        "@standard-schema/spec": "^1.0.0",
-        "eventsource-parser": "^3.0.5"
+        "@ai-sdk/provider": "3.0.8",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.6"
       },
       "engines": {
         "node": ">=18"
@@ -1252,9 +1252,9 @@
       "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ=="
     },
     "node_modules/@freedomofpress/crypto-browser": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@freedomofpress/crypto-browser/-/crypto-browser-0.1.6.tgz",
-      "integrity": "sha512-2tCPDKefb7gLzwmBNdCLmLq1h1mPLaHgPYdY+cJjX8W+FjoWZh6VenLEqvNQ7sznAJfagMQJoWHnh53GkG0I2g==",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@freedomofpress/crypto-browser/-/crypto-browser-0.1.7.tgz",
+      "integrity": "sha512-zjWmZDKdAu8g0Zq1IjBQ+sKQ/NpfzStBDFjy/qHUSMVEL4wNlNGtA7lhtw8v8asXa0yqF2QTYQ3rq6xCTQeADw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/curves": "^1.6.0"
@@ -2056,6 +2056,18 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@noble/ciphers": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-2.1.1.tgz",
+      "integrity": "sha512-bysYuiVfhxNJuldNXlFEitTVdNnYUc+XNJZd7Qm2a5j1vZHgY+fazadNFWFaMK/2vye0JVlxV3gHmC0WDfAOQw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@noble/curves": {
       "version": "1.9.7",
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
@@ -2078,6 +2090,49 @@
       "license": "MIT",
       "engines": {
         "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/post-quantum": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@noble/post-quantum/-/post-quantum-0.5.4.tgz",
+      "integrity": "sha512-leww0zzIirrvwaYMPI9fj6aRIlA/c6Y0/lifQQ1YOOyHEr0MNH3yYpjXeiVG+tWdPps4XxGclFWX2INPO3Yo5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~2.0.0",
+        "@noble/hashes": "~2.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/post-quantum/node_modules/@noble/curves": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.0.1.tgz",
+      "integrity": "sha512-vs1Az2OOTBiP4q0pwjW5aF0xp9n4MxVrmkFBxc6EKZc6ddYx5gaZiAsZoq0uRRXWbi3AT/sBqn05eRPtn1JCPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.0.1"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/post-quantum/node_modules/@noble/hashes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
+      "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -2122,6 +2177,51 @@
       "dev": true,
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@panva/hpke-noble": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@panva/hpke-noble/-/hpke-noble-1.0.3.tgz",
+      "integrity": "sha512-ReI7S0xZmLKcYooUBFouOP//4lz2hTYEpZ3/SZmHZFLbqoHNHvSLUqaYH9nwdISYcJ5QGBG3MqQBr6pmBxRlyw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/ciphers": "^2.0.1",
+        "@noble/curves": "^2.0.1",
+        "@noble/hashes": "^2.0.1",
+        "@noble/post-quantum": "^0.5.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      },
+      "peerDependencies": {
+        "hpke": "^1.0.0"
+      }
+    },
+    "node_modules/@panva/hpke-noble/node_modules/@noble/curves": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.0.1.tgz",
+      "integrity": "sha512-vs1Az2OOTBiP4q0pwjW5aF0xp9n4MxVrmkFBxc6EKZc6ddYx5gaZiAsZoq0uRRXWbi3AT/sBqn05eRPtn1JCPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.0.1"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@panva/hpke-noble/node_modules/@noble/hashes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
+      "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -3269,9 +3369,9 @@
       "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ=="
     },
     "node_modules/@standard-schema/spec": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
-      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "license": "MIT"
     },
     "node_modules/@swc/helpers": {
@@ -3424,12 +3524,12 @@
       }
     },
     "node_modules/@tinfoilsh/verifier": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@tinfoilsh/verifier/-/verifier-1.0.5.tgz",
-      "integrity": "sha512-Dejy7U4FBW4ZEV04tN9DF+hHYii8VwuAGGttW899uf3r0LVFEEXIsOeNeBoXwYf+wgiJ4JZhvZbCFnK/jhkdiw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@tinfoilsh/verifier/-/verifier-1.1.0.tgz",
+      "integrity": "sha512-QQtCgZXL868MMnaDxh64NTfUi33/DXtJap343oeAWRCiu+D24fTbZHpZzj+fdcD0p8S41r3lo028sDwu71yZGQ==",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
-        "@freedomofpress/crypto-browser": "^0.1.6",
+        "@freedomofpress/crypto-browser": "^0.1.7",
         "@freedomofpress/sigstore-browser": "^0.1.11",
         "@freedomofpress/tuf-browser": "^0.1.8"
       },
@@ -8083,10 +8183,11 @@
       "integrity": "sha512-PDEfEF102G23vHmPhLyPboFCD+BkMGu+GuJe2d9/eH4FsCwvgBpnc9n0pGE+ffKdph38s6foEZiEjdgHdzp+IA=="
     },
     "node_modules/hpke": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/hpke/-/hpke-1.0.3.tgz",
-      "integrity": "sha512-82pfChKRiz5vQXKSNhXCigoCp+HQWHePqgjJVuIZQFVGCYOCIWL41DAF2o6UJLwHzM7jkOGG55XotA0B5m2+uw==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/hpke/-/hpke-1.0.4.tgz",
+      "integrity": "sha512-/WWT4tf9CPVDi/ciTwQW87xcHLPVUBjGoimacz/Ke2gOe+1FoVo7JxbJS2DmvFQ+ZwwCouK7XocFUekmtMoazg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -10876,16 +10977,16 @@
       }
     },
     "node_modules/openai": {
-      "version": "5.23.2",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-5.23.2.tgz",
-      "integrity": "sha512-MQBzmTulj+MM5O8SKEk/gL8a7s5mktS9zUtAkU257WjvobGc9nKcBuVwjyEEcb9SI8a8Y2G/mzn3vm9n1Jlleg==",
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.22.0.tgz",
+      "integrity": "sha512-7Yvy17F33Bi9RutWbsaYt5hJEEJ/krRPOrwan+f9aCPuMat1WVsb2VNSII5W1EksKT6fF69TG/xj4XzodK3JZw==",
       "license": "Apache-2.0",
       "bin": {
         "openai": "bin/cli"
       },
       "peerDependencies": {
         "ws": "^8.18.0",
-        "zod": "^3.23.8"
+        "zod": "^3.25 || ^4.0"
       },
       "peerDependenciesMeta": {
         "ws": {
@@ -13185,22 +13286,22 @@
       }
     },
     "node_modules/tinfoil": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/tinfoil/-/tinfoil-1.0.5.tgz",
-      "integrity": "sha512-mqAf6Qv6x0W+xeOp//qgb5WZH1xlXnTYOjFXc/iYSuKXsb7LBB6nTHlCAzTENgllz64NlDoqnYl6xaHv8atl9w==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/tinfoil/-/tinfoil-1.1.0.tgz",
+      "integrity": "sha512-sQipH1ug+EFjIgFZAWRs0sqaOr5bc2cVsxZ7rrbIgaxVU6x9D3OKtAeUpmRN77PrR+kBYfVlfLTBZExEsWDQFw==",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
-        "@ai-sdk/openai-compatible": "^1.0.10",
+        "@ai-sdk/openai-compatible": "^2.0.26",
         "@freedomofpress/sigstore-browser": "^0.1.11",
-        "@tinfoilsh/verifier": "1.0.5",
-        "ehbp": "^0.1.5",
-        "openai": "^5.13.1"
+        "@tinfoilsh/verifier": "1.1.0",
+        "ehbp": "^0.1.7",
+        "openai": "^6.17.0"
       },
       "engines": {
         "node": ">=20"
       },
       "peerDependencies": {
-        "ai": "^5.0.19"
+        "ai": "^6.0.69"
       },
       "peerDependenciesMeta": {
         "ai": {
@@ -13209,11 +13310,12 @@
       }
     },
     "node_modules/tinfoil/node_modules/ehbp": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/ehbp/-/ehbp-0.1.5.tgz",
-      "integrity": "sha512-gI8IQby3PdOpAjL+Yu5IUA9Ot4DJJD7MT79ft5kGZplg1wif5NNMG14KPKc3PHb6ef9Nu0WBsPqilu/kWNT2KA==",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/ehbp/-/ehbp-0.1.7.tgz",
+      "integrity": "sha512-mtebY3nTTdkD2FzNExPdXEBshjFmHAna5HKEgKSVZg0ySx5ji5H/V2P5QTdu3bczTopvvrNgqcHnjZ2qIbOjoQ==",
       "license": "MIT",
       "dependencies": {
+        "@panva/hpke-noble": "^1.0.3",
         "hpke": "^1.0.1"
       },
       "engines": {
@@ -14523,9 +14625,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
       "peer": true,
       "funding": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "remark-math": "^6.0.0",
     "tailwind-merge": "^2.6.0",
     "tailwindcss-animate": "^1.0.7",
-    "tinfoil": "^1.0.5",
+    "tinfoil": "^1.1.0",
     "uuid": "^11.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Upgrade tinfoil to ^1.1.0 to pick up the latest verifier and align with OpenAI/AI SDK v6. This keeps verification dependencies current and reduces future compatibility issues.

- **Dependencies**
  - Transitive updates: @tinfoilsh/verifier 1.1.0 and @freedomofpress/crypto-browser 0.1.7.
  - OpenAI SDK updated to 6.x; AI provider packages bumped (@ai-sdk/openai-compatible 2.x, provider 3.x).
  - ehbp 0.1.7 with HPKE updates; adds @panva/hpke-noble and new @noble/* crypto packages.
  - zod peer moved to v4 (only relevant if installed in the app).

- **Migration**
  - If using the ai package, upgrade to ^6.x to satisfy tinfoil’s peer requirement.
  - Node 20+ required (unchanged). No app code changes expected.

<sup>Written for commit 2c1af12037d6b209460afb93021b233b639405e7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

