### PR TITLE
fix: apply chat font to input and message editing textareas

### DIFF
--- a/src/components/chat/chat-input.tsx
+++ b/src/components/chat/chat-input.tsx
@@ -27,6 +27,7 @@ import {
 } from 'react-icons/pi'
 import { MacFileIcon } from './components/mac-file-icon'
 import { CONSTANTS } from './constants'
+import { CHAT_FONT_CLASSES, useChatFont } from './hooks/use-chat-font'
 import type { ProcessedDocument } from './renderers/types'
 import type { LoadingState } from './types'
 
@@ -74,6 +75,7 @@ export function ChatInput({
   const fileInputRef = useRef<HTMLInputElement>(null)
   const documentsScrollRef = useRef<HTMLDivElement>(null)
   const { toast } = useToast()
+  const chatFont = useChatFont()
   const { isProjectMode, activeProject } = useProject()
   const [textareaResetNonce, setTextareaResetNonce] = useState(0)
   const prevInputValueRef = useRef(input)
@@ -784,7 +786,10 @@ export function ChatInput({
             }}
             placeholder={hasMessages ? 'Reply to Tin...' : placeholder}
             rows={1}
-            className="w-full resize-none bg-transparent text-lg leading-relaxed text-content-primary placeholder:text-content-muted focus:outline-none"
+            className={cn(
+              'w-full resize-none bg-transparent text-lg leading-relaxed text-content-primary placeholder:text-content-muted focus:outline-none',
+              CHAT_FONT_CLASSES[chatFont],
+            )}
             style={{
               minHeight: inputMinHeight,
               maxHeight: '240px',

--- a/src/components/chat/renderers/default/DefaultMessageRenderer.tsx
+++ b/src/components/chat/renderers/default/DefaultMessageRenderer.tsx
@@ -10,6 +10,7 @@ import { BsCheckLg } from 'react-icons/bs'
 import { GoClockFill } from 'react-icons/go'
 import { RxCopy } from 'react-icons/rx'
 import { hasMessageAttachments } from '../../attachment-helpers'
+import { CHAT_FONT_CLASSES, useChatFont } from '../../hooks/use-chat-font'
 import { DocumentList } from '../components/DocumentList'
 import { MessageActions } from '../components/MessageActions'
 import { StreamingChunkedText } from '../components/StreamingChunkedText'
@@ -31,6 +32,7 @@ const DefaultMessageComponent = ({
   onRegenerateMessage,
 }: MessageRenderProps) => {
   const isUser = message.role === 'user'
+  const chatFont = useChatFont()
   const [isEditing, setIsEditing] = React.useState(false)
   const [editContent, setEditContent] = React.useState(message.content || '')
   const [copiedUser, setCopiedUser] = React.useState(false)
@@ -405,7 +407,10 @@ const DefaultMessageComponent = ({
                       handleCancelEdit()
                     }
                   }}
-                  className="w-full resize-none bg-transparent text-base leading-relaxed text-content-primary placeholder:text-content-muted focus:outline-none"
+                  className={cn(
+                    'w-full resize-none bg-transparent text-base leading-relaxed text-content-primary placeholder:text-content-muted focus:outline-none',
+                    CHAT_FONT_CLASSES[chatFont],
+                  )}
                   rows={Math.min(
                     10,
                     Math.max(3, editContent.split('\n').length),


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Applied the selected chat font to the chat input and the message editing textarea. This keeps typing and editing consistent with the conversation font.

<sup>Written for commit ce3bbd8d0ac8e2c324f67fce499007abc7109a80. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

