### PR TITLE
fix: let doc-upload router handle pipeline selection

### DIFF
--- a/src/components/chat/document-uploader.tsx
+++ b/src/components/chat/document-uploader.tsx
@@ -5,7 +5,6 @@ import {
 } from '@/services/inference/tinfoil-client'
 import { logError } from '@/utils/error-handling'
 import {
-  getDocumentFormat,
   getFileIconType as getFileIcon,
   isPlainTextFile,
 } from '@/utils/file-types'
@@ -65,11 +64,6 @@ export const useDocumentUploader = (
       })
       throw error
     }
-  }
-
-  // Determine the format based on file extension
-  const getFormatFromFileType = (file: File): string => {
-    return getDocumentFormat(file.name)
   }
 
   // Handle text files directly in the browser
@@ -277,26 +271,9 @@ export const useDocumentUploader = (
       // Create a FormData object for the file
       const formData = new FormData()
 
-      // Add the file - make sure it's correctly named as expected by the API
       formData.append('files', file)
 
-      // Add essential parameters - ensure they're formatted as arrays if needed
-      formData.append('to_formats[]', 'md')
-      formData.append('from_formats[]', getFormatFromFileType(file))
-      formData.append('pipeline', 'standard')
-      formData.append('return_as_file', 'false')
-
-      // Add parameters to control image handling
-      formData.append('include_images', 'false')
-      formData.append('do_picture_classification', 'false')
-      formData.append('do_picture_description', 'false')
-      formData.append('image_export_mode', 'placeholder')
-      formData.append('do_ocr', 'true')
-
-      const { endpoint, modelName } = await getDocUploadModel()
-
-      // Add model parameter to formData
-      formData.append('model', modelName)
+      const { endpoint } = await getDocUploadModel()
 
       const apiKey = await getSessionToken()
       const client = new SecureClient()


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Let the doc-upload router choose the pipeline and model so uploads use the correct processing automatically. The client now only sends the file and relies on the server for format and image/OCR handling.

- **Bug Fixes**
  - Removed client-side params: `pipeline`, `to_formats[]`, `from_formats[]`, image/OCR flags, and `model`.
  - Dropped `getDocumentFormat` usage; the router infers formats.
  - `FormData` now only includes `files`; `getDocUploadModel()` is used for `endpoint` only.

<sup>Written for commit 350600fabd2843b34051079082f19cf1b7f341e3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

