### PR TITLE
Improvements to chat layout

### DIFF
--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -2227,7 +2227,7 @@ export function ChatInterface({
             data-scroll-container="main"
             className="relative flex flex-1 overflow-y-auto bg-surface-chat-background"
           >
-            <div className="flex min-w-0 flex-1">
+            <div className="flex min-w-0 flex-1 [container-type:inline-size]">
               <ChatMessages
                 messages={currentChat?.messages || []}
                 isDarkMode={isDarkMode}

--- a/src/components/chat/chat-messages.tsx
+++ b/src/components/chat/chat-messages.tsx
@@ -430,7 +430,7 @@ export function ChatMessages({
 
   return (
     <div
-      className={`mx-auto w-full min-w-0 max-w-3xl px-4 pb-6 pt-24 ${CHAT_FONT_CLASSES[chatFont]}`}
+      className={`mx-auto w-full min-w-0 px-4 pb-6 pt-24 ${CHAT_FONT_CLASSES[chatFont]}`}
     >
       {/* Archived Messages - only shown if there are more than the max prompt messages */}
       {archivedMessages.length > 0 && (

--- a/src/components/chat/renderers/components/ExpandableTable.tsx
+++ b/src/components/chat/renderers/components/ExpandableTable.tsx
@@ -1,0 +1,92 @@
+'use client'
+
+import { ChevronLeftIcon, ChevronRightIcon } from '@heroicons/react/24/outline'
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+const COLLAPSED_MAX_WIDTH_REM = 52
+
+interface ExpandableTableProps {
+  children: React.ReactNode
+}
+
+export function ExpandableTable({ children }: ExpandableTableProps) {
+  const [isExpanded, setIsExpanded] = useState(false)
+  const [canExpand, setCanExpand] = useState(false)
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  const checkOverflow = useCallback(() => {
+    const el = containerRef.current
+    if (!el) return
+    const collapsedPx =
+      COLLAPSED_MAX_WIDTH_REM *
+      parseFloat(getComputedStyle(document.documentElement).fontSize)
+    setCanExpand(el.scrollWidth > collapsedPx)
+  }, [])
+
+  useEffect(() => {
+    checkOverflow()
+
+    const observer = new ResizeObserver(checkOverflow)
+    if (containerRef.current) {
+      observer.observe(containerRef.current)
+    }
+    return () => observer.disconnect()
+  }, [checkOverflow])
+
+  const toggle = () => setIsExpanded((prev) => !prev)
+
+  const chevronBase =
+    'pointer-events-auto flex h-7 w-7 items-center justify-center rounded-full border border-border-subtle bg-white text-content-secondary shadow hover:text-content-primary dark:bg-zinc-800'
+
+  const collapsed = canExpand && !isExpanded
+  const expanded = canExpand && isExpanded
+
+  return (
+    <div
+      className={`table-breakout group/table relative my-4 ${collapsed ? 'rounded-lg border border-border-subtle' : ''}`}
+      style={{
+        maxWidth: isExpanded
+          ? 'calc(100cqw - 2rem)'
+          : `${COLLAPSED_MAX_WIDTH_REM}rem`,
+      }}
+    >
+      <div ref={containerRef} className="relative z-0 overflow-x-auto">
+        <table
+          className="divide-y divide-border-subtle"
+          style={{ minWidth: 'max-content' }}
+        >
+          {children}
+        </table>
+      </div>
+
+      {canExpand && (
+        <div className="pointer-events-none absolute inset-0 z-10">
+          <button
+            type="button"
+            onClick={toggle}
+            className={`${chevronBase} absolute left-1.5 top-1/2 -translate-y-1/2 ${expanded ? 'opacity-0 transition-opacity group-hover/table:opacity-100' : ''}`}
+            aria-label={collapsed ? 'Expand table' : 'Collapse table'}
+          >
+            {collapsed ? (
+              <ChevronLeftIcon className="h-4 w-4" />
+            ) : (
+              <ChevronRightIcon className="h-4 w-4" />
+            )}
+          </button>
+          <button
+            type="button"
+            onClick={toggle}
+            className={`${chevronBase} absolute right-1.5 top-1/2 -translate-y-1/2 ${expanded ? 'opacity-0 transition-opacity group-hover/table:opacity-100' : ''}`}
+            aria-label={collapsed ? 'Expand table' : 'Collapse table'}
+          >
+            {collapsed ? (
+              <ChevronRightIcon className="h-4 w-4" />
+            ) : (
+              <ChevronLeftIcon className="h-4 w-4" />
+            )}
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/chat/renderers/components/markdown-components.tsx
+++ b/src/components/chat/renderers/components/markdown-components.tsx
@@ -7,6 +7,7 @@ import {
 import { sanitizeUrl } from '@braintree/sanitize-url'
 import { useState } from 'react'
 import type { Components } from 'react-markdown'
+import { ExpandableTable } from './ExpandableTable'
 
 function getFaviconUrl(url: string): string {
   try {
@@ -159,18 +160,8 @@ export function createMarkdownComponents({
     },
 
     // Table elements
-    table({ children, ...props }: any) {
-      return (
-        <div className="my-4 w-full overflow-x-auto">
-          <table
-            {...props}
-            className="divide-y divide-border-subtle"
-            style={{ minWidth: 'max-content' }}
-          >
-            {children}
-          </table>
-        </div>
-      )
+    table({ children }: any) {
+      return <ExpandableTable>{children}</ExpandableTable>
     },
 
     thead({ children, ...props }: any) {
@@ -202,7 +193,6 @@ export function createMarkdownComponents({
           {...props}
           className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-content-primary"
           style={{
-            maxWidth: '300px',
             wordWrap: 'break-word',
             whiteSpace: 'normal',
           }}
@@ -218,7 +208,6 @@ export function createMarkdownComponents({
           {...props}
           className="px-4 py-3 text-sm text-content-primary"
           style={{
-            maxWidth: '300px',
             wordWrap: 'break-word',
             whiteSpace: 'normal',
           }}

--- a/src/components/chat/renderers/default/DefaultMessageRenderer.tsx
+++ b/src/components/chat/renderers/default/DefaultMessageRenderer.tsx
@@ -189,7 +189,7 @@ const DefaultMessageComponent = ({
 
   return (
     <div
-      className={`relative flex flex-col ${isUser ? 'items-end' : 'w-full items-start'} group mb-6`}
+      className={`relative mx-auto flex w-full max-w-3xl flex-col ${isUser ? 'items-end' : 'items-start'} group mb-6`}
       data-message-role={message.role}
     >
       {/* Display documents and images for user messages */}
@@ -295,7 +295,7 @@ const DefaultMessageComponent = ({
                   >
                     <div
                       className={cn(
-                        'prose w-full max-w-none overflow-x-auto text-lg prose-pre:bg-transparent prose-pre:p-0',
+                        'prose w-full max-w-none text-lg prose-pre:bg-transparent prose-pre:p-0',
                         'text-content-primary prose-headings:text-content-primary prose-strong:text-content-primary prose-code:text-content-primary',
                         'prose-a:text-blue-500 hover:prose-a:text-blue-600',
                       )}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -136,8 +136,17 @@
   -webkit-overflow-scrolling: touch;
 }
 
+/* Allow tables to break out of the max-w-3xl message container */
+.table-breakout {
+  width: fit-content;
+  position: relative;
+  left: 50%;
+  transform: translateX(-50%);
+  transition: max-width 0.3s ease;
+}
+
 /* Prevent horizontal scroll at message level */
-.prose > * {
+.prose > *:not(.table-breakout) {
   max-width: 100%;
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Improved chat readability by collapsing long user messages and adding expandable, full-width tables. This reduces scrolling and makes wide content easier to view without breaking the layout.

- New Features
  - Collapsible user messages: auto-detect overflow, fade-out gradient, and a Show more/less toggle.
  - Expandable tables: new ExpandableTable wraps markdown tables, collapsed at 52rem with left/right chevrons to expand to full container width; auto-detects overflow and centers the table.
  - Layout/CSS tweaks: added container queries to the main pane, moved max width to each message, enabled table breakout while preventing horizontal scroll for other prose.

<sup>Written for commit 1e3cea98236b758013be2e4c9973c850072ec4f3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

