### PR TITLE
fix: prevent false LaTeX matches on currency dollar

### DIFF
--- a/src/utils/latex-processing.ts
+++ b/src/utils/latex-processing.ts
@@ -227,11 +227,9 @@ function findMatchingInlineClose(segment: string, startIndex: number): number {
   return -1
 }
 
-// Convert $...$ to $$...$$ when the content contains LaTeX commands.
-// This handles cases where the model uses single-dollar math (e.g. $\$10,000$)
-// despite being prompted to use \(...\) syntax.
-// We only convert when LaTeX commands are detected to avoid treating
-// currency amounts like $10,000 as math.
+// Convert $...$ to $$...$$ for remark-math (singleDollarTextMath is off).
+// Skips markdown link URLs and checks for unescaped inner $ to avoid
+// false positives.
 function convertSingleDollarLatex(segment: string): string {
   let output = ''
   let index = 0
@@ -315,6 +313,8 @@ function findSingleDollarClose(segment: string, startIndex: number): number {
     if (
       segment[index] === '$' &&
       (index + 1 >= segment.length || segment[index + 1] !== '$') &&
+      // A $ followed by a digit is a currency opening ($3M, $100), not a math closer
+      (index + 1 >= segment.length || !/\d/.test(segment[index + 1])) &&
       segment[index - 1] !== '\\' &&
       segment[index - 1] !== ' ' &&
       segment[index - 1] !== '\t' &&

--- a/tests/utils/latex-processing.test.ts
+++ b/tests/utils/latex-processing.test.ts
@@ -548,6 +548,55 @@ describe('latex-processing', () => {
         expect(result).toContain('](#cite~https://example.com/price)')
       })
 
+      // --- Currency $ followed by digits should not be treated as closers ---
+
+      it('does not match currency $ signs separated by long prose', () => {
+        const input =
+          'Before you celebrate the $2M, model the after-tax outcome. If your shares qualify for **QSBS** (federal 0% up to $10M gain), that $2M might be entirely tax-free. If QSBS has expired, you need to gross ~$3M+ in sale value to net $2M.'
+        const result = processLatexTags(input)
+        expect(result).toBe(input)
+      })
+
+      it('does not match currency $ signs across sentences with citations', () => {
+        const input =
+          "that $2M might be entirely tax-free[1](#cite-1~https://keystonegp.com/calculator/~Secondary%20Sale%20Calculator). If QSBS has expired or doesn't apply, you're looking at ~30–37% effective tax (federal + state), meaning you need to gross ~$3M+ in sale value to net $2M."
+        const result = processLatexTags(input)
+        expect(result).toBe(input)
+      })
+
+      it('does not treat $DIGIT as a math closer', () => {
+        const input = 'between $5 and $15 dollars'
+        const result = processLatexTags(input)
+        expect(result).toBe(input)
+      })
+
+      it('does not treat ~$3M+ as a math closer', () => {
+        const input =
+          'that $2M might be tax-free, you need to gross ~$3M+ to net $2M.'
+        const result = processLatexTags(input)
+        expect(result).toBe(input)
+      })
+
+      it('does not match $10-$20 range as math', () => {
+        const input = 'costs $10-$20 per item'
+        const result = processLatexTags(input)
+        expect(result).toBe(input)
+      })
+
+      it('does not match $100/$200 as math', () => {
+        const input = 'the ratio is $100/$200 per unit'
+        const result = processLatexTags(input)
+        expect(result).toBe(input)
+      })
+
+      it('still converts short $...$ math despite nearby currency', () => {
+        const input =
+          'The cost is $500 per unit and the formula is $\\frac{a}{b}$ exactly.'
+        const result = processLatexTags(input)
+        expect(result).toContain('$500')
+        expect(result).toContain('$$\\frac{a}{b}$$')
+      })
+
       it('handles links with nested parentheses in URL', () => {
         const input =
           'See $x$[1](#cite~https://example.com/path_(section)) for info'


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix LaTeX parsing so currency amounts (e.g., $2M, $10-$20, $100/$200) are not treated as inline math, while valid $...$ math still converts to $$...$$.

- **Bug Fixes**
  - Do not treat a `$` followed by a digit as a math closer.
  - Skip markdown link URLs and ignore unescaped inner `$` when scanning.
  - Added tests covering common currency patterns and mixed math/currency cases.

<sup>Written for commit c5f63d9625f0c7d23d1d936b62c36c2c16ce6f63. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

