### PR TITLE
Add ability to quote text from a chat

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -3,9 +3,11 @@ import { fileURLToPath } from 'node:url'
 
 const projectRoot = dirname(fileURLToPath(import.meta.url))
 
+const isDev = process.env.NODE_ENV === 'development'
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  output: 'export',
+  ...(isDev ? {} : { output: 'export' }),
   outputFileTracingRoot: projectRoot,
 
   // Disable image optimization for static export

--- a/package-lock.json
+++ b/package-lock.json
@@ -5234,9 +5234,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001735",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001735.tgz",
-      "integrity": "sha512-EV/laoX7Wq2J9TQlyIXRxTJqIw4sxfXS4OYgudGxBYRuTv0q7AM6yMEpU/Vo1I94thg9U6EZ2NfZx9GJq83u7w==",
+      "version": "1.0.30001788",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz",
+      "integrity": "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -5250,7 +5250,8 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ]
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/canvg": {
       "version": "3.0.11",
@@ -11188,7 +11189,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/src/components/chat/chat-input.tsx
+++ b/src/components/chat/chat-input.tsx
@@ -23,6 +23,7 @@ import {
   PiGlobeX,
   PiPaperclipLight,
   PiPlusLight,
+  PiQuotes,
   PiSpinner,
 } from 'react-icons/pi'
 import { MacFileIcon } from './components/mac-file-icon'
@@ -50,7 +51,12 @@ type ChatInputProps = {
   modelSelectorButton?: React.ReactNode
   webSearchEnabled?: boolean
   onWebSearchToggle?: () => void
+  quote?: string | null
+  onClearQuote?: () => void
 }
+
+// Maximum number of characters displayed in the collapsed quote preview.
+const QUOTE_PREVIEW_MAX_LENGTH = 240
 
 export function ChatInput({
   input,
@@ -71,6 +77,8 @@ export function ChatInput({
   modelSelectorButton,
   webSearchEnabled,
   onWebSearchToggle,
+  quote,
+  onClearQuote,
 }: ChatInputProps) {
   const fileInputRef = useRef<HTMLInputElement>(null)
   const documentsScrollRef = useRef<HTMLDivElement>(null)
@@ -455,6 +463,38 @@ export function ChatInput({
             }
           />
 
+          {quote && (
+            <div className="mb-3 mt-1 flex items-start gap-2 rounded-2xl border border-border-subtle bg-surface-chat-background px-3 py-2">
+              <PiQuotes className="mt-0.5 h-4 w-4 flex-shrink-0 text-content-secondary" />
+              <p className="line-clamp-3 flex-1 whitespace-pre-wrap text-sm text-content-secondary">
+                {quote.length > QUOTE_PREVIEW_MAX_LENGTH
+                  ? `${quote.slice(0, QUOTE_PREVIEW_MAX_LENGTH).trimEnd()}…`
+                  : quote}
+              </p>
+              {onClearQuote && (
+                <button
+                  type="button"
+                  onClick={onClearQuote}
+                  aria-label="Remove quote"
+                  className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full text-content-secondary transition-colors hover:bg-surface-chat hover:text-content-primary"
+                >
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    className="h-3.5 w-3.5"
+                    viewBox="0 0 20 20"
+                    fill="currentColor"
+                  >
+                    <path
+                      fillRule="evenodd"
+                      d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
+                      clipRule="evenodd"
+                    />
+                  </svg>
+                </button>
+              )}
+            </div>
+          )}
+
           {processedDocuments && processedDocuments.length > 0 && (
             <div
               ref={documentsScrollRef}
@@ -709,10 +749,11 @@ export function ChatInput({
                     (doc) => !doc.isUploading && !doc.isGeneratingDescription,
                   )
                 const hasInput = input.trim().length > 0
+                const hasQuote = Boolean(quote)
                 if (
                   loadingState === 'idle' &&
                   !isTranscribing &&
-                  (hasInput || hasDocuments)
+                  (hasInput || hasDocuments || hasQuote)
                 ) {
                   shouldRemountOnClearRef.current = true
                   handleSubmit(e)
@@ -987,6 +1028,7 @@ export function ChatInput({
                   loadingState !== 'retrying' &&
                   (isTranscribing ||
                     (!input.trim() &&
+                      !quote &&
                       (!processedDocuments ||
                         !processedDocuments.some(
                           (doc) =>

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -86,6 +86,7 @@ import { useChatState } from './hooks/use-chat-state'
 import { useCustomSystemPrompt } from './hooks/use-custom-system-prompt'
 import { useReasoningEffort } from './hooks/use-reasoning-effort'
 import { ModelSelector } from './model-selector'
+import { QuoteSelectionPopover } from './quote-selection-popover'
 import { initializeRenderers } from './renderers/client'
 import type { ProcessedDocument } from './renderers/types'
 import type { SettingsTab } from './settings-modal'
@@ -407,6 +408,9 @@ export function ChatInterface({
   // State for add-to-project-context modal
   const [showAddToProjectModal, setShowAddToProjectModal] = useState(false)
   const [pendingUploadFiles, setPendingUploadFiles] = useState<File[]>([])
+
+  // Quote state for highlighted text from messages
+  const [quote, setQuote] = useState<string | null>(null)
 
   // State for web search toggle (persisted in localStorage)
   const [webSearchEnabled, setWebSearchEnabled] = useState(() => {
@@ -1622,8 +1626,8 @@ export function ChatInterface({
 
     const messageText = input.trim()
 
-    // Don't proceed if there's no input text and no documents
-    if (!messageText && completedDocuments.length === 0) {
+    // Don't proceed if there's no input text, no quote, and no documents
+    if (!messageText && !quote && completedDocuments.length === 0) {
       return
     }
 
@@ -1652,10 +1656,21 @@ export function ChatInterface({
         )
       })
 
-    handleQuery(messageText, attachments.length > 0 ? attachments : undefined)
+    handleQuery(
+      messageText,
+      attachments.length > 0 ? attachments : undefined,
+      undefined,
+      undefined,
+      quote ?? undefined,
+    )
 
     if (rateLimit) {
       snapshotAndDecrementRemaining()
+    }
+
+    // Clear the quote after submission
+    if (quote) {
+      setQuote(null)
     }
 
     // Keep documents that are still uploading or generating descriptions
@@ -2401,6 +2416,13 @@ export function ChatInterface({
           )}
 
           {/* Messages Area */}
+          <QuoteSelectionPopover
+            containerRef={scrollContainerRef}
+            onQuote={(text) => {
+              setQuote(text)
+              inputRef.current?.focus()
+            }}
+          />
           <div
             ref={scrollContainerRef}
             onScroll={handleScroll}
@@ -2471,6 +2493,8 @@ export function ChatInterface({
                     processedDocuments={processedDocuments}
                     removeDocument={removeDocument}
                     isPremium={isPremium}
+                    quote={quote}
+                    onClearQuote={() => setQuote(null)}
                     hasMessages={
                       currentChat?.messages && currentChat.messages.length > 0
                     }
@@ -2643,6 +2667,3 @@ export function ChatInterface({
     </div>
   )
 }
-
-// Default export as well
-export default ChatInterface

--- a/src/components/chat/hooks/use-chat-messaging.ts
+++ b/src/components/chat/hooks/use-chat-messaging.ts
@@ -69,6 +69,7 @@ interface UseChatMessagingReturn {
     attachments?: import('@/components/chat/types').Attachment[],
     systemPromptOverride?: string,
     baseMessages?: Message[],
+    quote?: string,
   ) => void
   cancelGeneration: () => Promise<void>
   editMessage: (messageIndex: number, newContent: string) => void
@@ -224,10 +225,14 @@ export function useChatMessaging({
       attachments?: import('@/components/chat/types').Attachment[],
       systemPromptOverride?: string,
       baseMessages?: Message[],
+      quote?: string,
     ) => {
-      // Allow empty query if systemPromptOverride or attachments are provided
+      // Allow empty query if systemPromptOverride, attachments, or a quote are provided
       if (
-        (!query.trim() && !systemPromptOverride && !attachments?.length) ||
+        (!query.trim() &&
+          !systemPromptOverride &&
+          !attachments?.length &&
+          !quote) ||
         loadingState !== 'idle'
       )
         return
@@ -258,7 +263,9 @@ export function useChatMessaging({
       // Only create a user message if there's actual query content
       // When using system prompt override with empty query, skip user message
       const hasUserContent =
-        query.trim() !== '' || (attachments && attachments.length > 0)
+        query.trim() !== '' ||
+        (attachments && attachments.length > 0) ||
+        Boolean(quote)
 
       const userMessage: Message | null = hasUserContent
         ? {
@@ -267,6 +274,7 @@ export function useChatMessaging({
             attachments:
               attachments && attachments.length > 0 ? attachments : undefined,
             timestamp: new Date(),
+            quote: quote || undefined,
           }
         : null
 

--- a/src/components/chat/hooks/use-chat-state.ts
+++ b/src/components/chat/hooks/use-chat-state.ts
@@ -1,6 +1,6 @@
 import type { BaseModel } from '@/config/models'
 import { useEffect, useRef } from 'react'
-import type { AIModel, Chat, LabelType, LoadingState } from '../types'
+import type { AIModel, Chat, LabelType, LoadingState, Message } from '../types'
 import { useChatMessaging } from './use-chat-messaging'
 import { useChatStorage } from './use-chat-storage'
 import { useModelManagement } from './use-model-management'
@@ -45,6 +45,8 @@ interface UseChatStateReturn {
     query: string,
     attachments?: import('@/components/chat/types').Attachment[],
     systemPromptOverride?: string,
+    baseMessages?: Message[],
+    quote?: string,
   ) => void
   createNewChat: (isLocalOnly?: boolean, fromUserAction?: boolean) => void
   deleteChat: (chatId: string) => void

--- a/src/components/chat/quote-selection-popover.tsx
+++ b/src/components/chat/quote-selection-popover.tsx
@@ -1,0 +1,154 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { PiQuotes } from 'react-icons/pi'
+
+type PopoverPosition = {
+  top: number
+  left: number
+}
+
+type QuoteSelectionPopoverProps = {
+  containerRef: React.RefObject<HTMLElement>
+  onQuote: (text: string) => void
+}
+
+// Minimum number of characters required for the popover to appear.
+const MIN_SELECTION_LENGTH = 2
+
+// Vertical offset (in pixels) above the selection for the popover.
+const POPOVER_VERTICAL_OFFSET = 40
+
+export function QuoteSelectionPopover({
+  containerRef,
+  onQuote,
+}: QuoteSelectionPopoverProps) {
+  const [position, setPosition] = useState<PopoverPosition | null>(null)
+  const [selectedText, setSelectedText] = useState<string>('')
+  const popoverRef = useRef<HTMLDivElement>(null)
+
+  const hidePopover = useCallback(() => {
+    setPosition(null)
+    setSelectedText('')
+  }, [])
+
+  const updateFromSelection = useCallback(() => {
+    const container = containerRef.current
+    if (!container) {
+      hidePopover()
+      return
+    }
+
+    const selection = window.getSelection()
+    if (!selection || selection.isCollapsed || selection.rangeCount === 0) {
+      hidePopover()
+      return
+    }
+
+    const range = selection.getRangeAt(0)
+    const commonAncestor = range.commonAncestorContainer
+    const ancestorElement =
+      commonAncestor.nodeType === Node.ELEMENT_NODE
+        ? (commonAncestor as Element)
+        : commonAncestor.parentElement
+
+    if (!ancestorElement || !container.contains(ancestorElement)) {
+      hidePopover()
+      return
+    }
+
+    // Only allow selection inside messages, not the input area itself.
+    const isInsideInput = ancestorElement.closest(
+      '#chat-input, textarea, input',
+    )
+    if (isInsideInput) {
+      hidePopover()
+      return
+    }
+
+    const text = selection.toString().trim()
+    if (text.length < MIN_SELECTION_LENGTH) {
+      hidePopover()
+      return
+    }
+
+    const rect = range.getBoundingClientRect()
+    if (rect.width === 0 && rect.height === 0) {
+      hidePopover()
+      return
+    }
+
+    setSelectedText(text)
+    setPosition({
+      top: rect.top - POPOVER_VERTICAL_OFFSET,
+      left: rect.left + rect.width / 2,
+    })
+  }, [containerRef, hidePopover])
+
+  useEffect(() => {
+    const handleSelectionChange = () => {
+      // Defer to allow the selection to fully settle (important on mobile).
+      requestAnimationFrame(updateFromSelection)
+    }
+
+    const handleMouseUp = () => {
+      requestAnimationFrame(updateFromSelection)
+    }
+
+    const handleScrollOrResize = () => {
+      hidePopover()
+    }
+
+    document.addEventListener('selectionchange', handleSelectionChange)
+    document.addEventListener('mouseup', handleMouseUp)
+    window.addEventListener('scroll', handleScrollOrResize, true)
+    window.addEventListener('resize', handleScrollOrResize)
+
+    return () => {
+      document.removeEventListener('selectionchange', handleSelectionChange)
+      document.removeEventListener('mouseup', handleMouseUp)
+      window.removeEventListener('scroll', handleScrollOrResize, true)
+      window.removeEventListener('resize', handleScrollOrResize)
+    }
+  }, [updateFromSelection, hidePopover])
+
+  const handleQuoteClick = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault()
+      e.stopPropagation()
+      if (!selectedText) return
+      onQuote(selectedText)
+      window.getSelection()?.removeAllRanges()
+      hidePopover()
+    },
+    [selectedText, onQuote, hidePopover],
+  )
+
+  if (!position) return null
+
+  return (
+    <div
+      ref={popoverRef}
+      role="dialog"
+      aria-label="Quote selection"
+      style={{
+        position: 'fixed',
+        top: position.top,
+        left: position.left,
+        transform: 'translateX(-50%)',
+        zIndex: 50,
+      }}
+      onMouseDown={(e) => {
+        // Prevent losing the selection when clicking the popover.
+        e.preventDefault()
+      }}
+    >
+      <button
+        type="button"
+        onClick={handleQuoteClick}
+        className="flex items-center gap-1.5 rounded-full border border-border-subtle bg-surface-chat px-3 py-1.5 text-sm font-medium text-content-primary shadow-md transition-colors hover:bg-surface-chat-background"
+      >
+        <PiQuotes className="h-4 w-4" />
+        <span>Quote</span>
+      </button>
+    </div>
+  )
+}

--- a/src/components/chat/renderers/default/DefaultMessageRenderer.tsx
+++ b/src/components/chat/renderers/default/DefaultMessageRenderer.tsx
@@ -1,11 +1,12 @@
 import { cn } from '@/components/ui/utils'
 import {
   ArrowPathIcon,
+  ArrowUturnLeftIcon,
   ChevronDownIcon,
   InformationCircleIcon,
   PencilSquareIcon,
 } from '@heroicons/react/24/outline'
-import React, { memo } from 'react'
+import React, { memo, useState } from 'react'
 import { BsCheckLg } from 'react-icons/bs'
 import { GoClockFill } from 'react-icons/go'
 import { RxCopy } from 'react-icons/rx'
@@ -127,6 +128,14 @@ const DefaultMessageComponent = ({
   }, [message.content, isUser, isLastMessage, showActions])
 
   const USER_MESSAGE_MAX_HEIGHT = 150
+  const QUOTE_PREVIEW_MAX_LENGTH = 240
+  const [isQuoteExpanded, setIsQuoteExpanded] = useState(false)
+  const shouldTruncateQuote =
+    !!message.quote && message.quote.length > QUOTE_PREVIEW_MAX_LENGTH
+  const displayedQuote =
+    message.quote && shouldTruncateQuote && !isQuoteExpanded
+      ? `${message.quote.slice(0, QUOTE_PREVIEW_MAX_LENGTH).trimEnd()}…`
+      : (message.quote ?? '')
 
   React.useEffect(() => {
     if (isUser && userMessageContentRef.current) {
@@ -204,6 +213,34 @@ const DefaultMessageComponent = ({
       className={`relative mx-auto flex w-full max-w-3xl flex-col ${isUser ? 'items-end' : 'items-start'} group mb-6`}
       data-message-role={message.role}
     >
+      {/* Display the quoted reply preview above the user's message */}
+      {isUser && message.quote && !isEditing && (
+        <div className="flex w-full justify-end px-4 pb-1 pt-2">
+          <div className="flex max-w-[95%] items-start gap-2 opacity-70">
+            <ArrowUturnLeftIcon className="mt-1 h-3.5 w-3.5 flex-shrink-0 text-content-secondary" />
+            <div className="min-w-0">
+              <p
+                className={cn(
+                  'whitespace-pre-wrap text-sm italic text-content-secondary',
+                  !isQuoteExpanded && 'line-clamp-3',
+                )}
+              >
+                {displayedQuote}
+              </p>
+              {shouldTruncateQuote && (
+                <button
+                  type="button"
+                  onClick={() => setIsQuoteExpanded((prev) => !prev)}
+                  className="mt-0.5 text-xs font-medium text-content-secondary underline-offset-2 transition-colors hover:text-content-primary hover:underline"
+                >
+                  {isQuoteExpanded ? 'Show less' : 'Show more'}
+                </button>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+
       {/* Display documents and images for user messages */}
       {isUser && hasMessageAttachments(message) && (
         <DocumentList

--- a/src/components/chat/types.ts
+++ b/src/components/chat/types.ts
@@ -62,6 +62,7 @@ export type Message = {
   webSearchBeforeThinking?: boolean // True if web search started before thinking
   annotations?: Annotation[] // URL citations from web search
   searchReasoning?: string // Search agent's reasoning for multi-turn context
+  quote?: string // Highlighted text the user is replying to
 }
 
 export type TitleState = 'placeholder' | 'generated' | 'manual'

--- a/src/services/inference/chat-query-builder.ts
+++ b/src/services/inference/chat-query-builder.ts
@@ -154,6 +154,17 @@ export class ChatQueryBuilder {
     | Array<{ type: string; text?: string; image_url?: { url: string } }> {
     let textContent = msg.content
 
+    // Prepend the quoted reference so the model knows what the user is replying to.
+    if (msg.quote) {
+      const quoted = msg.quote
+        .split('\n')
+        .map((line) => `> ${line}`)
+        .join('\n')
+      textContent = textContent
+        ? `In reply to:\n${quoted}\n\n${textContent}`
+        : `In reply to:\n${quoted}`
+    }
+
     // Derive document content from attachments (or legacy fields via helpers)
     const docAttachments = getMessageDocuments(msg)
     if (docAttachments.length > 0) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add quoting to chat replies so users can select text from earlier messages, attach it to their reply, and send it to the model for context.

- New Features
  - Add selection popover in the messages area with a Quote action; ignores selections in inputs and hides on scroll/resize.
  - Show a quote preview in the chat input (truncated to 240 chars) with a clear button; allow sending with quote-only or quote+attachments.
  - Render quoted text above user messages with show more/less.
  - Include the quote in the model payload, prepended as “In reply to:” with blockquote formatting.
  - API updates: add Message.quote, and extend handleQuery(..., quote?) through `use-chat-messaging` and `use-chat-state`.

- Bug Fixes
  - Only set Next.js `output: 'export'` in production to avoid full page reloads during development.

<sup>Written for commit 77389e829965ceaf77461c6d3fda413a54afd360. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

