### PR TITLE
fix: kimi k2.5 reasoning output

### DIFF
--- a/src/components/chat/hooks/streaming-processor.ts
+++ b/src/components/chat/hooks/streaming-processor.ts
@@ -416,9 +416,11 @@ export async function processStreamingResponse(
           }
 
           const deltaReasoningContent =
-            json.choices?.[0]?.delta?.reasoning_content
+            json.choices?.[0]?.delta?.reasoning_content ??
+            json.choices?.[0]?.delta?.reasoning
           const messageReasoningContent =
-            json.choices?.[0]?.message?.reasoning_content
+            json.choices?.[0]?.message?.reasoning_content ??
+            json.choices?.[0]?.message?.reasoning
           const hasReasoningContent =
             (deltaReasoningContent !== undefined &&
               deltaReasoningContent !== null) ||
@@ -426,7 +428,9 @@ export async function processStreamingResponse(
               messageReasoningContent !== null)
           const reasoningContent =
             json.choices?.[0]?.message?.reasoning_content ||
+            json.choices?.[0]?.message?.reasoning ||
             json.choices?.[0]?.delta?.reasoning_content ||
+            json.choices?.[0]?.delta?.reasoning ||
             ''
           let content = json.choices?.[0]?.delta?.content || ''
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add fallback for Kimi K2.5 reasoning output in the streaming processor. We now read `reasoning` when `reasoning_content` is missing for both delta and message objects so reasoning text renders consistently during streaming.

<sup>Written for commit 6ec11f271e1189b92263e8ebb221389ece9a758e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

