### PR TITLE
fix: avoid blocking fresh cloud sync setup

### DIFF
--- a/src/components/modals/cloud-sync-setup-modal.tsx
+++ b/src/components/modals/cloud-sync-setup-modal.tsx
@@ -1,3 +1,7 @@
+import {
+  determineGeneratedKeySetupMode,
+  type CloudKeySetupMode,
+} from '@/components/modals/cloud-sync-setup-mode'
 import { SETTINGS_HAS_SEEN_CLOUD_SYNC_MODAL } from '@/constants/storage-keys'
 import { useToast } from '@/hooks/use-toast'
 import { encryptionService } from '@/services/encryption/encryption-service'
@@ -37,9 +41,6 @@ interface CloudSyncSetupModalBaseProps {
   prfSupported?: boolean
   manualRecoveryNeeded?: boolean
 }
-
-type CloudKeySetupMode = 'recoverExisting' | 'explicitStartFresh'
-
 type CloudSyncSetupModalProps = CloudSyncSetupModalBaseProps &
   (
     | {
@@ -133,10 +134,11 @@ export function CloudSyncSetupModal({
     setIsProcessing(true)
     try {
       const newKey = await encryptionService.generateKey()
+      const keySetupMode = await determineGeneratedKeySetupMode({
+        manualRecoveryNeeded,
+      })
       setGeneratedKey(newKey)
-      setGeneratedKeyMode(
-        manualRecoveryNeeded ? 'explicitStartFresh' : 'recoverExisting',
-      )
+      setGeneratedKeyMode(keySetupMode)
 
       logInfo('Generated new encryption key for cloud sync', {
         component: 'CloudSyncSetupModal',

--- a/src/components/modals/cloud-sync-setup-modal.tsx
+++ b/src/components/modals/cloud-sync-setup-modal.tsx
@@ -178,7 +178,8 @@ export function CloudSyncSetupModal({
       if (!success) {
         toast({
           title: 'Invalid key',
-          description: "This key doesn't match your existing cloud data",
+          description:
+            "This key doesn't match your existing cloud data. Try using your existing key instead.",
           variant: 'destructive',
         })
         return
@@ -348,7 +349,8 @@ ${generatedKey.replace('key_', '')}
         if (!success) {
           toast({
             title: 'Setup failed',
-            description: "This key couldn't be verified for cloud sync",
+            description:
+              "This key couldn't be verified for cloud sync. Try using your existing key instead.",
             variant: 'destructive',
           })
           return

--- a/src/components/modals/cloud-sync-setup-mode.ts
+++ b/src/components/modals/cloud-sync-setup-mode.ts
@@ -1,0 +1,22 @@
+import { inspectRemoteEncryptedState } from '@/services/cloud/cloud-key-preflight'
+
+export type CloudKeySetupMode = 'recoverExisting' | 'explicitStartFresh'
+
+interface DetermineGeneratedKeySetupModeOptions {
+  manualRecoveryNeeded: boolean
+}
+
+export async function determineGeneratedKeySetupMode({
+  manualRecoveryNeeded,
+}: DetermineGeneratedKeySetupModeOptions): Promise<CloudKeySetupMode> {
+  if (manualRecoveryNeeded) {
+    return 'explicitStartFresh'
+  }
+
+  try {
+    const remoteState = await inspectRemoteEncryptedState()
+    return remoteState === 'exists' ? 'explicitStartFresh' : 'recoverExisting'
+  } catch {
+    return 'recoverExisting'
+  }
+}

--- a/src/services/cloud/cloud-key-preflight.ts
+++ b/src/services/cloud/cloud-key-preflight.ts
@@ -247,6 +247,7 @@ function blockedResult(
     remoteState: 'exists',
     canWrite: false,
     probe,
-    message: "This key doesn't match your existing cloud data.",
+    message:
+      "This key doesn't match your existing cloud data. Try using your existing key instead.",
   }
 }

--- a/tests/components/cloud-sync-setup-mode.test.ts
+++ b/tests/components/cloud-sync-setup-mode.test.ts
@@ -1,0 +1,66 @@
+import { determineGeneratedKeySetupMode } from '@/components/modals/cloud-sync-setup-mode'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockInspectRemoteEncryptedState = vi.fn()
+
+vi.mock('@/services/cloud/cloud-key-preflight', () => ({
+  inspectRemoteEncryptedState: (...args: unknown[]) =>
+    mockInspectRemoteEncryptedState(...args),
+}))
+
+describe('determineGeneratedKeySetupMode', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('uses explicitStartFresh when manual recovery is required', async () => {
+    const mode = await determineGeneratedKeySetupMode({
+      manualRecoveryNeeded: true,
+    })
+
+    expect(mode).toBe('explicitStartFresh')
+    expect(mockInspectRemoteEncryptedState).not.toHaveBeenCalled()
+  })
+
+  it('keeps recoverExisting when the remote cloud state is empty', async () => {
+    mockInspectRemoteEncryptedState.mockResolvedValue('empty')
+
+    const mode = await determineGeneratedKeySetupMode({
+      manualRecoveryNeeded: false,
+    })
+
+    expect(mode).toBe('recoverExisting')
+  })
+
+  it('uses explicitStartFresh when encrypted cloud data already exists', async () => {
+    mockInspectRemoteEncryptedState.mockResolvedValue('exists')
+
+    const mode = await determineGeneratedKeySetupMode({
+      manualRecoveryNeeded: false,
+    })
+
+    expect(mode).toBe('explicitStartFresh')
+  })
+
+  it('uses explicitStartFresh when the remote cloud state is unknown', async () => {
+    mockInspectRemoteEncryptedState.mockResolvedValue('unknown')
+
+    const mode = await determineGeneratedKeySetupMode({
+      manualRecoveryNeeded: false,
+    })
+
+    expect(mode).toBe('recoverExisting')
+  })
+
+  it('falls back to recoverExisting when remote inspection fails', async () => {
+    mockInspectRemoteEncryptedState.mockRejectedValue(
+      new Error('Network error'),
+    )
+
+    const mode = await determineGeneratedKeySetupMode({
+      manualRecoveryNeeded: false,
+    })
+
+    expect(mode).toBe('recoverExisting')
+  })
+})


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix cloud sync setup so starting fresh isn’t blocked, defaulting to a safe mode when checks fail. Also clarified key mismatch errors to guide users to use their existing key.

- **Bug Fixes**
  - Added `determineGeneratedKeySetupMode` using `inspectRemoteEncryptedState`; respects `manualRecoveryNeeded`.
  - Use `explicitStartFresh` only when remote data exists; default to `recoverExisting` for empty, unknown, or errors (fail closed).
  - Clarified key mismatch messages in preflight and modal toasts (“Try using your existing key instead.”).
  - Updated `CloudSyncSetupModal` to use this logic and added unit tests.

<sup>Written for commit f12d0a22ed3e7d37fe2f7121590f4e4e7c097df5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

