### PR TITLE
feat: custom default user avatar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@tailwindcss/typography": "^0.5.16",
         "@tinfoilsh/tinfoil-icons": "^1.1.1",
         "autoprefixer": "^10.4.21",
+        "boring-avatars": "^2.0.4",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "framer-motion": "^11.18.2",
@@ -5054,6 +5055,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/boring-avatars": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/boring-avatars/-/boring-avatars-2.0.4.tgz",
+      "integrity": "sha512-xhZO/w/6aFmRfkaWohcl2NfyIy87gK5SBbys8kctZeTGF1Apjpv/10pfUuv+YEfVPkESU/h2Y6tt/Dwp+bIZPw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
       }
     },
     "node_modules/brace-expansion": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@tailwindcss/typography": "^0.5.16",
     "@tinfoilsh/tinfoil-icons": "^1.1.1",
     "autoprefixer": "^10.4.21",
+    "boring-avatars": "^2.0.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "framer-motion": "^11.18.2",

--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -1,5 +1,6 @@
 import { TextureGrid } from '@/components/texture-grid'
 import { cn } from '@/components/ui/utils'
+import { UserAvatar } from '@/components/user-avatar'
 import { API_BASE_URL } from '@/config'
 import {
   SETTINGS_CHAT_FONT,
@@ -38,7 +39,7 @@ import {
 } from '@/utils/cloud-sync-settings'
 import { logError, logInfo } from '@/utils/error-handling'
 import { generateReverseId } from '@/utils/reverse-id'
-import { SignInButton, UserButton, useAuth, useUser } from '@clerk/nextjs'
+import { SignInButton, useAuth, useUser } from '@clerk/nextjs'
 import {
   ArrowDownTrayIcon,
   ArrowPathIcon,
@@ -1758,12 +1759,8 @@ ${encryptionKey.replace('key_', '')}
                     : 'text-content-secondary hover:bg-surface-chat/50',
                 )}
               >
-                {item.id === 'account' && isSignedIn && user?.imageUrl ? (
-                  <img
-                    src={user.imageUrl}
-                    alt=""
-                    className="h-4 w-4 rounded-full object-cover"
-                  />
+                {item.id === 'account' && isSignedIn ? (
+                  <UserAvatar size={16} />
                 ) : (
                   <item.icon className="h-4 w-4" />
                 )}
@@ -1798,12 +1795,8 @@ ${encryptionKey.replace('key_', '')}
                     : 'text-content-secondary hover:bg-surface-chat/50',
                 )}
               >
-                {item.id === 'account' && isSignedIn && user?.imageUrl ? (
-                  <img
-                    src={user.imageUrl}
-                    alt=""
-                    className="h-5 w-5 rounded-full object-cover"
-                  />
+                {item.id === 'account' && isSignedIn ? (
+                  <UserAvatar size={20} />
                 ) : (
                   <item.icon className="h-5 w-5" />
                 )}
@@ -3390,13 +3383,7 @@ ${encryptionKey.replace('key_', '')}
                       >
                         <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between md:gap-4">
                           <div className="flex items-center gap-4">
-                            <UserButton
-                              appearance={{
-                                elements: {
-                                  avatarBox: 'w-12 h-12',
-                                },
-                              }}
-                            />
+                            <UserAvatar size={48} />
                             <div>
                               <div className="font-aeonik text-base font-medium text-content-primary">
                                 {user?.firstName

--- a/src/components/user-avatar.tsx
+++ b/src/components/user-avatar.tsx
@@ -1,0 +1,73 @@
+'use client'
+
+import { useUser } from '@clerk/nextjs'
+import Avatar from 'boring-avatars'
+
+const AVATAR_COLORS = ['#061820', '#004444', '#68C7AC', '#F0F4F4', '#F9F8F6']
+
+type UserAvatarProps = {
+  size?: number
+  className?: string
+}
+
+export function UserAvatar({ size = 32, className }: UserAvatarProps) {
+  const { user } = useUser()
+
+  if (!user) return null
+
+  const displayName =
+    [user.firstName, user.lastName].filter(Boolean).join(' ') || user.id
+  const initials = (
+    user.firstName?.[0] ||
+    user.lastName?.[0] ||
+    ''
+  ).toUpperCase()
+  const fontSize = size * 0.4
+
+  if (user.hasImage) {
+    return (
+      <img
+        src={user.imageUrl}
+        alt={displayName}
+        width={size}
+        height={size}
+        className={className}
+        style={{ borderRadius: '50%' }}
+      />
+    )
+  }
+
+  return (
+    <div
+      className={className}
+      style={{ position: 'relative', width: size, height: size }}
+    >
+      <Avatar
+        size={size}
+        name={user.id}
+        variant="pixel"
+        colors={AVATAR_COLORS}
+      />
+      {initials && (
+        <span
+          style={{
+            position: 'absolute',
+            inset: 0,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            fontSize,
+            fontWeight: 800,
+            color: 'white',
+            textShadow:
+              '0 1px 3px rgba(0, 0, 0, 0.8), 0 0 6px rgba(0, 0, 0, 0.4)',
+            letterSpacing: '0.02em',
+            pointerEvents: 'none',
+          }}
+        >
+          {initials}
+        </span>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a custom UserAvatar component that shows the Clerk profile image when available and a generated default avatar with initials otherwise. Replaces avatar rendering in Settings for a consistent, always-present avatar.

- **New Features**
  - Added src/components/user-avatar.tsx with size support, a pixel-style fallback (boring-avatars), and initials overlay.
  - Replaced inline <img> and <UserButton> in settings-modal with <UserAvatar> (16, 20, 48).

- **Dependencies**
  - Added boring-avatars ^2.0.4.

<sup>Written for commit 8b55bb3981f5e0fed3250c8522f914fc87a0f2b8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

