### PR TITLE
fix: update default avatar color

### DIFF
--- a/src/components/user-avatar.tsx
+++ b/src/components/user-avatar.tsx
@@ -3,7 +3,7 @@
 import { useUser } from '@clerk/nextjs'
 import Avatar from 'boring-avatars'
 
-const AVATAR_COLORS = ['#061820', '#004444', '#68C7AC', '#F0F4F4', '#F9F8F6']
+const AVATAR_COLORS = ['#004444', '#F9F8F6']
 
 type UserAvatarProps = {
   size?: number
@@ -17,12 +17,6 @@ export function UserAvatar({ size = 32, className }: UserAvatarProps) {
 
   const displayName =
     [user.firstName, user.lastName].filter(Boolean).join(' ') || user.id
-  const initials = (
-    user.firstName?.[0] ||
-    user.lastName?.[0] ||
-    ''
-  ).toUpperCase()
-  const fontSize = size * 0.4
 
   if (user.hasImage) {
     return (
@@ -38,36 +32,6 @@ export function UserAvatar({ size = 32, className }: UserAvatarProps) {
   }
 
   return (
-    <div
-      className={className}
-      style={{ position: 'relative', width: size, height: size }}
-    >
-      <Avatar
-        size={size}
-        name={user.id}
-        variant="pixel"
-        colors={AVATAR_COLORS}
-      />
-      {initials && (
-        <span
-          style={{
-            position: 'absolute',
-            inset: 0,
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            fontSize,
-            fontWeight: 800,
-            color: 'white',
-            textShadow:
-              '0 1px 3px rgba(0, 0, 0, 0.8), 0 0 6px rgba(0, 0, 0, 0.4)',
-            letterSpacing: '0.02em',
-            pointerEvents: 'none',
-          }}
-        >
-          {initials}
-        </span>
-      )}
-    </div>
+    <Avatar size={size} name={user.id} variant="pixel" colors={AVATAR_COLORS} />
   )
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated the default user avatar colors and simplified the fallback avatar for a cleaner, consistent look. The avatar now uses a two-color palette (#004444, #F9F8F6) and renders the Avatar component directly without an initials overlay.

<sup>Written for commit da926ca2cd64b0bee17bf9559abff47d02b15f2f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

