### PR TITLE
fix: reduce vertical padding on pro badge

### DIFF
--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -3362,7 +3362,7 @@ ${encryptionKey.replace('key_', '')}
                           <ArrowUpTrayIcon className="h-4 w-4" />
                           Projects
                           {!isPremium && (
-                            <span className="ml-1 rounded-full bg-brand-accent-light/20 px-1.5 py-0.5 text-[10px] font-medium text-brand-accent-light">
+                            <span className="ml-1 rounded-full bg-brand-accent-light/20 px-1.5 py-px text-[10px] font-medium text-brand-accent-light">
                               Pro
                             </span>
                           )}
@@ -3439,7 +3439,7 @@ ${encryptionKey.replace('key_', '')}
                           <span className="text-xs text-content-muted">
                             Projects are a premium feature.
                           </span>
-                          <span className="rounded-full bg-brand-accent-light/20 px-1.5 py-0.5 text-[10px] font-medium text-brand-accent-light">
+                          <span className="rounded-full bg-brand-accent-light/20 px-1.5 py-px text-[10px] font-medium text-brand-accent-light">
                             Pro
                           </span>
                         </div>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Reduce vertical padding on the “Pro” badge in the Settings modal to tighten its height and align better with surrounding text. Updates both badge instances to use 1px vertical padding for a cleaner look.

<sup>Written for commit 99f50020fde0e6db4de248d3b3f6fb9b6a442e25. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

