### PR TITLE
Feat: markdown thoughts

### DIFF
--- a/src/components/chat/hooks/streaming-processor.ts
+++ b/src/components/chat/hooks/streaming-processor.ts
@@ -10,6 +10,7 @@
  * to storage directly. All persistence goes through updateChatWithHistoryCheck.
  */
 import { streamingTracker } from '@/services/cloud/streaming-tracker'
+import { processCitationMarkers } from '@/utils/citation-processing'
 import { logError } from '@/utils/error-handling'
 import type {
   Annotation,
@@ -19,33 +20,6 @@ import type {
   WebSearchSource,
   WebSearchState,
 } from '../types'
-
-/**
- * Process citation markers (e.g. 【1】) into markdown links.
- * Called once at stream end to store processed content.
- */
-export function processCitationMarkers(
-  content: string,
-  sources: WebSearchSource[],
-): string {
-  if (sources.length === 0) return content
-
-  return content.replace(/【(\d+)[^】]*】/g, (match, num) => {
-    const index = parseInt(num, 10) - 1
-    const source = sources[index]
-    if (!source) return match
-    const encodedUrl = source.url
-      .replace(/\(/g, '%28')
-      .replace(/\)/g, '%29')
-      .replace(/\|/g, '%7C')
-      .replace(/~/g, '%7E')
-    const encodedTitle = encodeURIComponent(source.title || '')
-      .replace(/\(/g, '%28')
-      .replace(/\)/g, '%29')
-      .replace(/~/g, '%7E')
-    return `[${num}](#cite-${num}~${encodedUrl}~${encodedTitle})`
-  })
-}
 
 export interface StreamingContext {
   updatedChat: Chat

--- a/src/components/chat/renderers/components/ThoughtProcess.tsx
+++ b/src/components/chat/renderers/components/ThoughtProcess.tsx
@@ -1,7 +1,7 @@
-import { processCitationMarkers } from '@/components/chat/hooks/streaming-processor'
 import type { WebSearchSource } from '@/components/chat/types'
 import { LoadingDots } from '@/components/loading-dots'
 import { summarize } from '@/services/inference/summary-client'
+import { processCitationMarkers } from '@/utils/citation-processing'
 import { logError } from '@/utils/error-handling'
 import {
   processLatexTags,
@@ -81,13 +81,8 @@ export const ThoughtProcess = memo(function ThoughtProcess({
           style: 'thoughts_summary',
         })
 
-        const cleaned = generatedSummary
-          .replace(/^["'\s]+|["'.\s]+$/g, '')
-          .replace(/\s+/g, ' ')
-          .trim()
-        const capitalized = cleaned.charAt(0).toUpperCase() + cleaned.slice(1)
-        if (isMountedRef.current && capitalized) {
-          setThoughtSummary(capitalized)
+        if (isMountedRef.current && generatedSummary.trim()) {
+          setThoughtSummary(generatedSummary.trim())
         }
       } catch (error) {
         logError('Failed to generate thought summary', error, {
@@ -383,9 +378,14 @@ export const ThoughtProcess = memo(function ThoughtProcess({
                     const secondTildeIndex = rest.indexOf('~')
                     if (secondTildeIndex !== -1) {
                       const url = rest.slice(0, secondTildeIndex)
-                      const title = decodeURIComponent(
-                        rest.slice(secondTildeIndex + 1),
-                      )
+                      let title: string
+                      try {
+                        title = decodeURIComponent(
+                          rest.slice(secondTildeIndex + 1),
+                        )
+                      } catch {
+                        title = rest.slice(secondTildeIndex + 1)
+                      }
                       const sanitizedHref = sanitizeUrl(url)
                       return (
                         <a

--- a/src/components/chat/renderers/default/DefaultMessageRenderer.tsx
+++ b/src/components/chat/renderers/default/DefaultMessageRenderer.tsx
@@ -50,6 +50,15 @@ const DefaultMessageComponent = ({
       : Date.now()
     return `${message.role}-${timestamp}`
   }, [message.role, message.timestamp])
+  const thoughtSources = React.useMemo(
+    () =>
+      message.webSearch?.sources ??
+      message.annotations?.map((a) => ({
+        title: a.url_citation.title,
+        url: a.url_citation.url,
+      })),
+    [message.webSearch?.sources, message.annotations],
+  )
   const [showActions, setShowActions] = React.useState(false)
   const lastContentRef = React.useRef(message.content)
   const showActionsTimeoutRef = React.useRef<ReturnType<
@@ -236,7 +245,7 @@ const DefaultMessageComponent = ({
                 messageId={messageUniqueId}
                 expandedThoughtsState={expandedThoughtsState}
                 setExpandedThoughtsState={setExpandedThoughtsState}
-                sources={message.webSearch?.sources}
+                sources={thoughtSources}
               />
             </div>
           </div>

--- a/src/utils/citation-processing.ts
+++ b/src/utils/citation-processing.ts
@@ -1,0 +1,29 @@
+import type { WebSearchSource } from '@/components/chat/types'
+
+/**
+ * Replace Chinese bracket citation markers like 【1】 with markdown links
+ * that encode the source URL and title for rendering.
+ * Called once at stream end to store processed content.
+ */
+export function processCitationMarkers(
+  content: string,
+  sources: WebSearchSource[],
+): string {
+  if (sources.length === 0) return content
+
+  return content.replace(/【(\d+)[^】]*】/g, (match, num) => {
+    const index = parseInt(num, 10) - 1
+    const source = sources[index]
+    if (!source) return match
+    const encodedUrl = source.url
+      .replace(/\(/g, '%28')
+      .replace(/\)/g, '%29')
+      .replace(/\|/g, '%7C')
+      .replace(/~/g, '%7E')
+    const encodedTitle = encodeURIComponent(source.title || '')
+      .replace(/\(/g, '%28')
+      .replace(/\)/g, '%29')
+      .replace(/~/g, '%7E')
+    return `[${num}](#cite-${num}~${encodedUrl}~${encodedTitle})`
+  })
+}

--- a/tests/hooks/citation-processing.test.ts
+++ b/tests/hooks/citation-processing.test.ts
@@ -1,5 +1,5 @@
-import { processCitationMarkers } from '@/components/chat/hooks/streaming-processor'
 import type { WebSearchSource } from '@/components/chat/types'
+import { processCitationMarkers } from '@/utils/citation-processing'
 import { describe, expect, it } from 'vitest'
 
 describe('processCitationMarkers', () => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Render citations inside the assistant’s Thoughts as clickable source pills and streamline summaries for faster, cleaner results.

- **New Features**
  - Parse inline citation markers and render pill links that open in a new tab; show titles when available; URLs sanitized with `@braintree/sanitize-url`.
  - Pass `sources` to Thoughts from `message.webSearch?.sources`, falling back to `message.annotations` `url_citation`.

- **Refactors**
  - Simplified summaries: use the model’s summary as-is (trimmed) and summarize only the last 200 words.
  - Moved citation parsing to `src/utils/citation-processing.ts` and use it at render time; updated tests to the new import.

<sup>Written for commit 957a2ae2c92a624cd3f169b32be4aaae3bfaf12b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

