### PR TITLE
Refactor cloud sync and key set up to avoid split brain

### DIFF
--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -293,6 +293,7 @@ export function ChatInterface({
     encryptionKey,
     initialized: cloudSyncInitialized,
     setEncryptionKey,
+    addRecoveryKey,
     retryDecryptionWithNewKey,
     decryptionProgress,
   } = useCloudSync({
@@ -304,6 +305,7 @@ export function ChatInterface({
   const {
     passkeyActive,
     passkeyRecoveryNeeded,
+    manualRecoveryNeeded,
     passkeySetupAvailable,
     passkeyIntroNeeded,
     setupPasskey,
@@ -318,7 +320,7 @@ export function ChatInterface({
     user,
     onEncryptionKeyRecovered: useCallback(
       (key: string) => {
-        void setEncryptionKey(key)
+        void setEncryptionKey(key, { mode: 'recoverExisting' })
       },
       [setEncryptionKey],
     ),
@@ -353,6 +355,12 @@ export function ChatInterface({
 
   // State for cloud sync setup modal
   const [showCloudSyncSetupModal, setShowCloudSyncSetupModal] = useState(false)
+
+  useEffect(() => {
+    if (manualRecoveryNeeded) {
+      setShowCloudSyncSetupModal(true)
+    }
+  }, [manualRecoveryNeeded])
 
   // State for add-to-project-context modal
   const [showAddToProjectModal, setShowAddToProjectModal] = useState(false)
@@ -1041,8 +1049,13 @@ export function ChatInterface({
   }
 
   const handleKeyChanged = useCallback(
-    async (key: string) => {
-      const syncResult = await setEncryptionKey(key)
+    async (
+      key: string,
+      options?: {
+        mode?: 'recoverExisting' | 'explicitStartFresh'
+      },
+    ) => {
+      const syncResult = await setEncryptionKey(key, options)
       if (syncResult) {
         await retryProfileDecryption()
         await reloadChats()
@@ -1050,6 +1063,15 @@ export function ChatInterface({
       }
     },
     [setEncryptionKey, retryProfileDecryption, reloadChats],
+  )
+
+  const handleAddRecoveryKey = useCallback(
+    async (key: string) => {
+      await addRecoveryKey(key)
+      await retryProfileDecryption()
+      await reloadChats()
+    },
+    [addRecoveryKey, retryProfileDecryption, reloadChats],
   )
 
   // Handler for creating a new project with a random name
@@ -2279,6 +2301,7 @@ export function ChatInterface({
         isPremium={isPremium}
         encryptionKey={encryptionKey}
         onKeyChange={handleKeyChanged}
+        onAddRecoveryKey={handleAddRecoveryKey}
         passkeyActive={passkeyActive}
         passkeySetupAvailable={passkeySetupAvailable}
         onSetupPasskey={setupPasskey}
@@ -2512,9 +2535,14 @@ export function ChatInterface({
               setCloudSyncEnabled(false)
             }
           }}
-          onSetupComplete={async (key: string) => {
-            await handleKeyChanged(key)
-            setShowCloudSyncSetupModal(false)
+          onSetupComplete={async (key: string, mode) => {
+            try {
+              await handleKeyChanged(key, { mode })
+              setShowCloudSyncSetupModal(false)
+              return true
+            } catch {
+              return false
+            }
           }}
           isDarkMode={isDarkMode}
           initialCloudSyncEnabled={true}
@@ -2522,17 +2550,18 @@ export function ChatInterface({
             passkeyActive || passkeyRecoveryNeeded || passkeySetupAvailable
           }
           passkeyRecoveryNeeded={passkeyRecoveryNeeded}
+          manualRecoveryNeeded={manualRecoveryNeeded}
           onRecoverWithPasskey={async () => {
             const key = await recoverWithPasskey()
             if (!key) return false
-            await handleKeyChanged(key)
+            await handleKeyChanged(key, { mode: 'recoverExisting' })
             setShowCloudSyncSetupModal(false)
             return true
           }}
           onSetupNewKey={async () => {
             const key = await setupNewKeySplit()
             if (!key) return false
-            await handleKeyChanged(key)
+            await handleKeyChanged(key, { mode: 'explicitStartFresh' })
             setShowCloudSyncSetupModal(false)
             return true
           }}

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -2554,14 +2554,22 @@ export function ChatInterface({
           onRecoverWithPasskey={async () => {
             const key = await recoverWithPasskey()
             if (!key) return false
-            await handleKeyChanged(key, { mode: 'recoverExisting' })
+            try {
+              await handleKeyChanged(key, { mode: 'recoverExisting' })
+            } catch {
+              return false
+            }
             setShowCloudSyncSetupModal(false)
             return true
           }}
           onSetupNewKey={async () => {
             const key = await setupNewKeySplit()
             if (!key) return false
-            await handleKeyChanged(key, { mode: 'explicitStartFresh' })
+            try {
+              await handleKeyChanged(key, { mode: 'explicitStartFresh' })
+            } catch {
+              return false
+            }
             setShowCloudSyncSetupModal(false)
             return true
           }}

--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -1543,7 +1543,11 @@ export function SettingsModal({
     }
   }
 
-  const handleUpdateKey = async () => {
+  const handleKeyAction = async (
+    action: (key: string) => Promise<void>,
+    successTitle: string,
+    successDescription: string,
+  ) => {
     if (!inputKey.trim()) {
       toast({
         title: 'Invalid key',
@@ -1555,11 +1559,8 @@ export function SettingsModal({
 
     setIsUpdating(true)
     try {
-      await onKeyChange(inputKey)
-      toast({
-        title: 'Primary key replaced',
-        description: 'Future cloud writes will use the new primary key',
-      })
+      await action(inputKey)
+      toast({ title: successTitle, description: successDescription })
       setInputKey('')
     } catch (error) {
       toast({
@@ -1575,37 +1576,19 @@ export function SettingsModal({
     }
   }
 
-  const handleAddRecoveryKey = async () => {
-    if (!inputKey.trim()) {
-      toast({
-        title: 'Invalid key',
-        description: 'Please enter a valid encryption key',
-        variant: 'destructive',
-      })
-      return
-    }
+  const handleUpdateKey = () =>
+    handleKeyAction(
+      onKeyChange,
+      'Primary key replaced',
+      'Future cloud writes will use the new primary key',
+    )
 
-    setIsUpdating(true)
-    try {
-      await onAddRecoveryKey(inputKey)
-      toast({
-        title: 'Recovery key added',
-        description: 'Older encrypted data can now be retried with this key',
-      })
-      setInputKey('')
-    } catch (error) {
-      toast({
-        title: 'Invalid key',
-        description:
-          error instanceof Error
-            ? error.message
-            : 'The encryption key you entered is invalid',
-        variant: 'destructive',
-      })
-    } finally {
-      setIsUpdating(false)
-    }
-  }
+  const handleAddRecoveryKey = () =>
+    handleKeyAction(
+      onAddRecoveryKey,
+      'Recovery key added',
+      'Older encrypted data can now be retried with this key',
+    )
 
   const downloadKeyAsPEM = () => {
     if (!encryptionKey) return

--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -180,6 +180,7 @@ type SettingsModalProps = {
   isPremium?: boolean
   encryptionKey: string | null
   onKeyChange: (key: string) => Promise<void>
+  onAddRecoveryKey: (key: string) => Promise<void>
   passkeyActive?: boolean
   passkeySetupAvailable?: boolean
   onSetupPasskey?: () => Promise<boolean>
@@ -201,6 +202,7 @@ export function SettingsModal({
   isPremium,
   encryptionKey,
   onKeyChange,
+  onAddRecoveryKey,
   passkeyActive,
   passkeySetupAvailable,
   onSetupPasskey,
@@ -1555,14 +1557,49 @@ export function SettingsModal({
     try {
       await onKeyChange(inputKey)
       toast({
-        title: 'Key updated',
-        description: 'Your encryption key has been updated successfully',
+        title: 'Primary key replaced',
+        description: 'Future cloud writes will use the new primary key',
       })
       setInputKey('')
-    } catch {
+    } catch (error) {
       toast({
         title: 'Invalid key',
-        description: 'The encryption key you entered is invalid',
+        description:
+          error instanceof Error
+            ? error.message
+            : 'The encryption key you entered is invalid',
+        variant: 'destructive',
+      })
+    } finally {
+      setIsUpdating(false)
+    }
+  }
+
+  const handleAddRecoveryKey = async () => {
+    if (!inputKey.trim()) {
+      toast({
+        title: 'Invalid key',
+        description: 'Please enter a valid encryption key',
+        variant: 'destructive',
+      })
+      return
+    }
+
+    setIsUpdating(true)
+    try {
+      await onAddRecoveryKey(inputKey)
+      toast({
+        title: 'Recovery key added',
+        description: 'Older encrypted data can now be retried with this key',
+      })
+      setInputKey('')
+    } catch (error) {
+      toast({
+        title: 'Invalid key',
+        description:
+          error instanceof Error
+            ? error.message
+            : 'The encryption key you entered is invalid',
         variant: 'destructive',
       })
     } finally {
@@ -2643,11 +2680,12 @@ ${encryptionKey.replace('key_', '')}
                           {/* Restore or Update Encryption Key */}
                           <div className="space-y-2 pt-2">
                             <h4 className="font-aeonik text-xs font-medium text-content-secondary">
-                              Restore or Update Encryption Key
+                              Recovery and Primary Keys
                             </h4>
                             <p className="text-xs text-content-muted">
-                              Enter or import your existing encryption key to
-                              access your chats on this device.
+                              Add a recovery key to decrypt older data without
+                              changing your current primary key, or replace the
+                              primary key used for future cloud writes.
                             </p>
                             <form
                               onSubmit={(e) => {
@@ -2716,19 +2754,37 @@ ${encryptionKey.replace('key_', '')}
                                     </div>
                                   )}
                                 </div>
-                                <button
-                                  type="submit"
-                                  disabled={isUpdating || !inputKey.trim()}
-                                  aria-label="Update encryption key"
-                                  className={cn(
-                                    'rounded-lg px-4 py-2 text-sm font-medium transition-colors',
-                                    isUpdating || !inputKey.trim()
-                                      ? 'cursor-not-allowed bg-surface-chat text-content-muted'
-                                      : 'bg-blue-500 text-white hover:bg-blue-600',
-                                  )}
-                                >
-                                  {isUpdating ? 'Updating...' : 'Update'}
-                                </button>
+                                <div className="flex gap-2">
+                                  <button
+                                    type="button"
+                                    onClick={handleAddRecoveryKey}
+                                    disabled={isUpdating || !inputKey.trim()}
+                                    aria-label="Add recovery key"
+                                    className={cn(
+                                      'rounded-lg px-4 py-2 text-sm font-medium transition-colors',
+                                      isUpdating || !inputKey.trim()
+                                        ? 'cursor-not-allowed bg-surface-chat text-content-muted'
+                                        : 'border border-border-subtle bg-surface-chat text-content-primary hover:bg-surface-chat/80',
+                                    )}
+                                  >
+                                    {isUpdating ? 'Saving...' : 'Add Recovery'}
+                                  </button>
+                                  <button
+                                    type="submit"
+                                    disabled={isUpdating || !inputKey.trim()}
+                                    aria-label="Replace primary encryption key"
+                                    className={cn(
+                                      'rounded-lg px-4 py-2 text-sm font-medium transition-colors',
+                                      isUpdating || !inputKey.trim()
+                                        ? 'cursor-not-allowed bg-surface-chat text-content-muted'
+                                        : 'bg-blue-500 text-white hover:bg-blue-600',
+                                    )}
+                                  >
+                                    {isUpdating
+                                      ? 'Saving...'
+                                      : 'Replace Primary'}
+                                  </button>
+                                </div>
                               </div>
                             </form>
                           </div>

--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -2674,55 +2674,63 @@ ${encryptionKey.replace('key_', '')}
                           {/* Restore or Update Encryption Key */}
                           <div className="space-y-2 pt-2">
                             <h4 className="font-aeonik text-xs font-medium text-content-secondary">
-                              Recovery and Primary Keys
+                              {passkeyActive
+                                ? 'Add Decryption Key'
+                                : 'Recovery and Primary Keys'}
                             </h4>
                             <p className="text-xs text-content-muted">
-                              Add a recovery key to decrypt older data without
-                              changing your current primary key, or replace the
-                              primary key used for future cloud writes.
+                              {passkeyActive
+                                ? 'Add an older key to decrypt data from before a key rotation. Your passkey manages the primary key.'
+                                : 'Add a recovery key to decrypt older data without changing your current primary key, or replace the primary key used for future cloud writes.'}
                             </p>
-                            <div className="space-y-2 rounded-lg border border-border-subtle bg-surface-chat p-3">
-                              <div className="grid grid-cols-2 gap-2">
-                                <button
-                                  type="button"
-                                  onClick={() =>
-                                    setPrimaryKeyMode('recoverExisting')
-                                  }
-                                  className={cn(
-                                    'rounded-lg px-3 py-2 text-sm font-medium transition-colors',
-                                    primaryKeyMode === 'recoverExisting'
-                                      ? 'border border-blue-500 bg-blue-500/10 text-blue-500'
-                                      : 'border border-border-subtle bg-surface-input text-content-secondary hover:text-content-primary',
-                                  )}
-                                >
-                                  Recover Existing
-                                </button>
-                                <button
-                                  type="button"
-                                  onClick={() =>
-                                    setPrimaryKeyMode('explicitStartFresh')
-                                  }
-                                  className={cn(
-                                    'rounded-lg px-3 py-2 text-sm font-medium transition-colors',
-                                    primaryKeyMode === 'explicitStartFresh'
-                                      ? 'border border-amber-500 bg-amber-500/10 text-amber-500'
-                                      : 'border border-border-subtle bg-surface-input text-content-secondary hover:text-content-primary',
-                                  )}
-                                >
-                                  Start Fresh
-                                </button>
+                            {!passkeyActive && (
+                              <div className="space-y-2 rounded-lg border border-border-subtle bg-surface-chat p-3">
+                                <div className="grid grid-cols-2 gap-2">
+                                  <button
+                                    type="button"
+                                    onClick={() =>
+                                      setPrimaryKeyMode('recoverExisting')
+                                    }
+                                    className={cn(
+                                      'rounded-lg px-3 py-2 text-sm font-medium transition-colors',
+                                      primaryKeyMode === 'recoverExisting'
+                                        ? 'border border-blue-500 bg-blue-500/10 text-blue-500'
+                                        : 'border border-border-subtle bg-surface-input text-content-secondary hover:text-content-primary',
+                                    )}
+                                  >
+                                    Recover Existing
+                                  </button>
+                                  <button
+                                    type="button"
+                                    onClick={() =>
+                                      setPrimaryKeyMode('explicitStartFresh')
+                                    }
+                                    className={cn(
+                                      'rounded-lg px-3 py-2 text-sm font-medium transition-colors',
+                                      primaryKeyMode === 'explicitStartFresh'
+                                        ? 'border border-amber-500 bg-amber-500/10 text-amber-500'
+                                        : 'border border-border-subtle bg-surface-input text-content-secondary hover:text-content-primary',
+                                    )}
+                                  >
+                                    Start Fresh
+                                  </button>
+                                </div>
+                                <p className="text-xs text-content-muted">
+                                  {primaryKeyMode === 'recoverExisting'
+                                    ? 'Verify this key against your existing cloud data before this device resumes writing.'
+                                    : 'Use this key for future cloud writes on this device without validating it against older cloud data.'}
+                                </p>
                               </div>
-                              <p className="text-xs text-content-muted">
-                                {primaryKeyMode === 'recoverExisting'
-                                  ? 'Verify this key against your existing cloud data before this device resumes writing.'
-                                  : 'Use this key for future cloud writes on this device without validating it against older cloud data.'}
-                              </p>
-                            </div>
+                            )}
                             <form
                               onSubmit={(e) => {
                                 e.preventDefault()
                                 if (!isUpdating && inputKey.trim()) {
-                                  handleUpdateKey()
+                                  if (passkeyActive) {
+                                    handleAddRecoveryKey()
+                                  } else {
+                                    handleUpdateKey()
+                                  }
                                 }
                               }}
                               onDragOver={handleDragOver}
@@ -2785,42 +2793,60 @@ ${encryptionKey.replace('key_', '')}
                                     </div>
                                   )}
                                 </div>
-                                <div className="flex gap-2">
-                                  <button
-                                    type="button"
-                                    onClick={handleAddRecoveryKey}
-                                    disabled={isUpdating || !inputKey.trim()}
-                                    aria-label="Add recovery key"
-                                    className={cn(
-                                      'rounded-lg px-4 py-2 text-sm font-medium transition-colors',
-                                      isUpdating || !inputKey.trim()
-                                        ? 'cursor-not-allowed bg-surface-chat text-content-muted'
-                                        : 'border border-border-subtle bg-surface-chat text-content-primary hover:bg-surface-chat/80',
-                                    )}
-                                  >
-                                    {isUpdating ? 'Saving...' : 'Add Recovery'}
-                                  </button>
+                                {passkeyActive ? (
                                   <button
                                     type="submit"
                                     disabled={isUpdating || !inputKey.trim()}
-                                    aria-label="Replace primary encryption key"
+                                    aria-label="Add decryption key"
                                     className={cn(
                                       'rounded-lg px-4 py-2 text-sm font-medium transition-colors',
                                       isUpdating || !inputKey.trim()
                                         ? 'cursor-not-allowed bg-surface-chat text-content-muted'
-                                        : primaryKeyMode ===
-                                            'explicitStartFresh'
-                                          ? 'bg-amber-500 text-white hover:bg-amber-600'
-                                          : 'bg-blue-500 text-white hover:bg-blue-600',
+                                        : 'bg-blue-500 text-white hover:bg-blue-600',
                                     )}
                                   >
-                                    {isUpdating
-                                      ? 'Saving...'
-                                      : primaryKeyMode === 'recoverExisting'
-                                        ? 'Recover Existing'
-                                        : 'Start Fresh'}
+                                    {isUpdating ? 'Saving...' : 'Add Key'}
                                   </button>
-                                </div>
+                                ) : (
+                                  <div className="flex gap-2">
+                                    <button
+                                      type="button"
+                                      onClick={handleAddRecoveryKey}
+                                      disabled={isUpdating || !inputKey.trim()}
+                                      aria-label="Add recovery key"
+                                      className={cn(
+                                        'rounded-lg px-4 py-2 text-sm font-medium transition-colors',
+                                        isUpdating || !inputKey.trim()
+                                          ? 'cursor-not-allowed bg-surface-chat text-content-muted'
+                                          : 'border border-border-subtle bg-surface-chat text-content-primary hover:bg-surface-chat/80',
+                                      )}
+                                    >
+                                      {isUpdating
+                                        ? 'Saving...'
+                                        : 'Add Recovery'}
+                                    </button>
+                                    <button
+                                      type="submit"
+                                      disabled={isUpdating || !inputKey.trim()}
+                                      aria-label="Replace primary encryption key"
+                                      className={cn(
+                                        'rounded-lg px-4 py-2 text-sm font-medium transition-colors',
+                                        isUpdating || !inputKey.trim()
+                                          ? 'cursor-not-allowed bg-surface-chat text-content-muted'
+                                          : primaryKeyMode ===
+                                              'explicitStartFresh'
+                                            ? 'bg-amber-500 text-white hover:bg-amber-600'
+                                            : 'bg-blue-500 text-white hover:bg-blue-600',
+                                      )}
+                                    >
+                                      {isUpdating
+                                        ? 'Saving...'
+                                        : primaryKeyMode === 'recoverExisting'
+                                          ? 'Recover Existing'
+                                          : 'Start Fresh'}
+                                    </button>
+                                  </div>
+                                )}
                               </div>
                             </form>
                           </div>

--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -179,7 +179,10 @@ type SettingsModalProps = {
   isSignedIn?: boolean
   isPremium?: boolean
   encryptionKey: string | null
-  onKeyChange: (key: string) => Promise<void>
+  onKeyChange: (
+    key: string,
+    options?: { mode?: 'recoverExisting' | 'explicitStartFresh' },
+  ) => Promise<void>
   onAddRecoveryKey: (key: string) => Promise<void>
   passkeyActive?: boolean
   passkeySetupAvailable?: boolean
@@ -233,6 +236,9 @@ export function SettingsModal({
   const [showSignOutConfirm, setShowSignOutConfirm] = useState(false)
   const [isHowItWorksOpen, setIsHowItWorksOpen] = useState(false)
   const [isEncryptionKeyOpen, setIsEncryptionKeyOpen] = useState(false)
+  const [primaryKeyMode, setPrimaryKeyMode] = useState<
+    'recoverExisting' | 'explicitStartFresh'
+  >('recoverExisting')
   const copyTimeoutRef = useRef<NodeJS.Timeout | null>(null)
 
   // Structured personalization fields
@@ -1516,6 +1522,7 @@ export function SettingsModal({
     if (!isOpen) {
       setIsQRCodeExpanded(false)
       setShowSignOutConfirm(false)
+      setPrimaryKeyMode('recoverExisting')
     }
   }, [isOpen])
 
@@ -1578,9 +1585,13 @@ export function SettingsModal({
 
   const handleUpdateKey = () =>
     handleKeyAction(
-      onKeyChange,
-      'Primary key replaced',
-      'Future cloud writes will use the new primary key',
+      (key) => onKeyChange(key, { mode: primaryKeyMode }),
+      primaryKeyMode === 'recoverExisting'
+        ? 'Primary key verified'
+        : 'Primary key replaced',
+      primaryKeyMode === 'recoverExisting'
+        ? 'This device verified the key against your existing cloud data'
+        : 'Future cloud writes will use the new primary key on this device',
     )
 
   const handleAddRecoveryKey = () =>
@@ -2670,6 +2681,43 @@ ${encryptionKey.replace('key_', '')}
                               changing your current primary key, or replace the
                               primary key used for future cloud writes.
                             </p>
+                            <div className="space-y-2 rounded-lg border border-border-subtle bg-surface-chat p-3">
+                              <div className="grid grid-cols-2 gap-2">
+                                <button
+                                  type="button"
+                                  onClick={() =>
+                                    setPrimaryKeyMode('recoverExisting')
+                                  }
+                                  className={cn(
+                                    'rounded-lg px-3 py-2 text-sm font-medium transition-colors',
+                                    primaryKeyMode === 'recoverExisting'
+                                      ? 'border border-blue-500 bg-blue-500/10 text-blue-500'
+                                      : 'border border-border-subtle bg-surface-input text-content-secondary hover:text-content-primary',
+                                  )}
+                                >
+                                  Recover Existing
+                                </button>
+                                <button
+                                  type="button"
+                                  onClick={() =>
+                                    setPrimaryKeyMode('explicitStartFresh')
+                                  }
+                                  className={cn(
+                                    'rounded-lg px-3 py-2 text-sm font-medium transition-colors',
+                                    primaryKeyMode === 'explicitStartFresh'
+                                      ? 'border border-amber-500 bg-amber-500/10 text-amber-500'
+                                      : 'border border-border-subtle bg-surface-input text-content-secondary hover:text-content-primary',
+                                  )}
+                                >
+                                  Start Fresh
+                                </button>
+                              </div>
+                              <p className="text-xs text-content-muted">
+                                {primaryKeyMode === 'recoverExisting'
+                                  ? 'Verify this key against your existing cloud data before this device resumes writing.'
+                                  : 'Use this key for future cloud writes on this device without validating it against older cloud data.'}
+                              </p>
+                            </div>
                             <form
                               onSubmit={(e) => {
                                 e.preventDefault()
@@ -2760,12 +2808,17 @@ ${encryptionKey.replace('key_', '')}
                                       'rounded-lg px-4 py-2 text-sm font-medium transition-colors',
                                       isUpdating || !inputKey.trim()
                                         ? 'cursor-not-allowed bg-surface-chat text-content-muted'
-                                        : 'bg-blue-500 text-white hover:bg-blue-600',
+                                        : primaryKeyMode ===
+                                            'explicitStartFresh'
+                                          ? 'bg-amber-500 text-white hover:bg-amber-600'
+                                          : 'bg-blue-500 text-white hover:bg-blue-600',
                                     )}
                                   >
                                     {isUpdating
                                       ? 'Saving...'
-                                      : 'Replace Primary'}
+                                      : primaryKeyMode === 'recoverExisting'
+                                        ? 'Recover Existing'
+                                        : 'Start Fresh'}
                                   </button>
                                 </div>
                               </div>

--- a/src/components/modals/cloud-sync-setup-modal.tsx
+++ b/src/components/modals/cloud-sync-setup-modal.tsx
@@ -28,11 +28,17 @@ import QRCode from 'react-qr-code'
 interface CloudSyncSetupModalBaseProps {
   isOpen: boolean
   onClose: () => void
-  onSetupComplete: (encryptionKey: string) => void
+  onSetupComplete: (
+    encryptionKey: string,
+    mode: CloudKeySetupMode,
+  ) => Promise<boolean>
   isDarkMode: boolean
   initialCloudSyncEnabled?: boolean
   prfSupported?: boolean
+  manualRecoveryNeeded?: boolean
 }
+
+type CloudKeySetupMode = 'recoverExisting' | 'explicitStartFresh'
 
 type CloudSyncSetupModalProps = CloudSyncSetupModalBaseProps &
   (
@@ -64,19 +70,24 @@ export function CloudSyncSetupModal({
   initialCloudSyncEnabled = false,
   passkeyRecoveryNeeded = false,
   prfSupported = false,
+  manualRecoveryNeeded = false,
   onRecoverWithPasskey,
   onSetupNewKey,
 }: CloudSyncSetupModalProps) {
   const initialStep: SetupStep = passkeyRecoveryNeeded
     ? 'passkey-recovery'
-    : prfSupported
+    : manualRecoveryNeeded
       ? 'generate-or-restore'
-      : 'intro'
+      : prfSupported
+        ? 'generate-or-restore'
+        : 'intro'
   const [currentStep, setCurrentStep] = useState<SetupStep>(initialStep)
   const [cloudSyncEnabled, setCloudSyncEnabled] = useState(
     initialCloudSyncEnabled,
   )
   const [generatedKey, setGeneratedKey] = useState<string | null>(null)
+  const [generatedKeyMode, setGeneratedKeyMode] =
+    useState<CloudKeySetupMode>('recoverExisting')
   const [inputKey, setInputKey] = useState('')
   const [isProcessing, setIsProcessing] = useState(false)
   const [isRecovering, setIsRecovering] = useState(false)
@@ -122,10 +133,10 @@ export function CloudSyncSetupModal({
     setIsProcessing(true)
     try {
       const newKey = await encryptionService.generateKey()
-      await encryptionService.setKey(newKey)
       setGeneratedKey(newKey)
-      setCloudSyncEnabled(true)
-      persistCloudSyncEnabled(true)
+      setGeneratedKeyMode(
+        manualRecoveryNeeded ? 'explicitStartFresh' : 'recoverExisting',
+      )
 
       logInfo('Generated new encryption key for cloud sync', {
         component: 'CloudSyncSetupModal',
@@ -160,7 +171,17 @@ export function CloudSyncSetupModal({
 
     setIsProcessing(true)
     try {
-      await encryptionService.setKey(inputKey)
+      const success = await onSetupComplete(inputKey, 'recoverExisting')
+
+      if (!success) {
+        toast({
+          title: 'Invalid key',
+          description: "This key doesn't match your existing cloud data",
+          variant: 'destructive',
+        })
+        return
+      }
+
       setCloudSyncEnabled(true)
       persistCloudSyncEnabled(true)
       localStorage.setItem(SETTINGS_HAS_SEEN_CLOUD_SYNC_MODAL, 'true')
@@ -175,7 +196,6 @@ export function CloudSyncSetupModal({
         description: 'Encryption key restored successfully',
       })
 
-      onSetupComplete(inputKey)
       onClose()
     } catch (error) {
       logError('Failed to restore encryption key', error, {
@@ -318,11 +338,37 @@ ${generatedKey.replace('key_', '')}
   }
 
   const handleComplete = () => {
-    localStorage.setItem(SETTINGS_HAS_SEEN_CLOUD_SYNC_MODAL, 'true')
-    if (generatedKey) {
-      onSetupComplete(generatedKey)
-    }
-    onClose()
+    if (!generatedKey) return
+
+    setIsProcessing(true)
+    void onSetupComplete(generatedKey, generatedKeyMode)
+      .then((success) => {
+        if (!success) {
+          toast({
+            title: 'Setup failed',
+            description: "This key couldn't be verified for cloud sync",
+            variant: 'destructive',
+          })
+          return
+        }
+
+        localStorage.setItem(SETTINGS_HAS_SEEN_CLOUD_SYNC_MODAL, 'true')
+        persistCloudSyncEnabled(true)
+        onClose()
+      })
+      .catch((error) => {
+        toast({
+          title: 'Setup failed',
+          description:
+            error instanceof Error
+              ? error.message
+              : 'Failed to finish cloud sync setup',
+          variant: 'destructive',
+        })
+      })
+      .finally(() => {
+        setIsProcessing(false)
+      })
   }
 
   const renderIntroStep = () => (
@@ -404,8 +450,9 @@ ${generatedKey.replace('key_', '')}
       <h2 className="text-center text-xl font-bold">Encryption Key</h2>
 
       <p className="text-sm text-content-secondary">
-        Generate a new personal encryption key or restore an existing one. Your
-        chats will be encrypted and synced with this personal key.
+        {manualRecoveryNeeded
+          ? 'Restore your existing encryption key to unlock cloud data, or explicitly start fresh with a new key.'
+          : 'Generate a new personal encryption key or restore an existing one. Your chats will be encrypted and synced with this personal key.'}
       </p>
 
       <button
@@ -428,7 +475,11 @@ ${generatedKey.replace('key_', '')}
           disabled={isProcessing}
           className="flex-1 rounded-lg bg-orange-500 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-orange-600"
         >
-          {isProcessing ? 'Generating...' : 'Generate Key'}
+          {isProcessing
+            ? 'Generating...'
+            : manualRecoveryNeeded
+              ? 'Start Fresh with New Key'
+              : 'Generate Key'}
         </button>
       </div>
     </div>
@@ -445,8 +496,9 @@ ${generatedKey.replace('key_', '')}
       <h2 className="text-center text-xl font-bold">Success!</h2>
 
       <p className="text-center text-sm text-content-secondary">
-        Save this key securely. You&apos;ll need it to access your chats and
-        projects on other devices.
+        {generatedKeyMode === 'explicitStartFresh'
+          ? 'Save this key securely. Using it will start a new encrypted cloud history on this device.'
+          : "Save this key securely. You'll need it to access your chats and projects on other devices."}
       </p>
 
       {generatedKey && (

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,4 +12,5 @@ export const CLOUD_SYNC = {
   RETRY_DELAY: 100, // milliseconds
   CHAT_SYNC_INTERVAL: 60000, // 60 seconds (1 minute) - frequency for syncing chats
   PROFILE_SYNC_INTERVAL: 300000, // 5 minutes - frequency for syncing profile (less frequent)
+  KEY_VALIDATION_PROBE_LIMIT: 3,
 } as const

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,3 +14,7 @@ export const CLOUD_SYNC = {
   PROFILE_SYNC_INTERVAL: 300000, // 5 minutes - frequency for syncing profile (less frequent)
   KEY_VALIDATION_PROBE_LIMIT: 3,
 } as const
+
+export const PASSKEY = {
+  CREDENTIAL_SAVE_MAX_ATTEMPTS: 3,
+} as const

--- a/src/constants/storage-keys.ts
+++ b/src/constants/storage-keys.ts
@@ -10,6 +10,8 @@ export const USER_ENCRYPTION_KEY_HISTORY =
 export const SECRET_PASSKEY_PRF_OUTPUT = 'tinfoil-secret-passkey-prf-output'
 export const SECRET_PASSKEY_BACKED_UP = 'tinfoil-secret-passkey-backed-up'
 export const PASSKEY_SYNC_VERSION = 'tinfoil-passkey-sync-version'
+export const SECRET_CLOUD_KEY_AUTHORIZATION_PREFIX =
+  'tinfoil-secret-cloud-key-authorization-'
 
 // --- localStorage: Auth ----------------------------------------------------
 export const AUTH_ACTIVE_USER_ID = 'tinfoil-auth-active-user-id'

--- a/src/constants/storage-keys.ts
+++ b/src/constants/storage-keys.ts
@@ -7,6 +7,8 @@
 export const USER_ENCRYPTION_KEY = 'tinfoil-user-personal-encryption-key'
 export const USER_ENCRYPTION_KEY_HISTORY =
   'tinfoil-user-personal-encryption-key-history'
+export const LEGACY_ENCRYPTION_KEY = 'tinfoil-encryption-key'
+export const LEGACY_ENCRYPTION_KEY_HISTORY = 'tinfoil-encryption-key-history'
 export const SECRET_PASSKEY_PRF_OUTPUT = 'tinfoil-secret-passkey-prf-output'
 export const SECRET_PASSKEY_BACKED_UP = 'tinfoil-secret-passkey-backed-up'
 export const PASSKEY_SYNC_VERSION = 'tinfoil-passkey-sync-version'

--- a/src/constants/storage-keys.ts
+++ b/src/constants/storage-keys.ts
@@ -12,6 +12,7 @@ export const LEGACY_ENCRYPTION_KEY_HISTORY = 'tinfoil-encryption-key-history'
 export const SECRET_PASSKEY_PRF_OUTPUT = 'tinfoil-secret-passkey-prf-output'
 export const SECRET_PASSKEY_BACKED_UP = 'tinfoil-secret-passkey-backed-up'
 export const PASSKEY_SYNC_VERSION = 'tinfoil-passkey-sync-version'
+export const PASSKEY_BUNDLE_VERSION = 'tinfoil-passkey-bundle-version'
 export const SECRET_CLOUD_KEY_AUTHORIZATION_PREFIX =
   'tinfoil-secret-cloud-key-authorization-'
 

--- a/src/hooks/use-cloud-sync.ts
+++ b/src/hooks/use-cloud-sync.ts
@@ -5,6 +5,7 @@ import {
 import { authTokenManager } from '@/services/auth'
 import {
   authorizeCurrentPrimaryKeyOrThrow,
+  canWriteToCloud,
   clearCloudKeyAuthorization,
 } from '@/services/cloud/cloud-key-authorization'
 import { validateCurrentPrimaryKey } from '@/services/cloud/cloud-key-preflight'
@@ -130,6 +131,16 @@ export function useCloudSync(options?: UseCloudSyncOptions) {
 
         // Initialize encryption (does not auto-generate keys)
         const key = await encryptionService.initialize()
+
+        // Ensure the current key is authorized for cloud writes.
+        // Existing users upgrading may have a valid key but no
+        // authorization record yet.
+        if (key && !(await canWriteToCloud())) {
+          const validation = await validateCurrentPrimaryKey()
+          if (validation.canWrite) {
+            await authorizeCurrentPrimaryKeyOrThrow('validated')
+          }
+        }
 
         if (isMountedRef.current) {
           setState((prev) => ({

--- a/src/hooks/use-cloud-sync.ts
+++ b/src/hooks/use-cloud-sync.ts
@@ -404,7 +404,16 @@ export function useCloudSync(options?: UseCloudSyncOptions) {
         await encryptionService.setKey(key)
 
         if (mode === 'recoverExisting') {
-          const validation = await validateCurrentPrimaryKey()
+          let validation: Awaited<ReturnType<typeof validateCurrentPrimaryKey>>
+          try {
+            validation = await validateCurrentPrimaryKey()
+          } catch (validationError) {
+            await encryptionService.replaceKeyBundle(
+              previousKeys.primary,
+              previousKeys.alternatives,
+            )
+            throw validationError
+          }
           if (!validation.canWrite) {
             await encryptionService.replaceKeyBundle(
               previousKeys.primary,

--- a/src/hooks/use-cloud-sync.ts
+++ b/src/hooks/use-cloud-sync.ts
@@ -3,6 +3,8 @@ import {
   USER_ENCRYPTION_KEY,
 } from '@/constants/storage-keys'
 import { authTokenManager } from '@/services/auth'
+import { authorizeCurrentPrimaryKey } from '@/services/cloud/cloud-key-authorization'
+import { validateCurrentPrimaryKey } from '@/services/cloud/cloud-key-preflight'
 import { cloudSync } from '@/services/cloud/cloud-sync'
 import { encryptionService } from '@/services/encryption/encryption-service'
 import {
@@ -31,6 +33,8 @@ interface UseCloudSyncOptions {
   /** Called after a key change so the passkey hook can re-encrypt the backup */
   onKeyChanged?: () => void
 }
+
+type CloudKeyActivationMode = 'recoverExisting' | 'explicitStartFresh'
 
 export function useCloudSync(options?: UseCloudSyncOptions) {
   const { getToken, isSignedIn } = useAuth()
@@ -381,8 +385,10 @@ export function useCloudSync(options?: UseCloudSyncOptions) {
 
   // Set encryption key (for syncing across devices)
   const setEncryptionKey = useCallback(
-    async (key: string) => {
+    async (key: string, options?: { mode?: CloudKeyActivationMode }) => {
+      const mode = options?.mode ?? 'explicitStartFresh'
       try {
+        const previousKeys = encryptionService.getAllKeys()
         // Check both encryptionService (source of truth for the crypto layer) and
         // React state (source of truth for the hook). The passkey init effect may
         // have already persisted the key to encryptionService before the consumer
@@ -396,8 +402,29 @@ export function useCloudSync(options?: UseCloudSyncOptions) {
         })
 
         await encryptionService.setKey(key)
+
+        if (mode === 'recoverExisting') {
+          const validation = await validateCurrentPrimaryKey()
+          if (!validation.canWrite) {
+            await encryptionService.replaceKeyBundle(
+              previousKeys.primary,
+              previousKeys.alternatives,
+            )
+            throw new Error(
+              validation.message ??
+                "This key doesn't match your existing cloud data.",
+            )
+          }
+          await authorizeCurrentPrimaryKey('validated')
+        } else {
+          await authorizeCurrentPrimaryKey('explicit_start_fresh')
+        }
+
         if (isMountedRef.current) {
-          setState((prev) => ({ ...prev, encryptionKey: key }))
+          setState((prev) => ({
+            ...prev,
+            encryptionKey: encryptionService.getKey(),
+          }))
         }
 
         const keyValueChanged = !serviceKey || serviceKey !== key
@@ -437,10 +464,34 @@ export function useCloudSync(options?: UseCloudSyncOptions) {
           component: 'useCloudSync',
           action: 'setEncryptionKey',
         })
-        throw new Error('Invalid encryption key')
+        throw new Error(
+          error instanceof Error ? error.message : 'Invalid encryption key',
+        )
       }
     },
     [syncChats, retryDecryptionWithNewKey],
+  )
+
+  const addRecoveryKey = useCallback(
+    async (key: string) => {
+      try {
+        encryptionService.addDecryptionKey(key)
+        void retryDecryptionWithNewKey({
+          runInBackground: true,
+        })
+
+        if (hasPasskeyBackup()) {
+          onKeyChangedRef.current?.()
+        }
+      } catch (error) {
+        logError('Failed to add recovery key', error, {
+          component: 'useCloudSync',
+          action: 'addRecoveryKey',
+        })
+        throw new Error('Invalid encryption key')
+      }
+    },
+    [retryDecryptionWithNewKey],
   )
 
   return {
@@ -450,6 +501,7 @@ export function useCloudSync(options?: UseCloudSyncOptions) {
     syncProjectChats,
     backupChat,
     setEncryptionKey,
+    addRecoveryKey,
     retryDecryptionWithNewKey,
   }
 }

--- a/src/hooks/use-cloud-sync.ts
+++ b/src/hooks/use-cloud-sync.ts
@@ -408,7 +408,7 @@ export function useCloudSync(options?: UseCloudSyncOptions) {
   // Set encryption key (for syncing across devices)
   const setEncryptionKey = useCallback(
     async (key: string, options?: { mode?: CloudKeyActivationMode }) => {
-      const mode = options?.mode ?? 'explicitStartFresh'
+      const mode = options?.mode ?? 'recoverExisting'
       let previousKeys: {
         primary: string | null
         alternatives: string[]

--- a/src/hooks/use-cloud-sync.ts
+++ b/src/hooks/use-cloud-sync.ts
@@ -4,7 +4,7 @@ import {
 } from '@/constants/storage-keys'
 import { authTokenManager } from '@/services/auth'
 import {
-  authorizeCurrentPrimaryKey,
+  authorizeCurrentPrimaryKeyOrThrow,
   clearCloudKeyAuthorization,
 } from '@/services/cloud/cloud-key-authorization'
 import { validateCurrentPrimaryKey } from '@/services/cloud/cloud-key-preflight'
@@ -449,10 +449,10 @@ export function useCloudSync(options?: UseCloudSyncOptions) {
                 "This key doesn't match your existing cloud data.",
             )
           }
-          await authorizeCurrentPrimaryKey('validated')
+          await authorizeCurrentPrimaryKeyOrThrow('validated')
         } else {
           try {
-            await authorizeCurrentPrimaryKey('explicit_start_fresh')
+            await authorizeCurrentPrimaryKeyOrThrow('explicit_start_fresh')
           } catch (authorizationError) {
             await rollbackToPreviousKeys(previousKeys)
             rolledBack = true

--- a/src/hooks/use-cloud-sync.ts
+++ b/src/hooks/use-cloud-sync.ts
@@ -3,7 +3,10 @@ import {
   USER_ENCRYPTION_KEY,
 } from '@/constants/storage-keys'
 import { authTokenManager } from '@/services/auth'
-import { authorizeCurrentPrimaryKey } from '@/services/cloud/cloud-key-authorization'
+import {
+  authorizeCurrentPrimaryKey,
+  clearCloudKeyAuthorization,
+} from '@/services/cloud/cloud-key-authorization'
 import { validateCurrentPrimaryKey } from '@/services/cloud/cloud-key-preflight'
 import { cloudSync } from '@/services/cloud/cloud-sync'
 import { encryptionService } from '@/services/encryption/encryption-service'
@@ -383,12 +386,37 @@ export function useCloudSync(options?: UseCloudSyncOptions) {
     [],
   )
 
+  const rollbackToPreviousKeys = useCallback(
+    async (previousKeys: {
+      primary: string | null
+      alternatives: string[]
+    }) => {
+      try {
+        await encryptionService.replaceKeyBundle(
+          previousKeys.primary,
+          previousKeys.alternatives,
+        )
+      } catch (rollbackError) {
+        encryptionService.clearKey()
+        clearCloudKeyAuthorization()
+        throw rollbackError
+      }
+    },
+    [],
+  )
+
   // Set encryption key (for syncing across devices)
   const setEncryptionKey = useCallback(
     async (key: string, options?: { mode?: CloudKeyActivationMode }) => {
       const mode = options?.mode ?? 'explicitStartFresh'
+      let previousKeys: {
+        primary: string | null
+        alternatives: string[]
+      } | null = null
+      let didSetKey = false
+      let rolledBack = false
       try {
-        const previousKeys = encryptionService.getAllKeys()
+        previousKeys = encryptionService.getAllKeys()
         // Check both encryptionService (source of truth for the crypto layer) and
         // React state (source of truth for the hook). The passkey init effect may
         // have already persisted the key to encryptionService before the consumer
@@ -402,23 +430,20 @@ export function useCloudSync(options?: UseCloudSyncOptions) {
         })
 
         await encryptionService.setKey(key)
+        didSetKey = true
 
         if (mode === 'recoverExisting') {
           let validation: Awaited<ReturnType<typeof validateCurrentPrimaryKey>>
           try {
             validation = await validateCurrentPrimaryKey()
           } catch (validationError) {
-            await encryptionService.replaceKeyBundle(
-              previousKeys.primary,
-              previousKeys.alternatives,
-            )
+            await rollbackToPreviousKeys(previousKeys)
+            rolledBack = true
             throw validationError
           }
           if (!validation.canWrite) {
-            await encryptionService.replaceKeyBundle(
-              previousKeys.primary,
-              previousKeys.alternatives,
-            )
+            await rollbackToPreviousKeys(previousKeys)
+            rolledBack = true
             throw new Error(
               validation.message ??
                 "This key doesn't match your existing cloud data.",
@@ -426,7 +451,13 @@ export function useCloudSync(options?: UseCloudSyncOptions) {
           }
           await authorizeCurrentPrimaryKey('validated')
         } else {
-          await authorizeCurrentPrimaryKey('explicit_start_fresh')
+          try {
+            await authorizeCurrentPrimaryKey('explicit_start_fresh')
+          } catch (authorizationError) {
+            await rollbackToPreviousKeys(previousKeys)
+            rolledBack = true
+            throw authorizationError
+          }
         }
 
         if (isMountedRef.current) {
@@ -469,6 +500,20 @@ export function useCloudSync(options?: UseCloudSyncOptions) {
 
         return false // Key didn't change
       } catch (error) {
+        if (didSetKey && previousKeys && !rolledBack) {
+          try {
+            await rollbackToPreviousKeys(previousKeys)
+          } catch (rollbackError) {
+            logError(
+              'Failed to rollback encryption key after setEncryptionKey error',
+              rollbackError,
+              {
+                component: 'useCloudSync',
+                action: 'setEncryptionKey.rollback',
+              },
+            )
+          }
+        }
         logError('Failed to set encryption key', error, {
           component: 'useCloudSync',
           action: 'setEncryptionKey',
@@ -478,7 +523,7 @@ export function useCloudSync(options?: UseCloudSyncOptions) {
         )
       }
     },
-    [syncChats, retryDecryptionWithNewKey],
+    [rollbackToPreviousKeys, syncChats, retryDecryptionWithNewKey],
   )
 
   const addRecoveryKey = useCallback(

--- a/src/hooks/use-passkey-backup.ts
+++ b/src/hooks/use-passkey-backup.ts
@@ -2,8 +2,9 @@ import {
   PASSKEY_SYNC_VERSION,
   SECRET_PASSKEY_BACKED_UP,
 } from '@/constants/storage-keys'
+import type { CloudKeyAuthorizationMode } from '@/services/cloud/cloud-key-authorization'
 import {
-  authorizeCurrentPrimaryKey,
+  authorizeCurrentPrimaryKeyOrThrow,
   getCurrentCloudKeyAuthorizationMode,
 } from '@/services/cloud/cloud-key-authorization'
 import {
@@ -153,7 +154,11 @@ export function usePasskeyBackup({
    */
   const createAndStorePasskeyBackup = async (
     userInfo: { userId: string; userName: string; displayName: string },
-    keys: { primary: string; alternatives: string[] },
+    keys: {
+      primary: string
+      alternatives: string[]
+      authorizationMode: CloudKeyAuthorizationMode
+    },
   ): Promise<boolean> => {
     const passkeyResult = await createPrfPasskey(
       userInfo.userId,
@@ -179,23 +184,27 @@ export function usePasskeyBackup({
    * and enable cloud sync. Returns the new key on success, null on cancel/failure.
    * Shared by first-time setup and "Start Fresh" flows.
    */
-  const generateKeyWithPasskeyBackup = useCallback(async (): Promise<
-    string | null
-  > => {
-    const userInfo = getPasskeyUserInfo()
-    if (!userInfo) return null
+  const generateKeyWithPasskeyBackup = useCallback(
+    async (
+      authorizationMode: CloudKeyAuthorizationMode = 'validated',
+    ): Promise<string | null> => {
+      const userInfo = getPasskeyUserInfo()
+      if (!userInfo) return null
 
-    const newKey = await encryptionService.generateKey()
+      const newKey = await encryptionService.generateKey()
 
-    const created = await createAndStorePasskeyBackup(userInfo, {
-      primary: newKey,
-      alternatives: [],
-    })
-    if (!created) return null
+      const created = await createAndStorePasskeyBackup(userInfo, {
+        primary: newKey,
+        alternatives: [],
+        authorizationMode,
+      })
+      if (!created) return null
 
-    await encryptionService.setKey(newKey)
-    return newKey
-  }, [])
+      await encryptionService.setKey(newKey)
+      return newKey
+    },
+    [],
+  )
 
   /**
    * Core passkey recovery: load credentials, authenticate, derive KEK, decrypt bundle.
@@ -206,6 +215,7 @@ export function usePasskeyBackup({
     keyBundle: {
       primary: string
       alternatives: string[]
+      authorizationMode?: CloudKeyAuthorizationMode
     }
     credentialId: string
     syncVersion: number | null
@@ -221,10 +231,6 @@ export function usePasskeyBackup({
     const keyBundle = await retrieveEncryptedKeys(result.credentialId, kek)
     if (!keyBundle) return null
 
-    await encryptionService.setAllKeys(
-      keyBundle.primary,
-      keyBundle.alternatives,
-    )
     const entry = entries.find((e) => e.id === result.credentialId)
     return {
       keyBundle,
@@ -241,6 +247,7 @@ export function usePasskeyBackup({
     keyBundle: {
       primary: string
       alternatives: string[]
+      authorizationMode?: CloudKeyAuthorizationMode
     }
     credentialId: string
     syncVersion: number | null
@@ -279,6 +286,81 @@ export function usePasskeyBackup({
     }
   }
 
+  const rollbackToPreviousKeys = useCallback(
+    async (previousKeys: {
+      primary: string | null
+      alternatives: string[]
+    }): Promise<void> => {
+      await encryptionService.replaceKeyBundle(
+        previousKeys.primary,
+        previousKeys.alternatives,
+      )
+    },
+    [],
+  )
+
+  const getRecoveredAuthorizationMode = useCallback(
+    (
+      authorizationMode?: CloudKeyAuthorizationMode,
+    ): CloudKeyAuthorizationMode =>
+      authorizationMode === 'explicit_start_fresh'
+        ? 'explicit_start_fresh'
+        : 'validated',
+    [],
+  )
+
+  const applyRecoveredKeyBundle = useCallback(
+    async (
+      bundle: {
+        primary: string
+        alternatives: string[]
+        authorizationMode?: CloudKeyAuthorizationMode
+      },
+      previousKeys: {
+        primary: string | null
+        alternatives: string[]
+      },
+    ): Promise<CloudKeyAuthorizationMode | null> => {
+      await encryptionService.setAllKeys(bundle.primary, bundle.alternatives)
+
+      const authorizationMode = getRecoveredAuthorizationMode(
+        bundle.authorizationMode,
+      )
+
+      if (authorizationMode === 'explicit_start_fresh') {
+        try {
+          await authorizeCurrentPrimaryKeyOrThrow('explicit_start_fresh')
+          return 'explicit_start_fresh'
+        } catch {
+          await rollbackToPreviousKeys(previousKeys)
+          return null
+        }
+      }
+
+      let validation: Awaited<ReturnType<typeof validateCurrentPrimaryKey>>
+      try {
+        validation = await validateCurrentPrimaryKey()
+      } catch {
+        await rollbackToPreviousKeys(previousKeys)
+        return null
+      }
+
+      if (!validation.canWrite) {
+        await rollbackToPreviousKeys(previousKeys)
+        return null
+      }
+
+      try {
+        await authorizeCurrentPrimaryKeyOrThrow('validated')
+        return 'validated'
+      } catch {
+        await rollbackToPreviousKeys(previousKeys)
+        return null
+      }
+    },
+    [getRecoveredAuthorizationMode, rollbackToPreviousKeys],
+  )
+
   /**
    * Re-encrypt the passkey backup with the current key bundle.
    * Called after key changes to keep the backup in sync.
@@ -308,6 +390,7 @@ export function usePasskeyBackup({
       const stored = await storeEncryptedKeys(result.credentialId, kek, {
         primary: keys.primary,
         alternatives: keys.alternatives,
+        authorizationMode,
       })
 
       if (stored) {
@@ -359,32 +442,8 @@ export function usePasskeyBackup({
       }
 
       const previousKeys = encryptionService.getAllKeys()
-      const previousMode = await getCurrentCloudKeyAuthorizationMode()
-
-      // Key differs — apply the recovered key bundle
-      await encryptionService.setAllKeys(bundle.primary, bundle.alternatives)
-
-      let validation: Awaited<ReturnType<typeof validateCurrentPrimaryKey>>
-      try {
-        validation = await validateCurrentPrimaryKey()
-      } catch {
-        await encryptionService.replaceKeyBundle(
-          previousKeys.primary,
-          previousKeys.alternatives,
-        )
-        return
-      }
-      if (validation.canWrite) {
-        await authorizeCurrentPrimaryKey('validated')
-      } else if (previousMode === 'explicit_start_fresh') {
-        await authorizeCurrentPrimaryKey('explicit_start_fresh')
-      } else {
-        await encryptionService.replaceKeyBundle(
-          previousKeys.primary,
-          previousKeys.alternatives,
-        )
-        return
-      }
+      const appliedMode = await applyRecoveredKeyBundle(bundle, previousKeys)
+      if (!appliedMode) return
 
       setLocalSyncVersion(cached.credentialId, entry.sync_version)
       onEncryptionKeyRecoveredRef.current?.(bundle.primary)
@@ -400,7 +459,7 @@ export function usePasskeyBackup({
         action: 'refreshKeyFromPasskeyBackup',
       })
     }
-  }, [])
+  }, [applyRecoveredKeyBundle])
 
   /**
    * Retry passkey authentication to recover keys from the backend.
@@ -413,25 +472,12 @@ export function usePasskeyBackup({
       const recovery = await performPasskeyRecovery()
       if (!recovery) return null
 
-      let validation: Awaited<ReturnType<typeof validateCurrentPrimaryKey>>
-      try {
-        validation = await validateCurrentPrimaryKey()
-      } catch {
-        await encryptionService.replaceKeyBundle(
-          previousKeys.primary,
-          previousKeys.alternatives,
-        )
-        return null
-      }
-      if (!validation.canWrite) {
-        await encryptionService.replaceKeyBundle(
-          previousKeys.primary,
-          previousKeys.alternatives,
-        )
-        return null
-      }
+      const appliedMode = await applyRecoveredKeyBundle(
+        recovery.keyBundle,
+        previousKeys,
+      )
+      if (!appliedMode) return null
 
-      await authorizeCurrentPrimaryKey('validated')
       applyRecoveredKeys(recovery)
 
       logInfo('Recovered encryption keys via passkey retry', {
@@ -447,7 +493,7 @@ export function usePasskeyBackup({
       })
       return null
     }
-  }, [])
+  }, [applyRecoveredKeyBundle])
 
   // --- Passkey initialization (runs once after cloud sync init completes) ---
   useEffect(() => {
@@ -550,30 +596,18 @@ export function usePasskeyBackup({
     const setupFirstTimePasskeyUser = async (): Promise<void> => {
       try {
         const previousKeys = encryptionService.getAllKeys()
-        const newKey = await generateKeyWithPasskeyBackup()
+        const newKey = await generateKeyWithPasskeyBackup('validated')
 
         if (newKey) {
-          let validation: Awaited<ReturnType<typeof validateCurrentPrimaryKey>>
-          try {
-            validation = await validateCurrentPrimaryKey()
-          } catch {
-            await encryptionService.replaceKeyBundle(
-              previousKeys.primary,
-              previousKeys.alternatives,
-            )
-            if (isMountedRef.current) {
-              setState((prev) => ({
-                ...prev,
-                manualRecoveryNeeded: true,
-              }))
-            }
-            return
-          }
-          if (!validation.canWrite) {
-            await encryptionService.replaceKeyBundle(
-              previousKeys.primary,
-              previousKeys.alternatives,
-            )
+          const appliedMode = await applyRecoveredKeyBundle(
+            {
+              primary: newKey,
+              alternatives: [],
+              authorizationMode: 'validated',
+            },
+            previousKeys,
+          )
+          if (!appliedMode) {
             if (isMountedRef.current) {
               setState((prev) => ({
                 ...prev,
@@ -583,7 +617,6 @@ export function usePasskeyBackup({
             return
           }
 
-          await authorizeCurrentPrimaryKey('validated')
           applyNewPasskeyKey()
           onEncryptionKeyRecoveredRef.current?.(newKey)
 
@@ -631,6 +664,7 @@ export function usePasskeyBackup({
 
     initializePasskey()
   }, [
+    applyRecoveredKeyBundle,
     initialized,
     isSignedIn,
     encryptionKey,
@@ -659,13 +693,14 @@ export function usePasskeyBackup({
     if (!userInfo) return false
 
     try {
-      const authorizationMode = await getCurrentCloudKeyAuthorizationMode()
+      let authorizationMode = await getCurrentCloudKeyAuthorizationMode()
       if (!authorizationMode) {
         const validation = await validateCurrentPrimaryKey()
         if (!validation.canWrite) {
           return false
         }
-        await authorizeCurrentPrimaryKey('validated')
+        await authorizeCurrentPrimaryKeyOrThrow('validated')
+        authorizationMode = 'validated'
       }
 
       const keys = encryptionService.getAllKeys()
@@ -674,6 +709,7 @@ export function usePasskeyBackup({
       const created = await createAndStorePasskeyBackup(userInfo, {
         primary: keys.primary,
         alternatives: keys.alternatives,
+        authorizationMode,
       })
       if (!created) return false
 
@@ -707,10 +743,10 @@ export function usePasskeyBackup({
    */
   const setupNewKeySplit = useCallback(async (): Promise<string | null> => {
     try {
-      const newKey = await generateKeyWithPasskeyBackup()
+      const newKey = await generateKeyWithPasskeyBackup('explicit_start_fresh')
       if (!newKey) return null
 
-      await authorizeCurrentPrimaryKey('explicit_start_fresh')
+      await authorizeCurrentPrimaryKeyOrThrow('explicit_start_fresh')
       applyNewPasskeyKey()
 
       logInfo('New key split created with passkey', {

--- a/src/hooks/use-passkey-backup.ts
+++ b/src/hooks/use-passkey-backup.ts
@@ -1,4 +1,5 @@
 import {
+  PASSKEY_BUNDLE_VERSION,
   PASSKEY_SYNC_VERSION,
   SECRET_PASSKEY_BACKED_UP,
 } from '@/constants/storage-keys'
@@ -20,6 +21,7 @@ import {
   getCachedPrfResult,
   getPasskeyCredentialState,
   loadPasskeyCredentials,
+  PasskeyCredentialConflictError,
   PrfNotSupportedError,
   retrieveEncryptedKeys,
   storeEncryptedKeys,
@@ -93,6 +95,25 @@ function setLocalSyncVersion(credentialId: string, version: number): void {
   }
 }
 
+function getLocalBundleVersion(): number | null {
+  try {
+    const raw = localStorage.getItem(PASSKEY_BUNDLE_VERSION)
+    if (!raw) return null
+    const parsed = Number.parseInt(raw, 10)
+    return Number.isFinite(parsed) ? parsed : null
+  } catch {
+    return null
+  }
+}
+
+function setLocalBundleVersion(version: number): void {
+  try {
+    localStorage.setItem(PASSKEY_BUNDLE_VERSION, String(version))
+  } catch {
+    // best-effort
+  }
+}
+
 export function usePasskeyBackup({
   encryptionKey,
   initialized,
@@ -159,6 +180,11 @@ export function usePasskeyBackup({
       alternatives: string[]
       authorizationMode: CloudKeyAuthorizationMode
     },
+    options?: {
+      knownBundleVersion?: number | null
+      incrementBundleVersion?: boolean
+      enforceRemoteBundleVersion?: boolean
+    },
   ): Promise<boolean> => {
     const passkeyResult = await createPrfPasskey(
       userInfo.userId,
@@ -172,10 +198,16 @@ export function usePasskeyBackup({
       passkeyResult.credentialId,
       kek,
       keys,
+      {
+        knownBundleVersion: options?.knownBundleVersion,
+        incrementBundleVersion: options?.incrementBundleVersion,
+        enforceRemoteBundleVersion: options?.enforceRemoteBundleVersion,
+      },
     )
     if (!result) return false
     localStorage.setItem(SECRET_PASSKEY_BACKED_UP, 'true')
     setLocalSyncVersion(passkeyResult.credentialId, result.syncVersion)
+    setLocalBundleVersion(result.bundleVersion)
     return true
   }
 
@@ -187,17 +219,29 @@ export function usePasskeyBackup({
   const generateKeyWithPasskeyBackup = useCallback(
     async (
       authorizationMode: CloudKeyAuthorizationMode = 'validated',
+      options?: {
+        incrementBundleVersion?: boolean
+        enforceRemoteBundleVersion?: boolean
+      },
     ): Promise<string | null> => {
       const userInfo = getPasskeyUserInfo()
       if (!userInfo) return null
 
       const newKey = await encryptionService.generateKey()
 
-      const created = await createAndStorePasskeyBackup(userInfo, {
-        primary: newKey,
-        alternatives: [],
-        authorizationMode,
-      })
+      const created = await createAndStorePasskeyBackup(
+        userInfo,
+        {
+          primary: newKey,
+          alternatives: [],
+          authorizationMode,
+        },
+        {
+          knownBundleVersion: getLocalBundleVersion(),
+          incrementBundleVersion: options?.incrementBundleVersion,
+          enforceRemoteBundleVersion: options?.enforceRemoteBundleVersion,
+        },
+      )
       if (!created) return null
 
       await encryptionService.setKey(newKey)
@@ -219,6 +263,7 @@ export function usePasskeyBackup({
     }
     credentialId: string
     syncVersion: number | null
+    bundleVersion: number
   } | null> => {
     const entries = await loadPasskeyCredentials()
     if (entries.length === 0) return null
@@ -236,6 +281,7 @@ export function usePasskeyBackup({
       keyBundle,
       credentialId: result.credentialId,
       syncVersion: entry?.sync_version ?? null,
+      bundleVersion: entry?.bundle_version ?? 0,
     }
   }
 
@@ -251,12 +297,14 @@ export function usePasskeyBackup({
     }
     credentialId: string
     syncVersion: number | null
+    bundleVersion: number
   }): void => {
     setCloudSyncEnabled(true)
     localStorage.setItem(SECRET_PASSKEY_BACKED_UP, 'true')
     if (recovery.syncVersion !== null) {
       setLocalSyncVersion(recovery.credentialId, recovery.syncVersion)
     }
+    setLocalBundleVersion(recovery.bundleVersion)
 
     if (isMountedRef.current) {
       setState((prev) => ({
@@ -307,6 +355,49 @@ export function usePasskeyBackup({
         ? 'explicit_start_fresh'
         : 'validated',
     [],
+  )
+
+  const doesCurrentStateMatchBundle = useCallback(
+    async (bundle: {
+      primary: string
+      alternatives: string[]
+      authorizationMode?: CloudKeyAuthorizationMode
+    }): Promise<boolean> => {
+      const currentKeys = encryptionService.getAllKeys()
+      if (currentKeys.primary !== bundle.primary) {
+        return false
+      }
+
+      const normalizeAlternatives = (primary: string, alternatives: string[]) =>
+        alternatives
+          .filter((key) => key !== primary)
+          .slice()
+          .sort()
+
+      const currentAlternatives = normalizeAlternatives(
+        currentKeys.primary,
+        currentKeys.alternatives,
+      )
+      const bundleAlternatives = normalizeAlternatives(
+        bundle.primary,
+        bundle.alternatives,
+      )
+
+      if (
+        currentAlternatives.length !== bundleAlternatives.length ||
+        currentAlternatives.some(
+          (key, index) => key !== bundleAlternatives[index],
+        )
+      ) {
+        return false
+      }
+
+      const currentMode = await getCurrentCloudKeyAuthorizationMode()
+      return (
+        currentMode === getRecoveredAuthorizationMode(bundle.authorizationMode)
+      )
+    },
+    [getRecoveredAuthorizationMode],
   )
 
   const applyRecoveredKeyBundle = useCallback(
@@ -386,15 +477,45 @@ export function usePasskeyBackup({
       const kek = await deriveKeyEncryptionKey(result.prfOutput)
       const keys = encryptionService.getAllKeys()
       if (!keys.primary) return
+      const currentEntry = entries.find((e) => e.id === result.credentialId)
 
-      const stored = await storeEncryptedKeys(result.credentialId, kek, {
-        primary: keys.primary,
-        alternatives: keys.alternatives,
-        authorizationMode,
-      })
+      let localSyncVersion = getLocalSyncVersion(result.credentialId)
+      let localBundleVersion = getLocalBundleVersion()
+
+      if (
+        (localSyncVersion === null || localBundleVersion === null) &&
+        currentEntry
+      ) {
+        const currentRemoteBundle = await decryptKeyBundle(kek, {
+          iv: currentEntry.iv,
+          data: currentEntry.encrypted_keys,
+        })
+
+        if (await doesCurrentStateMatchBundle(currentRemoteBundle)) {
+          localSyncVersion ??= currentEntry.sync_version
+          localBundleVersion ??= currentEntry.bundle_version ?? 0
+        }
+      }
+
+      const stored = await storeEncryptedKeys(
+        result.credentialId,
+        kek,
+        {
+          primary: keys.primary,
+          alternatives: keys.alternatives,
+          authorizationMode,
+        },
+        {
+          expectedSyncVersion: localSyncVersion,
+          knownBundleVersion: localBundleVersion,
+          incrementBundleVersion: true,
+          enforceRemoteBundleVersion: true,
+        },
+      )
 
       if (stored) {
         setLocalSyncVersion(result.credentialId, stored.syncVersion)
+        setLocalBundleVersion(stored.bundleVersion)
       }
 
       logInfo('Updated passkey backup after key change', {
@@ -402,12 +523,26 @@ export function usePasskeyBackup({
         action: 'updatePasskeyBackup',
       })
     } catch (error) {
+      if (error instanceof PasskeyCredentialConflictError) {
+        logInfo(
+          'Skipped passkey backup update because a newer backup already exists',
+          {
+            component: 'usePasskeyBackup',
+            action: 'updatePasskeyBackup',
+            metadata: {
+              remoteSyncVersion: error.remoteSyncVersion,
+              remoteBundleVersion: error.remoteBundleVersion,
+            },
+          },
+        )
+        return
+      }
       logError('Failed to update passkey backup after key change', error, {
         component: 'usePasskeyBackup',
         action: 'updatePasskeyBackup',
       })
     }
-  }, [])
+  }, [doesCurrentStateMatchBundle])
 
   /**
    * Check if the passkey backup has been updated by another device (sync_version
@@ -434,10 +569,11 @@ export function usePasskeyBackup({
         data: entry.encrypted_keys,
       })
 
-      const localKey = encryptionService.getKey()
-      if (bundle.primary === localKey) {
-        // Key matches — just record the version
+      if (await doesCurrentStateMatchBundle(bundle)) {
         setLocalSyncVersion(cached.credentialId, entry.sync_version)
+        if (entry.bundle_version !== undefined) {
+          setLocalBundleVersion(entry.bundle_version)
+        }
         return
       }
 
@@ -446,7 +582,12 @@ export function usePasskeyBackup({
       if (!appliedMode) return
 
       setLocalSyncVersion(cached.credentialId, entry.sync_version)
-      onEncryptionKeyRecoveredRef.current?.(bundle.primary)
+      if (entry.bundle_version !== undefined) {
+        setLocalBundleVersion(entry.bundle_version)
+      }
+      if (bundle.primary !== previousKeys.primary) {
+        onEncryptionKeyRecoveredRef.current?.(bundle.primary)
+      }
 
       logInfo('Refreshed encryption key from passkey backup', {
         component: 'usePasskeyBackup',
@@ -459,7 +600,7 @@ export function usePasskeyBackup({
         action: 'refreshKeyFromPasskeyBackup',
       })
     }
-  }, [applyRecoveredKeyBundle])
+  }, [applyRecoveredKeyBundle, doesCurrentStateMatchBundle])
 
   /**
    * Retry passkey authentication to recover keys from the backend.
@@ -706,11 +847,19 @@ export function usePasskeyBackup({
       const keys = encryptionService.getAllKeys()
       if (!keys.primary) return false
 
-      const created = await createAndStorePasskeyBackup(userInfo, {
-        primary: keys.primary,
-        alternatives: keys.alternatives,
-        authorizationMode,
-      })
+      const created = await createAndStorePasskeyBackup(
+        userInfo,
+        {
+          primary: keys.primary,
+          alternatives: keys.alternatives,
+          authorizationMode,
+        },
+        {
+          knownBundleVersion: getLocalBundleVersion(),
+          incrementBundleVersion: false,
+          enforceRemoteBundleVersion: true,
+        },
+      )
       if (!created) return false
 
       if (isMountedRef.current) {
@@ -746,7 +895,13 @@ export function usePasskeyBackup({
     let didSetNewKey = false
 
     try {
-      const newKey = await generateKeyWithPasskeyBackup('explicit_start_fresh')
+      const newKey = await generateKeyWithPasskeyBackup(
+        'explicit_start_fresh',
+        {
+          incrementBundleVersion: true,
+          enforceRemoteBundleVersion: false,
+        },
+      )
       if (!newKey) return null
       didSetNewKey = true
 

--- a/src/hooks/use-passkey-backup.ts
+++ b/src/hooks/use-passkey-backup.ts
@@ -742,9 +742,13 @@ export function usePasskeyBackup({
    * Returns the new primary key on success, null on failure/cancel.
    */
   const setupNewKeySplit = useCallback(async (): Promise<string | null> => {
+    const previousKeys = encryptionService.getAllKeys()
+    let didSetNewKey = false
+
     try {
       const newKey = await generateKeyWithPasskeyBackup('explicit_start_fresh')
       if (!newKey) return null
+      didSetNewKey = true
 
       await authorizeCurrentPrimaryKeyOrThrow('explicit_start_fresh')
       applyNewPasskeyKey()
@@ -756,13 +760,16 @@ export function usePasskeyBackup({
       return newKey
     } catch (error) {
       if (error instanceof PrfNotSupportedError) throw error
+      if (didSetNewKey) {
+        await rollbackToPreviousKeys(previousKeys)
+      }
       logError('Failed to create new key split', error, {
         component: 'usePasskeyBackup',
         action: 'setupNewKeySplit',
       })
       return null
     }
-  }, [generateKeyWithPasskeyBackup])
+  }, [generateKeyWithPasskeyBackup, rollbackToPreviousKeys])
 
   /**
    * User accepted the passkey intro modal — trigger the actual WebAuthn passkey flow.

--- a/src/hooks/use-passkey-backup.ts
+++ b/src/hooks/use-passkey-backup.ts
@@ -2,6 +2,14 @@ import {
   PASSKEY_SYNC_VERSION,
   SECRET_PASSKEY_BACKED_UP,
 } from '@/constants/storage-keys'
+import {
+  authorizeCurrentPrimaryKey,
+  getCurrentCloudKeyAuthorizationMode,
+} from '@/services/cloud/cloud-key-authorization'
+import {
+  inspectRemoteEncryptedState,
+  validateCurrentPrimaryKey,
+} from '@/services/cloud/cloud-key-preflight'
 import { encryptionService } from '@/services/encryption/encryption-service'
 import {
   authenticatePrfPasskey,
@@ -9,7 +17,7 @@ import {
   decryptKeyBundle,
   deriveKeyEncryptionKey,
   getCachedPrfResult,
-  hasPasskeyCredentials,
+  getPasskeyCredentialState,
   loadPasskeyCredentials,
   PrfNotSupportedError,
   retrieveEncryptedKeys,
@@ -26,6 +34,8 @@ export interface PasskeyBackupState {
   passkeyActive: boolean
   /** Backend has passkey credentials but auth failed on this device */
   passkeyRecoveryNeeded: boolean
+  /** Remote encrypted data exists but this device needs a manual recovery key */
+  manualRecoveryNeeded: boolean
   /** PRF supported + keys exist locally; user can register a passkey backup from settings */
   passkeySetupAvailable: boolean
   /** True when the intro modal should be shown before the first passkey prompt */
@@ -92,6 +102,7 @@ export function usePasskeyBackup({
   const [state, setState] = useState<PasskeyBackupState>({
     passkeyActive: false,
     passkeyRecoveryNeeded: false,
+    manualRecoveryNeeded: false,
     passkeySetupAvailable: false,
     passkeyIntroNeeded: false,
   })
@@ -183,7 +194,6 @@ export function usePasskeyBackup({
     if (!created) return null
 
     await encryptionService.setKey(newKey)
-    setCloudSyncEnabled(true)
     return newKey
   }, [])
 
@@ -193,8 +203,12 @@ export function usePasskeyBackup({
    * Throws on unexpected errors (callers decide how to handle).
    */
   const performPasskeyRecovery = async (): Promise<{
-    primary: string
-    alternatives: string[]
+    keyBundle: {
+      primary: string
+      alternatives: string[]
+    }
+    credentialId: string
+    syncVersion: number | null
   } | null> => {
     const entries = await loadPasskeyCredentials()
     if (entries.length === 0) return null
@@ -211,32 +225,38 @@ export function usePasskeyBackup({
       keyBundle.primary,
       keyBundle.alternatives,
     )
-
-    setCloudSyncEnabled(true)
-    localStorage.setItem(SECRET_PASSKEY_BACKED_UP, 'true')
-
-    // Record sync_version so the periodic check has a baseline
     const entry = entries.find((e) => e.id === result.credentialId)
-    if (entry) {
-      setLocalSyncVersion(result.credentialId, entry.sync_version)
+    return {
+      keyBundle,
+      credentialId: result.credentialId,
+      syncVersion: entry?.sync_version ?? null,
     }
-
-    return keyBundle
   }
 
   /**
    * Apply recovered keys to component state. Shared by tryPasskeyRecovery
    * (init effect) and recoverWithPasskey (UI-triggered retry).
    */
-  const applyRecoveredKeys = (keyBundle: {
-    primary: string
-    alternatives: string[]
+  const applyRecoveredKeys = (recovery: {
+    keyBundle: {
+      primary: string
+      alternatives: string[]
+    }
+    credentialId: string
+    syncVersion: number | null
   }): void => {
+    setCloudSyncEnabled(true)
+    localStorage.setItem(SECRET_PASSKEY_BACKED_UP, 'true')
+    if (recovery.syncVersion !== null) {
+      setLocalSyncVersion(recovery.credentialId, recovery.syncVersion)
+    }
+
     if (isMountedRef.current) {
       setState((prev) => ({
         ...prev,
         passkeyActive: true,
         passkeyRecoveryNeeded: false,
+        manualRecoveryNeeded: false,
       }))
     }
   }
@@ -246,11 +266,15 @@ export function usePasskeyBackup({
    * setupFirstTimePasskeyUser (init effect) and setupNewKeySplit (UI-triggered).
    */
   const applyNewPasskeyKey = (): void => {
+    setCloudSyncEnabled(true)
+    localStorage.setItem(SECRET_PASSKEY_BACKED_UP, 'true')
+
     if (isMountedRef.current) {
       setState((prev) => ({
         ...prev,
         passkeyActive: true,
         passkeyRecoveryNeeded: false,
+        manualRecoveryNeeded: false,
       }))
     }
   }
@@ -261,6 +285,9 @@ export function usePasskeyBackup({
    */
   const updatePasskeyBackup = useCallback(async (): Promise<void> => {
     try {
+      const authorizationMode = await getCurrentCloudKeyAuthorizationMode()
+      if (!authorizationMode) return
+
       const entries = await loadPasskeyCredentials()
       if (entries.length === 0) return
 
@@ -331,8 +358,25 @@ export function usePasskeyBackup({
         return
       }
 
+      const previousKeys = encryptionService.getAllKeys()
+      const previousMode = await getCurrentCloudKeyAuthorizationMode()
+
       // Key differs — apply the recovered key bundle
       await encryptionService.setAllKeys(bundle.primary, bundle.alternatives)
+
+      const validation = await validateCurrentPrimaryKey()
+      if (validation.canWrite) {
+        await authorizeCurrentPrimaryKey('validated')
+      } else if (previousMode === 'explicit_start_fresh') {
+        await authorizeCurrentPrimaryKey('explicit_start_fresh')
+      } else {
+        await encryptionService.replaceKeyBundle(
+          previousKeys.primary,
+          previousKeys.alternatives,
+        )
+        return
+      }
+
       setLocalSyncVersion(cached.credentialId, entry.sync_version)
       onEncryptionKeyRecoveredRef.current?.(bundle.primary)
 
@@ -356,17 +400,28 @@ export function usePasskeyBackup({
    */
   const recoverWithPasskey = useCallback(async (): Promise<string | null> => {
     try {
-      const keyBundle = await performPasskeyRecovery()
-      if (!keyBundle) return null
+      const previousKeys = encryptionService.getAllKeys()
+      const recovery = await performPasskeyRecovery()
+      if (!recovery) return null
 
-      applyRecoveredKeys(keyBundle)
+      const validation = await validateCurrentPrimaryKey()
+      if (!validation.canWrite) {
+        await encryptionService.replaceKeyBundle(
+          previousKeys.primary,
+          previousKeys.alternatives,
+        )
+        return null
+      }
+
+      await authorizeCurrentPrimaryKey('validated')
+      applyRecoveredKeys(recovery)
 
       logInfo('Recovered encryption keys via passkey retry', {
         component: 'usePasskeyBackup',
         action: 'recoverWithPasskey',
-        metadata: { alternativeKeys: keyBundle.alternatives.length },
+        metadata: { alternativeKeys: recovery.keyBundle.alternatives.length },
       })
-      return keyBundle.primary
+      return recovery.keyBundle.primary
     } catch (error) {
       logError('Passkey recovery retry failed', error, {
         component: 'usePasskeyBackup',
@@ -387,18 +442,22 @@ export function usePasskeyBackup({
 
       if (encryptionKey) {
         // User has local keys — check for existing backup
-        const credentialsExist = await hasPasskeyCredentials()
+        const credentialState = await getPasskeyCredentialState()
 
-        if (credentialsExist) {
+        if (credentialState === 'exists') {
           // Already backed up — show green badge, hide setup button
           localStorage.setItem(SECRET_PASSKEY_BACKED_UP, 'true')
           if (isMountedRef.current) {
             setState((prev) => ({
               ...prev,
               passkeyActive: true,
+              manualRecoveryNeeded: false,
             }))
           }
-        } else if (!passkeyFlowInProgressRef.current) {
+        } else if (
+          credentialState === 'empty' &&
+          !passkeyFlowInProgressRef.current
+        ) {
           const hasSeen =
             userRef.current?.unsafeMetadata?.has_seen_passkey_intro === true
           if (!hasSeen) {
@@ -421,9 +480,9 @@ export function usePasskeyBackup({
         }
       } else {
         // No localStorage keys — try passkey recovery
-        const credentialsExist = await hasPasskeyCredentials()
+        const credentialState = await getPasskeyCredentialState()
 
-        if (credentialsExist) {
+        if (credentialState === 'exists') {
           const recovered = await tryPasskeyRecovery()
           if (!recovered && isMountedRef.current) {
             setState((prev) => ({
@@ -431,9 +490,22 @@ export function usePasskeyBackup({
               passkeyRecoveryNeeded: true,
             }))
           }
-        } else {
-          // First-time user with PRF support: auto-generate key + create passkey
-          await setupFirstTimePasskeyUser()
+        } else if (credentialState === 'empty') {
+          const remoteState = await inspectRemoteEncryptedState()
+
+          if (remoteState === 'empty') {
+            await setupFirstTimePasskeyUser()
+          } else if (isMountedRef.current) {
+            setState((prev) => ({
+              ...prev,
+              manualRecoveryNeeded: true,
+            }))
+          }
+        } else if (isMountedRef.current) {
+          setState((prev) => ({
+            ...prev,
+            manualRecoveryNeeded: true,
+          }))
         }
       }
     }
@@ -459,9 +531,26 @@ export function usePasskeyBackup({
      */
     const setupFirstTimePasskeyUser = async (): Promise<void> => {
       try {
+        const previousKeys = encryptionService.getAllKeys()
         const newKey = await generateKeyWithPasskeyBackup()
 
         if (newKey) {
+          const validation = await validateCurrentPrimaryKey()
+          if (!validation.canWrite) {
+            await encryptionService.replaceKeyBundle(
+              previousKeys.primary,
+              previousKeys.alternatives,
+            )
+            if (isMountedRef.current) {
+              setState((prev) => ({
+                ...prev,
+                manualRecoveryNeeded: true,
+              }))
+            }
+            return
+          }
+
+          await authorizeCurrentPrimaryKey('validated')
           applyNewPasskeyKey()
           onEncryptionKeyRecoveredRef.current?.(newKey)
 
@@ -537,6 +626,15 @@ export function usePasskeyBackup({
     if (!userInfo) return false
 
     try {
+      const authorizationMode = await getCurrentCloudKeyAuthorizationMode()
+      if (!authorizationMode) {
+        const validation = await validateCurrentPrimaryKey()
+        if (!validation.canWrite) {
+          return false
+        }
+        await authorizeCurrentPrimaryKey('validated')
+      }
+
       const keys = encryptionService.getAllKeys()
       if (!keys.primary) return false
 
@@ -579,6 +677,7 @@ export function usePasskeyBackup({
       const newKey = await generateKeyWithPasskeyBackup()
       if (!newKey) return null
 
+      await authorizeCurrentPrimaryKey('explicit_start_fresh')
       applyNewPasskeyKey()
 
       logInfo('New key split created with passkey', {

--- a/src/hooks/use-passkey-backup.ts
+++ b/src/hooks/use-passkey-backup.ts
@@ -364,7 +364,17 @@ export function usePasskeyBackup({
       // Key differs — apply the recovered key bundle
       await encryptionService.setAllKeys(bundle.primary, bundle.alternatives)
 
-      const validation = await validateCurrentPrimaryKey()
+      let validation: Awaited<ReturnType<typeof validateCurrentPrimaryKey>>
+      try {
+        validation = await validateCurrentPrimaryKey()
+      } catch {
+        await encryptionService.replaceKeyBundle(
+          previousKeys.primary,
+          previousKeys.alternatives,
+        )
+        setLocalSyncVersion(cached.credentialId, entry.sync_version)
+        return
+      }
       if (validation.canWrite) {
         await authorizeCurrentPrimaryKey('validated')
       } else if (previousMode === 'explicit_start_fresh') {
@@ -374,6 +384,7 @@ export function usePasskeyBackup({
           previousKeys.primary,
           previousKeys.alternatives,
         )
+        setLocalSyncVersion(cached.credentialId, entry.sync_version)
         return
       }
 
@@ -404,7 +415,16 @@ export function usePasskeyBackup({
       const recovery = await performPasskeyRecovery()
       if (!recovery) return null
 
-      const validation = await validateCurrentPrimaryKey()
+      let validation: Awaited<ReturnType<typeof validateCurrentPrimaryKey>>
+      try {
+        validation = await validateCurrentPrimaryKey()
+      } catch {
+        await encryptionService.replaceKeyBundle(
+          previousKeys.primary,
+          previousKeys.alternatives,
+        )
+        return null
+      }
       if (!validation.canWrite) {
         await encryptionService.replaceKeyBundle(
           previousKeys.primary,
@@ -535,7 +555,22 @@ export function usePasskeyBackup({
         const newKey = await generateKeyWithPasskeyBackup()
 
         if (newKey) {
-          const validation = await validateCurrentPrimaryKey()
+          let validation: Awaited<ReturnType<typeof validateCurrentPrimaryKey>>
+          try {
+            validation = await validateCurrentPrimaryKey()
+          } catch {
+            await encryptionService.replaceKeyBundle(
+              previousKeys.primary,
+              previousKeys.alternatives,
+            )
+            if (isMountedRef.current) {
+              setState((prev) => ({
+                ...prev,
+                manualRecoveryNeeded: true,
+              }))
+            }
+            return
+          }
           if (!validation.canWrite) {
             await encryptionService.replaceKeyBundle(
               previousKeys.primary,

--- a/src/hooks/use-passkey-backup.ts
+++ b/src/hooks/use-passkey-backup.ts
@@ -372,7 +372,6 @@ export function usePasskeyBackup({
           previousKeys.primary,
           previousKeys.alternatives,
         )
-        setLocalSyncVersion(cached.credentialId, entry.sync_version)
         return
       }
       if (validation.canWrite) {
@@ -384,7 +383,6 @@ export function usePasskeyBackup({
           previousKeys.primary,
           previousKeys.alternatives,
         )
-        setLocalSyncVersion(cached.credentialId, entry.sync_version)
         return
       }
 

--- a/src/hooks/use-profile-sync.ts
+++ b/src/hooks/use-profile-sync.ts
@@ -1,5 +1,6 @@
 import { CLOUD_SYNC } from '@/config'
 import { SYNC_PROFILE_STATUS } from '@/constants/storage-keys'
+import { getCurrentCloudKeyAuthorizationMode } from '@/services/cloud/cloud-key-authorization'
 import type { ProfileSyncStatus } from '@/services/cloud/cloud-storage'
 import {
   applySettingsToLocal,
@@ -201,6 +202,20 @@ export function useProfileSync() {
       if (!isCloudSyncEnabled()) return
 
       try {
+        const authorizationMode = await getCurrentCloudKeyAuthorizationMode()
+        if (!authorizationMode) {
+          hasPendingChanges.current = false
+          return
+        }
+
+        if (
+          profileSync.hasFailedRemoteDecryption() &&
+          authorizationMode !== 'explicit_start_fresh'
+        ) {
+          hasPendingChanges.current = false
+          return
+        }
+
         const localSettings = loadLocalSettings()
 
         // Check if local settings are different from last synced profile
@@ -247,11 +262,11 @@ export function useProfileSync() {
         })
         // Keep pending changes flag on error
       } finally {
-        // Clear pending changes after a reasonable time even on error
-        // to prevent permanent blocking of cloud sync
-        setTimeout(() => {
-          hasPendingChanges.current = false
-        }, 10000) // 10 seconds
+        if (hasPendingChanges.current) {
+          setTimeout(() => {
+            hasPendingChanges.current = false
+          }, 10000)
+        }
       }
     }, 2000) // 2 second debounce
   }, [isSignedIn])

--- a/src/hooks/use-profile-sync.ts
+++ b/src/hooks/use-profile-sync.ts
@@ -204,7 +204,6 @@ export function useProfileSync() {
       try {
         const authorizationMode = await getCurrentCloudKeyAuthorizationMode()
         if (!authorizationMode) {
-          hasPendingChanges.current = false
           return
         }
 

--- a/src/services/cloud/cloud-key-authorization.ts
+++ b/src/services/cloud/cloud-key-authorization.ts
@@ -67,8 +67,12 @@ export async function getCurrentCloudKeyAuthorizationMode(): Promise<CloudKeyAut
   const record = loadRecord(userId)
   if (!record) return null
 
-  const fingerprint = await fingerprintForKey(currentKey)
-  return record.fingerprint === fingerprint ? record.mode : null
+  try {
+    const fingerprint = await fingerprintForKey(currentKey)
+    return record.fingerprint === fingerprint ? record.mode : null
+  } catch {
+    return null
+  }
 }
 
 export async function canWriteToCloud(): Promise<boolean> {

--- a/src/services/cloud/cloud-key-authorization.ts
+++ b/src/services/cloud/cloud-key-authorization.ts
@@ -1,0 +1,81 @@
+import {
+  AUTH_ACTIVE_USER_ID,
+  SECRET_CLOUD_KEY_AUTHORIZATION_PREFIX,
+} from '@/constants/storage-keys'
+import { encryptionService } from '../encryption/encryption-service'
+
+export type CloudKeyAuthorizationMode = 'validated' | 'explicit_start_fresh'
+
+interface CloudKeyAuthorizationRecord {
+  fingerprint: string
+  mode: CloudKeyAuthorizationMode
+}
+
+function getActiveUserId(): string | null {
+  if (typeof window === 'undefined') return null
+  return localStorage.getItem(AUTH_ACTIVE_USER_ID)
+}
+
+function storageKey(userId: string): string {
+  return `${SECRET_CLOUD_KEY_AUTHORIZATION_PREFIX}${userId}`
+}
+
+function loadRecord(userId: string): CloudKeyAuthorizationRecord | null {
+  if (typeof window === 'undefined') return null
+
+  try {
+    const raw = localStorage.getItem(storageKey(userId))
+    if (!raw) return null
+    return JSON.parse(raw) as CloudKeyAuthorizationRecord
+  } catch {
+    return null
+  }
+}
+
+async function fingerprintForKey(key: string): Promise<string> {
+  const digest = await crypto.subtle.digest(
+    'SHA-256',
+    new TextEncoder().encode(key),
+  )
+
+  return Array.from(new Uint8Array(digest))
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('')
+}
+
+export async function getCurrentCloudKeyAuthorizationMode(): Promise<CloudKeyAuthorizationMode | null> {
+  const userId = getActiveUserId()
+  const currentKey = encryptionService.getKey()
+  if (!userId || !currentKey) return null
+
+  const record = loadRecord(userId)
+  if (!record) return null
+
+  const fingerprint = await fingerprintForKey(currentKey)
+  return record.fingerprint === fingerprint ? record.mode : null
+}
+
+export async function canWriteToCloud(): Promise<boolean> {
+  return (await getCurrentCloudKeyAuthorizationMode()) !== null
+}
+
+export async function authorizeCurrentPrimaryKey(
+  mode: CloudKeyAuthorizationMode,
+): Promise<void> {
+  const userId = getActiveUserId()
+  const currentKey = encryptionService.getKey()
+  if (!userId || !currentKey || typeof window === 'undefined') return
+
+  const fingerprint = await fingerprintForKey(currentKey)
+  const record: CloudKeyAuthorizationRecord = { fingerprint, mode }
+  localStorage.setItem(storageKey(userId), JSON.stringify(record))
+}
+
+export function clearCloudKeyAuthorization(userId?: string | null): void {
+  if (typeof window === 'undefined') return
+
+  const resolvedUserId = userId ?? getActiveUserId()
+  if (!resolvedUserId) return
+
+  localStorage.removeItem(storageKey(resolvedUserId))
+}

--- a/src/services/cloud/cloud-key-authorization.ts
+++ b/src/services/cloud/cloud-key-authorization.ts
@@ -11,6 +11,12 @@ interface CloudKeyAuthorizationRecord {
   mode: CloudKeyAuthorizationMode
 }
 
+function isCloudKeyAuthorizationMode(
+  value: unknown,
+): value is CloudKeyAuthorizationMode {
+  return value === 'validated' || value === 'explicit_start_fresh'
+}
+
 function getActiveUserId(): string | null {
   if (typeof window === 'undefined') return null
   return localStorage.getItem(AUTH_ACTIVE_USER_ID)
@@ -26,7 +32,17 @@ function loadRecord(userId: string): CloudKeyAuthorizationRecord | null {
   try {
     const raw = localStorage.getItem(storageKey(userId))
     if (!raw) return null
-    return JSON.parse(raw) as CloudKeyAuthorizationRecord
+    const parsed = JSON.parse(raw) as Partial<CloudKeyAuthorizationRecord>
+    if (
+      typeof parsed?.fingerprint !== 'string' ||
+      !isCloudKeyAuthorizationMode(parsed.mode)
+    ) {
+      return null
+    }
+    return {
+      fingerprint: parsed.fingerprint,
+      mode: parsed.mode,
+    }
   } catch {
     return null
   }

--- a/src/services/cloud/cloud-key-authorization.ts
+++ b/src/services/cloud/cloud-key-authorization.ts
@@ -61,14 +61,29 @@ export async function canWriteToCloud(): Promise<boolean> {
 
 export async function authorizeCurrentPrimaryKey(
   mode: CloudKeyAuthorizationMode,
-): Promise<void> {
+): Promise<boolean> {
   const userId = getActiveUserId()
   const currentKey = encryptionService.getKey()
-  if (!userId || !currentKey || typeof window === 'undefined') return
+  if (!userId || !currentKey || typeof window === 'undefined') return false
 
-  const fingerprint = await fingerprintForKey(currentKey)
-  const record: CloudKeyAuthorizationRecord = { fingerprint, mode }
-  localStorage.setItem(storageKey(userId), JSON.stringify(record))
+  try {
+    const fingerprint = await fingerprintForKey(currentKey)
+    const record: CloudKeyAuthorizationRecord = { fingerprint, mode }
+    localStorage.setItem(storageKey(userId), JSON.stringify(record))
+    return true
+  } catch {
+    clearCloudKeyAuthorization(userId)
+    return false
+  }
+}
+
+export async function authorizeCurrentPrimaryKeyOrThrow(
+  mode: CloudKeyAuthorizationMode,
+): Promise<void> {
+  const authorized = await authorizeCurrentPrimaryKey(mode)
+  if (!authorized) {
+    throw new Error('Failed to authorize the current encryption key')
+  }
 }
 
 export function clearCloudKeyAuthorization(userId?: string | null): void {

--- a/src/services/cloud/cloud-key-preflight.ts
+++ b/src/services/cloud/cloud-key-preflight.ts
@@ -1,0 +1,278 @@
+import { CLOUD_SYNC } from '@/config'
+import { base64ToUint8Array } from '@/utils/binary-codec'
+import { encryptionService } from '../encryption/encryption-service'
+import { cloudStorage } from './cloud-storage'
+import { profileSync } from './profile-sync'
+import { projectStorage } from './project-storage'
+
+export type CloudRemoteState = 'empty' | 'exists' | 'unknown'
+export type CloudKeyValidationProbe = 'none' | 'profile' | 'project' | 'chat'
+
+export interface CloudKeyValidationResult {
+  remoteState: CloudRemoteState
+  canWrite: boolean
+  probe: CloudKeyValidationProbe
+  message?: string
+}
+
+export async function inspectRemoteEncryptedState(): Promise<CloudRemoteState> {
+  const profileStatus = await profileSync.getSyncStatus()
+  if (!profileStatus) return 'unknown'
+  if (profileStatus.exists) return 'exists'
+
+  try {
+    const projectStatus = await projectStorage.getProjectSyncStatus()
+    if (projectStatus.count > 0) return 'exists'
+  } catch {
+    return 'unknown'
+  }
+
+  try {
+    const chatStatus = await cloudStorage.getChatSyncStatus()
+    return chatStatus.count > 0 ? 'exists' : 'empty'
+  } catch {
+    return 'unknown'
+  }
+}
+
+export async function validateCurrentPrimaryKey(): Promise<CloudKeyValidationResult> {
+  if (!encryptionService.getKey()) {
+    return {
+      remoteState: 'unknown',
+      canWrite: false,
+      probe: 'none',
+      message: 'No encryption key is currently loaded.',
+    }
+  }
+
+  const profileStatus = await profileSync.getSyncStatus()
+  if (!profileStatus) {
+    return {
+      remoteState: 'unknown',
+      canWrite: false,
+      probe: 'none',
+      message:
+        "We couldn't verify whether encrypted cloud data already exists.",
+    }
+  }
+
+  if (profileStatus.exists) {
+    return validateProfileProbe()
+  }
+
+  try {
+    const projectStatus = await projectStorage.getProjectSyncStatus()
+    if (projectStatus.count > 0) {
+      return validateProjectProbe()
+    }
+  } catch {
+    return {
+      remoteState: 'unknown',
+      canWrite: false,
+      probe: 'none',
+      message:
+        "We couldn't verify whether encrypted cloud data already exists.",
+    }
+  }
+
+  try {
+    const chatStatus = await cloudStorage.getChatSyncStatus()
+    if (chatStatus.count > 0) {
+      return validateChatProbe()
+    }
+  } catch {
+    return {
+      remoteState: 'unknown',
+      canWrite: false,
+      probe: 'none',
+      message:
+        "We couldn't verify whether encrypted cloud data already exists.",
+    }
+  }
+
+  return {
+    remoteState: 'empty',
+    canWrite: true,
+    probe: 'none',
+  }
+}
+
+async function validateProfileProbe(): Promise<CloudKeyValidationResult> {
+  let payload: string | null
+  try {
+    payload = await profileSync.fetchEncryptedProfilePayload()
+    if (!payload) {
+      return {
+        remoteState: 'unknown',
+        canWrite: false,
+        probe: 'profile',
+        message: "We couldn't verify your existing cloud profile.",
+      }
+    }
+  } catch {
+    return {
+      remoteState: 'unknown',
+      canWrite: false,
+      probe: 'profile',
+      message: "We couldn't verify your existing cloud profile.",
+    }
+  }
+
+  try {
+    const encrypted = JSON.parse(payload)
+    const result = await encryptionService.decryptWithFallbackInfo(encrypted)
+
+    return result.usedFallbackKey
+      ? blockedResult('profile')
+      : {
+          remoteState: 'exists',
+          canWrite: true,
+          probe: 'profile',
+        }
+  } catch {
+    return blockedResult('profile')
+  }
+}
+
+async function validateProjectProbe(): Promise<CloudKeyValidationResult> {
+  try {
+    const response = await projectStorage.listProjects({
+      limit: CLOUD_SYNC.KEY_VALIDATION_PROBE_LIMIT,
+      includeContent: true,
+    })
+
+    if (!response.projects.length) {
+      return {
+        remoteState: 'unknown',
+        canWrite: false,
+        probe: 'project',
+        message: "We couldn't verify your existing cloud projects.",
+      }
+    }
+
+    let sawMismatch = false
+
+    for (const project of response.projects.slice(
+      0,
+      CLOUD_SYNC.KEY_VALIDATION_PROBE_LIMIT,
+    )) {
+      if (!project.content) continue
+
+      try {
+        const encrypted = JSON.parse(project.content)
+        const result =
+          await encryptionService.decryptWithFallbackInfo(encrypted)
+        if (!result.usedFallbackKey) {
+          return {
+            remoteState: 'exists',
+            canWrite: true,
+            probe: 'project',
+          }
+        }
+        sawMismatch = true
+      } catch {
+        sawMismatch = true
+      }
+    }
+
+    return sawMismatch
+      ? blockedResult('project')
+      : {
+          remoteState: 'unknown',
+          canWrite: false,
+          probe: 'project',
+          message: "We couldn't verify your existing cloud projects.",
+        }
+  } catch {
+    return {
+      remoteState: 'unknown',
+      canWrite: false,
+      probe: 'project',
+      message: "We couldn't verify your existing cloud projects.",
+    }
+  }
+}
+
+async function validateChatProbe(): Promise<CloudKeyValidationResult> {
+  try {
+    const response = await cloudStorage.listChats({
+      limit: CLOUD_SYNC.KEY_VALIDATION_PROBE_LIMIT,
+      includeContent: true,
+    })
+
+    if (!response.conversations.length) {
+      return {
+        remoteState: 'unknown',
+        canWrite: false,
+        probe: 'chat',
+        message: "We couldn't verify your existing cloud chats.",
+      }
+    }
+
+    let sawMismatch = false
+
+    for (const chat of response.conversations.slice(
+      0,
+      CLOUD_SYNC.KEY_VALIDATION_PROBE_LIMIT,
+    )) {
+      if (!chat.content) continue
+
+      try {
+        if (chat.formatVersion === 1) {
+          const result = await encryptionService.decryptV1WithFallbackInfo(
+            base64ToUint8Array(chat.content),
+          )
+          if (!result.usedFallbackKey) {
+            return {
+              remoteState: 'exists',
+              canWrite: true,
+              probe: 'chat',
+            }
+          }
+        } else {
+          const encrypted = JSON.parse(chat.content)
+          const result =
+            await encryptionService.decryptWithFallbackInfo(encrypted)
+          if (!result.usedFallbackKey) {
+            return {
+              remoteState: 'exists',
+              canWrite: true,
+              probe: 'chat',
+            }
+          }
+        }
+
+        sawMismatch = true
+      } catch {
+        sawMismatch = true
+      }
+    }
+
+    return sawMismatch
+      ? blockedResult('chat')
+      : {
+          remoteState: 'unknown',
+          canWrite: false,
+          probe: 'chat',
+          message: "We couldn't verify your existing cloud chats.",
+        }
+  } catch {
+    return {
+      remoteState: 'unknown',
+      canWrite: false,
+      probe: 'chat',
+      message: "We couldn't verify your existing cloud chats.",
+    }
+  }
+}
+
+function blockedResult(
+  probe: Exclude<CloudKeyValidationProbe, 'none'>,
+): CloudKeyValidationResult {
+  return {
+    remoteState: 'exists',
+    canWrite: false,
+    probe,
+    message: "This key doesn't match your existing cloud data.",
+  }
+}

--- a/src/services/cloud/cloud-key-preflight.ts
+++ b/src/services/cloud/cloud-key-preflight.ts
@@ -37,23 +37,15 @@ export async function inspectRemoteEncryptedState(): Promise<CloudRemoteState> {
 
 export async function validateCurrentPrimaryKey(): Promise<CloudKeyValidationResult> {
   if (!encryptionService.getKey()) {
-    return {
-      remoteState: 'unknown',
-      canWrite: false,
-      probe: 'none',
-      message: 'No encryption key is currently loaded.',
-    }
+    return unknownResult('none', 'No encryption key is currently loaded.')
   }
 
   const profileStatus = await profileSync.getSyncStatus()
   if (!profileStatus) {
-    return {
-      remoteState: 'unknown',
-      canWrite: false,
-      probe: 'none',
-      message:
-        "We couldn't verify whether encrypted cloud data already exists.",
-    }
+    return unknownResult(
+      'none',
+      "We couldn't verify whether encrypted cloud data already exists.",
+    )
   }
 
   if (profileStatus.exists) {
@@ -66,13 +58,10 @@ export async function validateCurrentPrimaryKey(): Promise<CloudKeyValidationRes
       return validateProjectProbe()
     }
   } catch {
-    return {
-      remoteState: 'unknown',
-      canWrite: false,
-      probe: 'none',
-      message:
-        "We couldn't verify whether encrypted cloud data already exists.",
-    }
+    return unknownResult(
+      'none',
+      "We couldn't verify whether encrypted cloud data already exists.",
+    )
   }
 
   try {
@@ -81,13 +70,10 @@ export async function validateCurrentPrimaryKey(): Promise<CloudKeyValidationRes
       return validateChatProbe()
     }
   } catch {
-    return {
-      remoteState: 'unknown',
-      canWrite: false,
-      probe: 'none',
-      message:
-        "We couldn't verify whether encrypted cloud data already exists.",
-    }
+    return unknownResult(
+      'none',
+      "We couldn't verify whether encrypted cloud data already exists.",
+    )
   }
 
   return {
@@ -102,20 +88,16 @@ async function validateProfileProbe(): Promise<CloudKeyValidationResult> {
   try {
     payload = await profileSync.fetchEncryptedProfilePayload()
     if (!payload) {
-      return {
-        remoteState: 'unknown',
-        canWrite: false,
-        probe: 'profile',
-        message: "We couldn't verify your existing cloud profile.",
-      }
+      return unknownResult(
+        'profile',
+        "We couldn't verify your existing cloud profile.",
+      )
     }
   } catch {
-    return {
-      remoteState: 'unknown',
-      canWrite: false,
-      probe: 'profile',
-      message: "We couldn't verify your existing cloud profile.",
-    }
+    return unknownResult(
+      'profile',
+      "We couldn't verify your existing cloud profile.",
+    )
   }
 
   try {
@@ -142,12 +124,10 @@ async function validateProjectProbe(): Promise<CloudKeyValidationResult> {
     })
 
     if (!response.projects.length) {
-      return {
-        remoteState: 'unknown',
-        canWrite: false,
-        probe: 'project',
-        message: "We couldn't verify your existing cloud projects.",
-      }
+      return unknownResult(
+        'project',
+        "We couldn't verify your existing cloud projects.",
+      )
     }
 
     let sawMismatch = false
@@ -177,19 +157,15 @@ async function validateProjectProbe(): Promise<CloudKeyValidationResult> {
 
     return sawMismatch
       ? blockedResult('project')
-      : {
-          remoteState: 'unknown',
-          canWrite: false,
-          probe: 'project',
-          message: "We couldn't verify your existing cloud projects.",
-        }
+      : unknownResult(
+          'project',
+          "We couldn't verify your existing cloud projects.",
+        )
   } catch {
-    return {
-      remoteState: 'unknown',
-      canWrite: false,
-      probe: 'project',
-      message: "We couldn't verify your existing cloud projects.",
-    }
+    return unknownResult(
+      'project',
+      "We couldn't verify your existing cloud projects.",
+    )
   }
 }
 
@@ -201,12 +177,10 @@ async function validateChatProbe(): Promise<CloudKeyValidationResult> {
     })
 
     if (!response.conversations.length) {
-      return {
-        remoteState: 'unknown',
-        canWrite: false,
-        probe: 'chat',
-        message: "We couldn't verify your existing cloud chats.",
-      }
+      return unknownResult(
+        'chat',
+        "We couldn't verify your existing cloud chats.",
+      )
     }
 
     let sawMismatch = false
@@ -250,20 +224,20 @@ async function validateChatProbe(): Promise<CloudKeyValidationResult> {
 
     return sawMismatch
       ? blockedResult('chat')
-      : {
-          remoteState: 'unknown',
-          canWrite: false,
-          probe: 'chat',
-          message: "We couldn't verify your existing cloud chats.",
-        }
+      : unknownResult('chat', "We couldn't verify your existing cloud chats.")
   } catch {
-    return {
-      remoteState: 'unknown',
-      canWrite: false,
-      probe: 'chat',
-      message: "We couldn't verify your existing cloud chats.",
-    }
+    return unknownResult(
+      'chat',
+      "We couldn't verify your existing cloud chats.",
+    )
   }
+}
+
+function unknownResult(
+  probe: CloudKeyValidationProbe,
+  message: string,
+): CloudKeyValidationResult {
+  return { remoteState: 'unknown', canWrite: false, probe, message }
 }
 
 function blockedResult(

--- a/src/services/cloud/cloud-sync.ts
+++ b/src/services/cloud/cloud-sync.ts
@@ -10,6 +10,7 @@ import { deletedChatsTracker } from '../storage/deleted-chats-tracker'
 import { indexedDBStorage, type StoredChat } from '../storage/indexed-db'
 import { processRemoteChat } from './chat-codec'
 import { ingestRemoteChats, syncRemoteDeletions } from './chat-ingestion'
+import { canWriteToCloud } from './cloud-key-authorization'
 import { cloudStorage, type ChatSyncStatus } from './cloud-storage'
 import {
   reencryptAndUploadChats as doReencryptAndUpload,
@@ -454,6 +455,10 @@ export class CloudSyncService {
       return
     }
 
+    if (!(await canWriteToCloud())) {
+      return
+    }
+
     // Use the upload coalescer - it handles:
     // - Coalescing rapid edits into a single upload
     // - Exponential backoff retry on failure
@@ -479,6 +484,10 @@ export class CloudSyncService {
 
   private async doBackupChat(chatId: string): Promise<void> {
     try {
+      if (!(await canWriteToCloud())) {
+        return
+      }
+
       // Check if chat is currently streaming
       if (streamingTracker.isStreaming(chatId)) {
         // Check if we already have a callback registered for this chat
@@ -573,6 +582,10 @@ export class CloudSyncService {
       uploaded: 0,
       downloaded: 0,
       errors: [],
+    }
+
+    if (!(await canWriteToCloud())) {
+      return result
     }
 
     try {
@@ -818,6 +831,10 @@ export class CloudSyncService {
       return
     }
 
+    if (!(await canWriteToCloud())) {
+      return
+    }
+
     try {
       await cloudStorage.deleteChat(chatId)
 
@@ -848,6 +865,10 @@ export class CloudSyncService {
     projectId: string | null,
   ): Promise<void> {
     if (!(await cloudStorage.isAuthenticated())) {
+      return
+    }
+
+    if (!(await canWriteToCloud())) {
       return
     }
 

--- a/src/services/cloud/cloud-sync.ts
+++ b/src/services/cloud/cloud-sync.ts
@@ -831,10 +831,6 @@ export class CloudSyncService {
       return
     }
 
-    if (!(await canWriteToCloud())) {
-      return
-    }
-
     try {
       await cloudStorage.deleteChat(chatId)
 

--- a/src/services/cloud/profile-sync.ts
+++ b/src/services/cloud/profile-sync.ts
@@ -43,10 +43,33 @@ export class ProfileSyncService {
     return authTokenManager.isAuthenticated()
   }
 
+  async fetchEncryptedProfilePayload(): Promise<string | null> {
+    if (!(await this.isAuthenticated())) {
+      return null
+    }
+
+    const response = await fetch(`${API_BASE_URL}/api/profile/`, {
+      headers: await this.getHeaders(),
+    })
+
+    if (response.status === 401 || response.status === 404) {
+      return null
+    }
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch profile: ${response.statusText}`)
+    }
+
+    const data = await response.json()
+    return data.data as string
+  }
+
   // Get profile from cloud
   async fetchProfile(): Promise<ProfileData | null> {
     try {
-      if (!(await this.isAuthenticated())) {
+      const payload = await this.fetchEncryptedProfilePayload()
+      if (!payload) {
+        this.failedDecryptionData = null
         logInfo('Skipping profile fetch - not authenticated', {
           component: 'ProfileSync',
           action: 'fetchProfile',
@@ -54,23 +77,9 @@ export class ProfileSyncService {
         return null
       }
 
-      const response = await fetch(`${API_BASE_URL}/api/profile/`, {
-        headers: await this.getHeaders(),
-      })
-
-      if (response.status === 401 || response.status === 404) {
-        return null
-      }
-
-      if (!response.ok) {
-        throw new Error(`Failed to fetch profile: ${response.statusText}`)
-      }
-
-      const data = await response.json()
-
       // Try to decrypt the profile data
       try {
-        const encrypted = JSON.parse(data.data)
+        const encrypted = JSON.parse(payload)
         const decrypted = await encryptionService.decrypt(encrypted)
 
         // Cache the decrypted profile
@@ -81,7 +90,7 @@ export class ProfileSyncService {
           component: 'ProfileSync',
           action: 'fetchProfile',
           metadata: {
-            version: data.version,
+            version: decrypted.version,
             hasNickname: !!decrypted.nickname,
             hasLanguage: !!decrypted.language,
             hasPersonalization: !!decrypted.isUsingPersonalization,
@@ -91,7 +100,7 @@ export class ProfileSyncService {
         return decrypted
       } catch (decryptError) {
         // Failed to decrypt - store for later retry
-        this.failedDecryptionData = data.data
+        this.failedDecryptionData = payload
         this.cachedProfile = null
 
         logInfo('Profile decryption failed, stored for retry', {
@@ -258,6 +267,10 @@ export class ProfileSyncService {
   // Get cached profile (for quick access)
   getCachedProfile(): ProfileData | null {
     return this.cachedProfile
+  }
+
+  hasFailedRemoteDecryption(): boolean {
+    return this.failedDecryptionData !== null
   }
 
   // Clear cache

--- a/src/services/cloud/profile-sync.ts
+++ b/src/services/cloud/profile-sync.ts
@@ -69,7 +69,6 @@ export class ProfileSyncService {
     try {
       const payload = await this.fetchEncryptedProfilePayload()
       if (!payload) {
-        this.failedDecryptionData = null
         logInfo('Skipping profile fetch - not authenticated', {
           component: 'ProfileSync',
           action: 'fetchProfile',

--- a/src/services/cloud/project-storage.ts
+++ b/src/services/cloud/project-storage.ts
@@ -14,6 +14,7 @@ import type {
 import { logError } from '@/utils/error-handling'
 import { authTokenManager } from '../auth'
 import { encryptionService } from '../encryption/encryption-service'
+import { canWriteToCloud } from './cloud-key-authorization'
 
 const API_BASE_URL =
   process.env.NEXT_PUBLIC_API_BASE_URL || 'https://api.tinfoil.sh'
@@ -45,6 +46,12 @@ export class ProjectStorageService {
   }
 
   async createProject(data: CreateProjectData): Promise<Project> {
+    if (!(await canWriteToCloud())) {
+      throw new Error(
+        'Cloud writes are blocked until your encryption key is verified',
+      )
+    }
+
     const { projectId } = await this.generateProjectId()
 
     const projectData: ProjectData = {
@@ -84,6 +91,12 @@ export class ProjectStorageService {
     projectId: string,
     data: UpdateProjectData,
   ): Promise<void> {
+    if (!(await canWriteToCloud())) {
+      throw new Error(
+        'Cloud writes are blocked until your encryption key is verified',
+      )
+    }
+
     const existing = await this.getProject(projectId)
     if (!existing) {
       throw new Error('Project not found')
@@ -157,6 +170,12 @@ export class ProjectStorageService {
   }
 
   async deleteProject(projectId: string): Promise<void> {
+    if (!(await canWriteToCloud())) {
+      throw new Error(
+        'Cloud writes are blocked until your encryption key is verified',
+      )
+    }
+
     const response = await fetch(
       `${API_BASE_URL}/api/storage/project/${projectId}`,
       {
@@ -262,6 +281,12 @@ export class ProjectStorageService {
     contentType: string,
     content: string,
   ): Promise<ProjectDocument> {
+    if (!(await canWriteToCloud())) {
+      throw new Error(
+        'Cloud writes are blocked until your encryption key is verified',
+      )
+    }
+
     const { documentId } = await this.generateDocumentId(projectId)
 
     const encrypted = await encryptionService.encrypt({
@@ -351,6 +376,12 @@ export class ProjectStorageService {
   }
 
   async deleteDocument(projectId: string, documentId: string): Promise<void> {
+    if (!(await canWriteToCloud())) {
+      throw new Error(
+        'Cloud writes are blocked until your encryption key is verified',
+      )
+    }
+
     const response = await fetch(
       `${API_BASE_URL}/api/projects/${projectId}/documents/${documentId}`,
       {

--- a/src/services/encryption/encryption-service.ts
+++ b/src/services/encryption/encryption-service.ts
@@ -419,21 +419,9 @@ export class EncryptionService {
       return
     }
 
-    const keyBytes = this.getKeyBytes(primary)
-    this.encryptionKey = await crypto.subtle.importKey(
-      'raw',
-      keyBytes.buffer.slice(
-        keyBytes.byteOffset,
-        keyBytes.byteOffset + keyBytes.byteLength,
-      ) as ArrayBuffer,
-      { name: 'AES-GCM' },
-      false,
-      ['encrypt', 'decrypt'],
-    )
+    const importedKey = await this.importCryptoKey(primary)
 
-    this.currentKeyString = primary
-    this.fallbackKeyCache.clear()
-    this.fallbackKeyStrings = Array.from(
+    const validAlternatives = Array.from(
       new Set(
         alternatives.filter(
           (candidate) =>
@@ -452,7 +440,12 @@ export class EncryptionService {
 
     localStorage.setItem(USER_ENCRYPTION_KEY, primary)
     localStorage.setItem('tinfoil-encryption-key', primary)
-    this.saveKeyHistoryToStorage(this.fallbackKeyStrings)
+    this.saveKeyHistoryToStorage(validAlternatives)
+
+    this.encryptionKey = importedKey
+    this.currentKeyString = primary
+    this.fallbackKeyCache.clear()
+    this.fallbackKeyStrings = validAlternatives
   }
 
   /**

--- a/src/services/encryption/encryption-service.ts
+++ b/src/services/encryption/encryption-service.ts
@@ -410,6 +410,51 @@ export class EncryptionService {
     }
   }
 
+  async replaceKeyBundle(
+    primary: string | null,
+    alternatives: string[],
+  ): Promise<void> {
+    if (!primary) {
+      this.clearKey()
+      return
+    }
+
+    const keyBytes = this.getKeyBytes(primary)
+    this.encryptionKey = await crypto.subtle.importKey(
+      'raw',
+      keyBytes.buffer.slice(
+        keyBytes.byteOffset,
+        keyBytes.byteOffset + keyBytes.byteLength,
+      ) as ArrayBuffer,
+      { name: 'AES-GCM' },
+      false,
+      ['encrypt', 'decrypt'],
+    )
+
+    this.currentKeyString = primary
+    this.fallbackKeyCache.clear()
+    this.fallbackKeyStrings = Array.from(
+      new Set(
+        alternatives.filter(
+          (candidate) =>
+            candidate !== primary &&
+            (() => {
+              try {
+                this.getKeyBytes(candidate)
+                return true
+              } catch {
+                return false
+              }
+            })(),
+        ),
+      ),
+    )
+
+    localStorage.setItem(USER_ENCRYPTION_KEY, primary)
+    localStorage.setItem('tinfoil-encryption-key', primary)
+    this.saveKeyHistoryToStorage(this.fallbackKeyStrings)
+  }
+
   /**
    * Register a callback to be called when a fallback key is added.
    * Returns an unsubscribe function.

--- a/src/services/encryption/encryption-service.ts
+++ b/src/services/encryption/encryption-service.ts
@@ -420,27 +420,65 @@ export class EncryptionService {
     }
 
     const importedKey = await this.importCryptoKey(primary)
+    const previousKey =
+      this.currentKeyString ??
+      localStorage.getItem(USER_ENCRYPTION_KEY) ??
+      localStorage.getItem('tinfoil-encryption-key')
+    const previousHistory = this.loadKeyHistoryFromStorage()
 
     const validAlternatives = Array.from(
       new Set(
-        alternatives.filter(
-          (candidate) =>
-            candidate !== primary &&
-            (() => {
-              try {
-                this.getKeyBytes(candidate)
-                return true
-              } catch {
-                return false
-              }
-            })(),
-        ),
+        alternatives.filter((candidate) => {
+          if (candidate === primary) return false
+          try {
+            this.getKeyBytes(candidate)
+            return true
+          } catch {
+            return false
+          }
+        }),
       ),
     )
 
-    localStorage.setItem(USER_ENCRYPTION_KEY, primary)
-    localStorage.setItem('tinfoil-encryption-key', primary)
-    this.saveKeyHistoryToStorage(validAlternatives)
+    try {
+      localStorage.setItem(USER_ENCRYPTION_KEY, primary)
+      localStorage.setItem('tinfoil-encryption-key', primary)
+      this.saveKeyHistoryToStorage(validAlternatives)
+    } catch (persistError) {
+      try {
+        if (previousKey) {
+          localStorage.setItem(USER_ENCRYPTION_KEY, previousKey)
+          localStorage.setItem('tinfoil-encryption-key', previousKey)
+        } else {
+          localStorage.removeItem(USER_ENCRYPTION_KEY)
+          localStorage.removeItem('tinfoil-encryption-key')
+        }
+        this.saveKeyHistoryToStorage(previousHistory)
+      } catch (rollbackError) {
+        logInfo('Failed to rollback key bundle persistence', {
+          component: 'EncryptionService',
+          action: 'replaceKeyBundleRollback',
+          metadata: {
+            persistError:
+              persistError instanceof Error
+                ? persistError.message
+                : String(persistError),
+            rollbackError:
+              rollbackError instanceof Error
+                ? rollbackError.message
+                : String(rollbackError),
+          },
+        })
+      }
+
+      throw new Error(
+        `Failed to persist encryption key bundle: ${
+          persistError instanceof Error
+            ? persistError.message
+            : String(persistError)
+        }`,
+      )
+    }
 
     this.encryptionKey = importedKey
     this.currentKeyString = primary

--- a/src/services/encryption/encryption-service.ts
+++ b/src/services/encryption/encryption-service.ts
@@ -228,42 +228,22 @@ export class EncryptionService {
         ]
       }
 
-      try {
-        localStorage.setItem(USER_ENCRYPTION_KEY, keyString)
-        this.saveKeyHistoryToStorage(history)
-      } catch (persistError) {
-        try {
-          if (previousKey) {
-            localStorage.setItem(USER_ENCRYPTION_KEY, previousKey)
-          } else {
-            localStorage.removeItem(USER_ENCRYPTION_KEY)
-          }
-          this.saveKeyHistoryToStorage(previousHistory)
-        } catch (rollbackError) {
-          logInfo('Failed to rollback encryption key persistence', {
-            component: 'EncryptionService',
-            action: 'setKeyRollback',
-            metadata: {
-              persistError:
-                persistError instanceof Error
-                  ? persistError.message
-                  : String(persistError),
-              rollbackError:
-                rollbackError instanceof Error
-                  ? rollbackError.message
-                  : String(rollbackError),
-            },
-          })
-        }
-
-        throw new Error(
-          `Failed to persist encryption key: ${
-            persistError instanceof Error
-              ? persistError.message
-              : String(persistError)
-          }`,
-        )
-      }
+      this.persistKeyState(
+        {
+          primaryKey: keyString,
+          history,
+          includeLegacyKey: false,
+        },
+        {
+          previousKey,
+          previousHistory,
+          includeLegacyKey: false,
+        },
+        {
+          failurePrefix: 'Failed to persist encryption key',
+          rollbackAction: 'setKeyRollback',
+        },
+      )
 
       this.encryptionKey = importedKey
       this.currentKeyString = keyString
@@ -440,45 +420,22 @@ export class EncryptionService {
       ),
     )
 
-    try {
-      localStorage.setItem(USER_ENCRYPTION_KEY, primary)
-      localStorage.setItem('tinfoil-encryption-key', primary)
-      this.saveKeyHistoryToStorage(validAlternatives)
-    } catch (persistError) {
-      try {
-        if (previousKey) {
-          localStorage.setItem(USER_ENCRYPTION_KEY, previousKey)
-          localStorage.setItem('tinfoil-encryption-key', previousKey)
-        } else {
-          localStorage.removeItem(USER_ENCRYPTION_KEY)
-          localStorage.removeItem('tinfoil-encryption-key')
-        }
-        this.saveKeyHistoryToStorage(previousHistory)
-      } catch (rollbackError) {
-        logInfo('Failed to rollback key bundle persistence', {
-          component: 'EncryptionService',
-          action: 'replaceKeyBundleRollback',
-          metadata: {
-            persistError:
-              persistError instanceof Error
-                ? persistError.message
-                : String(persistError),
-            rollbackError:
-              rollbackError instanceof Error
-                ? rollbackError.message
-                : String(rollbackError),
-          },
-        })
-      }
-
-      throw new Error(
-        `Failed to persist encryption key bundle: ${
-          persistError instanceof Error
-            ? persistError.message
-            : String(persistError)
-        }`,
-      )
-    }
+    this.persistKeyState(
+      {
+        primaryKey: primary,
+        history: validAlternatives,
+        includeLegacyKey: true,
+      },
+      {
+        previousKey,
+        previousHistory,
+        includeLegacyKey: true,
+      },
+      {
+        failurePrefix: 'Failed to persist encryption key bundle',
+        rollbackAction: 'replaceKeyBundleRollback',
+      },
+    )
 
     this.encryptionKey = importedKey
     this.currentKeyString = primary
@@ -513,6 +470,72 @@ export class EncryptionService {
           },
         })
       }
+    }
+  }
+
+  private persistKeyState(
+    nextState: {
+      primaryKey: string
+      history: string[]
+      includeLegacyKey: boolean
+    },
+    previousState: {
+      previousKey: string | null
+      previousHistory: string[]
+      includeLegacyKey: boolean
+    },
+    options: {
+      failurePrefix: string
+      rollbackAction: 'setKeyRollback' | 'replaceKeyBundleRollback'
+    },
+  ): void {
+    try {
+      localStorage.setItem(USER_ENCRYPTION_KEY, nextState.primaryKey)
+      if (nextState.includeLegacyKey) {
+        localStorage.setItem('tinfoil-encryption-key', nextState.primaryKey)
+      }
+      this.saveKeyHistoryToStorage(nextState.history)
+    } catch (persistError) {
+      try {
+        if (previousState.previousKey) {
+          localStorage.setItem(USER_ENCRYPTION_KEY, previousState.previousKey)
+          if (previousState.includeLegacyKey) {
+            localStorage.setItem(
+              'tinfoil-encryption-key',
+              previousState.previousKey,
+            )
+          }
+        } else {
+          localStorage.removeItem(USER_ENCRYPTION_KEY)
+          if (previousState.includeLegacyKey) {
+            localStorage.removeItem('tinfoil-encryption-key')
+          }
+        }
+        this.saveKeyHistoryToStorage(previousState.previousHistory)
+      } catch (rollbackError) {
+        logInfo('Failed to rollback encryption key persistence', {
+          component: 'EncryptionService',
+          action: options.rollbackAction,
+          metadata: {
+            persistError:
+              persistError instanceof Error
+                ? persistError.message
+                : String(persistError),
+            rollbackError:
+              rollbackError instanceof Error
+                ? rollbackError.message
+                : String(rollbackError),
+          },
+        })
+      }
+
+      throw new Error(
+        `${options.failurePrefix}: ${
+          persistError instanceof Error
+            ? persistError.message
+            : String(persistError)
+        }`,
+      )
     }
   }
 

--- a/src/services/encryption/encryption-service.ts
+++ b/src/services/encryption/encryption-service.ts
@@ -1,6 +1,8 @@
 // Encryption service for end-to-end encryption of chat data
 
 import {
+  LEGACY_ENCRYPTION_KEY,
+  LEGACY_ENCRYPTION_KEY_HISTORY,
   USER_ENCRYPTION_KEY,
   USER_ENCRYPTION_KEY_HISTORY,
 } from '@/constants/storage-keys'
@@ -105,7 +107,7 @@ export class EncryptionService {
   private loadKeyHistoryFromStorage(): string[] {
     const rawHistory =
       localStorage.getItem(USER_ENCRYPTION_KEY_HISTORY) ??
-      localStorage.getItem('tinfoil-encryption-key-history')
+      localStorage.getItem(LEGACY_ENCRYPTION_KEY_HISTORY)
 
     if (!rawHistory) {
       return []
@@ -191,7 +193,7 @@ export class EncryptionService {
   async initialize(): Promise<string | null> {
     const storedKey =
       localStorage.getItem(USER_ENCRYPTION_KEY) ??
-      localStorage.getItem('tinfoil-encryption-key')
+      localStorage.getItem(LEGACY_ENCRYPTION_KEY)
     this.fallbackKeyStrings = this.loadKeyHistoryFromStorage()
     this.pruneFallbackCache(this.fallbackKeyStrings)
 
@@ -209,7 +211,7 @@ export class EncryptionService {
       const previousKey =
         this.currentKeyString ??
         localStorage.getItem(USER_ENCRYPTION_KEY) ??
-        localStorage.getItem('tinfoil-encryption-key')
+        localStorage.getItem(LEGACY_ENCRYPTION_KEY)
 
       const previousHistory = this.loadKeyHistoryFromStorage()
 
@@ -265,7 +267,7 @@ export class EncryptionService {
   getKey(): string | null {
     return (
       localStorage.getItem(USER_ENCRYPTION_KEY) ??
-      localStorage.getItem('tinfoil-encryption-key')
+      localStorage.getItem(LEGACY_ENCRYPTION_KEY)
     )
   }
 
@@ -281,8 +283,8 @@ export class EncryptionService {
       try {
         localStorage.removeItem(USER_ENCRYPTION_KEY)
         localStorage.removeItem(USER_ENCRYPTION_KEY_HISTORY)
-        localStorage.removeItem('tinfoil-encryption-key')
-        localStorage.removeItem('tinfoil-encryption-key-history')
+        localStorage.removeItem(LEGACY_ENCRYPTION_KEY)
+        localStorage.removeItem(LEGACY_ENCRYPTION_KEY_HISTORY)
       } catch (error) {
         logInfo('Failed to remove encryption keys from storage', {
           component: 'EncryptionService',
@@ -403,7 +405,7 @@ export class EncryptionService {
     const previousKey =
       this.currentKeyString ??
       localStorage.getItem(USER_ENCRYPTION_KEY) ??
-      localStorage.getItem('tinfoil-encryption-key')
+      localStorage.getItem(LEGACY_ENCRYPTION_KEY)
     const previousHistory = this.loadKeyHistoryFromStorage()
 
     const validAlternatives = Array.from(
@@ -492,7 +494,7 @@ export class EncryptionService {
     try {
       localStorage.setItem(USER_ENCRYPTION_KEY, nextState.primaryKey)
       if (nextState.includeLegacyKey) {
-        localStorage.setItem('tinfoil-encryption-key', nextState.primaryKey)
+        localStorage.setItem(LEGACY_ENCRYPTION_KEY, nextState.primaryKey)
       }
       this.saveKeyHistoryToStorage(nextState.history)
     } catch (persistError) {
@@ -501,14 +503,14 @@ export class EncryptionService {
           localStorage.setItem(USER_ENCRYPTION_KEY, previousState.previousKey)
           if (previousState.includeLegacyKey) {
             localStorage.setItem(
-              'tinfoil-encryption-key',
+              LEGACY_ENCRYPTION_KEY,
               previousState.previousKey,
             )
           }
         } else {
           localStorage.removeItem(USER_ENCRYPTION_KEY)
           if (previousState.includeLegacyKey) {
-            localStorage.removeItem('tinfoil-encryption-key')
+            localStorage.removeItem(LEGACY_ENCRYPTION_KEY)
           }
         }
         this.saveKeyHistoryToStorage(previousState.previousHistory)

--- a/src/services/passkey/index.ts
+++ b/src/services/passkey/index.ts
@@ -1,13 +1,18 @@
 export {
   decryptKeyBundle,
   encryptKeyBundle,
+  getPasskeyCredentialState,
   hasPasskeyCredentials,
   loadPasskeyCredentials,
   retrieveEncryptedKeys,
   savePasskeyCredentials,
   storeEncryptedKeys,
 } from './passkey-key-storage'
-export type { KeyBundle, PasskeyCredentialEntry } from './passkey-key-storage'
+export type {
+  KeyBundle,
+  PasskeyCredentialEntry,
+  PasskeyCredentialState,
+} from './passkey-key-storage'
 export {
   PrfNotSupportedError,
   authenticatePrfPasskey,

--- a/src/services/passkey/index.ts
+++ b/src/services/passkey/index.ts
@@ -1,4 +1,5 @@
 export {
+  PasskeyCredentialConflictError,
   decryptKeyBundle,
   encryptKeyBundle,
   getPasskeyCredentialState,
@@ -12,6 +13,7 @@ export type {
   KeyBundle,
   PasskeyCredentialEntry,
   PasskeyCredentialState,
+  StoreEncryptedKeysOptions,
 } from './passkey-key-storage'
 export {
   PrfNotSupportedError,

--- a/src/services/passkey/passkey-key-storage.ts
+++ b/src/services/passkey/passkey-key-storage.ts
@@ -11,6 +11,7 @@
 import { base64ToUint8Array, uint8ArrayToBase64 } from '@/utils/binary-codec'
 import { logError, logInfo } from '@/utils/error-handling'
 import { authTokenManager } from '../auth'
+import type { CloudKeyAuthorizationMode } from '../cloud/cloud-key-authorization'
 
 const API_BASE_URL =
   process.env.NEXT_PUBLIC_API_BASE_URL || 'https://api.tinfoil.sh'
@@ -20,6 +21,7 @@ const AES_GCM_IV_BYTES = 12
 export interface KeyBundle {
   primary: string
   alternatives: string[]
+  authorizationMode?: CloudKeyAuthorizationMode
 }
 
 export interface PasskeyCredentialEntry {
@@ -81,7 +83,10 @@ export async function decryptKeyBundle(
 
   if (
     typeof parsed.primary !== 'string' ||
-    !Array.isArray(parsed.alternatives)
+    !Array.isArray(parsed.alternatives) ||
+    (parsed.authorizationMode !== undefined &&
+      parsed.authorizationMode !== 'validated' &&
+      parsed.authorizationMode !== 'explicit_start_fresh')
   ) {
     throw new Error('Invalid key bundle structure')
   }

--- a/src/services/passkey/passkey-key-storage.ts
+++ b/src/services/passkey/passkey-key-storage.ts
@@ -8,6 +8,7 @@
  * The backend is a dumb JSONB store — all crypto happens client-side.
  */
 
+import { PASSKEY } from '@/config'
 import { base64ToUint8Array, uint8ArrayToBase64 } from '@/utils/binary-codec'
 import { logError, logInfo } from '@/utils/error-handling'
 import { authTokenManager } from '../auth'
@@ -31,11 +32,37 @@ export interface PasskeyCredentialEntry {
   created_at: string
   version: number // schema version (1 = AES-256-GCM + HKDF-SHA256 KEK)
   sync_version: number // monotonic counter, incremented each time the key bundle is re-encrypted
+  bundle_version?: number // logical key-bundle version shared across credential updates
 }
 
 const CURRENT_CREDENTIAL_VERSION = 1
 
 export type PasskeyCredentialState = 'exists' | 'empty' | 'unknown'
+
+export interface StoreEncryptedKeysOptions {
+  expectedSyncVersion?: number | null
+  knownBundleVersion?: number | null
+  incrementBundleVersion?: boolean
+  enforceRemoteBundleVersion?: boolean
+}
+
+export class PasskeyCredentialConflictError extends Error {
+  readonly remoteSyncVersion: number | null
+  readonly remoteBundleVersion: number
+
+  constructor(
+    message: string,
+    details: {
+      remoteSyncVersion?: number | null
+      remoteBundleVersion?: number
+    } = {},
+  ) {
+    super(message)
+    this.name = 'PasskeyCredentialConflictError'
+    this.remoteSyncVersion = details.remoteSyncVersion ?? null
+    this.remoteBundleVersion = details.remoteBundleVersion ?? 0
+  }
+}
 
 // --- Encrypt / Decrypt ---
 
@@ -107,7 +134,34 @@ function isValidCredentialEntry(
     typeof e.iv === 'string' &&
     typeof e.created_at === 'string' &&
     typeof e.version === 'number' &&
-    typeof e.sync_version === 'number'
+    typeof e.sync_version === 'number' &&
+    (e.bundle_version === undefined || typeof e.bundle_version === 'number')
+  )
+}
+
+function getCredentialBundleVersion(
+  entry: Pick<PasskeyCredentialEntry, 'bundle_version'>,
+): number {
+  return entry.bundle_version ?? 0
+}
+
+function getHighestBundleVersion(entries: PasskeyCredentialEntry[]): number {
+  return entries.reduce(
+    (highest, entry) => Math.max(highest, getCredentialBundleVersion(entry)),
+    0,
+  )
+}
+
+function hasStoredCredentialEntry(
+  entry: PasskeyCredentialEntry,
+  expected: PasskeyCredentialEntry,
+): boolean {
+  return (
+    entry.sync_version === expected.sync_version &&
+    getCredentialBundleVersion(entry) ===
+      getCredentialBundleVersion(expected) &&
+    entry.iv === expected.iv &&
+    entry.encrypted_keys === expected.encrypted_keys
   )
 }
 
@@ -211,38 +265,110 @@ export async function storeEncryptedKeys(
   credentialId: string,
   kek: CryptoKey,
   keys: KeyBundle,
-): Promise<{ syncVersion: number } | null> {
+  options: StoreEncryptedKeysOptions = {},
+): Promise<{ syncVersion: number; bundleVersion: number } | null> {
   try {
     const encrypted = await encryptKeyBundle(kek, keys)
 
-    const existing = await loadPasskeyCredentials()
-    const previous = existing.find((e) => e.id === credentialId)
+    for (
+      let attempt = 0;
+      attempt < PASSKEY.CREDENTIAL_SAVE_MAX_ATTEMPTS;
+      attempt++
+    ) {
+      const existing = await loadPasskeyCredentials()
+      const previous = existing.find((e) => e.id === credentialId)
+      const remoteBundleVersion = getHighestBundleVersion(existing)
 
-    const newSyncVersion = previous ? previous.sync_version + 1 : 1
+      if (
+        options.expectedSyncVersion !== undefined &&
+        options.expectedSyncVersion !== null &&
+        (!previous || previous.sync_version > options.expectedSyncVersion)
+      ) {
+        throw new PasskeyCredentialConflictError(
+          'A newer passkey backup already exists for this credential. Recover the latest backup before updating it.',
+          {
+            remoteSyncVersion: previous?.sync_version ?? null,
+            remoteBundleVersion,
+          },
+        )
+      }
 
-    const entry: PasskeyCredentialEntry = {
-      id: credentialId,
-      encrypted_keys: encrypted.data,
-      iv: encrypted.iv,
-      created_at: previous?.created_at ?? new Date().toISOString(),
-      version: CURRENT_CREDENTIAL_VERSION,
-      sync_version: newSyncVersion,
+      if (options.enforceRemoteBundleVersion) {
+        if (
+          options.knownBundleVersion === undefined ||
+          options.knownBundleVersion === null
+        ) {
+          if (remoteBundleVersion > 0) {
+            throw new PasskeyCredentialConflictError(
+              'This device needs the latest passkey backup before it can save changes.',
+              {
+                remoteSyncVersion: previous?.sync_version ?? null,
+                remoteBundleVersion,
+              },
+            )
+          }
+        } else if (remoteBundleVersion > options.knownBundleVersion) {
+          throw new PasskeyCredentialConflictError(
+            'A newer passkey backup already exists on another device. Recover the latest backup before updating it.',
+            {
+              remoteSyncVersion: previous?.sync_version ?? null,
+              remoteBundleVersion,
+            },
+          )
+        }
+      }
+
+      const newSyncVersion = previous ? previous.sync_version + 1 : 1
+      const baseBundleVersion = Math.max(
+        remoteBundleVersion,
+        options.knownBundleVersion ?? 0,
+      )
+      const newBundleVersion = options.incrementBundleVersion
+        ? Math.max(baseBundleVersion + 1, 1)
+        : Math.max(baseBundleVersion, 1)
+
+      const entry: PasskeyCredentialEntry = {
+        id: credentialId,
+        encrypted_keys: encrypted.data,
+        iv: encrypted.iv,
+        created_at: previous?.created_at ?? new Date().toISOString(),
+        version: CURRENT_CREDENTIAL_VERSION,
+        sync_version: newSyncVersion,
+        bundle_version: newBundleVersion,
+      }
+
+      const updated = existing.filter((e) => e.id !== credentialId)
+      updated.push(entry)
+
+      const saved = await savePasskeyCredentials(updated)
+      if (!saved) {
+        continue
+      }
+
+      const verifiedEntries = await loadPasskeyCredentials()
+      const verifiedEntry = verifiedEntries.find((e) => e.id === credentialId)
+      if (verifiedEntry && hasStoredCredentialEntry(verifiedEntry, entry)) {
+        logInfo('Stored encrypted keys for passkey credential', {
+          component: 'PasskeyKeyStorage',
+          action: 'storeEncryptedKeys',
+          metadata: {
+            credentialId,
+            totalEntries: updated.length,
+            bundleVersion: newBundleVersion,
+          },
+        })
+        return {
+          syncVersion: newSyncVersion,
+          bundleVersion: newBundleVersion,
+        }
+      }
     }
 
-    const updated = existing.filter((e) => e.id !== credentialId)
-    updated.push(entry)
-
-    const saved = await savePasskeyCredentials(updated)
-    if (saved) {
-      logInfo('Stored encrypted keys for passkey credential', {
-        component: 'PasskeyKeyStorage',
-        action: 'storeEncryptedKeys',
-        metadata: { credentialId, totalEntries: updated.length },
-      })
-      return { syncVersion: newSyncVersion }
-    }
-    return null
+    throw new Error('Failed to confirm the latest passkey backup update')
   } catch (error) {
+    if (error instanceof PasskeyCredentialConflictError) {
+      throw error
+    }
     logError('Failed to store encrypted keys', error, {
       component: 'PasskeyKeyStorage',
       action: 'storeEncryptedKeys',

--- a/src/services/passkey/passkey-key-storage.ts
+++ b/src/services/passkey/passkey-key-storage.ts
@@ -33,6 +33,8 @@ export interface PasskeyCredentialEntry {
 
 const CURRENT_CREDENTIAL_VERSION = 1
 
+export type PasskeyCredentialState = 'exists' | 'empty' | 'unknown'
+
 // --- Encrypt / Decrypt ---
 
 /**
@@ -177,6 +179,19 @@ export async function hasPasskeyCredentials(): Promise<boolean> {
       action: 'hasPasskeyCredentials',
     })
     return false
+  }
+}
+
+export async function getPasskeyCredentialState(): Promise<PasskeyCredentialState> {
+  try {
+    const entries = await loadPasskeyCredentials()
+    return entries.length > 0 ? 'exists' : 'empty'
+  } catch (error) {
+    logError('Failed to check passkey credentials', error, {
+      component: 'PasskeyKeyStorage',
+      action: 'getPasskeyCredentialState',
+    })
+    return 'unknown'
   }
 }
 

--- a/tests/services/cloud/cloud-sync.test.ts
+++ b/tests/services/cloud/cloud-sync.test.ts
@@ -27,6 +27,7 @@ const mockOnStreamEnd = vi.fn()
 const mockChatEventsEmit = vi.fn()
 const mockIngestRemoteChats = vi.fn()
 const mockSyncRemoteDeletions = vi.fn()
+const mockCanWriteToCloud = vi.fn()
 
 vi.mock('@/utils/error-handling', () => ({
   logInfo: vi.fn(),
@@ -64,6 +65,10 @@ vi.mock('@/services/cloud/project-storage', () => ({
     getProjectChatsSyncStatus: (...args: any[]) =>
       mockGetProjectChatsSyncStatus(...args),
   },
+}))
+
+vi.mock('@/services/cloud/cloud-key-authorization', () => ({
+  canWriteToCloud: (...args: any[]) => mockCanWriteToCloud(...args),
 }))
 
 vi.mock('@/services/encryption/encryption-service', () => ({
@@ -128,6 +133,7 @@ describe('CloudSyncService', () => {
       errors: [],
       savedIds: [],
     })
+    mockCanWriteToCloud.mockResolvedValue(true)
     mockSyncRemoteDeletions.mockResolvedValue(undefined)
   })
 

--- a/tests/services/passkey/passkey-key-storage-store.test.ts
+++ b/tests/services/passkey/passkey-key-storage-store.test.ts
@@ -1,0 +1,210 @@
+import {
+  PasskeyCredentialConflictError,
+  storeEncryptedKeys,
+  type KeyBundle,
+  type PasskeyCredentialEntry,
+} from '@/services/passkey/passkey-key-storage'
+import { deriveKeyEncryptionKey } from '@/services/passkey/passkey-service'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockGetAuthHeaders = vi.fn()
+
+vi.mock('@/services/auth', () => ({
+  authTokenManager: {
+    getAuthHeaders: (...args: unknown[]) => mockGetAuthHeaders(...args),
+  },
+}))
+
+vi.mock('@/utils/error-handling', () => ({
+  logError: vi.fn(),
+  logInfo: vi.fn(),
+}))
+
+function generateTestPrfOutput(): ArrayBuffer {
+  return crypto.getRandomValues(new Uint8Array(32)).buffer as ArrayBuffer
+}
+
+function buildEntry(
+  id: string,
+  overrides: Partial<PasskeyCredentialEntry> = {},
+): PasskeyCredentialEntry {
+  return {
+    id,
+    encrypted_keys: 'ciphertext',
+    iv: 'iv',
+    created_at: '2026-01-01T00:00:00.000Z',
+    version: 1,
+    sync_version: 1,
+    bundle_version: 1,
+    ...overrides,
+  }
+}
+
+describe('passkey-key-storage storeEncryptedKeys', () => {
+  let fetchMock: ReturnType<typeof vi.fn>
+  let kek: CryptoKey
+
+  const keyBundle: KeyBundle = {
+    primary: 'key_primary1234567890abcdef',
+    alternatives: ['key_alt1abcdef1234567890'],
+    authorizationMode: 'validated',
+  }
+
+  beforeEach(async () => {
+    fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    mockGetAuthHeaders.mockResolvedValue({ Authorization: 'Bearer test-token' })
+    const prfOutput = generateTestPrfOutput()
+    kek = await deriveKeyEncryptionKey(prfOutput)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+  })
+
+  it('stores incremented sync and bundle versions after verifying the save', async () => {
+    const initialEntries = [
+      buildEntry('cred-1', { sync_version: 2, bundle_version: 4 }),
+      buildEntry('cred-2', { sync_version: 1, bundle_version: 4 }),
+    ]
+    let savedEntries: PasskeyCredentialEntry[] | null = null
+
+    fetchMock.mockImplementation(
+      async (_url: string, options?: RequestInit): Promise<Response> => {
+        const method = options?.method ?? 'GET'
+
+        if (method === 'GET') {
+          return {
+            ok: true,
+            status: 200,
+            statusText: 'OK',
+            json: async () => savedEntries ?? initialEntries,
+          } as Response
+        }
+
+        savedEntries = JSON.parse(
+          String(options?.body),
+        ) as PasskeyCredentialEntry[]
+        return {
+          ok: true,
+          status: 200,
+          statusText: 'OK',
+          json: async () => ({}),
+        } as Response
+      },
+    )
+
+    const result = await storeEncryptedKeys('cred-1', kek, keyBundle, {
+      expectedSyncVersion: 2,
+      knownBundleVersion: 4,
+      incrementBundleVersion: true,
+      enforceRemoteBundleVersion: true,
+    })
+
+    expect(result).toEqual({ syncVersion: 3, bundleVersion: 5 })
+    expect(savedEntries).not.toBeNull()
+    expect(savedEntries?.find((entry) => entry.id === 'cred-1')).toMatchObject({
+      sync_version: 3,
+      bundle_version: 5,
+    })
+  })
+
+  it('retries when the first post-save verification does not contain the new entry', async () => {
+    const initialEntries = [
+      buildEntry('cred-1', { sync_version: 1, bundle_version: 1 }),
+    ]
+    let savedEntries: PasskeyCredentialEntry[] | null = null
+    let getCount = 0
+
+    fetchMock.mockImplementation(
+      async (_url: string, options?: RequestInit): Promise<Response> => {
+        const method = options?.method ?? 'GET'
+
+        if (method === 'GET') {
+          getCount += 1
+          const payload =
+            getCount <= 3 ? initialEntries : (savedEntries ?? initialEntries)
+
+          return {
+            ok: true,
+            status: 200,
+            statusText: 'OK',
+            json: async () => payload,
+          } as Response
+        }
+
+        savedEntries = JSON.parse(
+          String(options?.body),
+        ) as PasskeyCredentialEntry[]
+        return {
+          ok: true,
+          status: 200,
+          statusText: 'OK',
+          json: async () => ({}),
+        } as Response
+      },
+    )
+
+    const result = await storeEncryptedKeys('cred-1', kek, keyBundle, {
+      expectedSyncVersion: 1,
+      knownBundleVersion: 1,
+      incrementBundleVersion: true,
+      enforceRemoteBundleVersion: true,
+    })
+
+    expect(result).toEqual({ syncVersion: 2, bundleVersion: 2 })
+    expect(
+      fetchMock.mock.calls.filter(([, options]) => options?.method === 'PUT'),
+    ).toHaveLength(2)
+  })
+
+  it('rejects stale sync_version updates for the same credential', async () => {
+    const initialEntries = [
+      buildEntry('cred-1', { sync_version: 4, bundle_version: 2 }),
+    ]
+
+    fetchMock.mockImplementation(async (): Promise<Response> => {
+      return {
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: async () => initialEntries,
+      } as Response
+    })
+
+    await expect(
+      storeEncryptedKeys('cred-1', kek, keyBundle, {
+        expectedSyncVersion: 3,
+        knownBundleVersion: 2,
+        incrementBundleVersion: true,
+        enforceRemoteBundleVersion: true,
+      }),
+    ).rejects.toBeInstanceOf(PasskeyCredentialConflictError)
+  })
+
+  it('rejects updates when another credential already advertises a newer bundle version', async () => {
+    const initialEntries = [
+      buildEntry('cred-1', { sync_version: 2, bundle_version: 4 }),
+      buildEntry('cred-2', { sync_version: 1, bundle_version: 5 }),
+    ]
+
+    fetchMock.mockImplementation(async (): Promise<Response> => {
+      return {
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: async () => initialEntries,
+      } as Response
+    })
+
+    await expect(
+      storeEncryptedKeys('cred-1', kek, keyBundle, {
+        expectedSyncVersion: 2,
+        knownBundleVersion: 4,
+        incrementBundleVersion: true,
+        enforceRemoteBundleVersion: true,
+      }),
+    ).rejects.toBeInstanceOf(PasskeyCredentialConflictError)
+  })
+})


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevents split‑brain by gating all cloud writes behind local key authorization and by validating the active key before writes; replacing the primary key is now an explicit opt‑in. Adds versioned passkey backups and clearer setup/recovery that separate “Recover Existing” from “Start Fresh.”

- **New Features**
  - Key setup and settings: choose “Recover Existing” (validate before writes) or “Start Fresh” (authorize without validating). `setEncryptionKey(key, { mode })` and `addRecoveryKey(key)` added; cloud writes require local authorization; existing users are auto‑authorized on sign‑in when validation passes. Setup auto‑opens when `manualRecoveryNeeded`; the setup modal returns the selected mode and supports “Start Fresh with New Key.” When a passkey is active, settings show “Add Decryption Key” only.
  - Passkey backup hardening: track `sync_version` and `bundle_version`, verify post‑save state, retry saves (`PASSKEY.CREDENTIAL_SAVE_MAX_ATTEMPTS`), enforce remote bundle version, and throw `PasskeyCredentialConflictError` to require recovering the latest backup first.

- **Bug Fixes**
  - Roll back keys on validation/authorization failures during recovery or start‑fresh, persist to localStorage before in‑memory updates, auto‑authorize validated keys after sign‑in, and keep cloud writes blocked until the key is authorized (applies across chats, projects, and profile).
  - Preserve wrong‑key guard when profile payloads are missing and avoid retry loops; withhold profile writes when remote decryption has failed unless the device explicitly chose “Start Fresh.” Added tests for passkey store semantics.

<sup>Written for commit 894eb9404535369ed24ef01b34c4f15879d0e7eb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

