### PR TITLE
Revert "feat: add chat key ttl and auto-retry on 401 errors"

### DIFF
--- a/src/services/inference/tinfoil-client.ts
+++ b/src/services/inference/tinfoil-client.ts
@@ -4,12 +4,10 @@ import { TinfoilAI } from 'tinfoil'
 import { authTokenManager } from '../auth'
 
 const PLACEHOLDER_API_KEY = 'tinfoil-placeholder-api-key'
-const API_KEY_TTL_MS = 5 * 60 * 1000 // 5 minutes
 
 let clientInstance: TinfoilAI | null = null
 let lastApiKey: string | null = null
 let cachedApiKey: string | null = null
-let cachedApiKeyTimestamp: number | null = null
 let hasSubscriptionFn: (() => boolean) | null = null
 
 export function setSubscriptionChecker(hasSubscription: () => boolean): void {
@@ -23,12 +21,7 @@ async function fetchApiKey(): Promise<string> {
     return PLACEHOLDER_API_KEY
   }
 
-  const now = Date.now()
-  if (
-    cachedApiKey &&
-    cachedApiKeyTimestamp &&
-    now - cachedApiKeyTimestamp < API_KEY_TTL_MS
-  ) {
+  if (cachedApiKey) {
     return cachedApiKey
   }
 
@@ -65,7 +58,6 @@ async function fetchApiKey(): Promise<string> {
 
     const data = await response.json()
     cachedApiKey = data.key
-    cachedApiKeyTimestamp = Date.now()
     return data.key
   } catch (error) {
     logError('Failed to fetch API key', error, {
@@ -80,12 +72,6 @@ export function resetTinfoilClient(): void {
   clientInstance = null
   lastApiKey = null
   cachedApiKey = null
-  cachedApiKeyTimestamp = null
-}
-
-export function clearCachedApiKey(): void {
-  cachedApiKey = null
-  cachedApiKeyTimestamp = null
 }
 
 async function initClient(apiKey: string): Promise<TinfoilAI> {


### PR DESCRIPTION
Reverts tinfoilsh/tinfoil-chat#187

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts chat API key TTL caching and 401 auto-retry to restore previous, stable request behavior. Chat streaming and title generation now make a single client call with the current key; no TTL and no auth retry.

- **Refactors**
  - Removed API key TTL and clearCachedApiKey; keep a single cached key until reset.
  - Dropped AuthenticationError catch/retry in chat stream and title generation; calls go directly through getTinfoilClient.

<sup>Written for commit 90f6e81c0234fcd62d4a301a4e6eebc643cf6bc6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

