### PR TITLE
refactor: replace in-line summarization with summary endpoint

### DIFF
--- a/src/components/chat/chat-messages.tsx
+++ b/src/components/chat/chat-messages.tsx
@@ -63,7 +63,6 @@ const ChatMessage = memo(
     isStreaming = false,
     expandedThoughtsState,
     setExpandedThoughtsState,
-    titleModelName,
     onEditMessage,
     onRegenerateMessage,
   }: {
@@ -77,7 +76,6 @@ const ChatMessage = memo(
     setExpandedThoughtsState: React.Dispatch<
       React.SetStateAction<Record<string, boolean>>
     >
-    titleModelName?: string
     onEditMessage?: (messageIndex: number, newContent: string) => void
     onRegenerateMessage?: (messageIndex: number) => void
   }) {
@@ -96,7 +94,6 @@ const ChatMessage = memo(
         isStreaming={isStreaming}
         expandedThoughtsState={expandedThoughtsState}
         setExpandedThoughtsState={setExpandedThoughtsState}
-        titleModelName={titleModelName}
         onEditMessage={onEditMessage}
         onRegenerateMessage={onRegenerateMessage}
       />
@@ -126,8 +123,7 @@ const ChatMessage = memo(
         prevProps.message.content === nextProps.message.content &&
         prevProps.message.thoughts === nextProps.message.thoughts &&
         prevProps.message.isThinking === nextProps.message.isThinking &&
-        prevExpanded === nextExpanded &&
-        prevProps.titleModelName === nextProps.titleModelName
+        prevExpanded === nextExpanded
       )
     }
 
@@ -147,8 +143,7 @@ const ChatMessage = memo(
         prevProps.isDarkMode === nextProps.isDarkMode &&
         prevProps.isLastMessage === nextProps.isLastMessage &&
         prevProps.isStreaming === nextProps.isStreaming &&
-        prevExpanded === nextExpanded &&
-        prevProps.titleModelName === nextProps.titleModelName
+        prevExpanded === nextExpanded
       )
     }
 
@@ -170,7 +165,6 @@ const ChatMessage = memo(
       prevExpanded === nextExpanded &&
       prevProps.setExpandedThoughtsState ===
         nextProps.setExpandedThoughtsState &&
-      prevProps.titleModelName === nextProps.titleModelName &&
       prevProps.onEditMessage === nextProps.onEditMessage &&
       prevProps.onRegenerateMessage === nextProps.onRegenerateMessage
     )
@@ -357,11 +351,6 @@ export function ChatMessages({
     return models.find((m) => m.modelName === selectedModel) || models[0]
   }, [models, selectedModel])
 
-  const titleModelName = useMemo(() => {
-    const titleModel = models?.find((m) => m.type === 'title')
-    return titleModel?.modelName
-  }, [models])
-
   // Separate messages into archived and live sections - memoize this calculation
   const { archivedMessages, liveMessages } = useMemo(() => {
     const archived =
@@ -444,7 +433,6 @@ export function ChatMessages({
                 isStreaming={false}
                 expandedThoughtsState={expandedThoughtsState}
                 setExpandedThoughtsState={memoizedSetExpandedThoughtsState}
-                titleModelName={titleModelName}
                 onEditMessage={onEditMessage}
                 onRegenerateMessage={onRegenerateMessage}
               />
@@ -468,7 +456,6 @@ export function ChatMessages({
           isStreaming={i === liveMessages.length - 1 && isStreamingResponse}
           expandedThoughtsState={expandedThoughtsState}
           setExpandedThoughtsState={memoizedSetExpandedThoughtsState}
-          titleModelName={titleModelName}
           onEditMessage={onEditMessage}
           onRegenerateMessage={onRegenerateMessage}
         />

--- a/src/components/chat/constants.ts
+++ b/src/components/chat/constants.ts
@@ -31,8 +31,6 @@ export const CONSTANTS = {
   LONG_PASTE_THRESHOLD: 3000,
   // Title generation settings
   TITLE_GENERATION_WORD_THRESHOLD: 100, // Words needed to trigger early title generation during streaming
-  TITLE_GENERATION_PROMPT: `Generate a concise, descriptive title of minimum 2 words, maximum 5 words for the following text. NEVER output markdown.`,
-  THOUGHT_SUMMARY_GENERATION_PROMPT: `Generate a summary sentence of minimum 5 words, maximum 15 words summarizing the following text. NEVER output markdown.`,
   // Document processing timeout in milliseconds (10 minutes)
   DOCUMENT_PROCESSING_TIMEOUT_MS: 600000,
   // Retry settings

--- a/src/components/chat/hooks/use-chat-messaging.ts
+++ b/src/components/chat/hooks/use-chat-messaging.ts
@@ -448,17 +448,13 @@ export function useChatMessaging({
       // Fire title generation in parallel with streaming (based on user's message).
       // The promise is awaited after streaming completes, before the final save.
       if (isFirstMessage && userMessage) {
-        const titleModel = models.find((m) => m.type === 'title')
-        if (titleModel) {
-          const titlePromise = generateTitle(
-            [{ role: 'user', content: userMessage.content || '' }],
-            titleModel.modelName,
-          )
-          // Prevent unhandled rejection if streaming exits early and the
-          // promise is never awaited (e.g. abort, navigation, empty response)
-          titlePromise.catch(() => {})
-          earlyTitlePromiseRef.current = titlePromise
-        }
+        const titlePromise = generateTitle([
+          { role: 'user', content: userMessage.content || '' },
+        ])
+        // Prevent unhandled rejection if streaming exits early and the
+        // promise is never awaited (e.g. abort, navigation, empty response)
+        titlePromise.catch(() => {})
+        earlyTitlePromiseRef.current = titlePromise
       }
 
       // Project memory is currently disabled - uncomment to re-enable

--- a/src/components/chat/renderers/components/ThoughtProcess.tsx
+++ b/src/components/chat/renderers/components/ThoughtProcess.tsx
@@ -1,6 +1,5 @@
-import { CONSTANTS } from '@/components/chat/constants'
 import { LoadingDots } from '@/components/loading-dots'
-import { getTinfoilClient } from '@/services/inference/tinfoil-client'
+import { summarize } from '@/services/inference/summary-client'
 import { logError } from '@/utils/error-handling'
 import {
   processLatexTags,
@@ -22,7 +21,6 @@ interface ThoughtProcessProps {
   setExpandedThoughtsState?: React.Dispatch<
     React.SetStateAction<Record<string, boolean>>
   >
-  titleModelName?: string
 }
 
 export const ThoughtProcess = memo(function ThoughtProcess({
@@ -34,7 +32,6 @@ export const ThoughtProcess = memo(function ThoughtProcess({
   messageId,
   expandedThoughtsState,
   setExpandedThoughtsState,
-  titleModelName,
 }: ThoughtProcessProps) {
   const isExpanded =
     messageId && expandedThoughtsState
@@ -65,7 +62,7 @@ export const ThoughtProcess = memo(function ThoughtProcess({
       thoughtText: string,
       isMountedRef: React.MutableRefObject<boolean>,
     ) => {
-      if (!titleModelName || !thoughtText.trim()) {
+      if (!thoughtText.trim()) {
         if (isMountedRef.current) {
           setThoughtSummary('')
         }
@@ -73,25 +70,11 @@ export const ThoughtProcess = memo(function ThoughtProcess({
       }
 
       try {
-        const client = await getTinfoilClient()
-        const completion = await client.chat.completions.create({
-          model: titleModelName,
-          messages: [
-            {
-              role: 'system',
-              content: CONSTANTS.THOUGHT_SUMMARY_GENERATION_PROMPT,
-            },
-            {
-              role: 'user',
-              content: thoughtText,
-            },
-          ],
-          stream: false,
-          max_tokens: 50,
+        const generatedSummary = await summarize({
+          content: thoughtText,
+          style: 'thoughts_summary',
         })
 
-        const generatedSummary =
-          completion.choices?.[0]?.message?.content?.trim() || ''
         const cleaned = generatedSummary
           .replace(/[".]/g, '')
           .replace(
@@ -114,7 +97,7 @@ export const ThoughtProcess = memo(function ThoughtProcess({
         }
       }
     },
-    [titleModelName],
+    [],
   )
 
   useEffect(() => {

--- a/src/components/chat/renderers/default/DefaultMessageRenderer.tsx
+++ b/src/components/chat/renderers/default/DefaultMessageRenderer.tsx
@@ -27,7 +27,6 @@ const DefaultMessageComponent = ({
   isStreaming,
   expandedThoughtsState,
   setExpandedThoughtsState,
-  titleModelName,
   onEditMessage,
   onRegenerateMessage,
 }: MessageRenderProps) => {
@@ -237,7 +236,6 @@ const DefaultMessageComponent = ({
                 messageId={messageUniqueId}
                 expandedThoughtsState={expandedThoughtsState}
                 setExpandedThoughtsState={setExpandedThoughtsState}
-                titleModelName={titleModelName}
               />
             </div>
           </div>

--- a/src/components/chat/renderers/types.ts
+++ b/src/components/chat/renderers/types.ts
@@ -27,7 +27,6 @@ export interface MessageRenderProps {
   setExpandedThoughtsState?: React.Dispatch<
     React.SetStateAction<Record<string, boolean>>
   >
-  titleModelName?: string
   onEditMessage?: (messageIndex: number, newContent: string) => void
   onRegenerateMessage?: (messageIndex: number) => void
 }

--- a/src/services/inference/summary-client.ts
+++ b/src/services/inference/summary-client.ts
@@ -1,0 +1,57 @@
+import { logError } from '@/utils/error-handling'
+import { SecureClient } from 'tinfoil'
+
+const SUMMARIZER_ENCLAVE = 'https://summarizer.tinfoil.sh'
+const SUMMARIZER_CONFIG_REPO = 'tinfoilsh/confidential-summarizer'
+
+let cachedClient: SecureClient | null = null
+
+function getClient(): SecureClient {
+  if (!cachedClient) {
+    cachedClient = new SecureClient({
+      enclaveURL: SUMMARIZER_ENCLAVE,
+      configRepo: SUMMARIZER_CONFIG_REPO,
+    })
+  }
+  return cachedClient
+}
+
+interface SummarizeRequest {
+  content: string
+  style: 'default' | 'thoughts_summary' | 'title_summary'
+}
+
+interface SummarizeResponse {
+  summary: string
+}
+
+export async function summarize(request: SummarizeRequest): Promise<string> {
+  const client = getClient()
+
+  const response = await client.fetch(`${SUMMARIZER_ENCLAVE}/summarize`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(request),
+  })
+
+  if (!response.ok) {
+    const errorText = await response.text()
+    logError(
+      `Summarize request failed with status: ${response.status}`,
+      undefined,
+      {
+        component: 'summary-client',
+        action: 'summarize',
+        metadata: {
+          status: response.status,
+          error: errorText,
+          style: request.style,
+        },
+      },
+    )
+    throw new Error(`Summarize request failed: ${response.status}`)
+  }
+
+  const data: SummarizeResponse = await response.json()
+  return data.summary
+}

--- a/src/services/inference/title.ts
+++ b/src/services/inference/title.ts
@@ -1,13 +1,11 @@
 import { CONSTANTS } from '@/components/chat/constants'
 import { logError } from '@/utils/error-handling'
-import { getTinfoilClient } from './tinfoil-client'
+import { summarize } from './summary-client'
 
 export async function generateTitle(
   messages: Array<{ role: string; content: string }>,
-  titleModelName?: string,
 ): Promise<string> {
   if (!messages || messages.length === 0) return 'Untitled'
-  if (!titleModelName) return 'Untitled'
 
   try {
     const userMessage = messages.find((msg) => msg.role === 'user')
@@ -18,22 +16,11 @@ export async function generateTitle(
       .slice(0, CONSTANTS.TITLE_GENERATION_WORD_THRESHOLD)
       .join(' ')
 
-    const client = await getTinfoilClient()
-
-    const completion = await client.chat.completions.create({
-      model: titleModelName,
-      messages: [
-        { role: 'system', content: CONSTANTS.TITLE_GENERATION_PROMPT },
-        {
-          role: 'user',
-          content: truncatedContent,
-        },
-      ],
-      stream: false,
-      max_tokens: 50,
+    const title = await summarize({
+      content: truncatedContent,
+      style: 'title_summary',
     })
 
-    const title = completion.choices?.[0]?.message?.content?.trim() || ''
     const cleanTitle = title.replace(/^["']|["']$/g, '').trim()
     if (cleanTitle && cleanTitle.length > 0 && cleanTitle.length <= 50) {
       return cleanTitle
@@ -43,9 +30,6 @@ export async function generateTitle(
     logError('Failed to generate title', error, {
       component: 'title',
       action: 'generateTitle',
-      metadata: {
-        modelName: titleModelName,
-      },
     })
     return 'Untitled'
   }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Replaced in-line summarization with a secure summary endpoint so titles and thought summaries are generated via the summarizer enclave, removing model plumbing and prompt strings.

- **Refactors**
  - Added `src/services/inference/summary-client.ts` using `tinfoil` `SecureClient` to call the summarizer enclave `/summarize`.
  - Updated `generateTitle` to use `summarize` with `title_summary`; removed model param and prompt constants.
  - Switched `ThoughtProcess` to use `summarize` with `thoughts_summary`; removed `getTinfoilClient` and `titleModelName` usage.
  - Removed `titleModelName` prop/compares from chat components and renderer; simplified early title generation in `use-chat-messaging`.
  - Deleted unused prompt constants in `constants.ts`.

<sup>Written for commit 94a00e83df0bc16cb634f502baa36f52f1cf3055. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

