### PR TITLE
Add onboarding flow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -304,54 +304,40 @@
       "license": "MIT"
     },
     "node_modules/@chevrotain/cst-dts-gen": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-11.0.3.tgz",
-      "integrity": "sha512-BvIKpRLeS/8UbfxXxgC33xOumsacaeCKAjAeLyOn7Pcp95HiRbrpl14S+9vaZLolnbssPIUuiUd8IvgkRyt6NQ==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-12.0.0.tgz",
+      "integrity": "sha512-fSL4KXjTl7cDgf0B5Rip9Q05BOrYvkJV/RrBTE/bKDN096E4hN/ySpcBK5B24T76dlQ2i32Zc3PAE27jFnFrKg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@chevrotain/gast": "11.0.3",
-        "@chevrotain/types": "11.0.3",
-        "lodash-es": "4.17.21"
+        "@chevrotain/gast": "12.0.0",
+        "@chevrotain/types": "12.0.0"
       }
-    },
-    "node_modules/@chevrotain/cst-dts-gen/node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
-      "license": "MIT"
     },
     "node_modules/@chevrotain/gast": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-11.0.3.tgz",
-      "integrity": "sha512-+qNfcoNk70PyS/uxmj3li5NiECO+2YKZZQMbmjTqRI3Qchu8Hig/Q9vgkHpI3alNjr7M+a2St5pw5w5F6NL5/Q==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-12.0.0.tgz",
+      "integrity": "sha512-1ne/m3XsIT8aEdrvT33so0GUC+wkctpUPK6zU9IlOyJLUbR0rg4G7ZiApiJbggpgPir9ERy3FRjT6T7lpgetnQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@chevrotain/types": "11.0.3",
-        "lodash-es": "4.17.21"
+        "@chevrotain/types": "12.0.0"
       }
     },
-    "node_modules/@chevrotain/gast/node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
-      "license": "MIT"
-    },
     "node_modules/@chevrotain/regexp-to-ast": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-11.0.3.tgz",
-      "integrity": "sha512-1fMHaBZxLFvWI067AVbGJav1eRY7N8DDvYCTwGBiE/ytKBgP8azTdgyrKyWZ9Mfh09eHWb5PgTSO8wi7U824RA==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-12.0.0.tgz",
+      "integrity": "sha512-p+EW9MaJwgaHguhoqwOtx/FwuGr+DnNn857sXWOi/mClXIkPGl3rn7hGNWvo31HA3vyeQxjqe+H36yZJwYU8cA==",
       "license": "Apache-2.0"
     },
     "node_modules/@chevrotain/types": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.0.3.tgz",
-      "integrity": "sha512-gsiM3G8b58kZC2HaWR50gu6Y1440cHiJ+i3JUvcp/35JchYejb2+5MVeJK0iKThYpAa/P2PYFV4hoi44HD+aHQ==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-12.0.0.tgz",
+      "integrity": "sha512-S+04vjFQKeuYw0/eW3U52LkAHQsB1ASxsPGsLPUyQgrZ2iNNibQrsidruDzjEX2JYfespXMG0eZmXlhA6z7nWA==",
       "license": "Apache-2.0"
     },
     "node_modules/@chevrotain/utils": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-11.0.3.tgz",
-      "integrity": "sha512-YslZMgtJUyuMbZ+aKvfF3x1f5liK4mWNxghFRv7jqRR9C3R3fAOGTTKvxXDa2Y1s9zSbcpuO0cAxDYsc9SrXoQ==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-12.0.0.tgz",
+      "integrity": "sha512-lB59uJoaGIfOOL9knQqQRfhl9g7x8/wqFkp13zTdkRu1huG9kg6IJs1O8hqj9rs6h7orGxHJUKb+mX3rPbWGhA==",
       "license": "Apache-2.0"
     },
     "node_modules/@clerk/backend": {
@@ -1854,12 +1840,12 @@
       }
     },
     "node_modules/@mermaid-js/parser": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-0.6.3.tgz",
-      "integrity": "sha512-lnjOhe7zyHjc+If7yT4zoedx2vo4sHaTmtkl1+or8BRTnCtDmcTpAjpzDSfCZrshM5bCoz0GyidzadJAH1xobA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.1.0.tgz",
+      "integrity": "sha512-gxK9ZX2+Fex5zu8LhRQoMeMPEHbc73UKZ0FQ54YrQtUxE1VVhMwzeNtKRPAu5aXks4FasbMe4xB4bWrmq6Jlxw==",
       "license": "MIT",
       "dependencies": {
-        "langium": "3.3.1"
+        "langium": "^4.0.0"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -1875,9 +1861,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.5.12",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.12.tgz",
-      "integrity": "sha512-pUvdJN1on574wQHjaBfNGDt9Mz5utDSZFsIIQkMzPgNS8ZvT4H2mwOrOIClwsQOb6EGx5M76/CZr6G8i6pSpLg==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.15.tgz",
+      "integrity": "sha512-vcmyu5/MyFzN7CdqRHO3uHO44p/QPCZkuTUXroeUmhNP8bL5PHFEhik22JUazt+CDDoD6EpBYRCaS2pISL+/hg==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -1890,9 +1876,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "15.5.12",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.12.tgz",
-      "integrity": "sha512-RnRjBtH8S8eXCpUNkQ+543DUc7ys8y15VxmFU9HRqlo9BG3CcBUiwNtF8SNoi2xvGCVJq1vl2yYq+3oISBS0Zg==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.15.tgz",
+      "integrity": "sha512-6PvFO2Tzt10GFK2Ro9tAVEtacMqRmTarYMFKAnV2vYMdwWc73xzmDQyAV7SwEdMhzmiRoo7+m88DuiXlJlGeaw==",
       "cpu": [
         "arm64"
       ],
@@ -1906,9 +1892,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "15.5.12",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.12.tgz",
-      "integrity": "sha512-nqa9/7iQlboF1EFtNhWxQA0rQstmYRSBGxSM6g3GxvxHxcoeqVXfGNr9stJOme674m2V7r4E3+jEhhGvSQhJRA==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.15.tgz",
+      "integrity": "sha512-G+YNV+z6FDZTp/+IdGyIMFqalBTaQSnvAA+X/hrt+eaTRFSznRMz9K7rTmzvM6tDmKegNtyzgufZW0HwVzEqaQ==",
       "cpu": [
         "x64"
       ],
@@ -1922,9 +1908,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.5.12",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.12.tgz",
-      "integrity": "sha512-dCzAjqhDHwmoB2M4eYfVKqXs99QdQxNQVpftvP1eGVppamXh/OkDAwV737Zr0KPXEqRUMN4uCjh6mjO+XtF3Mw==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.15.tgz",
+      "integrity": "sha512-eVkrMcVIBqGfXB+QUC7jjZ94Z6uX/dNStbQFabewAnk13Uy18Igd1YZ/GtPRzdhtm7QwC0e6o7zOQecul4iC1w==",
       "cpu": [
         "arm64"
       ],
@@ -1938,9 +1924,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.5.12",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.12.tgz",
-      "integrity": "sha512-+fpGWvQiITgf7PUtbWY1H7qUSnBZsPPLyyq03QuAKpVoTy/QUx1JptEDTQMVvQhvizCEuNLEeghrQUyXQOekuw==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.15.tgz",
+      "integrity": "sha512-RwSHKMQ7InLy5GfkY2/n5PcFycKA08qI1VST78n09nN36nUPqCvGSMiLXlfUmzmpQpF6XeBYP2KRWHi0UW3uNg==",
       "cpu": [
         "arm64"
       ],
@@ -1954,9 +1940,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.5.12",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.12.tgz",
-      "integrity": "sha512-jSLvgdRRL/hrFAPqEjJf1fFguC719kmcptjNVDJl26BnJIpjL3KH5h6mzR4mAweociLQaqvt4UyzfbFjgAdDcw==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.15.tgz",
+      "integrity": "sha512-nplqvY86LakS+eeiuWsNWvfmK8pFcOEW7ZtVRt4QH70lL+0x6LG/m1OpJ/tvrbwjmR8HH9/fH2jzW1GlL03TIg==",
       "cpu": [
         "x64"
       ],
@@ -1970,9 +1956,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.5.12",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.12.tgz",
-      "integrity": "sha512-/uaF0WfmYqQgLfPmN6BvULwxY0dufI2mlN2JbOKqqceZh1G4hjREyi7pg03zjfyS6eqNemHAZPSoP84x17vo6w==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.15.tgz",
+      "integrity": "sha512-eAgl9NKQ84/sww0v81DQINl/vL2IBxD7sMybd0cWRw6wqgouVI53brVRBrggqBRP/NWeIAE1dm5cbKYoiMlqDQ==",
       "cpu": [
         "x64"
       ],
@@ -1986,9 +1972,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.5.12",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.12.tgz",
-      "integrity": "sha512-xhsL1OvQSfGmlL5RbOmU+FV120urrgFpYLq+6U8C6KIym32gZT6XF/SDE92jKzzlPWskkbjOKCpqk5m4i8PEfg==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.15.tgz",
+      "integrity": "sha512-GJVZC86lzSquh0MtvZT+L7G8+jMnJcldloOjA8Kf3wXvBrvb6OGe2MzPuALxFshSm/IpwUtD2mIoof39ymf52A==",
       "cpu": [
         "arm64"
       ],
@@ -2002,9 +1988,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.5.12",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.12.tgz",
-      "integrity": "sha512-Z1Dh6lhFkxvBDH1FoW6OU/L6prYwPSlwjLiZkExIAh8fbP6iI/M7iGTQAJPYJ9YFlWobCZ1PHbchFhFYb2ADkw==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.15.tgz",
+      "integrity": "sha512-nFucjVdwlFqxh/JG3hWSJ4p8+YJV7Ii8aPDuBQULB6DzUF4UNZETXLfEUk+oI2zEznWWULPt7MeuTE6xtK1HSA==",
       "cpu": [
         "x64"
       ],
@@ -3004,9 +2990,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.53.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.53.5.tgz",
-      "integrity": "sha512-iDGS/h7D8t7tvZ1t6+WPK04KD0MwzLZrG0se1hzBjSi5fyxlsiggoJHwh18PCFNn7tG43OWb6pdZ6Y+rMlmyNQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
+      "integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
       "cpu": [
         "arm"
       ],
@@ -3018,9 +3004,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.53.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.53.5.tgz",
-      "integrity": "sha512-wrSAViWvZHBMMlWk6EJhvg8/rjxzyEhEdgfMMjREHEq11EtJ6IP6yfcCH57YAEca2Oe3FNCE9DSTgU70EIGmVw==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
+      "integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
       "cpu": [
         "arm64"
       ],
@@ -3032,9 +3018,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.53.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.53.5.tgz",
-      "integrity": "sha512-S87zZPBmRO6u1YXQLwpveZm4JfPpAa6oHBX7/ghSiGH3rz/KDgAu1rKdGutV+WUI6tKDMbaBJomhnT30Y2t4VQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
+      "integrity": "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==",
       "cpu": [
         "arm64"
       ],
@@ -3046,9 +3032,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.53.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.53.5.tgz",
-      "integrity": "sha512-YTbnsAaHo6VrAczISxgpTva8EkfQus0VPEVJCEaboHtZRIb6h6j0BNxRBOwnDciFTZLDPW5r+ZBmhL/+YpTZgA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
+      "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
       "cpu": [
         "x64"
       ],
@@ -3060,9 +3046,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.53.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.53.5.tgz",
-      "integrity": "sha512-1T8eY2J8rKJWzaznV7zedfdhD1BqVs1iqILhmHDq/bqCUZsrMt+j8VCTHhP0vdfbHK3e1IQ7VYx3jlKqwlf+vw==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
+      "integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
       "cpu": [
         "arm64"
       ],
@@ -3074,9 +3060,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.53.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.53.5.tgz",
-      "integrity": "sha512-sHTiuXyBJApxRn+VFMaw1U+Qsz4kcNlxQ742snICYPrY+DDL8/ZbaC4DVIB7vgZmp3jiDaKA0WpBdP0aqPJoBQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
+      "integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
       "cpu": [
         "x64"
       ],
@@ -3088,9 +3074,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.53.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.53.5.tgz",
-      "integrity": "sha512-dV3T9MyAf0w8zPVLVBptVlzaXxka6xg1f16VAQmjg+4KMSTWDvhimI/Y6mp8oHwNrmnmVl9XxJ/w/mO4uIQONA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
+      "integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
       "cpu": [
         "arm"
       ],
@@ -3102,9 +3088,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.53.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.53.5.tgz",
-      "integrity": "sha512-wIGYC1x/hyjP+KAu9+ewDI+fi5XSNiUi9Bvg6KGAh2TsNMA3tSEs+Sh6jJ/r4BV/bx/CyWu2ue9kDnIdRyafcQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
+      "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
       "cpu": [
         "arm"
       ],
@@ -3116,9 +3102,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.53.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.53.5.tgz",
-      "integrity": "sha512-Y+qVA0D9d0y2FRNiG9oM3Hut/DgODZbU9I8pLLPwAsU0tUKZ49cyV1tzmB/qRbSzGvY8lpgGkJuMyuhH7Ma+Vg==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
+      "integrity": "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==",
       "cpu": [
         "arm64"
       ],
@@ -3130,9 +3116,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.53.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.53.5.tgz",
-      "integrity": "sha512-juaC4bEgJsyFVfqhtGLz8mbopaWD+WeSOYr5E16y+1of6KQjc0BpwZLuxkClqY1i8sco+MdyoXPNiCkQou09+g==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
+      "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
       "cpu": [
         "arm64"
       ],
@@ -3144,9 +3130,23 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.53.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.53.5.tgz",
-      "integrity": "sha512-rIEC0hZ17A42iXtHX+EPJVL/CakHo+tT7W0pbzdAGuWOt2jxDFh7A/lRhsNHBcqL4T36+UiAgwO8pbmn3dE8wA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
+      "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
+      "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
       "cpu": [
         "loong64"
       ],
@@ -3158,9 +3158,23 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.53.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.53.5.tgz",
-      "integrity": "sha512-T7l409NhUE552RcAOcmJHj3xyZ2h7vMWzcwQI0hvn5tqHh3oSoclf9WgTl+0QqffWFG8MEVZZP1/OBglKZx52Q==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
+      "integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
+      "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
       "cpu": [
         "ppc64"
       ],
@@ -3172,9 +3186,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.53.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.53.5.tgz",
-      "integrity": "sha512-7OK5/GhxbnrMcxIFoYfhV/TkknarkYC1hqUw1wU2xUN3TVRLNT5FmBv4KkheSG2xZ6IEbRAhTooTV2+R5Tk0lQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
+      "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
       "cpu": [
         "riscv64"
       ],
@@ -3186,9 +3200,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.53.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.53.5.tgz",
-      "integrity": "sha512-GwuDBE/PsXaTa76lO5eLJTyr2k8QkPipAyOrs4V/KJufHCZBJ495VCGJol35grx9xryk4V+2zd3Ri+3v7NPh+w==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
+      "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
       "cpu": [
         "riscv64"
       ],
@@ -3200,9 +3214,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.53.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.53.5.tgz",
-      "integrity": "sha512-IAE1Ziyr1qNfnmiQLHBURAD+eh/zH1pIeJjeShleII7Vj8kyEm2PF77o+lf3WTHDpNJcu4IXJxNO0Zluro8bOw==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
+      "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
       "cpu": [
         "s390x"
       ],
@@ -3214,9 +3228,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.53.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.53.5.tgz",
-      "integrity": "sha512-Pg6E+oP7GvZ4XwgRJBuSXZjcqpIW3yCBhK4BcsANvb47qMvAbCjR6E+1a/U2WXz1JJxp9/4Dno3/iSJLcm5auw==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
       "cpu": [
         "x64"
       ],
@@ -3228,9 +3242,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.53.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.53.5.tgz",
-      "integrity": "sha512-txGtluxDKTxaMDzUduGP0wdfng24y1rygUMnmlUJ88fzCCULCLn7oE5kb2+tRB+MWq1QDZT6ObT5RrR8HFRKqg==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
+      "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
       "cpu": [
         "x64"
       ],
@@ -3241,10 +3255,24 @@
         "linux"
       ]
     },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
+      "integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.53.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.53.5.tgz",
-      "integrity": "sha512-3DFiLPnTxiOQV993fMc+KO8zXHTcIjgaInrqlG8zDp1TlhYl6WgrOHuJkJQ6M8zHEcntSJsUp1XFZSY8C1DYbg==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
+      "integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
       "cpu": [
         "arm64"
       ],
@@ -3256,9 +3284,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.53.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.53.5.tgz",
-      "integrity": "sha512-nggc/wPpNTgjGg75hu+Q/3i32R00Lq1B6N1DO7MCU340MRKL3WZJMjA9U4K4gzy3dkZPXm9E1Nc81FItBVGRlA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
+      "integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
       "cpu": [
         "arm64"
       ],
@@ -3270,9 +3298,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.53.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.53.5.tgz",
-      "integrity": "sha512-U/54pTbdQpPLBdEzCT6NBCFAfSZMvmjr0twhnD9f4EIvlm9wy3jjQ38yQj1AGznrNO65EWQMgm/QUjuIVrYF9w==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
+      "integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
       "cpu": [
         "ia32"
       ],
@@ -3284,9 +3312,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.53.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.53.5.tgz",
-      "integrity": "sha512-2NqKgZSuLH9SXBBV2dWNRCZmocgSOx8OJSdpRaEcRlIfX8YrKxUT6z0F1NpvDVhOsl190UFTRh2F2WDWWCYp3A==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
       "cpu": [
         "x64"
       ],
@@ -3298,9 +3326,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.53.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.53.5.tgz",
-      "integrity": "sha512-JRpZUhCfhZ4keB5v0fe02gQJy05GqboPOaxvjugW04RLSYYoB/9t2lx2u/tMs/Na/1NXfY8QYjgRljRpN+MjTQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
+      "integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
       "cpu": [
         "x64"
       ],
@@ -3943,6 +3971,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.40.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.40.0.tgz",
@@ -4125,10 +4163,11 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -4162,12 +4201,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -4471,6 +4511,16 @@
         "win32"
       ]
     },
+    "node_modules/@upsetjs/venn.js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@upsetjs/venn.js/-/venn.js-2.0.0.tgz",
+      "integrity": "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "d3-selection": "^3.0.0",
+        "d3-transition": "^3.0.1"
+      }
+    },
     "node_modules/@vitest/coverage-v8": {
       "version": "4.0.16",
       "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.0.16.tgz",
@@ -4644,10 +4694,11 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -5066,10 +5117,11 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -5292,36 +5344,32 @@
       }
     },
     "node_modules/chevrotain": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.0.3.tgz",
-      "integrity": "sha512-ci2iJH6LeIkvP9eJW6gpueU8cnZhv85ELY8w8WiFtNjMHA5ad6pQLaJo9mEly/9qUyCpvqX8/POVUTf18/HFdw==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-12.0.0.tgz",
+      "integrity": "sha512-csJvb+6kEiQaqo1woTdSAuOWdN0WTLIydkKrBnS+V5gZz0oqBrp4kQ35519QgK6TpBThiG3V1vNSHlIkv4AglQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@chevrotain/cst-dts-gen": "11.0.3",
-        "@chevrotain/gast": "11.0.3",
-        "@chevrotain/regexp-to-ast": "11.0.3",
-        "@chevrotain/types": "11.0.3",
-        "@chevrotain/utils": "11.0.3",
-        "lodash-es": "4.17.21"
+        "@chevrotain/cst-dts-gen": "12.0.0",
+        "@chevrotain/gast": "12.0.0",
+        "@chevrotain/regexp-to-ast": "12.0.0",
+        "@chevrotain/types": "12.0.0",
+        "@chevrotain/utils": "12.0.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
       }
     },
     "node_modules/chevrotain-allstar": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/chevrotain-allstar/-/chevrotain-allstar-0.3.1.tgz",
-      "integrity": "sha512-b7g+y9A0v4mxCW1qUhf3BSVPg+/NvGErk/dOkrDaHA0nQIQGAtrOjlX//9OQtRlSCy+x9rfB5N8yC71lH1nvMw==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/chevrotain-allstar/-/chevrotain-allstar-0.4.1.tgz",
+      "integrity": "sha512-PvVJm3oGqrveUVW2Vt/eZGeiAIsJszYweUcYwcskg9e+IubNYKKD+rHHem7A6XVO22eDAL+inxNIGAzZ/VIWlA==",
       "license": "MIT",
       "dependencies": {
         "lodash-es": "^4.17.21"
       },
       "peerDependencies": {
-        "chevrotain": "^11.0.0"
+        "chevrotain": "^12.0.0"
       }
-    },
-    "node_modules/chevrotain/node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
-      "license": "MIT"
     },
     "node_modules/chokidar": {
       "version": "3.6.0",
@@ -5881,6 +5929,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
       "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
       "engines": {
         "node": ">=12"
       }
@@ -5913,6 +5962,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
       "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
       "engines": {
         "node": ">=12"
       }
@@ -5921,6 +5971,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
       "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
       "dependencies": {
         "d3-dispatch": "1 - 3",
         "d3-selection": "3"
@@ -5967,6 +6018,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
       "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=12"
       }
@@ -5998,9 +6050,9 @@
       }
     },
     "node_modules/d3-format": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
-      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -6031,6 +6083,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
       "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
       "dependencies": {
         "d3-color": "1 - 3"
       },
@@ -6147,6 +6200,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
       "engines": {
         "node": ">=12"
       }
@@ -6191,6 +6245,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
       "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
       "engines": {
         "node": ">=12"
       }
@@ -6199,6 +6254,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
       "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
       "dependencies": {
         "d3-color": "1 - 3",
         "d3-dispatch": "1 - 3",
@@ -6217,6 +6273,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
       "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
       "dependencies": {
         "d3-dispatch": "1 - 3",
         "d3-drag": "2 - 3",
@@ -6229,9 +6286,9 @@
       }
     },
     "node_modules/dagre-d3-es": {
-      "version": "7.0.13",
-      "resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.13.tgz",
-      "integrity": "sha512-efEhnxpSuwpYOKRm/L5KbqoZmNNukHa/Flty4Wp62JRvgH2ojwVgPgdYyr4twpieZnyRDdIH7PY2mopX26+j2Q==",
+      "version": "7.0.14",
+      "resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.14.tgz",
+      "integrity": "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==",
       "license": "MIT",
       "dependencies": {
         "d3": "^7.9.0",
@@ -6398,9 +6455,9 @@
       }
     },
     "node_modules/delaunator": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.1.tgz",
-      "integrity": "sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
       "license": "ISC",
       "dependencies": {
         "robust-predicates": "^3.0.2"
@@ -6471,9 +6528,9 @@
       "peer": true
     },
     "node_modules/dompurify": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.1.tgz",
-      "integrity": "sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
+      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -7386,10 +7443,11 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
-      "dev": true
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/for-each": {
       "version": "0.3.5",
@@ -7662,19 +7720,21 @@
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
     },
     "node_modules/glob/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -7736,18 +7796,34 @@
       "license": "MIT"
     },
     "node_modules/happy-dom": {
-      "version": "20.0.11",
-      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.0.11.tgz",
-      "integrity": "sha512-QsCdAUHAmiDeKeaNojb1OHOPF7NjcWPBR7obdu3NwH2a/oyQaLg5d0aaCy/9My6CdPChYF07dvz5chaXBGaD4g==",
+      "version": "20.9.0",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.9.0.tgz",
+      "integrity": "sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/node": "^20.0.0",
+        "@types/node": ">=20.0.0",
         "@types/whatwg-mimetype": "^3.0.2",
-        "whatwg-mimetype": "^3.0.0"
+        "@types/ws": "^8.18.1",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.18.3"
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/happy-dom/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/has-bigints": {
@@ -8994,13 +9070,14 @@
       }
     },
     "node_modules/katex": {
-      "version": "0.16.22",
-      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.22.tgz",
-      "integrity": "sha512-XCHRdUw4lf3SKBaJe4EvgqIuWwkPSo9XoeO8GjQW94Bp7TWv9hNhzZjZ+OH9yf1UmLygb7DIT5GSFQiyt16zYg==",
+      "version": "0.16.45",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.45.tgz",
+      "integrity": "sha512-pQpZbdBu7wCTmQUh7ufPmLr0pFoObnGUoL/yhtwJDgmmQpbkg/0HSVti25Fu4rmd1oCR6NGWe9vqTWuWv3GcNA==",
       "funding": [
         "https://opencollective.com/katex",
         "https://github.com/sponsors/katex"
       ],
+      "license": "MIT",
       "dependencies": {
         "commander": "^8.3.0"
       },
@@ -9023,19 +9100,21 @@
       "integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="
     },
     "node_modules/langium": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/langium/-/langium-3.3.1.tgz",
-      "integrity": "sha512-QJv/h939gDpvT+9SiLVlY7tZC3xB2qK57v0J04Sh9wpMb6MP1q8gB21L3WIo8T5P1MSMg3Ep14L7KkDCFG3y4w==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/langium/-/langium-4.2.2.tgz",
+      "integrity": "sha512-JUshTRAfHI4/MF9dH2WupvjSXyn8JBuUEWazB8ZVJUtXutT0doDlAv1XKbZ1Pb5sMexa8FF4CFBc0iiul7gbUQ==",
       "license": "MIT",
       "dependencies": {
-        "chevrotain": "~11.0.3",
-        "chevrotain-allstar": "~0.3.0",
+        "@chevrotain/regexp-to-ast": "~12.0.0",
+        "chevrotain": "~12.0.0",
+        "chevrotain-allstar": "~0.4.1",
         "vscode-languageserver": "~9.0.1",
         "vscode-languageserver-textdocument": "~1.0.11",
-        "vscode-uri": "~3.0.8"
+        "vscode-uri": "~3.1.0"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
       }
     },
     "node_modules/language-subtag-registry": {
@@ -9224,9 +9303,9 @@
       }
     },
     "node_modules/lodash-es": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "license": "MIT"
     },
     "node_modules/lodash.castarray": {
@@ -9796,27 +9875,28 @@
       }
     },
     "node_modules/mermaid": {
-      "version": "11.12.2",
-      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.12.2.tgz",
-      "integrity": "sha512-n34QPDPEKmaeCG4WDMGy0OT6PSyxKCfy2pJgShP+Qow2KLrvWjclwbc3yXfSIf4BanqWEhQEpngWwNp/XhZt6w==",
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.14.0.tgz",
+      "integrity": "sha512-GSGloRsBs+JINmmhl0JDwjpuezCsHB4WGI4NASHxL3fHo3o/BRXTxhDLKnln8/Q0lRFRyDdEjmk1/d5Sn1Xz8g==",
       "license": "MIT",
       "dependencies": {
         "@braintree/sanitize-url": "^7.1.1",
-        "@iconify/utils": "^3.0.1",
-        "@mermaid-js/parser": "^0.6.3",
+        "@iconify/utils": "^3.0.2",
+        "@mermaid-js/parser": "^1.1.0",
         "@types/d3": "^7.4.3",
-        "cytoscape": "^3.29.3",
+        "@upsetjs/venn.js": "^2.0.0",
+        "cytoscape": "^3.33.1",
         "cytoscape-cose-bilkent": "^4.1.0",
         "cytoscape-fcose": "^2.2.0",
         "d3": "^7.9.0",
         "d3-sankey": "^0.12.3",
-        "dagre-d3-es": "7.0.13",
-        "dayjs": "^1.11.18",
-        "dompurify": "^3.2.5",
-        "katex": "^0.16.22",
+        "dagre-d3-es": "7.0.14",
+        "dayjs": "^1.11.19",
+        "dompurify": "^3.3.1",
+        "katex": "^0.16.25",
         "khroma": "^2.1.0",
-        "lodash-es": "^4.17.21",
-        "marked": "^16.2.1",
+        "lodash-es": "^4.17.23",
+        "marked": "^16.3.0",
         "roughjs": "^4.6.6",
         "stylis": "^4.3.6",
         "ts-dedent": "^2.2.0",
@@ -10423,10 +10503,11 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -10530,12 +10611,12 @@
       "dev": true
     },
     "node_modules/next": {
-      "version": "15.5.12",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.5.12.tgz",
-      "integrity": "sha512-Fi/wQ4Etlrn60rz78bebG1i1SR20QxvV8tVp6iJspjLUSHcZoeUXCt+vmWoEcza85ElZzExK/jJ/F6SvtGktjA==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.5.15.tgz",
+      "integrity": "sha512-VSqCrJwtLVGwAVE0Sb/yikrQfkwkZW9p+lL/J4+xe+G3ZA+QnWPqgcfH1tDUEuk9y+pthzzVFp4L/U8JerMfMQ==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "15.5.12",
+        "@next/env": "15.5.15",
         "@swc/helpers": "0.5.15",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
@@ -10548,14 +10629,14 @@
         "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "15.5.12",
-        "@next/swc-darwin-x64": "15.5.12",
-        "@next/swc-linux-arm64-gnu": "15.5.12",
-        "@next/swc-linux-arm64-musl": "15.5.12",
-        "@next/swc-linux-x64-gnu": "15.5.12",
-        "@next/swc-linux-x64-musl": "15.5.12",
-        "@next/swc-win32-arm64-msvc": "15.5.12",
-        "@next/swc-win32-x64-msvc": "15.5.12",
+        "@next/swc-darwin-arm64": "15.5.15",
+        "@next/swc-darwin-x64": "15.5.15",
+        "@next/swc-linux-arm64-gnu": "15.5.15",
+        "@next/swc-linux-arm64-musl": "15.5.15",
+        "@next/swc-linux-x64-gnu": "15.5.15",
+        "@next/swc-linux-x64-musl": "15.5.15",
+        "@next/swc-win32-arm64-msvc": "15.5.15",
+        "@next/swc-win32-x64-msvc": "15.5.15",
         "sharp": "^0.34.3"
       },
       "peerDependencies": {
@@ -11021,9 +11102,10 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },
@@ -12029,15 +12111,15 @@
       }
     },
     "node_modules/robust-predicates": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
-      "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
       "license": "Unlicense"
     },
     "node_modules/rollup": {
-      "version": "4.53.5",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.53.5.tgz",
-      "integrity": "sha512-iTNAbFSlRpcHeeWu73ywU/8KuU/LZmNCSxp6fjQkJBD3ivUb8tpDrXhIxEzA05HlYMEwmtaUnb3RP+YNv162OQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
+      "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12051,28 +12133,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.53.5",
-        "@rollup/rollup-android-arm64": "4.53.5",
-        "@rollup/rollup-darwin-arm64": "4.53.5",
-        "@rollup/rollup-darwin-x64": "4.53.5",
-        "@rollup/rollup-freebsd-arm64": "4.53.5",
-        "@rollup/rollup-freebsd-x64": "4.53.5",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.53.5",
-        "@rollup/rollup-linux-arm-musleabihf": "4.53.5",
-        "@rollup/rollup-linux-arm64-gnu": "4.53.5",
-        "@rollup/rollup-linux-arm64-musl": "4.53.5",
-        "@rollup/rollup-linux-loong64-gnu": "4.53.5",
-        "@rollup/rollup-linux-ppc64-gnu": "4.53.5",
-        "@rollup/rollup-linux-riscv64-gnu": "4.53.5",
-        "@rollup/rollup-linux-riscv64-musl": "4.53.5",
-        "@rollup/rollup-linux-s390x-gnu": "4.53.5",
-        "@rollup/rollup-linux-x64-gnu": "4.53.5",
-        "@rollup/rollup-linux-x64-musl": "4.53.5",
-        "@rollup/rollup-openharmony-arm64": "4.53.5",
-        "@rollup/rollup-win32-arm64-msvc": "4.53.5",
-        "@rollup/rollup-win32-ia32-msvc": "4.53.5",
-        "@rollup/rollup-win32-x64-gnu": "4.53.5",
-        "@rollup/rollup-win32-x64-msvc": "4.53.5",
+        "@rollup/rollup-android-arm-eabi": "4.60.1",
+        "@rollup/rollup-android-arm64": "4.60.1",
+        "@rollup/rollup-darwin-arm64": "4.60.1",
+        "@rollup/rollup-darwin-x64": "4.60.1",
+        "@rollup/rollup-freebsd-arm64": "4.60.1",
+        "@rollup/rollup-freebsd-x64": "4.60.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.1",
+        "@rollup/rollup-linux-arm64-musl": "4.60.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.1",
+        "@rollup/rollup-linux-loong64-musl": "4.60.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-musl": "4.60.1",
+        "@rollup/rollup-openbsd-x64": "4.60.1",
+        "@rollup/rollup-openharmony-arm64": "4.60.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.1",
+        "@rollup/rollup-win32-x64-gnu": "4.60.1",
+        "@rollup/rollup-win32-x64-msvc": "4.60.1",
         "fsevents": "~2.3.2"
       }
     },
@@ -13159,10 +13244,11 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -13751,9 +13837,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.0.tgz",
-      "integrity": "sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13844,9 +13930,9 @@
       }
     },
     "node_modules/vite/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -13935,9 +14021,9 @@
       }
     },
     "node_modules/vitest/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -13991,9 +14077,9 @@
       "license": "MIT"
     },
     "node_modules/vscode-uri": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.8.tgz",
-      "integrity": "sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
       "license": "MIT"
     },
     "node_modules/w3c-xmlserializer": {
@@ -14308,14 +14394,18 @@
       }
     },
     "node_modules/yaml": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
-      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
       },
       "engines": {
         "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yargs": {

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -250,7 +250,8 @@ export function ChatInterface({
   const [showOnboarding, setShowOnboarding] = useState(false)
   const isExistingUser =
     !!user?.unsafeMetadata?.has_seen_passkey_intro ||
-    !!localStorage.getItem(SETTINGS_HAS_SEEN_WEB_SEARCH_INTRO)
+    (typeof window !== 'undefined' &&
+      !!localStorage.getItem(SETTINGS_HAS_SEEN_WEB_SEARCH_INTRO))
   const onboardingNeeded =
     isSignedIn &&
     !!user &&

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -4,6 +4,7 @@ import {
   type BaseModel,
 } from '@/config/models'
 import {
+  SETTINGS_HAS_SEEN_WEB_SEARCH_INTRO,
   SETTINGS_PII_CHECK_ENABLED,
   SETTINGS_WEB_SEARCH_ENABLED,
   UI_EXPAND_PROJECT_DOCUMENTS,
@@ -247,8 +248,14 @@ export function ChatInterface({
 
   // Onboarding state (must be defined before usePasskeyBackup so we can gate it)
   const [showOnboarding, setShowOnboarding] = useState(false)
+  const isExistingUser =
+    !!user?.unsafeMetadata?.has_seen_passkey_intro ||
+    !!localStorage.getItem(SETTINGS_HAS_SEEN_WEB_SEARCH_INTRO)
   const onboardingNeeded =
-    isSignedIn && !!user && !user.unsafeMetadata?.has_completed_onboarding
+    isSignedIn &&
+    !!user &&
+    !user.unsafeMetadata?.has_completed_onboarding &&
+    !isExistingUser
 
   // iOS Safari keyboard fix: keep a CSS var in sync with the *visual* viewport height.
   // Without this, fixed full-screen layouts can leave an untouchable "dead zone"

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -2644,7 +2644,10 @@ export function ChatInterface({
 
       <OnboardingModal
         isOpen={showOnboarding}
-        onComplete={() => setShowOnboarding(false)}
+        onComplete={(selectedModel) => {
+          if (selectedModel) handleModelSelect(selectedModel)
+          setShowOnboarding(false)
+        }}
         models={models}
         isDarkMode={isDarkMode}
       />

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -258,6 +258,25 @@ export function ChatInterface({
     !user.unsafeMetadata?.has_completed_onboarding &&
     !isExistingUser
 
+  // Backfill: ensure existing users also get the onboarding flag set
+  useEffect(() => {
+    if (
+      isSignedIn &&
+      user &&
+      isExistingUser &&
+      !user.unsafeMetadata?.has_completed_onboarding
+    ) {
+      user
+        .update({
+          unsafeMetadata: {
+            ...user.unsafeMetadata,
+            has_completed_onboarding: true,
+          },
+        })
+        .catch(() => {})
+    }
+  }, [isSignedIn, user, isExistingUser])
+
   // iOS Safari keyboard fix: keep a CSS var in sync with the *visual* viewport height.
   // Without this, fixed full-screen layouts can leave an untouchable "dead zone"
   // after the keyboard is dismissed.

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -122,6 +122,10 @@ const PasskeyIntroModal = dynamic(
     import('../tutorial/PasskeyIntroModal').then((m) => m.PasskeyIntroModal),
   { ssr: false },
 )
+const OnboardingModal = dynamic(
+  () => import('../onboarding/onboarding-modal').then((m) => m.OnboardingModal),
+  { ssr: false },
+)
 
 type ChatInterfaceProps = {
   verificationState?: any
@@ -241,6 +245,11 @@ export function ChatInterface({
   const [failedImages, setFailedImages] = useState<Record<string, boolean>>({})
   const [rateLimit, setRateLimit] = useState<RateLimitInfo | null>(null)
 
+  // Onboarding state (must be defined before usePasskeyBackup so we can gate it)
+  const [showOnboarding, setShowOnboarding] = useState(false)
+  const onboardingNeeded =
+    isSignedIn && !!user && !user.unsafeMetadata?.has_completed_onboarding
+
   // iOS Safari keyboard fix: keep a CSS var in sync with the *visual* viewport height.
   // Without this, fixed full-screen layouts can leave an untouchable "dead zone"
   // after the keyboard is dismissed.
@@ -316,7 +325,7 @@ export function ChatInterface({
     updatePasskeyBackup,
   } = usePasskeyBackup({
     encryptionKey,
-    initialized: cloudSyncInitialized,
+    initialized: cloudSyncInitialized && !showOnboarding,
     isSignedIn,
     user,
     onEncryptionKeyRecovered: useCallback(
@@ -345,6 +354,13 @@ export function ChatInterface({
   const handleLogoAnimFinished = useCallback(() => {
     setLogoAnimDone(true)
   }, [])
+
+  // Show onboarding once models are loaded for new users
+  useEffect(() => {
+    if (onboardingNeeded && models.length > 0) {
+      setShowOnboarding(true)
+    }
+  }, [onboardingNeeded, models.length])
 
   // State for right sidebar
   const [isVerifierSidebarOpen, setIsVerifierSidebarOpen] = useState(false)
@@ -2595,8 +2611,15 @@ export function ChatInterface({
       />
 
       <PasskeyIntroModal
-        isOpen={passkeyIntroNeeded}
+        isOpen={passkeyIntroNeeded && !showOnboarding}
         onAccept={acceptPasskeyIntro}
+      />
+
+      <OnboardingModal
+        isOpen={showOnboarding}
+        onComplete={() => setShowOnboarding(false)}
+        models={models}
+        isDarkMode={isDarkMode}
       />
     </div>
   )

--- a/src/components/onboarding/onboarding-modal.tsx
+++ b/src/components/onboarding/onboarding-modal.tsx
@@ -217,16 +217,18 @@ function FeatureCarousel({
 
   return (
     <div className="flex w-full flex-col gap-2">
-      <div
-        ref={scrollRef}
-        className="scrollbar-hide flex w-full snap-x snap-mandatory gap-3 overflow-x-auto overflow-y-hidden"
-        style={{ WebkitOverflowScrolling: 'touch' }}
-      >
-        {items.map((item, i) => (
-          <div key={item.key} className="flex w-full shrink-0 snap-start">
-            {renderItem(item, i)}
-          </div>
-        ))}
+      <div className="w-full overflow-hidden">
+        <div
+          ref={scrollRef}
+          className="scrollbar-hide flex w-full snap-x snap-mandatory overflow-x-auto overflow-y-hidden"
+          style={{ WebkitOverflowScrolling: 'touch' }}
+        >
+          {items.map((item, i) => (
+            <div key={item.key} className="flex w-full shrink-0 snap-start">
+              {renderItem(item, i)}
+            </div>
+          ))}
+        </div>
       </div>
       <div className="flex justify-center gap-1.5">
         {items.map((item, i) => (

--- a/src/components/onboarding/onboarding-modal.tsx
+++ b/src/components/onboarding/onboarding-modal.tsx
@@ -223,14 +223,14 @@ function OnboardingPrivacyPage({
             >
               <ExplanationRow
                 icon={<PiEyeSlash className="h-4 w-4" />}
-                title="Zero Access"
-                description="Your messages are encrypted directly to AI models inside secure hardware. Tinfoil cannot read them."
+                title="Sealed Processing"
+                description="Your messages are end-to-end encrypted to AI models running inside secure hardware. Tinfoil cannot read them."
                 delay={0.1}
               />
               <ExplanationRow
                 icon={<PiShieldCheck className="h-4 w-4" />}
                 title="Verifiable Privacy"
-                description="Our infrastructure runs on confidential computing GPUs with hardware attestation you can verify."
+                description="Our infrastructure runs on confidential computing GPUs with hardware attestation and automatic client-side verification."
                 delay={0.2}
               />
               <ExplanationRow
@@ -393,7 +393,7 @@ function OnboardingEncryptionPage() {
           </h2>
           <p className="text-base text-content-secondary">
             Every chat is encrypted with a key that only exists on your device.
-            Nobody else can read your messages.
+            Nobody but you can read your conversations.
           </p>
         </div>
 
@@ -413,7 +413,7 @@ function OnboardingEncryptionPage() {
               </p>
               <p className="text-sm text-content-secondary">
                 Your encryption key never leaves your device. It&apos;s the only
-                way to decrypt your conversations.
+                way to decrypt your conversations - don&apos;t lose it!
               </p>
             </div>
           </div>

--- a/src/components/onboarding/onboarding-modal.tsx
+++ b/src/components/onboarding/onboarding-modal.tsx
@@ -19,7 +19,7 @@ import { TbBrain } from 'react-icons/tb'
 
 interface OnboardingModalProps {
   isOpen: boolean
-  onComplete: () => void
+  onComplete: (selectedModel?: string) => void
   models: BaseModel[]
   isDarkMode: boolean
 }
@@ -35,6 +35,9 @@ export function OnboardingModal({
   const { user } = useUser()
   const [currentPage, setCurrentPage] = useState(0)
   const [privacyEnabled, setPrivacyEnabled] = useState(false)
+  const [selectedModelName, setSelectedModelName] = useState<
+    string | undefined
+  >()
 
   const handleContinue = useCallback(() => {
     if (currentPage < TOTAL_PAGES - 1) {
@@ -49,9 +52,9 @@ export function OnboardingModal({
           },
         })
         .catch(() => {})
-      onComplete()
+      onComplete(selectedModelName)
     }
-  }, [currentPage, onComplete, user])
+  }, [currentPage, onComplete, user, selectedModelName])
 
   const handleSkip = useCallback(() => {
     user
@@ -113,6 +116,7 @@ export function OnboardingModal({
                           key="models"
                           models={models}
                           isDarkMode={isDarkMode}
+                          onSelectModel={setSelectedModelName}
                         />
                       )}
                     </AnimatePresence>
@@ -428,9 +432,11 @@ function OnboardingEncryptionPage() {
 function OnboardingModelsPage({
   models,
   isDarkMode,
+  onSelectModel,
 }: {
   models: BaseModel[]
   isDarkMode: boolean
+  onSelectModel: (modelName: string) => void
 }) {
   const [selectedIndex, setSelectedIndex] = useState(0)
   const scrollRef = useRef<HTMLDivElement>(null)
@@ -487,7 +493,10 @@ function OnboardingModelsPage({
             {chatModels.map((model, i) => (
               <button
                 key={model.modelName}
-                onClick={() => setSelectedIndex(i)}
+                onClick={() => {
+                  setSelectedIndex(i)
+                  onSelectModel(model.modelName)
+                }}
                 className={`flex shrink-0 flex-col items-center gap-1.5 rounded-xl px-3 py-2 transition-all ${
                   i === selectedIndex
                     ? 'bg-surface-chat ring-1 ring-border-subtle'

--- a/src/components/onboarding/onboarding-modal.tsx
+++ b/src/components/onboarding/onboarding-modal.tsx
@@ -216,19 +216,21 @@ function FeatureCarousel({
   }, [items.length])
 
   return (
-    <div className="flex w-full flex-col gap-2">
-      <div className="w-full overflow-hidden">
-        <div
-          ref={scrollRef}
-          className="scrollbar-hide flex w-full snap-x snap-mandatory overflow-x-auto overflow-y-hidden"
-          style={{ WebkitOverflowScrolling: 'touch' }}
-        >
-          {items.map((item, i) => (
-            <div key={item.key} className="flex w-full shrink-0 snap-start">
-              {renderItem(item, i)}
-            </div>
-          ))}
-        </div>
+    <div className="-mx-6 flex w-[calc(100%+3rem)] flex-col gap-2">
+      <div
+        ref={scrollRef}
+        className="scrollbar-hide flex w-full snap-x snap-mandatory overflow-x-auto overflow-y-hidden px-6"
+        style={{ WebkitOverflowScrolling: 'touch' }}
+      >
+        {items.map((item, i) => (
+          <div
+            key={item.key}
+            className="flex w-full shrink-0 snap-start"
+            style={{ paddingRight: i < items.length - 1 ? '0.75rem' : 0 }}
+          >
+            {renderItem(item, i)}
+          </div>
+        ))}
       </div>
       <div className="flex justify-center gap-1.5">
         {items.map((item, i) => (

--- a/src/components/onboarding/onboarding-modal.tsx
+++ b/src/components/onboarding/onboarding-modal.tsx
@@ -2,7 +2,14 @@ import type { BaseModel } from '@/config/models'
 import { useUser } from '@clerk/nextjs'
 import { Dialog, Transition } from '@headlessui/react'
 import { AnimatePresence, motion } from 'framer-motion'
-import { Fragment, useCallback, useEffect, useRef, useState } from 'react'
+import {
+  Fragment,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react'
 import { FaLock, FaLockOpen } from 'react-icons/fa6'
 import {
   PiCamera,
@@ -171,6 +178,74 @@ export function OnboardingModal({
   )
 }
 
+// MARK: - Shared: Snap Carousel for compact viewports
+
+function useIsShortViewport(threshold = 700) {
+  const [isShort, setIsShort] = useState(false)
+  useEffect(() => {
+    const mql = window.matchMedia(`(max-height: ${threshold}px)`)
+    setIsShort(mql.matches)
+    const handler = (e: MediaQueryListEvent) => setIsShort(e.matches)
+    mql.addEventListener('change', handler)
+    return () => mql.removeEventListener('change', handler)
+  }, [threshold])
+  return isShort
+}
+
+function FeatureCarousel({
+  items,
+  renderItem,
+}: {
+  items: { key: string }[]
+  renderItem: (item: { key: string }, index: number) => ReactNode
+}) {
+  const scrollRef = useRef<HTMLDivElement>(null)
+  const [activeIndex, setActiveIndex] = useState(0)
+
+  useEffect(() => {
+    const el = scrollRef.current
+    if (!el) return
+    const handleScroll = () => {
+      const scrollLeft = el.scrollLeft
+      const itemWidth = el.offsetWidth
+      const index = Math.round(scrollLeft / itemWidth)
+      setActiveIndex(Math.min(index, items.length - 1))
+    }
+    el.addEventListener('scroll', handleScroll, { passive: true })
+    return () => el.removeEventListener('scroll', handleScroll)
+  }, [items.length])
+
+  return (
+    <div className="flex w-full flex-col gap-2">
+      <div
+        ref={scrollRef}
+        className="scrollbar-hide flex w-full snap-x snap-mandatory overflow-x-auto"
+        style={{ WebkitOverflowScrolling: 'touch' }}
+      >
+        {items.map((item, i) => (
+          <div key={item.key} className="w-full shrink-0 snap-center px-1">
+            {renderItem(item, i)}
+          </div>
+        ))}
+      </div>
+      <div className="flex justify-center gap-1.5">
+        {items.map((item, i) => (
+          <motion.div
+            key={item.key}
+            className={`h-1.5 rounded-full ${i === activeIndex ? 'bg-brand-accent-dark dark:bg-brand-accent-light' : 'bg-border-subtle'}`}
+            animate={{ width: i === activeIndex ? 16 : 6 }}
+            transition={{
+              type: 'spring',
+              stiffness: 300,
+              damping: 25,
+            }}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}
+
 // MARK: - Page 1: Privacy
 
 function OnboardingPrivacyPage({
@@ -180,6 +255,32 @@ function OnboardingPrivacyPage({
   privacyEnabled: boolean
   onToggle: () => void
 }) {
+  const isShort = useIsShortViewport()
+
+  const explanationItems = [
+    {
+      key: 'sealed',
+      icon: <PiEyeSlash className="h-4 w-4" />,
+      title: 'Sealed Processing',
+      description:
+        'Your messages are end-to-end encrypted to AI models running inside secure hardware. Tinfoil cannot read them.',
+    },
+    {
+      key: 'verifiable',
+      icon: <PiShieldCheck className="h-4 w-4" />,
+      title: 'Verifiable Privacy',
+      description:
+        'Our infrastructure runs on confidential computing GPUs with hardware attestation and automatic client-side verification.',
+    },
+    {
+      key: 'protected',
+      icon: <PiLock className="h-4 w-4" />,
+      title: 'Everything is Protected',
+      description:
+        'Chats, images, documents, and voice input are all encrypted end-to-end.',
+    },
+  ]
+
   return (
     <motion.div
       className="flex flex-col items-center px-6 py-8"
@@ -215,34 +316,45 @@ function OnboardingPrivacyPage({
         {/* Toggle card with animated border */}
         <PrivacyToggleCard enabled={privacyEnabled} onToggle={onToggle} />
 
-        {/* Explanation rows matching iOS: Zero Access, Verifiable Privacy, Everything is Protected */}
+        {/* Explanation rows - carousel on short viewports, stacked on tall */}
         <AnimatePresence>
           {privacyEnabled && (
             <motion.div
-              className="flex w-full flex-col gap-3"
+              className="w-full"
               initial={{ opacity: 0, height: 0 }}
               animate={{ opacity: 1, height: 'auto' }}
               exit={{ opacity: 0, height: 0 }}
               transition={{ duration: 0.5, ease: 'easeInOut' }}
             >
-              <ExplanationRow
-                icon={<PiEyeSlash className="h-4 w-4" />}
-                title="Sealed Processing"
-                description="Your messages are end-to-end encrypted to AI models running inside secure hardware. Tinfoil cannot read them."
-                delay={0.1}
-              />
-              <ExplanationRow
-                icon={<PiShieldCheck className="h-4 w-4" />}
-                title="Verifiable Privacy"
-                description="Our infrastructure runs on confidential computing GPUs with hardware attestation and automatic client-side verification."
-                delay={0.2}
-              />
-              <ExplanationRow
-                icon={<PiLock className="h-4 w-4" />}
-                title="Everything is Protected"
-                description="Chats, images, documents, and voice input are all encrypted end-to-end."
-                delay={0.3}
-              />
+              {isShort ? (
+                <FeatureCarousel
+                  items={explanationItems}
+                  renderItem={(item, _i) => {
+                    const data = explanationItems.find(
+                      (e) => e.key === item.key,
+                    )!
+                    return (
+                      <ExplanationRow
+                        icon={data.icon}
+                        title={data.title}
+                        description={data.description}
+                      />
+                    )
+                  }}
+                />
+              ) : (
+                <div className="flex w-full flex-col gap-3">
+                  {explanationItems.map((item, i) => (
+                    <ExplanationRow
+                      key={item.key}
+                      icon={item.icon}
+                      title={item.title}
+                      description={item.description}
+                      delay={0.1 * (i + 1)}
+                    />
+                  ))}
+                </div>
+              )}
             </motion.div>
           )}
         </AnimatePresence>
@@ -461,16 +573,39 @@ function OnboardingModelsPage({
     return `/model-icons/${model.image}`
   }
 
+  const isShort = useIsShortViewport()
+
   const features = [
-    { icon: <PiCamera className="h-4 w-4" />, label: 'Image Upload' },
     {
+      key: 'image-upload',
+      icon: <PiCamera className="h-4 w-4" />,
+      label: 'Image Upload',
+    },
+    {
+      key: 'document-processing',
       icon: <PiFileText className="h-4 w-4" />,
       label: 'Document Processing',
     },
-    { icon: <PiGlobe className="h-4 w-4" />, label: 'Web Search' },
-    { icon: <PiWaveform className="h-4 w-4" />, label: 'Voice Input' },
-    { icon: <TbBrain className="h-4 w-4" />, label: 'Reasoning Models' },
-    { icon: <PiLightning className="h-4 w-4" />, label: 'Fast Responses' },
+    {
+      key: 'web-search',
+      icon: <PiGlobe className="h-4 w-4" />,
+      label: 'Web Search',
+    },
+    {
+      key: 'voice-input',
+      icon: <PiWaveform className="h-4 w-4" />,
+      label: 'Voice Input',
+    },
+    {
+      key: 'reasoning-models',
+      icon: <TbBrain className="h-4 w-4" />,
+      label: 'Reasoning Models',
+    },
+    {
+      key: 'fast-responses',
+      icon: <PiLightning className="h-4 w-4" />,
+      label: 'Fast Responses',
+    },
   ]
 
   return (
@@ -497,6 +632,7 @@ function OnboardingModelsPage({
           <div
             ref={scrollRef}
             className="scrollbar-hide flex w-full gap-3 overflow-x-auto px-1 py-2"
+            style={{ WebkitOverflowScrolling: 'touch' }}
           >
             {chatModels.map((model, i) => (
               <button
@@ -530,29 +666,48 @@ function OnboardingModelsPage({
           </div>
         )}
 
-        {/* Feature grid */}
-        <div className="grid w-full grid-cols-2 gap-2">
-          {features.map((feature, i) => (
-            <motion.div
-              key={feature.label}
-              className="flex items-center gap-2.5 rounded-xl bg-surface-chat px-3 py-2.5"
-              initial={{ opacity: 0, y: 12 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{
-                delay: 0.15 + i * 0.06,
-                duration: 0.35,
-                ease: 'easeOut',
-              }}
-            >
-              <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-surface-card text-content-primary">
-                {feature.icon}
-              </div>
-              <span className="text-sm font-medium text-content-primary">
-                {feature.label}
-              </span>
-            </motion.div>
-          ))}
-        </div>
+        {/* Feature grid - carousel on short viewports, grid on tall */}
+        {isShort ? (
+          <FeatureCarousel
+            items={features}
+            renderItem={(item) => {
+              const data = features.find((f) => f.key === item.key)!
+              return (
+                <div className="flex items-center gap-3 rounded-xl bg-surface-chat px-4 py-3">
+                  <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-surface-card text-content-primary">
+                    {data.icon}
+                  </div>
+                  <span className="text-sm font-medium text-content-primary">
+                    {data.label}
+                  </span>
+                </div>
+              )
+            }}
+          />
+        ) : (
+          <div className="grid w-full grid-cols-2 gap-2">
+            {features.map((feature, i) => (
+              <motion.div
+                key={feature.key}
+                className="flex items-center gap-2.5 rounded-xl bg-surface-chat px-3 py-2.5"
+                initial={{ opacity: 0, y: 12 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{
+                  delay: 0.15 + i * 0.06,
+                  duration: 0.35,
+                  ease: 'easeOut',
+                }}
+              >
+                <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-surface-card text-content-primary">
+                  {feature.icon}
+                </div>
+                <span className="text-sm font-medium text-content-primary">
+                  {feature.label}
+                </span>
+              </motion.div>
+            ))}
+          </div>
+        )}
       </div>
     </motion.div>
   )

--- a/src/components/onboarding/onboarding-modal.tsx
+++ b/src/components/onboarding/onboarding-modal.tsx
@@ -621,13 +621,15 @@ function OnboardingModelsPage({
 
   return (
     <motion.div
-      className="flex flex-col items-center px-6 py-8"
+      className={`flex flex-col items-center px-6 ${isShort ? 'py-5' : 'py-8'}`}
       initial={{ opacity: 0, x: 40 }}
       animate={{ opacity: 1, x: 0 }}
       exit={{ opacity: 0, x: -40 }}
       transition={{ duration: 0.3, ease: 'easeInOut' }}
     >
-      <div className="flex w-full flex-col items-center gap-5">
+      <div
+        className={`flex w-full flex-col items-center ${isShort ? 'gap-3' : 'gap-5'}`}
+      >
         <div className="space-y-2 text-center">
           <h2 className="font-aeonik text-3xl font-bold text-content-primary">
             Powerful Models
@@ -642,7 +644,7 @@ function OnboardingModelsPage({
         {chatModels.length > 0 && (
           <div
             ref={scrollRef}
-            className="scrollbar-hide flex w-full gap-3 overflow-x-auto px-1 py-2"
+            className={`scrollbar-hide flex w-full gap-3 overflow-x-auto px-1 ${isShort ? 'py-1' : 'py-2'}`}
             style={{ WebkitOverflowScrolling: 'touch' }}
           >
             {chatModels.map((model, i) => (
@@ -677,48 +679,29 @@ function OnboardingModelsPage({
           </div>
         )}
 
-        {/* Feature grid - carousel on short viewports, grid on tall */}
-        {isShort ? (
-          <FeatureCarousel
-            items={features}
-            renderItem={(item) => {
-              const data = features.find((f) => f.key === item.key)!
-              return (
-                <div className="flex h-full items-center gap-3 rounded-xl bg-surface-chat px-4 py-3">
-                  <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-surface-card text-content-primary">
-                    {data.icon}
-                  </div>
-                  <span className="text-sm font-medium text-content-primary">
-                    {data.label}
-                  </span>
-                </div>
-              )
-            }}
-          />
-        ) : (
-          <div className="grid w-full grid-cols-2 gap-2">
-            {features.map((feature, i) => (
-              <motion.div
-                key={feature.key}
-                className="flex items-center gap-2.5 rounded-xl bg-surface-chat px-3 py-2.5"
-                initial={{ opacity: 0, y: 12 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{
-                  delay: 0.15 + i * 0.06,
-                  duration: 0.35,
-                  ease: 'easeOut',
-                }}
-              >
-                <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-surface-card text-content-primary">
-                  {feature.icon}
-                </div>
-                <span className="text-sm font-medium text-content-primary">
-                  {feature.label}
-                </span>
-              </motion.div>
-            ))}
-          </div>
-        )}
+        {/* Feature grid - 4 items on short viewports, all 6 on tall */}
+        <div className="grid w-full grid-cols-2 gap-2">
+          {(isShort ? features.slice(0, 4) : features).map((feature, i) => (
+            <motion.div
+              key={feature.key}
+              className="flex items-center gap-2.5 rounded-xl bg-surface-chat px-3 py-2.5"
+              initial={{ opacity: 0, y: 12 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{
+                delay: 0.15 + i * 0.06,
+                duration: 0.35,
+                ease: 'easeOut',
+              }}
+            >
+              <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-surface-card text-content-primary">
+                {feature.icon}
+              </div>
+              <span className="text-sm font-medium text-content-primary">
+                {feature.label}
+              </span>
+            </motion.div>
+          ))}
+        </div>
       </div>
     </motion.div>
   )

--- a/src/components/onboarding/onboarding-modal.tsx
+++ b/src/components/onboarding/onboarding-modal.tsx
@@ -445,6 +445,12 @@ function OnboardingModelsPage({
     (m) => (m.type === 'chat' || m.type === 'code') && m.chat === true,
   )
 
+  useEffect(() => {
+    if (chatModels.length > 0) {
+      onSelectModel(chatModels[0].modelName)
+    }
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
+
   const getModelIcon = (model: BaseModel) => {
     if (model.image === 'openai.png')
       return `/model-icons/openai-${isDarkMode ? 'dark' : 'light'}.png`

--- a/src/components/onboarding/onboarding-modal.tsx
+++ b/src/components/onboarding/onboarding-modal.tsx
@@ -219,11 +219,11 @@ function FeatureCarousel({
     <div className="flex w-full flex-col gap-2">
       <div
         ref={scrollRef}
-        className="scrollbar-hide flex w-full snap-x snap-mandatory overflow-x-auto"
+        className="scrollbar-hide flex w-full snap-x snap-mandatory overflow-x-auto overflow-y-hidden"
         style={{ WebkitOverflowScrolling: 'touch' }}
       >
         {items.map((item, i) => (
-          <div key={item.key} className="w-full shrink-0 snap-center px-1">
+          <div key={item.key} className="flex w-full shrink-0 snap-start">
             {renderItem(item, i)}
           </div>
         ))}
@@ -232,7 +232,7 @@ function FeatureCarousel({
         {items.map((item, i) => (
           <motion.div
             key={item.key}
-            className={`h-1.5 rounded-full ${i === activeIndex ? 'bg-brand-accent-dark dark:bg-brand-accent-light' : 'bg-border-subtle'}`}
+            className={`h-1.5 rounded-full ${i === activeIndex ? 'bg-content-secondary' : 'bg-border-subtle'}`}
             animate={{ width: i === activeIndex ? 16 : 6 }}
             transition={{
               type: 'spring',
@@ -338,6 +338,7 @@ function OnboardingPrivacyPage({
                         icon={data.icon}
                         title={data.title}
                         description={data.description}
+                        fillHeight
                       />
                     )
                   }}
@@ -447,15 +448,17 @@ function ExplanationRow({
   title,
   description,
   delay = 0,
+  fillHeight = false,
 }: {
   icon: React.ReactNode
   title: string
   description: string
   delay?: number
+  fillHeight?: boolean
 }) {
   return (
     <motion.div
-      className="flex items-start gap-3 rounded-xl border border-border-subtle bg-surface-chat p-4"
+      className={`flex items-start gap-3 rounded-xl border border-border-subtle bg-surface-chat p-4 ${fillHeight ? 'h-full' : ''}`}
       initial={{ opacity: 0, y: 10 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.4, delay, ease: 'easeOut' }}
@@ -673,7 +676,7 @@ function OnboardingModelsPage({
             renderItem={(item) => {
               const data = features.find((f) => f.key === item.key)!
               return (
-                <div className="flex items-center gap-3 rounded-xl bg-surface-chat px-4 py-3">
+                <div className="flex h-full items-center gap-3 rounded-xl bg-surface-chat px-4 py-3">
                   <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-surface-card text-content-primary">
                     {data.icon}
                   </div>

--- a/src/components/onboarding/onboarding-modal.tsx
+++ b/src/components/onboarding/onboarding-modal.tsx
@@ -1,0 +1,542 @@
+import type { BaseModel } from '@/config/models'
+import { useUser } from '@clerk/nextjs'
+import { Dialog, Transition } from '@headlessui/react'
+import { AnimatePresence, motion } from 'framer-motion'
+import { Fragment, useCallback, useEffect, useRef, useState } from 'react'
+import { FaLock, FaLockOpen } from 'react-icons/fa6'
+import {
+  PiCamera,
+  PiEyeSlash,
+  PiFileText,
+  PiGlobe,
+  PiKey,
+  PiLightning,
+  PiLock,
+  PiShieldCheck,
+  PiWaveform,
+} from 'react-icons/pi'
+import { TbBrain } from 'react-icons/tb'
+
+interface OnboardingModalProps {
+  isOpen: boolean
+  onComplete: () => void
+  models: BaseModel[]
+  isDarkMode: boolean
+}
+
+const TOTAL_PAGES = 3
+
+export function OnboardingModal({
+  isOpen,
+  onComplete,
+  models,
+  isDarkMode,
+}: OnboardingModalProps) {
+  const { user } = useUser()
+  const [currentPage, setCurrentPage] = useState(0)
+  const [privacyEnabled, setPrivacyEnabled] = useState(false)
+
+  const handleContinue = useCallback(() => {
+    if (currentPage < TOTAL_PAGES - 1) {
+      setCurrentPage((p) => p + 1)
+    } else {
+      // Persist to Clerk unsafeMetadata
+      user
+        ?.update({
+          unsafeMetadata: {
+            ...user.unsafeMetadata,
+            has_completed_onboarding: true,
+          },
+        })
+        .catch(() => {})
+      onComplete()
+    }
+  }, [currentPage, onComplete, user])
+
+  const handleSkip = useCallback(() => {
+    user
+      ?.update({
+        unsafeMetadata: {
+          ...user.unsafeMetadata,
+          has_completed_onboarding: true,
+        },
+      })
+      .catch(() => {})
+    onComplete()
+  }, [onComplete, user])
+
+  const canContinue = currentPage !== 0 || privacyEnabled
+
+  return (
+    <Transition appear show={isOpen} as={Fragment}>
+      <Dialog as="div" className="relative z-50" onClose={() => {}}>
+        <Transition.Child
+          as={Fragment}
+          enter="ease-out duration-300"
+          enterFrom="opacity-0"
+          enterTo="opacity-100"
+          leave="ease-in duration-200"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <div className="fixed inset-0 bg-black/60 backdrop-blur-sm" />
+        </Transition.Child>
+
+        <div className="fixed inset-0 overflow-y-auto">
+          <div className="flex min-h-full items-center justify-center p-4">
+            <Transition.Child
+              as={Fragment}
+              enter="ease-out duration-300"
+              enterFrom="opacity-0 scale-95"
+              enterTo="opacity-100 scale-100"
+              leave="ease-in duration-200"
+              leaveFrom="opacity-100 scale-100"
+              leaveTo="opacity-0 scale-95"
+            >
+              <Dialog.Panel className="w-full max-w-md transform overflow-hidden rounded-2xl bg-surface-card shadow-2xl transition-all">
+                <div className="flex max-h-[85vh] min-h-[580px] flex-col">
+                  {/* Page content */}
+                  <div className="relative min-h-0 flex-1 overflow-y-auto">
+                    <AnimatePresence mode="wait">
+                      {currentPage === 0 && (
+                        <OnboardingPrivacyPage
+                          key="privacy"
+                          privacyEnabled={privacyEnabled}
+                          onToggle={() => setPrivacyEnabled(true)}
+                        />
+                      )}
+                      {currentPage === 1 && (
+                        <OnboardingEncryptionPage key="encryption" />
+                      )}
+                      {currentPage === 2 && (
+                        <OnboardingModelsPage
+                          key="models"
+                          models={models}
+                          isDarkMode={isDarkMode}
+                        />
+                      )}
+                    </AnimatePresence>
+                  </div>
+
+                  {/* Bottom navigation */}
+                  <div className="flex flex-col items-center gap-3 border-t border-border-subtle px-6 py-5">
+                    {/* Page dots */}
+                    <div className="flex gap-2">
+                      {Array.from({ length: TOTAL_PAGES }).map((_, i) => (
+                        <motion.div
+                          key={i}
+                          className={`h-1.5 rounded-full ${i === currentPage ? 'bg-brand-accent-dark dark:bg-brand-accent-light' : 'bg-border-subtle'}`}
+                          animate={{ width: i === currentPage ? 20 : 8 }}
+                          transition={{
+                            type: 'spring',
+                            stiffness: 300,
+                            damping: 25,
+                          }}
+                        />
+                      ))}
+                    </div>
+
+                    {/* Continue button */}
+                    <button
+                      onClick={handleContinue}
+                      disabled={!canContinue}
+                      className="w-full rounded-xl bg-button-send-background px-4 py-3 text-sm font-semibold text-button-send-foreground transition-all disabled:cursor-not-allowed disabled:opacity-30"
+                    >
+                      {currentPage === TOTAL_PAGES - 1
+                        ? 'Get Started'
+                        : 'Continue'}
+                    </button>
+
+                    {/* Skip */}
+                    {currentPage < TOTAL_PAGES - 1 && (
+                      <button
+                        onClick={handleSkip}
+                        className="text-sm text-content-muted transition-colors hover:text-content-secondary"
+                      >
+                        Skip
+                      </button>
+                    )}
+                  </div>
+                </div>
+              </Dialog.Panel>
+            </Transition.Child>
+          </div>
+        </div>
+      </Dialog>
+    </Transition>
+  )
+}
+
+// MARK: - Page 1: Privacy
+
+function OnboardingPrivacyPage({
+  privacyEnabled,
+  onToggle,
+}: {
+  privacyEnabled: boolean
+  onToggle: () => void
+}) {
+  return (
+    <motion.div
+      className="flex flex-col items-center px-6 py-8"
+      initial={{ opacity: 0, x: 40 }}
+      animate={{ opacity: 1, x: 0 }}
+      exit={{ opacity: 0, x: -40 }}
+      transition={{ duration: 0.3, ease: 'easeInOut' }}
+    >
+      <div className="flex w-full flex-col items-center gap-5">
+        {/* Lock icon in circle */}
+        <motion.div
+          className="flex h-16 w-16 items-center justify-center rounded-full border border-border-subtle bg-surface-chat"
+          animate={privacyEnabled ? { scale: [1, 1.15, 1] } : {}}
+          transition={{ duration: 0.4 }}
+        >
+          {privacyEnabled ? (
+            <FaLock className="h-7 w-7 text-content-primary" />
+          ) : (
+            <FaLockOpen className="h-7 w-7 text-content-primary" />
+          )}
+        </motion.div>
+
+        <div className="space-y-2 text-center">
+          <h2 className="text-3xl font-bold text-content-primary">
+            Privacy First
+          </h2>
+          <p className="text-base text-content-secondary">
+            Tinfoil is built for people who believe their conversations are
+            nobody else&apos;s business.
+          </p>
+        </div>
+
+        {/* Toggle card with animated border */}
+        <PrivacyToggleCard enabled={privacyEnabled} onToggle={onToggle} />
+
+        {/* Explanation rows matching iOS: Zero Access, Verifiable Privacy, Everything is Protected */}
+        <AnimatePresence>
+          {privacyEnabled && (
+            <motion.div
+              className="flex w-full flex-col gap-3"
+              initial={{ opacity: 0, height: 0 }}
+              animate={{ opacity: 1, height: 'auto' }}
+              exit={{ opacity: 0, height: 0 }}
+              transition={{ duration: 0.5, ease: 'easeInOut' }}
+            >
+              <ExplanationRow
+                icon={<PiEyeSlash className="h-4 w-4" />}
+                title="Zero Access"
+                description="Your messages are encrypted directly to AI models inside secure hardware. Tinfoil cannot read them."
+                delay={0.1}
+              />
+              <ExplanationRow
+                icon={<PiShieldCheck className="h-4 w-4" />}
+                title="Verifiable Privacy"
+                description="Our infrastructure runs on confidential computing GPUs with hardware attestation you can verify."
+                delay={0.2}
+              />
+              <ExplanationRow
+                icon={<PiLock className="h-4 w-4" />}
+                title="Everything is Protected"
+                description="Chats, images, documents, and voice input are all encrypted end-to-end."
+                delay={0.3}
+              />
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </div>
+    </motion.div>
+  )
+}
+
+function PrivacyToggleCard({
+  enabled,
+  onToggle,
+}: {
+  enabled: boolean
+  onToggle: () => void
+}) {
+  const borderRef = useRef<HTMLDivElement>(null)
+  const [borderAngle, setBorderAngle] = useState(0)
+
+  // Animated border rotation when not enabled
+  useEffect(() => {
+    if (enabled) return
+    let raf: number
+    const animate = () => {
+      setBorderAngle((a) => (a + 0.8) % 360)
+      raf = requestAnimationFrame(animate)
+    }
+    raf = requestAnimationFrame(animate)
+    return () => cancelAnimationFrame(raf)
+  }, [enabled])
+
+  return (
+    <div className="relative w-full">
+      {/* Animated border */}
+      {!enabled && (
+        <div
+          ref={borderRef}
+          className="absolute -inset-[1px] rounded-2xl"
+          style={{
+            background: `conic-gradient(from ${borderAngle}deg, transparent 0%, transparent 30%, hsl(var(--color-accent-light)) 50%, transparent 70%, transparent 100%)`,
+            opacity: 0.5,
+          }}
+        />
+      )}
+
+      <button
+        onClick={onToggle}
+        className={`relative flex w-full items-center justify-between rounded-2xl border p-5 text-left transition-all duration-500 ${
+          enabled
+            ? 'border-brand-accent-light/30 bg-brand-accent-light/5'
+            : 'border-transparent bg-surface-chat'
+        }`}
+      >
+        <div>
+          <p className="text-base font-semibold text-content-primary">
+            {enabled ? 'Private' : 'Tap to enable privacy'}
+          </p>
+          {enabled && (
+            <motion.p
+              className="mt-0.5 text-sm text-content-secondary"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              transition={{ delay: 0.2 }}
+            >
+              Your conversations are protected
+            </motion.p>
+          )}
+        </div>
+
+        {/* Toggle switch */}
+        <div
+          className={`flex h-7 w-12 items-center rounded-full px-1 transition-colors duration-300 ${
+            enabled
+              ? 'bg-brand-accent-dark dark:bg-brand-accent-light'
+              : 'bg-border-subtle'
+          }`}
+        >
+          <motion.div
+            className="h-5 w-5 rounded-full bg-white shadow-sm"
+            animate={{ x: enabled ? 18 : 0 }}
+            transition={{ type: 'spring', stiffness: 500, damping: 30 }}
+          />
+        </div>
+      </button>
+    </div>
+  )
+}
+
+function ExplanationRow({
+  icon,
+  title,
+  description,
+  delay = 0,
+}: {
+  icon: React.ReactNode
+  title: string
+  description: string
+  delay?: number
+}) {
+  return (
+    <motion.div
+      className="flex items-start gap-3"
+      initial={{ opacity: 0, y: 10 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.4, delay, ease: 'easeOut' }}
+    >
+      <div className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-surface-chat text-content-primary">
+        {icon}
+      </div>
+      <div>
+        <p className="text-sm font-semibold text-content-primary">{title}</p>
+        <p className="text-sm text-content-secondary">{description}</p>
+      </div>
+    </motion.div>
+  )
+}
+
+// MARK: - Page 2: Encryption
+
+function OnboardingEncryptionPage() {
+  return (
+    <motion.div
+      className="flex flex-col items-center px-6 py-8"
+      initial={{ opacity: 0, x: 40 }}
+      animate={{ opacity: 1, x: 0 }}
+      exit={{ opacity: 0, x: -40 }}
+      transition={{ duration: 0.3, ease: 'easeInOut' }}
+    >
+      <div className="flex w-full flex-col items-center gap-6">
+        {/* Animated icon */}
+        <motion.div
+          className="relative"
+          initial={{ scale: 0.8, opacity: 0 }}
+          animate={{ scale: 1, opacity: 1 }}
+          transition={{ duration: 0.5, ease: 'easeOut' }}
+        >
+          <div className="flex h-20 w-20 items-center justify-center rounded-full border border-border-subtle bg-surface-chat">
+            <PiKey className="h-9 w-9 text-content-primary" />
+          </div>
+          <motion.div
+            className="absolute -right-1 -top-1 flex h-7 w-7 items-center justify-center rounded-full border border-border-subtle bg-surface-card"
+            initial={{ scale: 0 }}
+            animate={{ scale: 1 }}
+            transition={{ delay: 0.3, type: 'spring', stiffness: 400 }}
+          >
+            <PiLock className="h-4 w-4 text-content-primary" />
+          </motion.div>
+        </motion.div>
+
+        <div className="space-y-2 text-center">
+          <h2 className="text-3xl font-bold text-content-primary">
+            Your Key, Your Data
+          </h2>
+          <p className="text-base text-content-secondary">
+            Every chat is encrypted with a key that only exists on your device.
+            Nobody else can read your messages.
+          </p>
+        </div>
+
+        <motion.div
+          className="w-full overflow-hidden rounded-xl border border-border-subtle bg-surface-chat"
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.4, duration: 0.4 }}
+        >
+          <div className="flex items-start gap-3 p-4">
+            <div className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-surface-card text-content-primary">
+              <PiKey className="h-4 w-4" />
+            </div>
+            <div>
+              <p className="text-sm font-semibold text-content-primary">
+                Device-Only Key
+              </p>
+              <p className="text-sm text-content-secondary">
+                Your encryption key never leaves your device. It&apos;s the only
+                way to decrypt your conversations.
+              </p>
+            </div>
+          </div>
+        </motion.div>
+      </div>
+    </motion.div>
+  )
+}
+
+// MARK: - Page 3: Models
+
+function OnboardingModelsPage({
+  models,
+  isDarkMode,
+}: {
+  models: BaseModel[]
+  isDarkMode: boolean
+}) {
+  const [selectedIndex, setSelectedIndex] = useState(0)
+  const scrollRef = useRef<HTMLDivElement>(null)
+
+  const chatModels = models.filter(
+    (m) => (m.type === 'chat' || m.type === 'code') && m.chat === true,
+  )
+
+  const getModelIcon = (model: BaseModel) => {
+    if (model.image === 'openai.png')
+      return `/model-icons/openai-${isDarkMode ? 'dark' : 'light'}.png`
+    if (model.image === 'moonshot.png')
+      return `/model-icons/moonshot-${isDarkMode ? 'dark' : 'light'}.png`
+    return `/model-icons/${model.image}`
+  }
+
+  const features = [
+    { icon: <PiCamera className="h-4 w-4" />, label: 'Image Upload' },
+    {
+      icon: <PiFileText className="h-4 w-4" />,
+      label: 'Document Processing',
+    },
+    { icon: <PiGlobe className="h-4 w-4" />, label: 'Web Search' },
+    { icon: <PiWaveform className="h-4 w-4" />, label: 'Voice Input' },
+    { icon: <TbBrain className="h-4 w-4" />, label: 'Reasoning Models' },
+    { icon: <PiLightning className="h-4 w-4" />, label: 'Fast Responses' },
+  ]
+
+  return (
+    <motion.div
+      className="flex flex-col items-center px-6 py-8"
+      initial={{ opacity: 0, x: 40 }}
+      animate={{ opacity: 1, x: 0 }}
+      exit={{ opacity: 0, x: -40 }}
+      transition={{ duration: 0.3, ease: 'easeInOut' }}
+    >
+      <div className="flex w-full flex-col items-center gap-5">
+        <div className="space-y-2 text-center">
+          <h2 className="text-3xl font-bold text-content-primary">
+            Powerful Models
+          </h2>
+          <p className="text-base text-content-secondary">
+            Access leading AI models, all running inside secure hardware with
+            verified privacy.
+          </p>
+        </div>
+
+        {/* Model carousel */}
+        {chatModels.length > 0 && (
+          <div
+            ref={scrollRef}
+            className="scrollbar-hide flex w-full gap-3 overflow-x-auto py-2"
+          >
+            {chatModels.map((model, i) => (
+              <button
+                key={model.modelName}
+                onClick={() => setSelectedIndex(i)}
+                className={`flex shrink-0 flex-col items-center gap-1.5 rounded-xl px-3 py-2 transition-all ${
+                  i === selectedIndex
+                    ? 'bg-surface-chat ring-1 ring-border-subtle'
+                    : 'opacity-60 hover:opacity-100'
+                }`}
+              >
+                <div
+                  className={`flex h-12 w-12 items-center justify-center rounded-full transition-transform ${
+                    i === selectedIndex ? 'scale-110' : ''
+                  }`}
+                >
+                  <img
+                    src={getModelIcon(model)}
+                    alt={model.name}
+                    className="h-8 w-8 object-contain"
+                  />
+                </div>
+                <span className="max-w-[60px] truncate text-[10px] font-medium text-content-secondary">
+                  {model.nameShort}
+                </span>
+              </button>
+            ))}
+          </div>
+        )}
+
+        {/* Feature grid */}
+        <div className="grid w-full grid-cols-2 gap-2">
+          {features.map((feature, i) => (
+            <motion.div
+              key={feature.label}
+              className="flex items-center gap-2.5 rounded-xl bg-surface-chat px-3 py-2.5"
+              initial={{ opacity: 0, y: 12 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{
+                delay: 0.15 + i * 0.06,
+                duration: 0.35,
+                ease: 'easeOut',
+              }}
+            >
+              <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-surface-card text-content-primary">
+                {feature.icon}
+              </div>
+              <span className="text-sm font-medium text-content-primary">
+                {feature.label}
+              </span>
+            </motion.div>
+          ))}
+        </div>
+      </div>
+    </motion.div>
+  )
+}

--- a/src/components/onboarding/onboarding-modal.tsx
+++ b/src/components/onboarding/onboarding-modal.tsx
@@ -635,8 +635,8 @@ function OnboardingModelsPage({
             Powerful Models
           </h2>
           <p className="text-base text-content-secondary">
-            Access leading AI models, all running inside secure hardware with
-            verified privacy.
+            Access leading AI models, all running inside secure hardware
+            enclaves with fully verified privacy.
           </p>
         </div>
 

--- a/src/components/onboarding/onboarding-modal.tsx
+++ b/src/components/onboarding/onboarding-modal.tsx
@@ -383,7 +383,7 @@ function OnboardingEncryptionPage() {
             animate={{ scale: 1 }}
             transition={{ delay: 0.3, type: 'spring', stiffness: 400 }}
           >
-            <PiLock className="h-4 w-4 text-content-primary" />
+            <FaLock className="h-3.5 w-3.5 text-content-primary" />
           </motion.div>
         </motion.div>
 

--- a/src/components/onboarding/onboarding-modal.tsx
+++ b/src/components/onboarding/onboarding-modal.tsx
@@ -203,7 +203,7 @@ function OnboardingPrivacyPage({
         </motion.div>
 
         <div className="space-y-2 text-center">
-          <h2 className="text-3xl font-bold text-content-primary">
+          <h2 className="font-aeonik text-3xl font-bold text-content-primary">
             Privacy First
           </h2>
           <p className="text-base text-content-secondary">
@@ -343,16 +343,18 @@ function ExplanationRow({
 }) {
   return (
     <motion.div
-      className="flex items-start gap-3"
+      className="flex items-start gap-3 rounded-xl border border-border-subtle bg-surface-chat p-4"
       initial={{ opacity: 0, y: 10 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.4, delay, ease: 'easeOut' }}
     >
-      <div className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-surface-chat text-content-primary">
+      <div className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-surface-card text-content-primary">
         {icon}
       </div>
       <div>
-        <p className="text-sm font-semibold text-content-primary">{title}</p>
+        <p className="font-aeonik text-sm font-semibold text-content-primary">
+          {title}
+        </p>
         <p className="text-sm text-content-secondary">{description}</p>
       </div>
     </motion.div>
@@ -392,7 +394,7 @@ function OnboardingEncryptionPage() {
         </motion.div>
 
         <div className="space-y-2 text-center">
-          <h2 className="text-3xl font-bold text-content-primary">
+          <h2 className="font-aeonik text-3xl font-bold text-content-primary">
             Your Key, Your Data
           </h2>
           <p className="text-base text-content-secondary">
@@ -412,7 +414,7 @@ function OnboardingEncryptionPage() {
               <PiKey className="h-4 w-4" />
             </div>
             <div>
-              <p className="text-sm font-semibold text-content-primary">
+              <p className="font-aeonik text-sm font-semibold text-content-primary">
                 Device-Only Key
               </p>
               <p className="text-sm text-content-secondary">
@@ -481,7 +483,7 @@ function OnboardingModelsPage({
     >
       <div className="flex w-full flex-col items-center gap-5">
         <div className="space-y-2 text-center">
-          <h2 className="text-3xl font-bold text-content-primary">
+          <h2 className="font-aeonik text-3xl font-bold text-content-primary">
             Powerful Models
           </h2>
           <p className="text-base text-content-secondary">
@@ -494,7 +496,7 @@ function OnboardingModelsPage({
         {chatModels.length > 0 && (
           <div
             ref={scrollRef}
-            className="scrollbar-hide flex w-full gap-3 overflow-x-auto py-2"
+            className="scrollbar-hide flex w-full gap-3 overflow-x-auto px-1 py-2"
           >
             {chatModels.map((model, i) => (
               <button

--- a/src/components/onboarding/onboarding-modal.tsx
+++ b/src/components/onboarding/onboarding-modal.tsx
@@ -646,7 +646,7 @@ function OnboardingModelsPage({
         {chatModels.length > 0 && (
           <div
             ref={scrollRef}
-            className={`scrollbar-hide flex w-full gap-3 overflow-x-auto px-1 ${isShort ? 'py-1' : 'py-2'}`}
+            className={`scrollbar-hide -mx-6 flex w-[calc(100%+3rem)] gap-3 overflow-x-auto px-6 ${isShort ? 'py-1' : 'py-2'}`}
             style={{ WebkitOverflowScrolling: 'touch' }}
           >
             {chatModels.map((model, i) => (

--- a/src/components/onboarding/onboarding-modal.tsx
+++ b/src/components/onboarding/onboarding-modal.tsx
@@ -219,7 +219,7 @@ function FeatureCarousel({
     <div className="flex w-full flex-col gap-2">
       <div
         ref={scrollRef}
-        className="scrollbar-hide flex w-full snap-x snap-mandatory overflow-x-auto overflow-y-hidden"
+        className="scrollbar-hide flex w-full snap-x snap-mandatory gap-3 overflow-x-auto overflow-y-hidden"
         style={{ WebkitOverflowScrolling: 'touch' }}
       >
         {items.map((item, i) => (
@@ -290,18 +290,20 @@ function OnboardingPrivacyPage({
       transition={{ duration: 0.3, ease: 'easeInOut' }}
     >
       <div className="flex w-full flex-col items-center gap-5">
-        {/* Lock icon in circle */}
-        <motion.div
-          className="flex h-16 w-16 items-center justify-center rounded-full border border-border-subtle bg-surface-chat"
-          animate={privacyEnabled ? { scale: [1, 1.15, 1] } : {}}
-          transition={{ duration: 0.4 }}
-        >
-          {privacyEnabled ? (
-            <FaLock className="h-7 w-7 text-content-primary" />
-          ) : (
-            <FaLockOpen className="h-7 w-7 text-content-primary" />
-          )}
-        </motion.div>
+        {/* Lock icon in circle - hidden on short viewports */}
+        {!isShort && (
+          <motion.div
+            className="flex h-16 w-16 items-center justify-center rounded-full border border-border-subtle bg-surface-chat"
+            animate={privacyEnabled ? { scale: [1, 1.15, 1] } : {}}
+            transition={{ duration: 0.4 }}
+          >
+            {privacyEnabled ? (
+              <FaLock className="h-7 w-7 text-content-primary" />
+            ) : (
+              <FaLockOpen className="h-7 w-7 text-content-primary" />
+            )}
+          </motion.div>
+        )}
 
         <div className="space-y-2 text-center">
           <h2 className="font-aeonik text-3xl font-bold text-content-primary">
@@ -479,6 +481,8 @@ function ExplanationRow({
 // MARK: - Page 2: Encryption
 
 function OnboardingEncryptionPage() {
+  const isShort = useIsShortViewport()
+
   return (
     <motion.div
       className="flex flex-col items-center px-6 py-8"
@@ -488,25 +492,27 @@ function OnboardingEncryptionPage() {
       transition={{ duration: 0.3, ease: 'easeInOut' }}
     >
       <div className="flex w-full flex-col items-center gap-6">
-        {/* Animated icon */}
-        <motion.div
-          className="relative"
-          initial={{ scale: 0.8, opacity: 0 }}
-          animate={{ scale: 1, opacity: 1 }}
-          transition={{ duration: 0.5, ease: 'easeOut' }}
-        >
-          <div className="flex h-20 w-20 items-center justify-center rounded-full border border-border-subtle bg-surface-chat">
-            <PiKey className="h-9 w-9 text-content-primary" />
-          </div>
+        {/* Animated icon - hidden on short viewports */}
+        {!isShort && (
           <motion.div
-            className="absolute -right-1 -top-1 flex h-7 w-7 items-center justify-center rounded-full border border-border-subtle bg-surface-card"
-            initial={{ scale: 0 }}
-            animate={{ scale: 1 }}
-            transition={{ delay: 0.3, type: 'spring', stiffness: 400 }}
+            className="relative"
+            initial={{ scale: 0.8, opacity: 0 }}
+            animate={{ scale: 1, opacity: 1 }}
+            transition={{ duration: 0.5, ease: 'easeOut' }}
           >
-            <FaLock className="h-3.5 w-3.5 text-content-primary" />
+            <div className="flex h-20 w-20 items-center justify-center rounded-full border border-border-subtle bg-surface-chat">
+              <PiKey className="h-9 w-9 text-content-primary" />
+            </div>
+            <motion.div
+              className="absolute -right-1 -top-1 flex h-7 w-7 items-center justify-center rounded-full border border-border-subtle bg-surface-card"
+              initial={{ scale: 0 }}
+              animate={{ scale: 1 }}
+              transition={{ delay: 0.3, type: 'spring', stiffness: 400 }}
+            >
+              <FaLock className="h-3.5 w-3.5 text-content-primary" />
+            </motion.div>
           </motion.div>
-        </motion.div>
+        )}
 
         <div className="space-y-2 text-center">
           <h2 className="font-aeonik text-3xl font-bold text-content-primary">


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a three-step onboarding modal for new users (privacy, encryption, model selection). It only shows for new accounts, applies the selected/default model, and pauses passkey prompts and backups until onboarding finishes.

- **New Features**
  - Gated in `src/components/chat/chat-interface.tsx`: shows only when `isSignedIn`, `unsafeMetadata.has_completed_onboarding` is false, and the user isn’t an existing user (via `user.unsafeMetadata.has_seen_passkey_intro` or `SETTINGS_HAS_SEEN_WEB_SEARCH_INTRO`).
  - Backfills `has_completed_onboarding` for existing users to prevent showing onboarding.
  - Selecting a model updates the active chat model; the first chat model is preselected on mount to sync a default automatically.
  - Suppresses `PasskeyIntroModal` and passkey backup initialization while onboarding is open.
  - Mobile polish: snap carousels with clipped overflow; edge-to-edge carousels (including the models carousel) with spacing; show top 4 features on small screens; hide top icons on short viewports; tighter spacing and refined dots/cards.
  - Copy update: models screen mentions secure hardware enclaves.

- **Dependencies**
  - Refreshed `package-lock.json` with minor bumps, including `next@15.5.15`, `rollup@4.60.1`, `vite@7.3.2`, `mermaid@11.14.0`, `katex@0.16.45`, `langium@4.2.2`, and transitive updates.
  - Added dev typings `@types/ws` (pulled by `happy-dom`).

<sup>Written for commit 963e814ddd210e02243136464d737d81fee11687. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

