### PR TITLE
fix: clear out active user on signout

### DIFF
--- a/src/components/auth-cleanup-handler.tsx
+++ b/src/components/auth-cleanup-handler.tsx
@@ -50,6 +50,7 @@ export function AuthCleanupHandler() {
   }, [isSignedIn, isLoaded, user?.id])
 
   const handleKeepData = () => {
+    localStorage.removeItem(ACTIVE_USER_ID_KEY)
     setShowModal(false)
     // Force reload to clear all React state
     window.location.reload()


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Clear the active user ID from localStorage on sign out to prevent auto-selecting the previous user and ensure a clean session after reload. We now remove ACTIVE_USER_ID_KEY in AuthCleanupHandler before forcing a reload.

<sup>Written for commit a62630b7ca0a0f20e93af7fa77168a4ef574ce94. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

