### PR TITLE
fix: show actionable error when passkey provider not supported

### DIFF
--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -22,6 +22,7 @@ import { cloudStorage } from '@/services/cloud/cloud-storage'
 import { cloudSync } from '@/services/cloud/cloud-sync'
 import { projectStorage } from '@/services/cloud/project-storage'
 import { encryptionService } from '@/services/encryption/encryption-service'
+import { PrfNotSupportedError } from '@/services/passkey'
 import { chatStorage } from '@/services/storage/chat-storage'
 import { TINFOIL_COLORS } from '@/theme/colors'
 import {
@@ -786,11 +787,16 @@ export function SettingsModal({
           setIsOpen(false)
           try {
             await onSetupPasskey()
-          } catch {
+          } catch (error) {
             toast({
-              title: 'Passkey setup failed',
+              title:
+                error instanceof PrfNotSupportedError
+                  ? 'Passkey provider not supported'
+                  : 'Passkey setup failed',
               description:
-                'Could not create passkey backup. You can try again later.',
+                error instanceof PrfNotSupportedError
+                  ? error.message
+                  : 'Could not create passkey backup. You can try again later.',
               variant: 'destructive',
             })
           }
@@ -2797,11 +2803,16 @@ ${encryptionKey.replace('key_', '')}
                                         'Your encryption key is now backed up with your passkey',
                                     })
                                   }
-                                } catch {
+                                } catch (error) {
                                   toast({
-                                    title: 'Passkey setup failed',
+                                    title:
+                                      error instanceof PrfNotSupportedError
+                                        ? 'Passkey provider not supported'
+                                        : 'Passkey setup failed',
                                     description:
-                                      'Could not create passkey backup. You can try again later.',
+                                      error instanceof PrfNotSupportedError
+                                        ? error.message
+                                        : 'Could not create passkey backup. You can try again later.',
                                     variant: 'destructive',
                                   })
                                 } finally {

--- a/src/components/modals/cloud-sync-setup-modal.tsx
+++ b/src/components/modals/cloud-sync-setup-modal.tsx
@@ -1,6 +1,7 @@
 import { SETTINGS_HAS_SEEN_CLOUD_SYNC_MODAL } from '@/constants/storage-keys'
 import { useToast } from '@/hooks/use-toast'
 import { encryptionService } from '@/services/encryption/encryption-service'
+import { PrfNotSupportedError } from '@/services/passkey'
 import { TINFOIL_COLORS } from '@/theme/colors'
 import { setCloudSyncEnabled as persistCloudSyncEnabled } from '@/utils/cloud-sync-settings'
 import { logError, logInfo } from '@/utils/error-handling'
@@ -662,15 +663,24 @@ ${generatedKey.replace('key_', '')}
         })
       }
     } catch (error) {
-      logError('Start fresh failed', error, {
-        component: 'CloudSyncSetupModal',
-        action: 'handleStartFresh',
-      })
-      toast({
-        title: 'Setup failed',
-        description: 'Could not create a new encryption key. Please try again.',
-        variant: 'destructive',
-      })
+      if (error instanceof PrfNotSupportedError) {
+        toast({
+          title: 'Passkey provider not supported',
+          description: error.message,
+          variant: 'destructive',
+        })
+      } else {
+        logError('Start fresh failed', error, {
+          component: 'CloudSyncSetupModal',
+          action: 'handleStartFresh',
+        })
+        toast({
+          title: 'Setup failed',
+          description:
+            'Could not create a new encryption key. Please try again.',
+          variant: 'destructive',
+        })
+      }
     } finally {
       setIsStartingFresh(false)
     }

--- a/src/hooks/use-passkey-backup.ts
+++ b/src/hooks/use-passkey-backup.ts
@@ -11,6 +11,7 @@ import {
   getCachedPrfResult,
   hasPasskeyCredentials,
   loadPasskeyCredentials,
+  PrfNotSupportedError,
   retrieveEncryptedKeys,
   storeEncryptedKeys,
 } from '@/services/passkey'
@@ -483,6 +484,22 @@ export function usePasskeyBackup({
           })
         }
       } catch (error) {
+        if (error instanceof PrfNotSupportedError) {
+          logInfo(
+            'Authenticator does not support PRF during first-time setup',
+            {
+              component: 'usePasskeyBackup',
+              action: 'setupFirstTimePasskeyUser',
+            },
+          )
+          if (isMountedRef.current) {
+            setState((prev) => ({
+              ...prev,
+              passkeySetupAvailable: true,
+            }))
+          }
+          return
+        }
         logError('First-time passkey user setup failed', error, {
           component: 'usePasskeyBackup',
           action: 'setupFirstTimePasskeyUser',
@@ -543,6 +560,7 @@ export function usePasskeyBackup({
       })
       return true
     } catch (error) {
+      if (error instanceof PrfNotSupportedError) throw error
       logError('Passkey setup failed', error, {
         component: 'usePasskeyBackup',
         action: 'setupPasskey',
@@ -569,6 +587,7 @@ export function usePasskeyBackup({
       })
       return newKey
     } catch (error) {
+      if (error instanceof PrfNotSupportedError) throw error
       logError('Failed to create new key split', error, {
         component: 'usePasskeyBackup',
         action: 'setupNewKeySplit',
@@ -590,9 +609,21 @@ export function usePasskeyBackup({
     }
 
     try {
-      const success = await setupPasskey()
+      let success = false
+      try {
+        success = await setupPasskey()
+      } catch (error) {
+        if (error instanceof PrfNotSupportedError) {
+          logInfo('Authenticator does not support PRF during intro setup', {
+            component: 'usePasskeyBackup',
+            action: 'acceptPasskeyIntro',
+          })
+        } else {
+          throw error
+        }
+      }
       if (!success && isMountedRef.current) {
-        // User cancelled the browser WebAuthn prompt — show option in settings
+        // User cancelled or provider unsupported — show option in settings
         setState((prev) => ({ ...prev, passkeySetupAvailable: true }))
       }
 

--- a/src/services/passkey/index.ts
+++ b/src/services/passkey/index.ts
@@ -9,6 +9,7 @@ export {
 } from './passkey-key-storage'
 export type { KeyBundle, PasskeyCredentialEntry } from './passkey-key-storage'
 export {
+  PrfNotSupportedError,
   authenticatePrfPasskey,
   clearCachedPrfResult,
   createPrfPasskey,

--- a/src/services/passkey/passkey-service.ts
+++ b/src/services/passkey/passkey-service.ts
@@ -20,6 +20,15 @@ import {
 } from '@/utils/binary-codec'
 import { logError, logInfo } from '@/utils/error-handling'
 
+export class PrfNotSupportedError extends Error {
+  constructor() {
+    super(
+      "Your passkey provider doesn't support the security features required by Tinfoil. Try using iCloud Keychain, Chrome's built-in passkey manager, or the Passwords app in your device settings.",
+    )
+    this.name = 'PrfNotSupportedError'
+  }
+}
+
 // Salt passed to PRF eval.first — the client internally computes:
 // SHA-256("WebAuthn PRF" || 0x00 || PRF_EVAL_FIRST)
 const PRF_EVAL_FIRST = new TextEncoder().encode('tinfoil-chat-key-encryption')
@@ -135,7 +144,7 @@ export async function createPrfPasskey(
         component: 'PasskeyService',
         action: 'createPrfPasskey',
       })
-      return null
+      throw new PrfNotSupportedError()
     }
 
     const credentialId = uint8ArrayToBase64Url(new Uint8Array(credential.rawId))
@@ -163,6 +172,8 @@ export async function createPrfPasskey(
     )
     return await authenticatePrfPasskey([credentialId])
   } catch (error) {
+    if (error instanceof PrfNotSupportedError) throw error
+
     // DOMException with name "NotAllowedError" means the user cancelled
     if (error instanceof DOMException && error.name === 'NotAllowedError') {
       logInfo('User cancelled passkey creation', {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Show an actionable error when a user's passkey provider doesn't support the required security features, and handle this case cleanly across passkey setup flows. Users now get guidance on supported providers and can retry setup later.

- **Bug Fixes**
  - Added PrfNotSupportedError in passkey-service and exported it; createPrfPasskey now throws this when WebAuthn PRF is unsupported.
  - Updated SettingsModal and CloudSyncSetupModal to show “Passkey provider not supported” and include the error’s guidance (e.g., use iCloud Keychain, Chrome’s passkey manager, or the Passwords app).
  - use-passkey-backup handles this error in first-time and intro setup: logs info, keeps passkeySetupAvailable so users can retry; rethrows in setupPasskey/setupNewKeySplit to avoid silent failures.

<sup>Written for commit 3f9a0242b6f3d3a02518a68cd0d5f1b2132e6d62. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

