### PR TITLE
feat: change loading dots

### DIFF
--- a/src/components/loading-dots.tsx
+++ b/src/components/loading-dots.tsx
@@ -11,13 +11,12 @@ export const LoadingDots = memo(function LoadingDots({
     <div
       style={
         {
-          height: '5px',
-          aspectRatio: '5',
-          '--_g': `no-repeat radial-gradient(farthest-side,${dotColor} 94%,transparent)`,
-          background: 'var(--_g),var(--_g),var(--_g),var(--_g)',
-          backgroundSize: '20% 100%',
-          animation:
-            'loading-dots-position .75s infinite alternate, loading-dots-flip 1.5s infinite alternate',
+          width: '36px',
+          aspectRatio: '4',
+          '--_g': `no-repeat radial-gradient(circle closest-side,${dotColor} 90%,transparent)`,
+          background: 'var(--_g) 0% 50%, var(--_g) 50% 50%, var(--_g) 100% 50%',
+          backgroundSize: 'calc(100%/3) 100%',
+          animation: 'loading-dots 1s infinite linear',
         } as React.CSSProperties
       }
     />

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -11,46 +11,24 @@
   }
 }
 
-@keyframes loading-dots-position {
-  0%,
-  10% {
-    background-position:
-      0 0,
-      0 0,
-      0 0,
-      0 0;
-  }
+@keyframes loading-dots {
   33% {
-    background-position:
-      0 0,
-      calc(100% / 3) 0,
-      calc(100% / 3) 0,
-      calc(100% / 3) 0;
+    background-size:
+      calc(100% / 3) 0%,
+      calc(100% / 3) 100%,
+      calc(100% / 3) 100%;
+  }
+  50% {
+    background-size:
+      calc(100% / 3) 100%,
+      calc(100% / 3) 0%,
+      calc(100% / 3) 100%;
   }
   66% {
-    background-position:
-      0 0,
-      calc(100% / 3) 0,
-      calc(2 * 100% / 3) 0,
-      calc(2 * 100% / 3) 0;
-  }
-  90%,
-  100% {
-    background-position:
-      0 0,
-      calc(100% / 3) 0,
-      calc(2 * 100% / 3) 0,
-      100% 0;
-  }
-}
-@keyframes loading-dots-flip {
-  0%,
-  49.99% {
-    transform: scale(1);
-  }
-  50%,
-  100% {
-    transform: scale(-1);
+    background-size:
+      calc(100% / 3) 100%,
+      calc(100% / 3) 100%,
+      calc(100% / 3) 0%;
   }
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Reworked the loading indicator to a three-dot pulse using a single CSS animation for smoother motion and simpler styles. Sizing is now more predictable.

- **Refactors**
  - Replaced `loading-dots-position` and `loading-dots-flip` with a single `loading-dots` keyframe controlling background-size.
  - Updated `LoadingDots` to use 3 radial gradients positioned at 0%, 50%, 100%, with width 36px and aspect-ratio 4.
  - Removed the flip effect and tuned the gradient to `circle closest-side` for a cleaner look.

<sup>Written for commit f2f44f026877365b85d58aa991e8f584c781857d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

