### PR TITLE
fix: use api key for doc upload

### DIFF
--- a/src/components/chat/document-uploader.tsx
+++ b/src/components/chat/document-uploader.tsx
@@ -1,5 +1,8 @@
 import { getAIModels } from '@/config/models'
-import { getTinfoilClient } from '@/services/inference/tinfoil-client'
+import {
+  getSessionToken,
+  getTinfoilClient,
+} from '@/services/inference/tinfoil-client'
 import { logError } from '@/utils/error-handling'
 import {
   getDocumentFormat,
@@ -295,6 +298,7 @@ export const useDocumentUploader = (
       // Add model parameter to formData
       formData.append('model', modelName)
 
+      const apiKey = await getSessionToken()
       const client = new SecureClient()
       const controller = new AbortController()
       const timeoutId = setTimeout(
@@ -305,6 +309,9 @@ export const useDocumentUploader = (
       const response = await client
         .fetch(endpoint, {
           method: 'POST',
+          headers: {
+            Authorization: `Bearer ${apiKey}`,
+          },
           body: formData,
           signal: controller.signal,
         })

--- a/src/services/inference/tinfoil-client.ts
+++ b/src/services/inference/tinfoil-client.ts
@@ -196,6 +196,10 @@ async function initClient(sessionToken: string): Promise<TinfoilAI> {
   }
 }
 
+export async function getSessionToken(): Promise<string> {
+  return fetchSessionToken()
+}
+
 async function getRawClient(): Promise<TinfoilAI> {
   const sessionToken = await fetchSessionToken()
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Send the session token with document uploads using an Authorization header to fix failures caused by missing auth.

- **Bug Fixes**
  - Call `getSessionToken` and set `Authorization: Bearer <token>` on the upload request.
  - Export `getSessionToken` from `tinfoil-client` for reuse.

<sup>Written for commit 45f1acf11972372c4b602be0c7f479fcd730d836. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

