### PR TITLE
chore: update csp to allow embedding in tinfoil.sh

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -41,11 +41,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval' https://*.tinfoil.sh https://clerk.accounts.dev https://*.clerk.accounts.dev https://tinfoilsh.github.io https://vercel.live https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; font-src 'self' data:; img-src 'self' data: blob: https:; connect-src 'self' data: https://*.tinfoil.sh https://tinfoilsh.github.io https://plausible.io https://vitals.vercel-insights.com https://clerk.accounts.dev https://*.clerk.accounts.dev wss://*.clerk.accounts.dev https://cdn.jsdelivr.net; frame-src 'self' data: https://vercel.live https://clerk.accounts.dev https://*.clerk.accounts.dev https://verification-center.tinfoil.sh; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests"
-        },
-        {
-          "key": "X-Frame-Options",
-          "value": "DENY"
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval' https://*.tinfoil.sh https://clerk.accounts.dev https://*.clerk.accounts.dev https://tinfoilsh.github.io https://vercel.live https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; font-src 'self' data:; img-src 'self' data: blob: https:; connect-src 'self' data: https://*.tinfoil.sh https://tinfoilsh.github.io https://plausible.io https://vitals.vercel-insights.com https://clerk.accounts.dev https://*.clerk.accounts.dev wss://*.clerk.accounts.dev https://cdn.jsdelivr.net; frame-src 'self' data: https://vercel.live https://clerk.accounts.dev https://*.clerk.accounts.dev https://verification-center.tinfoil.sh; frame-ancestors https://tinfoil.sh https://www.tinfoil.sh; base-uri 'self'; form-action 'self'; upgrade-insecure-requests"
         },
         {
           "key": "X-Content-Type-Options",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Allow embedding this app in `tinfoil.sh` by updating the Content Security Policy. Removed the `X-Frame-Options` header and set `frame-ancestors` to https://tinfoil.sh and https://www.tinfoil.sh; all other directives remain unchanged.

<sup>Written for commit 05b3049e104dae574868be87869005d9abc513ac. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

