### PR TITLE
fix: handle more dollar sign edge cases in rendering

### DIFF
--- a/src/utils/latex-processing.ts
+++ b/src/utils/latex-processing.ts
@@ -237,6 +237,16 @@ function convertSingleDollarLatex(segment: string): string {
   let index = 0
 
   while (index < segment.length) {
+    // Skip past markdown link URLs: ](...)
+    if (segment[index] === ']' && segment[index + 1] === '(') {
+      const closeParen = findClosingParen(segment, index + 2)
+      if (closeParen !== -1) {
+        output += segment.slice(index, closeParen + 1)
+        index = closeParen + 1
+        continue
+      }
+    }
+
     // Skip past existing $$...$$ blocks
     if (segment[index] === '$' && segment[index + 1] === '$') {
       const closeIdx = segment.indexOf('$$', index + 2)
@@ -276,9 +286,32 @@ function convertSingleDollarLatex(segment: string): string {
   return output
 }
 
+function findClosingParen(segment: string, startIndex: number): number {
+  let depth = 1
+  let index = startIndex
+  while (index < segment.length) {
+    if (segment[index] === '(') depth++
+    if (segment[index] === ')') {
+      depth--
+      if (depth === 0) return index
+    }
+    index++
+  }
+  return -1
+}
+
 function findSingleDollarClose(segment: string, startIndex: number): number {
   let index = startIndex
   while (index < segment.length) {
+    // Skip past markdown link URLs: ](...)
+    if (segment[index] === ']' && segment[index + 1] === '(') {
+      const closeParen = findClosingParen(segment, index + 2)
+      if (closeParen !== -1) {
+        index = closeParen + 1
+        continue
+      }
+    }
+
     if (
       segment[index] === '$' &&
       (index + 1 >= segment.length || segment[index + 1] !== '$') &&
@@ -292,10 +325,6 @@ function findSingleDollarClose(segment: string, startIndex: number): number {
     index++
   }
   return -1
-}
-
-function hasLatexCommands(content: string): boolean {
-  return /\\[a-zA-Z$]/.test(content)
 }
 
 function hasUnescapedDollar(content: string): boolean {

--- a/tests/utils/latex-processing.test.ts
+++ b/tests/utils/latex-processing.test.ts
@@ -494,6 +494,67 @@ describe('latex-processing', () => {
         const result = processLatexTags(input)
         expect(result).toBe('lost $$\\$-500$$ on the trade')
       })
+
+      // --- Dollar signs inside markdown link URLs ---
+
+      it('does not match $ inside a markdown link URL', () => {
+        const input =
+          "sold roughly $4.1M of common stock during the company's Series A[2](#cite-2~https://example.com/sells-$4.1m-stock~Title), though such transactions are unusual."
+        const result = processLatexTags(input)
+        expect(result).toBe(input)
+      })
+
+      it('does not match $ across multiple markdown link URLs', () => {
+        const input =
+          '**$10M+ ARR and a nine-figure valuation**[6](#cite-6~https://example.com/sell-stock/~Title)[4](#cite-4~https://example.com/$guide~Guide). If the valuation is north of $80–100M, most firms will accommodate.'
+        const result = processLatexTags(input)
+        expect(result).toBe(input)
+      })
+
+      it('preserves math inside link text while skipping URL dollars', () => {
+        const input = 'See [$x > 0$](https://example.com/$path) for details'
+        const result = processLatexTags(input)
+        expect(result).toBe(
+          'See [$$x > 0$$](https://example.com/$path) for details',
+        )
+      })
+
+      it('does not match currency $ with closer inside URL', () => {
+        const input =
+          'raised $50M in funding[1](#cite~https://example.com/raises-$50m~Title) last year'
+        const result = processLatexTags(input)
+        expect(result).toBe(input)
+      })
+
+      it('handles $ in URL-encoded text within links', () => {
+        const input =
+          'costs $100 per unit[3](#cite~https://example.com/~Product%20costs%20$100%20per%20unit) in bulk'
+        const result = processLatexTags(input)
+        expect(result).toBe(input)
+      })
+
+      it('handles multiple citations with $ in URLs after currency', () => {
+        const input =
+          'The price is $500 and $1,000[1](#cite~url/$500)[2](#cite~url/$1000). End.'
+        const result = processLatexTags(input)
+        expect(result).toBe(input)
+      })
+
+      it('still converts valid $\\$...$ when links are present', () => {
+        const input =
+          'Cost is $\\$100$ per unit[1](#cite~https://example.com/price).'
+        const result = processLatexTags(input)
+        expect(result).toContain('$$\\$100$$')
+        expect(result).toContain('](#cite~https://example.com/price)')
+      })
+
+      it('handles links with nested parentheses in URL', () => {
+        const input =
+          'See $x$[1](#cite~https://example.com/path_(section)) for info'
+        const result = processLatexTags(input)
+        expect(result).toContain('$$x$$')
+        expect(result).toContain('(#cite~https://example.com/path_(section))')
+      })
     })
 
     describe('edge cases', () => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes LaTeX rendering by ignoring dollar signs inside markdown link URLs and supporting nested parentheses in URLs, while still converting math in link text. Prevents false positives for currency/URL dollars.

- **Bug Fixes**
  - Skip dollars inside markdown link URLs by scanning and skipping ](...) segments; added `findClosingParen` to handle nested parentheses.
  - Preserve math conversion in link text while leaving URL dollars untouched, including URL-encoded and multi-citation cases.
  - Added tests for link URLs with $, nested parentheses, and mixed link + math scenarios.

<sup>Written for commit 727b68afabdbec3d299250688f72f45b056d876a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

