### PR TITLE
Expand supported doc formats

### DIFF
--- a/src/components/chat/chat-input.tsx
+++ b/src/components/chat/chat-input.tsx
@@ -450,8 +450,8 @@ export function ChatInput({
             multiple
             accept={
               isPremium
-                ? '.pdf,.docx,.xlsx,.pptx,.md,.html,.xhtml,.csv,.png,.jpg,.jpeg,.tiff,.bmp,.webp,.txt,.py,.js,.jsx,.ts,.tsx,.css,.json,.xml,.yaml,.yml,.toml,.sh,.rb,.java,.cpp,.c,.h,.hpp,.go,.rs,.swift,.kt,.r,.sql,.lua,.pl,.php,.env,.ini,.cfg,.conf,.log,.mp3,.wav,.ogg,.m4a,.aac,.flac,.webm,.wma'
-                : '.pdf,.docx,.xlsx,.pptx,.md,.html,.xhtml,.csv,.txt,.py,.js,.jsx,.ts,.tsx,.css,.json,.xml,.yaml,.yml,.toml,.sh,.rb,.java,.cpp,.c,.h,.hpp,.go,.rs,.swift,.kt,.r,.sql,.lua,.pl,.php,.env,.ini,.cfg,.conf,.log'
+                ? '.pdf,.docx,.xlsx,.pptx,.md,.html,.xhtml,.csv,.png,.jpg,.jpeg,.tiff,.bmp,.webp,.txt,.py,.js,.jsx,.ts,.tsx,.css,.json,.xml,.yaml,.yml,.toml,.sh,.rb,.java,.cpp,.c,.h,.hpp,.go,.rs,.swift,.kt,.r,.sql,.lua,.pl,.php,.env,.ini,.cfg,.conf,.log,.rtf,.mp3,.wav,.ogg,.m4a,.aac,.flac,.webm,.wma,.qfx,.qif,.ofx,.ifs,.qbo,.qbx,.bai,.bai2,.mt940,.sta,.tsv,.ics,.vcf'
+                : '.pdf,.docx,.xlsx,.pptx,.md,.html,.xhtml,.csv,.txt,.py,.js,.jsx,.ts,.tsx,.css,.json,.xml,.yaml,.yml,.toml,.sh,.rb,.java,.cpp,.c,.h,.hpp,.go,.rs,.swift,.kt,.r,.sql,.lua,.pl,.php,.env,.ini,.cfg,.conf,.log,.rtf,.qfx,.qif,.ofx,.ifs,.qbo,.qbx,.bai,.bai2,.mt940,.sta,.tsv,.ics,.vcf'
             }
           />
 

--- a/src/components/chat/chat-input.tsx
+++ b/src/components/chat/chat-input.tsx
@@ -463,7 +463,12 @@ export function ChatInput({
               {processedDocuments.map((doc) => (
                 <div
                   key={doc.id}
-                  className="group relative flex min-w-[200px] max-w-[300px] flex-shrink-0 flex-col rounded-2xl border border-border-subtle bg-surface-chat-background p-3 shadow-sm transition-colors"
+                  className={cn(
+                    'group relative flex min-w-[200px] max-w-[300px] flex-shrink-0 flex-col rounded-2xl border p-3 shadow-sm transition-colors',
+                    doc.isUnsupported
+                      ? 'border-red-400/50 bg-red-950/30'
+                      : 'border-border-subtle bg-surface-chat-background',
+                  )}
                 >
                   {removeDocument && (
                     <button
@@ -518,17 +523,31 @@ export function ChatInput({
                       />
                     )}
                     <div className="flex min-w-0 flex-col">
-                      <span className="truncate text-sm font-medium text-content-primary">
+                      <span
+                        className={cn(
+                          'truncate text-sm font-medium',
+                          doc.isUnsupported
+                            ? 'text-red-400'
+                            : 'text-content-primary',
+                        )}
+                      >
                         {doc.name}
                       </span>
-                      {!doc.isUploading && (
-                        <span className="text-xs text-content-muted">
-                          {doc.isGeneratingDescription
-                            ? 'Generating text description...'
-                            : doc.attachment?.type === 'image' || doc.imageData
-                              ? 'Image'
-                              : 'Document'}
+                      {doc.isUnsupported ? (
+                        <span className="text-xs font-medium text-red-400">
+                          Unsupported format
                         </span>
+                      ) : (
+                        !doc.isUploading && (
+                          <span className="text-xs text-content-muted">
+                            {doc.isGeneratingDescription
+                              ? 'Generating text description...'
+                              : doc.attachment?.type === 'image' ||
+                                  doc.imageData
+                                ? 'Image'
+                                : 'Document'}
+                          </span>
+                        )
                       )}
                     </div>
                   </div>

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -53,6 +53,7 @@ import {
   setCloudSyncEnabled,
 } from '@/utils/cloud-sync-settings'
 import { logError } from '@/utils/error-handling'
+import { isSupportedFile } from '@/utils/file-types'
 import {
   getProjectUploadPreference,
   setProjectUploadPreference,
@@ -1221,6 +1222,19 @@ export function ChatInterface({
     async (file: File) => {
       const tempDocId = crypto.randomUUID()
 
+      if (!isSupportedFile(file.name)) {
+        setProcessedDocuments((prev) => [
+          ...prev,
+          {
+            id: tempDocId,
+            name: file.name,
+            time: new Date(),
+            isUnsupported: true,
+          },
+        ])
+        return
+      }
+
       setProcessedDocuments((prev) => [
         ...prev,
         {
@@ -1538,7 +1552,8 @@ export function ChatInterface({
 
     // Filter out documents that are still uploading or generating descriptions
     const completedDocuments = processedDocuments.filter(
-      (doc) => !doc.isUploading && !doc.isGeneratingDescription,
+      (doc) =>
+        !doc.isUploading && !doc.isGeneratingDescription && !doc.isUnsupported,
     )
 
     const messageText = input.trim()

--- a/src/components/chat/renderers/types.ts
+++ b/src/components/chat/renderers/types.ts
@@ -8,6 +8,7 @@ export type ProcessedDocument = {
   time: Date
   content?: string
   isUploading?: boolean
+  isUnsupported?: boolean
   attachment?: Attachment // The resolved attachment for this document
   isImageDescription?: boolean // True if content is from multimodal image description
   hasDescription?: boolean // True if a multimodal description has been generated

--- a/src/components/project/project-document-upload.tsx
+++ b/src/components/project/project-document-upload.tsx
@@ -17,11 +17,8 @@ const ACCEPTED_FILE_TYPES = [
   '.json',
   '.csv',
   '.pdf',
-  '.doc',
   '.docx',
-  '.xls',
   '.xlsx',
-  '.ppt',
   '.pptx',
 ]
 

--- a/src/utils/file-types.ts
+++ b/src/utils/file-types.ts
@@ -100,6 +100,20 @@ const PLAIN_TEXT_EXTENSIONS = [
 // Archive extensions
 const ARCHIVE_EXTENSIONS = ['.zip', '.rar', '.tar']
 
+// All supported extensions combined
+const ALL_SUPPORTED_EXTENSIONS = [
+  ...IMAGE_EXTENSIONS,
+  ...Object.values(DOCUMENT_EXTENSIONS).flat(),
+  ...Object.values(MEDIA_EXTENSIONS).flat(),
+  ...Object.values(CODE_EXTENSIONS).flat(),
+  ...PLAIN_TEXT_EXTENSIONS,
+]
+
+export function isSupportedFile(filename: string): boolean {
+  const lowerFilename = filename.toLowerCase()
+  return ALL_SUPPORTED_EXTENSIONS.some((ext) => lowerFilename.endsWith(ext))
+}
+
 /**
  * Checks if a filename has an image extension
  * @param filename - The filename to check

--- a/src/utils/file-types.ts
+++ b/src/utils/file-types.ts
@@ -31,7 +31,7 @@ const MEDIA_EXTENSIONS = {
 
 // Supported code extensions
 const CODE_EXTENSIONS = {
-  html: ['.html', '.htm'],
+  html: ['.html', '.htm', '.xhtml'],
   js: ['.js', '.jsx'],
   ts: ['.ts', '.tsx'],
   css: ['.css'],
@@ -188,7 +188,11 @@ export function getDocumentFormat(filename: string): string {
   if (lowerFilename.endsWith('.pdf')) return 'pdf'
   if (lowerFilename.endsWith('.docx')) return 'docx'
   if (lowerFilename.endsWith('.pptx')) return 'pptx'
-  if (lowerFilename.endsWith('.html') || lowerFilename.endsWith('.htm'))
+  if (
+    lowerFilename.endsWith('.html') ||
+    lowerFilename.endsWith('.htm') ||
+    lowerFilename.endsWith('.xhtml')
+  )
     return 'html'
   if (lowerFilename.endsWith('.md')) return 'md'
   if (lowerFilename.endsWith('.csv')) return 'csv'

--- a/src/utils/file-types.ts
+++ b/src/utils/file-types.ts
@@ -17,9 +17,9 @@ const IMAGE_EXTENSIONS = [
 // Supported document extensions
 const DOCUMENT_EXTENSIONS = {
   pdf: ['.pdf'],
-  docx: ['.doc', '.docx'],
-  pptx: ['.ppt', '.pptx'],
-  xlsx: ['.xls', '.xlsx'],
+  docx: ['.docx'],
+  pptx: ['.pptx'],
+  xlsx: ['.xlsx'],
   csv: ['.csv'],
 }
 
@@ -38,6 +38,23 @@ const CODE_EXTENSIONS = {
   md: ['.md'],
   txt: ['.txt'],
 }
+
+// Financial data extensions that can be read as plain text
+const FINANCIAL_EXTENSIONS = [
+  '.qfx',
+  '.qif',
+  '.ofx',
+  '.ifs',
+  '.qbo',
+  '.qbx',
+  '.bai',
+  '.bai2',
+  '.mt940',
+  '.sta',
+  '.tsv',
+  '.ics',
+  '.vcf',
+]
 
 // Plain text / code extensions that can be read directly in the browser
 const PLAIN_TEXT_EXTENSIONS = [
@@ -76,6 +93,8 @@ const PLAIN_TEXT_EXTENSIONS = [
   '.cfg',
   '.conf',
   '.log',
+  '.rtf',
+  ...FINANCIAL_EXTENSIONS,
 ]
 
 // Archive extensions
@@ -123,6 +142,11 @@ export function getFileIconType(filename: string): string {
     }
   }
 
+  // Check financial types
+  if (FINANCIAL_EXTENSIONS.some((ext) => lowerFilename.endsWith(ext))) {
+    return 'csv'
+  }
+
   // Check archive types
   if (ARCHIVE_EXTENSIONS.some((ext) => lowerFilename.endsWith(ext))) {
     return 'zip'
@@ -148,16 +172,13 @@ export function getDocumentFormat(filename: string): string {
   const lowerFilename = filename.toLowerCase()
 
   if (lowerFilename.endsWith('.pdf')) return 'pdf'
-  if (lowerFilename.endsWith('.docx') || lowerFilename.endsWith('.doc'))
-    return 'docx'
-  if (lowerFilename.endsWith('.pptx') || lowerFilename.endsWith('.ppt'))
-    return 'pptx'
+  if (lowerFilename.endsWith('.docx')) return 'docx'
+  if (lowerFilename.endsWith('.pptx')) return 'pptx'
   if (lowerFilename.endsWith('.html') || lowerFilename.endsWith('.htm'))
     return 'html'
   if (lowerFilename.endsWith('.md')) return 'md'
   if (lowerFilename.endsWith('.csv')) return 'csv'
-  if (lowerFilename.endsWith('.xlsx') || lowerFilename.endsWith('.xls'))
-    return 'xlsx'
+  if (lowerFilename.endsWith('.xlsx')) return 'xlsx'
   if (hasImageExtension(filename)) return 'image'
   if (lowerFilename.endsWith('.txt')) return 'asciidoc'
 

--- a/tests/utils/file-types.test.ts
+++ b/tests/utils/file-types.test.ts
@@ -42,11 +42,8 @@ describe('file-types', () => {
     describe('document types', () => {
       it.each([
         ['document.pdf', 'pdf'],
-        ['file.doc', 'docx'],
         ['file.docx', 'docx'],
-        ['slides.ppt', 'pptx'],
         ['slides.pptx', 'pptx'],
-        ['data.xls', 'xlsx'],
         ['data.xlsx', 'xlsx'],
         ['data.csv', 'csv'],
       ])('should return %s for %s', (filename, expected) => {
@@ -110,15 +107,12 @@ describe('file-types', () => {
   describe('getDocumentFormat', () => {
     it.each([
       ['document.pdf', 'pdf'],
-      ['file.doc', 'docx'],
       ['file.docx', 'docx'],
-      ['slides.ppt', 'pptx'],
       ['slides.pptx', 'pptx'],
       ['page.html', 'html'],
       ['page.htm', 'html'],
       ['readme.md', 'md'],
       ['data.csv', 'csv'],
-      ['sheet.xls', 'xlsx'],
       ['sheet.xlsx', 'xlsx'],
       ['notes.txt', 'asciidoc'],
     ])('should return %s for %s', (filename, expected) => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Expanded supported formats for chat uploads by adding RTF, `.xhtml`, and common financial/text files. Project uploads now reject legacy Office files, and unsupported files are clearly marked in chat and never sent.

- **New Features**
  - Added `isSupportedFile` with a unified extension list.
  - New supported types: `.rtf`, `.xhtml`, `.qfx`, `.qif`, `.ofx`, `.ifs`, `.qbo`, `.qbx`, `.bai`, `.bai2`, `.mt940`, `.sta`, `.tsv`, `.ics`, `.vcf`.
  - Chat input flags unsupported files with a red style and "Unsupported format" label; they’re skipped when sending.
  - Icon mapping treats financial formats as `csv`.

- **Migration**
  - Dropped legacy Office formats: `.doc`, `.ppt`, `.xls`. Use `.docx`, `.pptx`, `.xlsx` instead.

<sup>Written for commit c42a4cd483894539dbca25f27e68da54c053c945. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

