### PR TITLE
Fix mermaid diagram text and SVG rendering

### DIFF
--- a/src/components/code-block.tsx
+++ b/src/components/code-block.tsx
@@ -280,6 +280,7 @@ const PreviewContainer = ({
 const SvgPreview = ({ code }: { code: string }) => {
   const sanitizedSvg = DOMPurify.sanitize(code, {
     USE_PROFILES: { svg: true, svgFilters: true },
+    ADD_TAGS: ['style'],
   })
 
   return (
@@ -636,7 +637,7 @@ const MermaidPreview = ({
   code: string
   isDarkMode: boolean
 }) => {
-  const [svg, setSvg] = useState<string>('')
+  const containerRef = useRef<HTMLDivElement>(null)
   const [error, setError] = useState<string | null>(null)
   const idRef = useMemo(
     () => `mermaid-${Math.random().toString(36).slice(2, 11)}`,
@@ -656,14 +657,16 @@ const MermaidPreview = ({
         })
 
         const { svg: renderedSvg } = await mermaid.render(idRef, code)
-        if (!cancelled) {
-          setSvg(renderedSvg)
+        if (!cancelled && containerRef.current) {
+          containerRef.current.innerHTML = renderedSvg
           setError(null)
         }
       } catch (e) {
         if (!cancelled) {
           setError(e instanceof Error ? e.message : String(e))
-          setSvg('')
+          if (containerRef.current) {
+            containerRef.current.innerHTML = ''
+          }
         }
       }
     }
@@ -678,14 +681,10 @@ const MermaidPreview = ({
     return <div className="text-sm text-red-500">Mermaid error: {error}</div>
   }
 
-  const sanitizedSvg = DOMPurify.sanitize(svg, {
-    USE_PROFILES: { svg: true, svgFilters: true },
-  })
-
   return (
     <div
+      ref={containerRef}
       className="flex w-full items-center justify-center [&>svg]:max-w-full"
-      dangerouslySetInnerHTML={{ __html: sanitizedSvg }}
     />
   )
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes text rendering in Mermaid diagrams and SVG previews by keeping Mermaid’s inline styles and allowing `<style>` tags. Diagrams now use the correct fonts and layout.

- **Bug Fixes**
  - `SvgPreview`: adds `ADD_TAGS: ['style']` to `DOMPurify` (with SVG profiles) to preserve embedded styles.
  - `MermaidPreview`: stops sanitizing and writes the rendered SVG into a ref container to keep Mermaid `<style>`/HTML nodes; clears the container on errors.

<sup>Written for commit bc9aa348efd4963c2da8574777c0f871c2d8a7f4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

