### PR TITLE
fix: cap markdown table column width

### DIFF
--- a/src/components/chat/constants.ts
+++ b/src/components/chat/constants.ts
@@ -16,6 +16,8 @@ export const CONSTANTS = {
   DEFAULT_AUDIO_MODEL: 'voxtral-small-24b',
   // Copy button timeout in milliseconds (2 seconds)
   COPY_TIMEOUT_MS: 2000,
+  // Maximum width for table columns in pixels
+  TABLE_COLUMN_MAX_WIDTH_PX: 300,
   // Chat initialization delay in milliseconds
   CHAT_INIT_DELAY_MS: 300,
   // State update delay for async operations

--- a/src/components/chat/renderers/components/markdown-components.tsx
+++ b/src/components/chat/renderers/components/markdown-components.tsx
@@ -1,3 +1,4 @@
+import { CONSTANTS } from '@/components/chat/constants'
 import { CodeBlock } from '@/components/code-block'
 import {
   Tooltip,
@@ -193,6 +194,7 @@ export function createMarkdownComponents({
           {...props}
           className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-content-primary"
           style={{
+            maxWidth: CONSTANTS.TABLE_COLUMN_MAX_WIDTH_PX,
             wordWrap: 'break-word',
             whiteSpace: 'normal',
           }}
@@ -208,6 +210,7 @@ export function createMarkdownComponents({
           {...props}
           className="px-4 py-3 text-sm text-content-primary"
           style={{
+            maxWidth: CONSTANTS.TABLE_COLUMN_MAX_WIDTH_PX,
             wordWrap: 'break-word',
             whiteSpace: 'normal',
           }}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Capped markdown table column width to 300px to stop wide columns from breaking layout in chat. Adds TABLE_COLUMN_MAX_WIDTH_PX and applies it to table headers and cells in the markdown renderer for better readability.

<sup>Written for commit b294a89c6367229443de97f1303b86a964cac537. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

