### PR TITLE
fix: button overflow on the onboarding

### DIFF
--- a/src/components/modals/cloud-sync-setup-modal.tsx
+++ b/src/components/modals/cloud-sync-setup-modal.tsx
@@ -482,7 +482,7 @@ ${generatedKey.replace('key_', '')}
           {isProcessing
             ? 'Generating...'
             : manualRecoveryNeeded
-              ? 'Start Fresh with New Key'
+              ? 'Start Fresh'
               : 'Generate Key'}
         </button>
       </div>
@@ -800,7 +800,7 @@ ${generatedKey.replace('key_', '')}
           disabled={isRecovering || isStartingFresh}
           className="flex w-full items-center justify-center gap-2 rounded-lg border border-border-subtle bg-surface-chat px-4 py-2 text-sm font-medium text-content-primary transition-colors hover:bg-surface-chat/80 disabled:cursor-not-allowed disabled:opacity-50"
         >
-          Start Fresh with New Key
+          Start Fresh
         </button>
       )}
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Shortened the "Start Fresh with New Key" button label to "Start Fresh" in the Cloud Sync setup modal to prevent text overflow on onboarding screens. This keeps the button readable and avoids layout shifts on smaller viewports.

<sup>Written for commit 97171544b7ed23bdc78eecd78bbbeb746d819054. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

