### PR TITLE
fix: generate image thumbnails for cross-platform sync

### DIFF
--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -197,7 +197,7 @@ function generateProjectName(): string {
 function buildAttachment(opts: {
   id: string
   fileName: string
-  imageData?: { base64: string; mimeType: string }
+  imageData?: { base64: string; mimeType: string; thumbnailBase64?: string }
   textContent?: string
   description?: string
 }): Attachment | undefined {
@@ -208,6 +208,7 @@ function buildAttachment(opts: {
       fileName: opts.fileName,
       mimeType: opts.imageData.mimeType,
       base64: opts.imageData.base64,
+      thumbnailBase64: opts.imageData.thumbnailBase64,
       description: opts.description ?? opts.fileName,
     }
   }

--- a/src/components/chat/document-uploader.tsx
+++ b/src/components/chat/document-uploader.tsx
@@ -9,6 +9,7 @@ import {
   isPlainTextFile,
 } from '@/utils/file-types'
 import {
+  generateThumbnailBase64,
   isAudioFile,
   isImageFile,
   scaleAndEncodeImage,
@@ -138,13 +139,21 @@ export const useDocumentUploader = (
     onSuccess: (
       content: string,
       documentId: string,
-      imageData?: { base64: string; mimeType: string },
+      imageData?: {
+        base64: string
+        mimeType: string
+        thumbnailBase64?: string
+      },
       hasDescription?: boolean,
     ) => void,
     onError: (error: Error, documentId: string) => void,
     onGeneratingDescription?: (
       documentId: string,
-      imageData?: { base64: string; mimeType: string },
+      imageData?: {
+        base64: string
+        mimeType: string
+        thumbnailBase64?: string
+      },
     ) => void,
   ) => {
     const documentId = getDocumentId()
@@ -185,11 +194,23 @@ export const useDocumentUploader = (
         }
 
         try {
-          const imageData = await scaleAndEncodeImage(file, {
+          const scaled = await scaleAndEncodeImage(file, {
             maxWidth: 768,
             maxHeight: 768,
             quality: 0.85,
           })
+
+          let thumbnailBase64: string | undefined
+          try {
+            thumbnailBase64 = await generateThumbnailBase64(
+              scaled.base64,
+              scaled.mimeType,
+            )
+          } catch {
+            // Non-fatal — proceed without thumbnail
+          }
+
+          const imageData = { ...scaled, thumbnailBase64 }
 
           // If current model is multimodal, skip description generation
           // The image will be sent directly to the model

--- a/src/utils/preprocessing/media.ts
+++ b/src/utils/preprocessing/media.ts
@@ -141,3 +141,67 @@ export async function scaleAndEncodeImage(
 
   return { base64, mimeType }
 }
+
+const THUMBNAIL_MAX_DIMENSION = 300
+const THUMBNAIL_QUALITY = 0.6
+
+/**
+ * Generate a small JPEG thumbnail from a base64-encoded image.
+ * Returns the thumbnail as a plain base64 string (no data-URL prefix).
+ */
+export async function generateThumbnailBase64(
+  base64: string,
+  mimeType: string,
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const img = new Image()
+    const canvas = document.createElement('canvas')
+    const ctx = canvas.getContext('2d')
+
+    if (!ctx) {
+      reject(new Error('Failed to get canvas context'))
+      return
+    }
+
+    img.onload = () => {
+      let width = img.width
+      let height = img.height
+
+      if (width > THUMBNAIL_MAX_DIMENSION || height > THUMBNAIL_MAX_DIMENSION) {
+        const ratio = THUMBNAIL_MAX_DIMENSION / Math.max(width, height)
+        width = Math.floor(width * ratio)
+        height = Math.floor(height * ratio)
+      }
+
+      canvas.width = width
+      canvas.height = height
+      ctx.drawImage(img, 0, 0, width, height)
+
+      canvas.toBlob(
+        (blob) => {
+          if (!blob) {
+            reject(new Error('Failed to create thumbnail blob'))
+            return
+          }
+          const reader = new FileReader()
+          reader.onload = (e) => {
+            if (e.target?.result) {
+              const dataUrl = e.target.result as string
+              resolve(dataUrl.split(',')[1])
+            } else {
+              reject(new Error('Failed to read thumbnail blob'))
+            }
+          }
+          reader.onerror = () =>
+            reject(new Error('Error reading thumbnail blob'))
+          reader.readAsDataURL(blob)
+        },
+        'image/jpeg',
+        THUMBNAIL_QUALITY,
+      )
+    }
+
+    img.onerror = () => reject(new Error('Failed to load image for thumbnail'))
+    img.src = `data:${mimeType};base64,${base64}`
+  })
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Generate small JPEG thumbnails for uploaded images and include them in attachments to improve cross‑platform sync and previews. Adds `thumbnailBase64` to image attachments with a safe fallback if thumbnail creation fails.

- **Bug Fixes**
  - Generate 300px JPEG thumbnails via `generateThumbnailBase64` in `media.ts`.
  - Include `thumbnailBase64` in uploader callbacks and `buildAttachment` for preview support across clients.
  - If thumbnail generation fails, proceed without a thumbnail (no breaking changes).

<sup>Written for commit f1559b4a6612fecf4de1e09965300e376fb457a7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

