### PR TITLE
fix: loading dot positioning

### DIFF
--- a/src/components/chat/chat-messages.tsx
+++ b/src/components/chat/chat-messages.tsx
@@ -214,7 +214,7 @@ const LoadingMessage = memo(function LoadingMessage({
   }
 
   return (
-    <div className="no-scroll-anchoring group mb-6 flex w-full flex-col items-start px-4">
+    <div className="no-scroll-anchoring group mx-auto mb-6 flex w-full max-w-3xl flex-col items-start px-4">
       <div className="flex items-center gap-3">
         <LoadingDots isThinking={false} />
         {isRetrying && (


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Centered the loading dots and aligned the loading message with the chat content by constraining its container width and centering it. Fixes misaligned dots on wide screens.

<sup>Written for commit 77f1f9a8955578e7411e98a86b53e459bcfa0242. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

