### PR TITLE
Fix chat loading errors when Clerk auth blips

### DIFF
--- a/src/components/auth-cleanup-handler.tsx
+++ b/src/components/auth-cleanup-handler.tsx
@@ -19,9 +19,7 @@ export function AuthCleanupHandler() {
   const [showModal, setShowModal] = useState(false)
   const [isDarkMode, setIsDarkMode] = useState(false)
   const hasCheckedRef = useRef(false)
-  const pendingSignoutCleanupRef = useRef<ReturnType<typeof setTimeout> | null>(
-    null,
-  )
+  const pendingSignoutCleanupRef = useRef<number | null>(null)
   const latestAuthStateRef = useRef({
     isLoaded,
     isSignedIn,

--- a/src/components/auth-cleanup-handler.tsx
+++ b/src/components/auth-cleanup-handler.tsx
@@ -9,7 +9,9 @@ import {
   performUserSwitchCleanup,
 } from '@/utils/signout-cleanup'
 import { useAuth, useUser } from '@clerk/nextjs'
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+const SIGNOUT_CLEANUP_GRACE_MS = 2000
 
 export function AuthCleanupHandler() {
   const { isSignedIn, isLoaded } = useAuth()
@@ -17,11 +19,81 @@ export function AuthCleanupHandler() {
   const [showModal, setShowModal] = useState(false)
   const [isDarkMode, setIsDarkMode] = useState(false)
   const hasCheckedRef = useRef(false)
+  const pendingSignoutCleanupRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  )
+  const latestAuthStateRef = useRef({
+    isLoaded,
+    isSignedIn,
+    userId: user?.id,
+  })
+
+  useEffect(() => {
+    latestAuthStateRef.current = {
+      isLoaded,
+      isSignedIn,
+      userId: user?.id,
+    }
+  }, [isLoaded, isSignedIn, user?.id])
+
+  const clearPendingSignoutCleanup = useCallback(() => {
+    if (pendingSignoutCleanupRef.current !== null) {
+      clearTimeout(pendingSignoutCleanupRef.current)
+      pendingSignoutCleanupRef.current = null
+    }
+  }, [])
+
+  const runSignoutCleanup = useCallback(() => {
+    const encryptionKey = getEncryptionKey()
+
+    if (hasPasskeyBackup() || !encryptionKey) {
+      const action = hasPasskeyBackup()
+        ? 'signoutWithPasskey'
+        : 'signoutWithoutKey'
+      logInfo('Auto-clearing all data on signout', {
+        component: 'AuthCleanupHandler',
+        action,
+      })
+      // Remove the active user ID first so that if cleanup throws before
+      // localStorage.clear(), the reload won't re-enter this branch and loop.
+      localStorage.removeItem(AUTH_ACTIVE_USER_ID)
+      performSignoutCleanup()
+        .catch((error) => {
+          logError('Failed to cleanup on signout', error, {
+            component: 'AuthCleanupHandler',
+            action,
+          })
+        })
+        .finally(() => {
+          window.location.reload()
+        })
+      return
+    }
+
+    logInfo('No passkey backup, preserving key for download prompt', {
+      component: 'AuthCleanupHandler',
+      action: 'signoutWithoutPasskey',
+    })
+    performSignoutCleanup({ preserveEncryptionKey: true })
+      .catch((error) => {
+        logError('Failed to cleanup on signout (preserving key)', error, {
+          component: 'AuthCleanupHandler',
+          action: 'signoutWithoutPasskey',
+        })
+      })
+      .finally(() => {
+        // Check theme from data-theme attribute (source of truth)
+        const dataTheme = document.documentElement.getAttribute('data-theme')
+        setIsDarkMode(dataTheme === 'dark')
+        setShowModal(true)
+      })
+  }, [])
 
   useEffect(() => {
     if (!isLoaded) return
 
     if (isSignedIn && user?.id) {
+      clearPendingSignoutCleanup()
       const storedUserId = localStorage.getItem(AUTH_ACTIVE_USER_ID)
 
       if (storedUserId && storedUserId !== user.id) {
@@ -37,60 +109,46 @@ export function AuthCleanupHandler() {
     // Check if user just signed out (stored user ID exists but no longer signed in)
     const storedUserId = localStorage.getItem(AUTH_ACTIVE_USER_ID)
     if (!isSignedIn && storedUserId && !hasCheckedRef.current) {
-      hasCheckedRef.current = true
+      if (pendingSignoutCleanupRef.current === null) {
+        pendingSignoutCleanupRef.current = window.setTimeout(() => {
+          pendingSignoutCleanupRef.current = null
 
-      const encryptionKey = getEncryptionKey()
+          const latestStoredUserId = localStorage.getItem(AUTH_ACTIVE_USER_ID)
+          const latestAuthState = latestAuthStateRef.current
 
-      if (hasPasskeyBackup() || !encryptionKey) {
-        // Keys are safely backed up via passkey, or no key exists — clear everything
-        const action = hasPasskeyBackup()
-          ? 'signoutWithPasskey'
-          : 'signoutWithoutKey'
-        logInfo('Auto-clearing all data on signout', {
-          component: 'AuthCleanupHandler',
-          action,
-        })
-        // Remove the active user ID first so that if cleanup throws before
-        // localStorage.clear(), the reload won't re-enter this branch and loop.
-        localStorage.removeItem(AUTH_ACTIVE_USER_ID)
-        performSignoutCleanup()
-          .catch((error) => {
-            logError('Failed to cleanup on signout', error, {
-              component: 'AuthCleanupHandler',
-              action,
-            })
-          })
-          .finally(() => {
-            window.location.reload()
-          })
-        return
+          if (
+            !latestAuthState.isLoaded ||
+            latestAuthState.isSignedIn ||
+            !latestStoredUserId
+          ) {
+            return
+          }
+
+          hasCheckedRef.current = true
+          runSignoutCleanup()
+        }, SIGNOUT_CLEANUP_GRACE_MS)
       }
+    } else {
+      clearPendingSignoutCleanup()
+    }
 
-      // Key exists but no passkey backup — preserve key and show download modal
-      logInfo('No passkey backup, preserving key for download prompt', {
-        component: 'AuthCleanupHandler',
-        action: 'signoutWithoutPasskey',
-      })
-      performSignoutCleanup({ preserveEncryptionKey: true })
-        .catch((error) => {
-          logError('Failed to cleanup on signout (preserving key)', error, {
-            component: 'AuthCleanupHandler',
-            action: 'signoutWithoutPasskey',
-          })
-        })
-        .finally(() => {
-          // Check theme from data-theme attribute (source of truth)
-          const dataTheme = document.documentElement.getAttribute('data-theme')
-          setIsDarkMode(dataTheme === 'dark')
-          setShowModal(true)
-        })
+    if (!storedUserId) {
+      clearPendingSignoutCleanup()
     }
 
     // Reset the check flag when user signs in
     if (isSignedIn) {
       hasCheckedRef.current = false
     }
-  }, [isSignedIn, isLoaded, user?.id])
+  }, [
+    isSignedIn,
+    isLoaded,
+    user?.id,
+    clearPendingSignoutCleanup,
+    runSignoutCleanup,
+  ])
+
+  useEffect(() => clearPendingSignoutCleanup, [clearPendingSignoutCleanup])
 
   const handleDone = () => {
     deleteEncryptionKey()

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -927,7 +927,7 @@ export function ChatInterface({
   // Profile sync is handled separately by useProfileSync hook
   // Context-aware: syncs personal chats when not in project mode, project chats when in project mode
   useEffect(() => {
-    if (!isSignedIn) return
+    if (!isAuthLoaded || !isSignedIn || !cloudSyncInitialized) return
 
     // Initial sync based on current mode
     const initialSync =
@@ -968,7 +968,9 @@ export function ChatInterface({
 
     return () => clearInterval(interval)
   }, [
+    isAuthLoaded,
     isSignedIn,
+    cloudSyncInitialized,
     isProjectMode,
     activeProject,
     syncChats,

--- a/src/services/cloud/cloud-storage.ts
+++ b/src/services/cloud/cloud-storage.ts
@@ -1,4 +1,5 @@
 import type { Message } from '@/components/chat/types'
+import { AUTH_ACTIVE_USER_ID } from '@/constants/storage-keys'
 import {
   base64ToUint8Array,
   decryptAttachment,
@@ -13,6 +14,7 @@ import { processRemoteChat, type RemoteChatData } from './chat-codec'
 
 const API_BASE_URL =
   process.env.NEXT_PUBLIC_API_BASE_URL || 'https://api.tinfoil.sh'
+const AUTH_INIT_WAIT_MS = 3000
 
 export interface ChatListResponse {
   conversations: Array<{
@@ -73,6 +75,16 @@ function stripBase64FromMessages(messages: Message[]): Message[] {
 }
 
 export class CloudStorageService {
+  private async ensureAuthReady(): Promise<void> {
+    if (
+      !authTokenManager.isInitialized() &&
+      typeof window !== 'undefined' &&
+      localStorage.getItem(AUTH_ACTIVE_USER_ID) !== null
+    ) {
+      await authTokenManager.waitForInit(AUTH_INIT_WAIT_MS)
+    }
+  }
+
   async generateConversationId(timestamp?: string): Promise<{
     conversationId: string
     timestamp: string
@@ -94,10 +106,12 @@ export class CloudStorageService {
   }
 
   private async getHeaders(): Promise<Record<string, string>> {
+    await this.ensureAuthReady()
     return authTokenManager.getAuthHeaders()
   }
 
   async isAuthenticated(): Promise<boolean> {
+    await this.ensureAuthReady()
     return authTokenManager.isAuthenticated()
   }
 

--- a/src/services/cloud/cloud-sync.ts
+++ b/src/services/cloud/cloud-sync.ts
@@ -4,7 +4,7 @@ import {
   SYNC_CHAT_STATUS,
   SYNC_PROJECT_CHAT_STATUS_PREFIX,
 } from '@/constants/storage-keys'
-import { logError, logInfo } from '@/utils/error-handling'
+import { logError, logInfo, logWarning } from '@/utils/error-handling'
 import { chatEvents } from '../storage/chat-events'
 import { deletedChatsTracker } from '../storage/deleted-chats-tracker'
 import { indexedDBStorage, type StoredChat } from '../storage/indexed-db'
@@ -43,6 +43,7 @@ export interface SyncStatusResult {
 const UPLOAD_BASE_DELAY_MS = 1000
 const UPLOAD_MAX_DELAY_MS = 8000
 const UPLOAD_MAX_RETRIES = 3
+const REMOTE_LIST_MAX_ATTEMPTS = 2
 
 const isStreaming = (id: string) => streamingTracker.isStreaming(id)
 
@@ -624,6 +625,65 @@ export class CloudSyncService {
     return this.withSyncLock(() => this.doSyncAllChats())
   }
 
+  private async listChatsWithRetry(options: {
+    includeContent: boolean
+    limit: number
+  }) {
+    let lastError: unknown
+
+    for (let attempt = 1; attempt <= REMOTE_LIST_MAX_ATTEMPTS; attempt++) {
+      try {
+        return await cloudStorage.listChats(options)
+      } catch (error) {
+        lastError = error
+
+        if (attempt < REMOTE_LIST_MAX_ATTEMPTS) {
+          logWarning('Failed to list remote chats, retrying', {
+            component: 'CloudSync',
+            action: 'listChatsWithRetry',
+            metadata: {
+              attempt,
+              maxAttempts: REMOTE_LIST_MAX_ATTEMPTS,
+              error: error instanceof Error ? error.message : String(error),
+            },
+          })
+        }
+      }
+    }
+
+    throw lastError instanceof Error ? lastError : new Error(String(lastError))
+  }
+
+  private async listProjectChatsWithRetry(
+    projectId: string,
+    options: { includeContent: boolean; continuationToken?: string },
+  ) {
+    let lastError: unknown
+
+    for (let attempt = 1; attempt <= REMOTE_LIST_MAX_ATTEMPTS; attempt++) {
+      try {
+        return await projectStorage.listProjectChats(projectId, options)
+      } catch (error) {
+        lastError = error
+
+        if (attempt < REMOTE_LIST_MAX_ATTEMPTS) {
+          logWarning('Failed to list project chats, retrying', {
+            component: 'CloudSync',
+            action: 'listProjectChatsWithRetry',
+            metadata: {
+              attempt,
+              maxAttempts: REMOTE_LIST_MAX_ATTEMPTS,
+              projectId,
+              error: error instanceof Error ? error.message : String(error),
+            },
+          })
+        }
+      }
+    }
+
+    throw lastError instanceof Error ? lastError : new Error(String(lastError))
+  }
+
   private async doSyncAllChats(): Promise<SyncResult> {
     const result: SyncResult = {
       uploaded: 0,
@@ -638,20 +698,10 @@ export class CloudSyncService {
       result.errors.push(...backupResult.errors)
 
       // Then, get list of remote chats with content
-      let remoteList
-      try {
-        remoteList = await cloudStorage.listChats({
-          includeContent: true,
-          limit: PAGINATION.CHATS_PER_PAGE,
-        })
-      } catch (error) {
-        // Log the error but continue with sync
-        logError('Failed to list remote chats', error, {
-          component: 'CloudSync',
-          action: 'syncAllChats',
-        })
-        return result
-      }
+      const remoteList = await this.listChatsWithRetry({
+        includeContent: true,
+        limit: PAGINATION.CHATS_PER_PAGE,
+      })
 
       const remoteConversations = [...(remoteList.conversations || [])]
 
@@ -699,9 +749,7 @@ export class CloudSyncService {
       // Detect cross-scope moves (chats moving between projects)
       await this.syncCrossScope(result)
     } catch (error) {
-      result.errors.push(
-        `Sync failed: ${error instanceof Error ? error.message : String(error)}`,
-      )
+      throw error instanceof Error ? error : new Error(String(error))
     }
 
     return result
@@ -1006,7 +1054,7 @@ export class CloudSyncService {
 
       while (hasMore) {
         // Fetch project chats with content for decryption
-        const projectChatsResponse = await projectStorage.listProjectChats(
+        const projectChatsResponse = await this.listProjectChatsWithRetry(
           projectId,
           { includeContent: true, continuationToken },
         )
@@ -1077,14 +1125,12 @@ export class CloudSyncService {
         )
       }
     } catch (error) {
-      result.errors.push(
-        `Failed to sync project chats: ${error instanceof Error ? error.message : String(error)}`,
-      )
       logError('Failed to sync project chats', error, {
         component: 'CloudSync',
         action: 'syncProjectChats',
         metadata: { projectId },
       })
+      throw error instanceof Error ? error : new Error(String(error))
     }
 
     return result

--- a/tests/components/auth-cleanup-handler.test.tsx
+++ b/tests/components/auth-cleanup-handler.test.tsx
@@ -1,6 +1,7 @@
 import { AuthCleanupHandler } from '@/components/auth-cleanup-handler'
 import { AUTH_ACTIVE_USER_ID } from '@/constants/storage-keys'
 import { act, render } from '@testing-library/react'
+import { createElement } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mockPerformSignoutCleanup = vi.fn()
@@ -68,7 +69,7 @@ describe('AuthCleanupHandler', () => {
   it('does not clear data for a transient signed-out state', async () => {
     localStorage.setItem(AUTH_ACTIVE_USER_ID, 'user_123')
 
-    const { rerender } = render(<AuthCleanupHandler />)
+    const { rerender } = render(createElement(AuthCleanupHandler))
 
     await act(async () => {
       vi.advanceTimersByTime(1000)
@@ -82,7 +83,7 @@ describe('AuthCleanupHandler', () => {
       user: { id: 'user_123' },
     }
 
-    rerender(<AuthCleanupHandler />)
+    rerender(createElement(AuthCleanupHandler))
 
     await act(async () => {
       vi.advanceTimersByTime(2000)
@@ -96,7 +97,7 @@ describe('AuthCleanupHandler', () => {
   it('clears data after the grace period when still signed out', async () => {
     localStorage.setItem(AUTH_ACTIVE_USER_ID, 'user_123')
 
-    render(<AuthCleanupHandler />)
+    render(createElement(AuthCleanupHandler))
 
     await act(async () => {
       vi.advanceTimersByTime(2000)
@@ -118,7 +119,7 @@ describe('AuthCleanupHandler', () => {
       user: { id: 'user_new' },
     }
 
-    render(<AuthCleanupHandler />)
+    render(createElement(AuthCleanupHandler))
 
     expect(mockPerformUserSwitchCleanup).toHaveBeenCalledWith('user_new')
     expect(mockPerformSignoutCleanup).not.toHaveBeenCalled()

--- a/tests/components/auth-cleanup-handler.test.tsx
+++ b/tests/components/auth-cleanup-handler.test.tsx
@@ -1,0 +1,126 @@
+import { AuthCleanupHandler } from '@/components/auth-cleanup-handler'
+import { AUTH_ACTIVE_USER_ID } from '@/constants/storage-keys'
+import { act, render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockPerformSignoutCleanup = vi.fn()
+const mockPerformUserSwitchCleanup = vi.fn()
+const mockGetEncryptionKey = vi.fn()
+const mockHasPasskeyBackup = vi.fn()
+
+let authState: { isSignedIn: boolean; isLoaded: boolean } = {
+  isSignedIn: false,
+  isLoaded: true,
+}
+let userState: { user: { id: string } | null } = {
+  user: null,
+}
+
+vi.mock('@clerk/nextjs', () => ({
+  useAuth: () => authState,
+  useUser: () => userState,
+}))
+
+vi.mock('@/components/modals/signout-confirmation-modal', () => ({
+  SignoutConfirmationModal: () => null,
+}))
+
+vi.mock('@/utils/error-handling', () => ({
+  logError: vi.fn(),
+  logInfo: vi.fn(),
+}))
+
+vi.mock('@/utils/signout-cleanup', () => ({
+  deleteEncryptionKey: vi.fn(),
+  getEncryptionKey: (...args: any[]) => mockGetEncryptionKey(...args),
+  hasPasskeyBackup: (...args: any[]) => mockHasPasskeyBackup(...args),
+  performSignoutCleanup: (...args: any[]) => mockPerformSignoutCleanup(...args),
+  performUserSwitchCleanup: (...args: any[]) =>
+    mockPerformUserSwitchCleanup(...args),
+}))
+
+describe('AuthCleanupHandler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+    localStorage.clear()
+
+    authState = {
+      isSignedIn: false,
+      isLoaded: true,
+    }
+    userState = {
+      user: null,
+    }
+
+    mockPerformSignoutCleanup.mockResolvedValue(undefined)
+    mockPerformUserSwitchCleanup.mockImplementation(() => {})
+    mockGetEncryptionKey.mockReturnValue(null)
+    mockHasPasskeyBackup.mockReturnValue(true)
+    vi.spyOn(window.location, 'reload').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.useRealTimers()
+  })
+
+  it('does not clear data for a transient signed-out state', async () => {
+    localStorage.setItem(AUTH_ACTIVE_USER_ID, 'user_123')
+
+    const { rerender } = render(<AuthCleanupHandler />)
+
+    await act(async () => {
+      vi.advanceTimersByTime(1000)
+    })
+
+    authState = {
+      isSignedIn: true,
+      isLoaded: true,
+    }
+    userState = {
+      user: { id: 'user_123' },
+    }
+
+    rerender(<AuthCleanupHandler />)
+
+    await act(async () => {
+      vi.advanceTimersByTime(2000)
+      await Promise.resolve()
+    })
+
+    expect(mockPerformSignoutCleanup).not.toHaveBeenCalled()
+    expect(mockPerformUserSwitchCleanup).not.toHaveBeenCalled()
+  })
+
+  it('clears data after the grace period when still signed out', async () => {
+    localStorage.setItem(AUTH_ACTIVE_USER_ID, 'user_123')
+
+    render(<AuthCleanupHandler />)
+
+    await act(async () => {
+      vi.advanceTimersByTime(2000)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(mockPerformSignoutCleanup).toHaveBeenCalledTimes(1)
+    expect(window.location.reload).toHaveBeenCalledTimes(1)
+  })
+
+  it('still clears data immediately on user switch', () => {
+    localStorage.setItem(AUTH_ACTIVE_USER_ID, 'user_old')
+    authState = {
+      isSignedIn: true,
+      isLoaded: true,
+    }
+    userState = {
+      user: { id: 'user_new' },
+    }
+
+    render(<AuthCleanupHandler />)
+
+    expect(mockPerformUserSwitchCleanup).toHaveBeenCalledWith('user_new')
+    expect(mockPerformSignoutCleanup).not.toHaveBeenCalled()
+  })
+})

--- a/tests/services/cloud/cloud-storage.test.ts
+++ b/tests/services/cloud/cloud-storage.test.ts
@@ -1,0 +1,65 @@
+import { AUTH_ACTIVE_USER_ID } from '@/constants/storage-keys'
+import { CloudStorageService } from '@/services/cloud/cloud-storage'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockGetAuthHeaders = vi.fn()
+const mockIsAuthenticated = vi.fn()
+const mockIsInitialized = vi.fn()
+const mockWaitForInit = vi.fn()
+
+vi.mock('@/services/auth', () => ({
+  authTokenManager: {
+    getAuthHeaders: (...args: any[]) => mockGetAuthHeaders(...args),
+    isAuthenticated: (...args: any[]) => mockIsAuthenticated(...args),
+    isInitialized: (...args: any[]) => mockIsInitialized(...args),
+    waitForInit: (...args: any[]) => mockWaitForInit(...args),
+  },
+}))
+
+describe('CloudStorageService auth readiness', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+    mockGetAuthHeaders.mockResolvedValue({ Authorization: 'Bearer token' })
+    mockIsAuthenticated.mockResolvedValue(true)
+    mockIsInitialized.mockReturnValue(true)
+    mockWaitForInit.mockResolvedValue(true)
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          conversations: [],
+          hasMore: false,
+        }),
+      }),
+    )
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('waits for auth token manager initialization before listing chats', async () => {
+    mockIsInitialized.mockReturnValue(false)
+    localStorage.setItem(AUTH_ACTIVE_USER_ID, 'user_123')
+
+    const service = new CloudStorageService()
+    await service.listChats()
+
+    expect(mockWaitForInit).toHaveBeenCalledWith(3000)
+    expect(mockGetAuthHeaders).toHaveBeenCalledTimes(1)
+  })
+
+  it('waits for auth token manager initialization before checking auth state', async () => {
+    mockIsInitialized.mockReturnValue(false)
+    localStorage.setItem(AUTH_ACTIVE_USER_ID, 'user_123')
+
+    const service = new CloudStorageService()
+    const isAuthenticated = await service.isAuthenticated()
+
+    expect(isAuthenticated).toBe(true)
+    expect(mockWaitForInit).toHaveBeenCalledWith(3000)
+    expect(mockIsAuthenticated).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tests/services/cloud/cloud-sync.test.ts
+++ b/tests/services/cloud/cloud-sync.test.ts
@@ -12,6 +12,12 @@ const mockDeleteChat = vi.fn()
 const mockIsAuthenticated = vi.fn()
 const mockUploadChat = vi.fn()
 const mockGetChatSyncStatus = vi.fn()
+const mockGetAllChatsSyncStatus = vi.fn()
+const mockGetAllChatsUpdatedSince = vi.fn()
+const mockListChats = vi.fn()
+
+const mockListProjectChats = vi.fn()
+const mockGetProjectChatsSyncStatus = vi.fn()
 
 const mockEncryptionInitialize = vi.fn()
 
@@ -19,6 +25,8 @@ const mockIsStreaming = vi.fn()
 const mockOnStreamEnd = vi.fn()
 
 const mockChatEventsEmit = vi.fn()
+const mockIngestRemoteChats = vi.fn()
+const mockSyncRemoteDeletions = vi.fn()
 
 vi.mock('@/utils/error-handling', () => ({
   logInfo: vi.fn(),
@@ -42,6 +50,19 @@ vi.mock('@/services/cloud/cloud-storage', () => ({
     isAuthenticated: (...args: any[]) => mockIsAuthenticated(...args),
     uploadChat: (...args: any[]) => mockUploadChat(...args),
     getChatSyncStatus: (...args: any[]) => mockGetChatSyncStatus(...args),
+    getAllChatsSyncStatus: (...args: any[]) =>
+      mockGetAllChatsSyncStatus(...args),
+    getAllChatsUpdatedSince: (...args: any[]) =>
+      mockGetAllChatsUpdatedSince(...args),
+    listChats: (...args: any[]) => mockListChats(...args),
+  },
+}))
+
+vi.mock('@/services/cloud/project-storage', () => ({
+  projectStorage: {
+    listProjectChats: (...args: any[]) => mockListProjectChats(...args),
+    getProjectChatsSyncStatus: (...args: any[]) =>
+      mockGetProjectChatsSyncStatus(...args),
   },
 }))
 
@@ -64,6 +85,11 @@ vi.mock('@/services/storage/chat-events', () => ({
   },
 }))
 
+vi.mock('@/services/cloud/chat-ingestion', () => ({
+  ingestRemoteChats: (...args: any[]) => mockIngestRemoteChats(...args),
+  syncRemoteDeletions: (...args: any[]) => mockSyncRemoteDeletions(...args),
+}))
+
 describe('CloudSyncService', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -74,9 +100,35 @@ describe('CloudSyncService', () => {
     mockIsAuthenticated.mockResolvedValue(true)
     mockUploadChat.mockResolvedValue(null)
     mockGetChatSyncStatus.mockResolvedValue({ count: 0, lastUpdated: null })
+    mockGetAllChatsSyncStatus.mockResolvedValue({
+      count: 0,
+      lastUpdated: null,
+    })
+    mockGetAllChatsUpdatedSince.mockResolvedValue({
+      conversations: [],
+      hasMore: false,
+    })
+    mockListChats.mockResolvedValue({
+      conversations: [],
+      hasMore: false,
+    })
+    mockListProjectChats.mockResolvedValue({
+      chats: [],
+      hasMore: false,
+    })
+    mockGetProjectChatsSyncStatus.mockResolvedValue({
+      count: 0,
+      lastUpdated: null,
+    })
     mockEncryptionInitialize.mockResolvedValue(null)
     mockIsStreaming.mockReturnValue(false)
     mockOnStreamEnd.mockImplementation(() => {})
+    mockIngestRemoteChats.mockResolvedValue({
+      downloaded: 0,
+      errors: [],
+      savedIds: [],
+    })
+    mockSyncRemoteDeletions.mockResolvedValue(undefined)
   })
 
   describe('reencryptAndUploadChats', () => {
@@ -345,6 +397,53 @@ describe('CloudSyncService', () => {
       const status = await service.checkSyncStatus()
 
       expect(status).toEqual({ needsSync: true, reason: 'error' })
+    })
+  })
+
+  describe('syncAllChats', () => {
+    it('retries listing remote chats before succeeding', async () => {
+      mockGetUnsyncedChats.mockResolvedValue([])
+      mockGetAllChats.mockResolvedValue([])
+      mockListChats
+        .mockRejectedValueOnce(new Error('temporary auth failure'))
+        .mockResolvedValue({
+          conversations: [],
+          hasMore: false,
+        })
+
+      const service = new CloudSyncService()
+      const result = await service.syncAllChats()
+
+      expect(mockListChats).toHaveBeenCalledTimes(2)
+      expect(result).toEqual({ uploaded: 0, downloaded: 0, errors: [] })
+    })
+
+    it('throws when remote chat listing still fails after retry', async () => {
+      mockGetUnsyncedChats.mockResolvedValue([])
+      mockListChats.mockRejectedValue(new Error('still failing'))
+
+      const service = new CloudSyncService()
+
+      await expect(service.syncAllChats()).rejects.toThrow('still failing')
+      expect(mockListChats).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  describe('syncProjectChats', () => {
+    it('retries listing project chats before succeeding', async () => {
+      mockGetAllChats.mockResolvedValue([])
+      mockListProjectChats
+        .mockRejectedValueOnce(new Error('temporary auth failure'))
+        .mockResolvedValue({
+          chats: [],
+          hasMore: false,
+        })
+
+      const service = new CloudSyncService()
+      const result = await service.syncProjectChats('project-1')
+
+      expect(mockListProjectChats).toHaveBeenCalledTimes(2)
+      expect(result).toEqual({ uploaded: 0, downloaded: 0, errors: [] })
     })
   })
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes chat loading errors and accidental local data clearing when Clerk briefly reports signed-out. Adds a short grace period and auth-init guards so sync waits for a stable, signed-in state and retries temporary failures.

- **Bug Fixes**
  - Add 2s grace period in the auth cleanup handler; cancel cleanup if auth recovers; still run immediate cleanup on user switch.
  - Preserve the encryption key and show the download modal when no passkey backup; otherwise clear and reload.
  - Gate chat sync until `isAuthLoaded`, `isSignedIn`, and `cloudSyncInitialized` are true.
  - In cloud storage, wait up to 3s for the auth token manager to initialize when `AUTH_ACTIVE_USER_ID` exists before sending requests.
  - In cloud sync, retry remote chat listing (user and project) up to 2 times with warnings; propagate failures instead of silently swallowing them.
  - Add tests for auth cleanup grace period, auth readiness in storage calls, and sync listing retries; fix CI checks for auth cleanup.

<sup>Written for commit 8656941ae012696d7117f49b84ff4dab55588c21. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

