### PR TITLE
fix: add thought summary generate debounce

### DIFF
--- a/src/components/chat/renderers/components/ThoughtProcess.tsx
+++ b/src/components/chat/renderers/components/ThoughtProcess.tsx
@@ -45,6 +45,7 @@ export const ThoughtProcess = memo(function ThoughtProcess({
   const isUserScrollingRef = useRef<boolean>(false)
   const [thoughtSummary, setThoughtSummary] = useState<string>('')
   const summaryGenerationRef = useRef<Promise<void> | null>(null)
+  const lastSummaryTimeRef = useRef<number>(0)
   const isMountedRef = useRef<boolean>(true)
   const wasExpandedRef = useRef<boolean>(isExpanded)
 
@@ -114,6 +115,25 @@ export const ThoughtProcess = memo(function ThoughtProcess({
 
     if (summaryGenerationRef.current) return
 
+    const MIN_SUMMARY_INTERVAL_MS = 3000
+    const timeSinceLastSummary = Date.now() - lastSummaryTimeRef.current
+    if (timeSinceLastSummary < MIN_SUMMARY_INTERVAL_MS) {
+      const delay = MIN_SUMMARY_INTERVAL_MS - timeSinceLastSummary
+      const timeoutId = setTimeout(() => {
+        if (!isMountedRef.current || !isThinking) return
+        if (summaryGenerationRef.current) return
+        lastSummaryTimeRef.current = Date.now()
+        summaryGenerationRef.current = generateSummary(
+          thoughts,
+          isMountedRef,
+        ).finally(() => {
+          summaryGenerationRef.current = null
+        })
+      }, delay)
+      return () => clearTimeout(timeoutId)
+    }
+
+    lastSummaryTimeRef.current = Date.now()
     summaryGenerationRef.current = generateSummary(
       thoughts,
       isMountedRef,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a 3s debounce to thought summary generation in `ThoughtProcess` to prevent rapid re-triggers while thinking. This avoids overlapping runs, reduces CPU churn, and prevents updates after unmount.

<sup>Written for commit 2feb9dd69046d9d97d7f740e8fbc00039220982e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

