### PR TITLE
fix: enable manual key setup when passkey setup fails

### DIFF
--- a/src/components/chat/chat-sidebar.tsx
+++ b/src/components/chat/chat-sidebar.tsx
@@ -646,8 +646,8 @@ export function ChatSidebar({
       if (!encryptionService.getKey()) {
         // Prefer passkey setup when available
         if (passkeySetupAvailable && onSetupPasskey) {
-          await onSetupPasskey()
-          return
+          const success = await onSetupPasskey()
+          if (success) return
         }
 
         // Turn on the toggle visually (but don't persist yet)
@@ -1170,8 +1170,10 @@ export function ChatSidebar({
                           <button
                             onClick={async () => {
                               if (passkeySetupAvailable && onSetupPasskey) {
-                                await onSetupPasskey()
-                              } else if (onCloudSyncSetupClick) {
+                                const success = await onSetupPasskey()
+                                if (success) return
+                              }
+                              if (onCloudSyncSetupClick) {
                                 onCloudSyncSetupClick()
                               }
                             }}
@@ -1711,8 +1713,10 @@ export function ChatSidebar({
                       <button
                         onClick={async () => {
                           if (passkeySetupAvailable && onSetupPasskey) {
-                            await onSetupPasskey()
-                          } else if (onCloudSyncSetupClick) {
+                            const success = await onSetupPasskey()
+                            if (success) return
+                          }
+                          if (onCloudSyncSetupClick) {
                             onCloudSyncSetupClick()
                           }
                         }}

--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -787,7 +787,8 @@ export function SettingsModal({
         if (passkeySetupAvailable && onSetupPasskey) {
           setIsOpen(false)
           try {
-            await onSetupPasskey()
+            const success = await onSetupPasskey()
+            if (success) return
           } catch (error) {
             toast({
               title:
@@ -800,6 +801,10 @@ export function SettingsModal({
                   : 'Could not create passkey backup. You can try again later.',
               variant: 'destructive',
             })
+          }
+          // Passkey setup didn't succeed — fall through to manual key setup
+          if (onCloudSyncSetupClick) {
+            onCloudSyncSetupClick()
           }
           return
         }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Allow users to fall back to manual key setup when passkey setup fails or is canceled, so encryption setup never gets stuck.

- **Bug Fixes**
  - Only continue with passkey flow if `onSetupPasskey()` returns success; otherwise trigger manual setup via `onCloudSyncSetupClick` in the sidebar.
  - In Settings modal, attempt passkey, show error on failure, then open manual key setup automatically.

<sup>Written for commit 4bae18204ee262d0206234aef474c6a018197b68. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

