### PR TITLE
fix: encode tildes in citation URLs and titles

### DIFF
--- a/src/components/chat/hooks/streaming-processor.ts
+++ b/src/components/chat/hooks/streaming-processor.ts
@@ -29,22 +29,21 @@ export function processCitationMarkers(
 ): string {
   if (sources.length === 0) return content
 
-  return content.replace(
-    /【(\d+)[^】]*】([.!?,;:。，！？；：]?)/g,
-    (match, num, punct) => {
-      const index = parseInt(num, 10) - 1
-      const source = sources[index]
-      if (!source) return match
-      const encodedUrl = source.url
-        .replace(/\(/g, '%28')
-        .replace(/\)/g, '%29')
-        .replace(/\|/g, '%7C')
-      const encodedTitle = encodeURIComponent(source.title || '')
-        .replace(/\(/g, '%28')
-        .replace(/\)/g, '%29')
-      return `${punct}[${num}](#cite-${num}~${encodedUrl}~${encodedTitle})`
-    },
-  )
+  return content.replace(/【(\d+)[^】]*】/g, (match, num) => {
+    const index = parseInt(num, 10) - 1
+    const source = sources[index]
+    if (!source) return match
+    const encodedUrl = source.url
+      .replace(/\(/g, '%28')
+      .replace(/\)/g, '%29')
+      .replace(/\|/g, '%7C')
+      .replace(/~/g, '%7E')
+    const encodedTitle = encodeURIComponent(source.title || '')
+      .replace(/\(/g, '%28')
+      .replace(/\)/g, '%29')
+      .replace(/~/g, '%7E')
+    return `[${num}](#cite-${num}~${encodedUrl}~${encodedTitle})`
+  })
 }
 
 export interface StreamingContext {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Encodes tildes in citation URLs and titles and standardizes punctuation to appear after citation links. This prevents broken cite anchors and fixes formatting for adjacent citations and CJK punctuation.

- **Bug Fixes**
  - Encode ~ as %7E in URLs and titles to avoid delimiter conflicts in #cite anchors.
  - Place punctuation after citation links (including CJK); no punctuation between adjacent citations.

<sup>Written for commit 0870c209bac4423f458fbad8820e9e190bb9d518. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

