### PR TITLE
feat: show more featured models in the selector

### DIFF
--- a/src/components/chat/model-selector.tsx
+++ b/src/components/chat/model-selector.tsx
@@ -142,7 +142,7 @@ export function ModelSelector({
       (model.type === 'chat' || model.type === 'code') && model.chat === true,
   )
 
-  const TOP_MODEL_COUNT = 1
+  const TOP_MODEL_COUNT = 3
   const topModels = displayModels.slice(0, TOP_MODEL_COUNT)
   const otherModels = displayModels.slice(TOP_MODEL_COUNT)
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Show three featured models at the top of the chat model selector instead of one, so users can pick popular options faster. This only changes the display count; filtering and ordering remain the same.

<sup>Written for commit c214531553399c70b7f33d57dda667cfcd4f6650. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

