### PR TITLE
Add ask sidebar for side questions

### DIFF
--- a/src/components/chat/ask-sidebar.tsx
+++ b/src/components/chat/ask-sidebar.tsx
@@ -1,0 +1,162 @@
+import { cn } from '@/components/ui/utils'
+import { type BaseModel } from '@/config/models'
+import {
+  ArrowTopRightOnSquareIcon,
+  XMarkIcon,
+} from '@heroicons/react/24/outline'
+import { memo } from 'react'
+import { PiChatCircleText } from 'react-icons/pi'
+import { LoadingDots } from '../loading-dots'
+import { CONSTANTS } from './constants'
+import type { SidebarChatState } from './hooks/use-sidebar-chat'
+import { getRendererRegistry } from './renderers/client'
+import type { AIModel, Message } from './types'
+
+type AskSidebarProps = {
+  isOpen: boolean
+  onClose: () => void
+  onOpenAsChat: () => void
+  state: SidebarChatState
+  models: BaseModel[]
+  selectedModel: AIModel
+  isDarkMode: boolean
+}
+
+const SidebarMessage = memo(function SidebarMessage({
+  message,
+  messageIndex,
+  model,
+  isDarkMode,
+  isLastMessage,
+  isStreaming,
+}: {
+  message: Message
+  messageIndex: number
+  model: BaseModel
+  isDarkMode: boolean
+  isLastMessage: boolean
+  isStreaming: boolean
+}) {
+  const renderer = getRendererRegistry().getMessageRenderer(message, model)
+  const Component = renderer.render
+  return (
+    <Component
+      message={message}
+      messageIndex={messageIndex}
+      model={model}
+      isDarkMode={isDarkMode}
+      isLastMessage={isLastMessage}
+      isStreaming={isStreaming}
+      expandedThoughtsState={{}}
+      setExpandedThoughtsState={() => {}}
+    />
+  )
+})
+
+export function AskSidebar({
+  isOpen,
+  onClose,
+  onOpenAsChat,
+  state,
+  models,
+  selectedModel,
+  isDarkMode,
+}: AskSidebarProps) {
+  const { messages, isWaitingForResponse, isStreaming, loadingState } = state
+  const hasMessages = messages.length > 0
+  const hasAssistantReply = messages.some((m) => m.role === 'assistant')
+  const canOpenAsChat = hasAssistantReply && loadingState === 'idle'
+  const currentModel =
+    models.find((m) => m.modelName === selectedModel) || models[0]
+
+  const lastMessage = messages[messages.length - 1]
+  const showLoadingDots =
+    isWaitingForResponse &&
+    !(
+      lastMessage &&
+      lastMessage.role === 'assistant' &&
+      (lastMessage.isThinking || (lastMessage.thoughts && !lastMessage.content))
+    )
+
+  return (
+    <>
+      <div
+        className={cn(
+          'fixed right-0 top-0 z-40 flex h-full w-[85vw] flex-col border-l border-border-subtle bg-surface-chat-background font-aeonik transition-transform duration-200 ease-in-out',
+          isOpen ? 'translate-x-0' : 'translate-x-full',
+        )}
+        style={{ maxWidth: `${CONSTANTS.ASK_SIDEBAR_WIDTH_PX}px` }}
+        aria-hidden={!isOpen}
+      >
+        {/* Header */}
+        <div className="flex flex-shrink-0 items-center justify-between border-b border-border-subtle px-4 py-3">
+          <div className="flex items-center gap-2 text-content-primary">
+            <PiChatCircleText className="h-5 w-5" />
+            <span className="text-sm font-medium">Ask</span>
+          </div>
+          <div className="flex items-center gap-1">
+            <button
+              type="button"
+              onClick={onOpenAsChat}
+              disabled={!canOpenAsChat}
+              className="flex h-9 items-center gap-1.5 rounded-lg border border-border-subtle bg-surface-chat px-2.5 text-xs font-medium text-content-primary transition-colors hover:bg-surface-chat-background disabled:cursor-not-allowed disabled:opacity-40"
+              title="Open as a new chat"
+            >
+              <ArrowTopRightOnSquareIcon className="h-4 w-4" />
+              <span>Open as chat</span>
+            </button>
+            <button
+              type="button"
+              onClick={onClose}
+              className="flex h-9 w-9 items-center justify-center rounded-lg border border-border-subtle bg-surface-chat text-content-secondary transition-colors hover:bg-surface-chat-background"
+              aria-label="Close ask sidebar"
+            >
+              <XMarkIcon className="h-4 w-4" />
+            </button>
+          </div>
+        </div>
+
+        {/* Messages area */}
+        <div className="flex flex-1 overflow-y-auto">
+          {hasMessages && currentModel ? (
+            <div className="flex-1 [container-type:inline-size]">
+              <div className="flex flex-col gap-2 px-2 py-4">
+                {messages.map((message, i) => (
+                  <SidebarMessage
+                    key={`${message.role}-${i}`}
+                    message={message}
+                    messageIndex={i}
+                    model={currentModel}
+                    isDarkMode={isDarkMode}
+                    isLastMessage={i === messages.length - 1}
+                    isStreaming={i === messages.length - 1 && isStreaming}
+                  />
+                ))}
+                {showLoadingDots && (
+                  <div className="mx-auto flex w-full max-w-3xl px-4">
+                    <LoadingDots isThinking={false} />
+                  </div>
+                )}
+              </div>
+            </div>
+          ) : (
+            <div className="flex flex-1 items-center justify-center px-6 text-center">
+              <p className="text-sm text-content-secondary">
+                Highlight text in the chat and choose <strong>Ask</strong> to
+                start a side-conversation about it.
+              </p>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Mobile overlay */}
+      {isOpen && (
+        <div
+          className="fixed inset-0 z-30 bg-black/50 md:hidden"
+          onClick={onClose}
+        />
+      )}
+    </>
+  )
+}

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -48,8 +48,10 @@ import { useProfileSync } from '@/hooks/use-profile-sync'
 
 import { cloudSync } from '@/services/cloud/cloud-sync'
 import { encryptionService } from '@/services/encryption/encryption-service'
+import { generateTitle } from '@/services/inference/title'
 import { chatStorage } from '@/services/storage/chat-storage'
 import { indexedDBStorage } from '@/services/storage/indexed-db'
+import { sessionChatStorage } from '@/services/storage/session-storage'
 import {
   isCloudSyncEnabled,
   setCloudSyncEnabled,
@@ -60,6 +62,7 @@ import {
   getProjectUploadPreference,
   setProjectUploadPreference,
 } from '@/utils/project-upload-preference'
+import { generateReverseId } from '@/utils/reverse-id'
 import { TfTinSad } from '@tinfoilsh/tinfoil-icons'
 import dynamic from 'next/dynamic'
 import {
@@ -76,6 +79,7 @@ const useLayoutEffect =
 
 import { UrlHashMessageHandler } from '../url-hash-message-handler'
 import { UrlHashSettingsHandler } from '../url-hash-settings-handler'
+import { AskSidebar } from './ask-sidebar'
 import { ChatInput } from './chat-input'
 import { ChatMessages } from './chat-messages'
 import { ChatSidebar } from './chat-sidebar'
@@ -84,13 +88,15 @@ import { useDocumentUploader } from './document-uploader'
 import { DragProvider } from './drag-context'
 import { useChatState } from './hooks/use-chat-state'
 import { useCustomSystemPrompt } from './hooks/use-custom-system-prompt'
+import { useMaxMessages } from './hooks/use-max-messages'
 import { useReasoningEffort } from './hooks/use-reasoning-effort'
+import { useSidebarChat } from './hooks/use-sidebar-chat'
 import { ModelSelector } from './model-selector'
 import { QuoteSelectionPopover } from './quote-selection-popover'
 import { initializeRenderers } from './renderers/client'
 import type { ProcessedDocument } from './renderers/types'
 import type { SettingsTab } from './settings-modal'
-import type { Attachment } from './types'
+import type { Attachment, Chat } from './types'
 // Lazy-load modals that aren't shown on initial load
 const CloudSyncSetupModal = dynamic(
   () =>
@@ -412,6 +418,10 @@ export function ChatInterface({
   // Quote state for highlighted text from messages
   const [quote, setQuote] = useState<string | null>(null)
 
+  // Ask-sidebar state: a disposable side conversation seeded with highlighted
+  // text. Nothing is persisted unless the user clicks "Open as chat".
+  const [isAskSidebarOpen, setIsAskSidebarOpen] = useState(false)
+
   // State for web search toggle (persisted in localStorage)
   const [webSearchEnabled, setWebSearchEnabled] = useState(() => {
     if (typeof window === 'undefined') return true
@@ -652,6 +662,90 @@ export function ChatInterface({
     piiCheckEnabled,
   })
 
+  // Ask sidebar - ephemeral streaming only. Nothing is persisted until the
+  // user clicks "Open as chat", which creates a new real chat seeded with the
+  // sidebar's messages.
+  const sidebarMaxMessages = useMaxMessages()
+  const sidebarChat = useSidebarChat({
+    systemPrompt: finalSystemPrompt,
+    rules: processedRules,
+    models,
+    selectedModel,
+    maxMessages: sidebarMaxMessages,
+    reasoningEffort,
+    webSearchEnabled,
+    piiCheckEnabled,
+  })
+
+  const handleOpenSidebarAsChat = useCallback(async () => {
+    const snapshotMessages = sidebarChat.messages
+    if (snapshotMessages.length === 0) return
+
+    const useCloudStorage = isSignedIn || !isCloudSyncEnabled()
+    const newChatId = generateReverseId().id
+    const newChat: Chat = {
+      id: newChatId,
+      title: 'Untitled',
+      titleState: 'placeholder',
+      messages: snapshotMessages,
+      createdAt: new Date(),
+      isLocalOnly: !isCloudSyncEnabled(),
+      projectId: isProjectMode && activeProject ? activeProject.id : undefined,
+    }
+
+    setIsAskSidebarOpen(false)
+    sidebarChat.reset()
+
+    try {
+      if (useCloudStorage) {
+        await chatStorage.saveChatAndSync(newChat)
+      } else {
+        sessionChatStorage.saveChat(newChat)
+      }
+    } catch (error) {
+      logError('Failed to persist sidebar chat as full chat', error, {
+        component: 'ChatInterface',
+        action: 'handleOpenSidebarAsChat',
+      })
+    }
+
+    // Title generation from the seeded conversation (best effort, non-blocking).
+    const firstUser = snapshotMessages.find((m) => m.role === 'user')
+    const firstAssistant = snapshotMessages.find((m) => m.role === 'assistant')
+    if (firstUser && firstAssistant) {
+      generateTitle([
+        {
+          role: 'user',
+          content: firstUser.quote
+            ? `In reply to:\n${firstUser.quote}\n\n${firstUser.content}`
+            : firstUser.content,
+        },
+        { role: 'assistant', content: firstAssistant.content },
+      ])
+        .then((title) => {
+          if (title && title !== 'Untitled') {
+            updateChatTitle(newChatId, title)
+          }
+        })
+        .catch(() => {})
+    }
+
+    try {
+      await reloadChats()
+    } catch {
+      // non-fatal
+    }
+    handleChatSelect(newChatId)
+  }, [
+    sidebarChat,
+    isSignedIn,
+    isProjectMode,
+    activeProject,
+    reloadChats,
+    handleChatSelect,
+    updateChatTitle,
+  ])
+
   // Sync URL with current chat state
   useEffect(() => {
     // Don't update URL during initial load
@@ -823,13 +917,23 @@ export function ChatInterface({
   useEffect(() => {
     // When window becomes narrow and both types of sidebars are open, close the right one
     if (windowWidth < CONSTANTS.SINGLE_SIDEBAR_BREAKPOINT) {
-      if (isSidebarOpen && (isVerifierSidebarOpen || isSettingsModalOpen)) {
+      if (
+        isSidebarOpen &&
+        (isVerifierSidebarOpen || isSettingsModalOpen || isAskSidebarOpen)
+      ) {
         // Close right sidebars to prioritize left sidebar
         setIsVerifierSidebarOpen(false)
         setIsSettingsModalOpen(false)
+        setIsAskSidebarOpen(false)
       }
     }
-  }, [windowWidth, isSidebarOpen, isVerifierSidebarOpen, isSettingsModalOpen])
+  }, [
+    windowWidth,
+    isSidebarOpen,
+    isVerifierSidebarOpen,
+    isSettingsModalOpen,
+    isAskSidebarOpen,
+  ])
 
   // Auto-focus input when component mounts and is ready (no autoscroll)
   useEffect(() => {
@@ -1040,9 +1144,11 @@ export function ChatInterface({
       // If already open, close it
       handleSetVerifierSidebarOpen(false)
     } else {
-      // Open verifier and close settings if open
+      // Open verifier and close other right-side panels
       handleSetVerifierSidebarOpen(true)
       setIsSettingsModalOpen(false)
+      setIsAskSidebarOpen(false)
+      sidebarChat.reset()
     }
   }
 
@@ -2067,7 +2173,7 @@ export function ChatInterface({
       {/* Mobile sidebar toggle - only visible when collapsed sidebar rail is hidden */}
       {windowWidth < CONSTANTS.SINGLE_SIDEBAR_BREAKPOINT &&
         !isSidebarOpen &&
-        !(isVerifierSidebarOpen || isSettingsModalOpen) && (
+        !(isVerifierSidebarOpen || isSettingsModalOpen || isAskSidebarOpen) && (
           <div className="group relative">
             <button
               className="fixed left-4 top-4 z-50 flex items-center justify-center gap-2 rounded-lg border border-border-subtle bg-surface-chat-background p-2.5 text-content-secondary transition-all duration-200 hover:bg-surface-chat hover:text-content-primary"
@@ -2090,16 +2196,21 @@ export function ChatInterface({
       {/* Right side toggle buttons */}
       {!(
         windowWidth < CONSTANTS.MOBILE_BREAKPOINT &&
-        (isSidebarOpen || isVerifierSidebarOpen || isSettingsModalOpen)
+        (isSidebarOpen ||
+          isVerifierSidebarOpen ||
+          isSettingsModalOpen ||
+          isAskSidebarOpen)
       ) && (
         <div
           className="fixed top-4 z-50 flex gap-2 transition-all duration-300"
           style={{
             right:
               windowWidth >= CONSTANTS.MOBILE_BREAKPOINT
-                ? isVerifierSidebarOpen
-                  ? `${CONSTANTS.VERIFIER_SIDEBAR_WIDTH_PX + 24}px`
-                  : '16px'
+                ? isAskSidebarOpen
+                  ? `${CONSTANTS.ASK_SIDEBAR_WIDTH_PX + 24}px`
+                  : isVerifierSidebarOpen
+                    ? `${CONSTANTS.VERIFIER_SIDEBAR_WIDTH_PX + 24}px`
+                    : '16px'
                 : '16px',
           }}
         >
@@ -2319,6 +2430,21 @@ export function ChatInterface({
         isClient={isClient}
       />
 
+      {/* Ask Sidebar - ephemeral side conversation seeded from highlighted text.
+          Discarded on close or on the next "Ask" click. */}
+      <AskSidebar
+        isOpen={isAskSidebarOpen}
+        onClose={() => {
+          setIsAskSidebarOpen(false)
+          sidebarChat.reset()
+        }}
+        onOpenAsChat={handleOpenSidebarAsChat}
+        state={sidebarChat}
+        models={models}
+        selectedModel={selectedModel}
+        isDarkMode={isDarkMode}
+      />
+
       {/* Share Modal */}
       <ShareModalLazy
         isOpen={isShareModalOpen}
@@ -2329,7 +2455,7 @@ export function ChatInterface({
           isSidebarOpen && windowWidth >= CONSTANTS.MOBILE_BREAKPOINT
         }
         isRightSidebarOpen={
-          (isVerifierSidebarOpen || isSettingsModalOpen) &&
+          (isVerifierSidebarOpen || isSettingsModalOpen || isAskSidebarOpen) &&
           windowWidth >= CONSTANTS.MOBILE_BREAKPOINT
         }
         chatTitle={currentChat?.title}
@@ -2368,9 +2494,11 @@ export function ChatInterface({
         style={{
           right:
             windowWidth >= CONSTANTS.MOBILE_BREAKPOINT
-              ? isVerifierSidebarOpen
-                ? `${CONSTANTS.VERIFIER_SIDEBAR_WIDTH_PX}px`
-                : '0'
+              ? isAskSidebarOpen
+                ? `${CONSTANTS.ASK_SIDEBAR_WIDTH_PX}px`
+                : isVerifierSidebarOpen
+                  ? `${CONSTANTS.VERIFIER_SIDEBAR_WIDTH_PX}px`
+                  : '0'
               : '0',
           bottom: 0,
           left:
@@ -2421,6 +2549,18 @@ export function ChatInterface({
             onQuote={(text) => {
               setQuote(text)
               inputRef.current?.focus()
+            }}
+            onAsk={(text) => {
+              setIsVerifierSidebarOpen(false)
+              setIsSettingsModalOpen(false)
+              if (
+                windowWidth < CONSTANTS.SINGLE_SIDEBAR_BREAKPOINT &&
+                isSidebarOpen
+              ) {
+                setIsSidebarOpen(false)
+              }
+              setIsAskSidebarOpen(true)
+              sidebarChat.askQuote(text)
             }}
           />
           <div

--- a/src/components/chat/constants.ts
+++ b/src/components/chat/constants.ts
@@ -27,6 +27,7 @@ export const CONSTANTS = {
   CHAT_SIDEBAR_COLLAPSED_WIDTH_PX: 48,
   SETTINGS_SIDEBAR_WIDTH_PX: 345,
   VERIFIER_SIDEBAR_WIDTH_PX: 345,
+  ASK_SIDEBAR_WIDTH_PX: 420,
   // Long text paste threshold (characters) - texts longer than this will be converted to .txt file
   LONG_PASTE_THRESHOLD: 3000,
   // Title generation settings

--- a/src/components/chat/hooks/use-sidebar-chat.ts
+++ b/src/components/chat/hooks/use-sidebar-chat.ts
@@ -1,0 +1,261 @@
+/**
+ * Ephemeral "Ask" sidebar chat hook.
+ *
+ * Drives a single, disposable streaming session for the quote-ask sidebar.
+ * Nothing is persisted — no IndexedDB, no sessionStorage, no cloud sync.
+ * Each call to askQuote() aborts the previous stream and starts fresh.
+ *
+ * Reuses the existing streaming pipeline (sendChatStream +
+ * processStreamingResponse) by shimming updateChatWithHistoryCheck with a
+ * pure in-memory setter. This keeps the stream parsing, thinking mode,
+ * web search, and citation processing identical to the main chat view
+ * without duplicating any of that logic.
+ */
+import { type BaseModel } from '@/config/models'
+import { sendChatStream } from '@/services/inference/inference-client'
+import { logError } from '@/utils/error-handling'
+import { useCallback, useRef, useState } from 'react'
+import type { AIModel, LoadingState, Message } from '../types'
+import { processStreamingResponse } from './streaming-processor'
+import type { ReasoningEffort } from './use-reasoning-effort'
+
+interface UseSidebarChatProps {
+  systemPrompt: string
+  rules?: string
+  models: BaseModel[]
+  selectedModel: AIModel
+  maxMessages: number
+  reasoningEffort?: ReasoningEffort
+  webSearchEnabled?: boolean
+  piiCheckEnabled?: boolean
+}
+
+export interface SidebarChatState {
+  messages: Message[]
+  quote: string | null
+  loadingState: LoadingState
+  isThinking: boolean
+  isWaitingForResponse: boolean
+  isStreaming: boolean
+  retryInfo: { attempt: number; maxRetries: number; error?: string } | null
+}
+
+interface UseSidebarChatReturn extends SidebarChatState {
+  askQuote: (quote: string) => void
+  cancel: () => void
+  reset: () => void
+}
+
+// A stable placeholder chat id used by the streaming processor. The id never
+// leaves this hook — nothing is saved under it.
+const EPHEMERAL_CHAT_ID = 'ask-sidebar-ephemeral'
+
+export function useSidebarChat({
+  systemPrompt,
+  rules = '',
+  models,
+  selectedModel,
+  maxMessages,
+  reasoningEffort,
+  webSearchEnabled,
+  piiCheckEnabled,
+}: UseSidebarChatProps): UseSidebarChatReturn {
+  const [messages, setMessages] = useState<Message[]>([])
+  const [quote, setQuote] = useState<string | null>(null)
+  const [loadingState, setLoadingState] = useState<LoadingState>('idle')
+  const [retryInfo, setRetryInfo] = useState<{
+    attempt: number
+    maxRetries: number
+    error?: string
+  } | null>(null)
+  const [isThinking, setIsThinking] = useState(false)
+  const [isWaitingForResponse, setIsWaitingForResponse] = useState(false)
+  const [isStreaming, setIsStreaming] = useState(false)
+
+  // Refs kept in sync with state so the streaming processor (which captures
+  // them once) can read the latest values.
+  const isStreamingRef = useRef(false)
+  const thinkingStartTimeRef = useRef<number | null>(null)
+  const currentChatIdRef = useRef<string>(EPHEMERAL_CHAT_ID)
+  const abortControllerRef = useRef<AbortController | null>(null)
+
+  const cancel = useCallback(() => {
+    if (abortControllerRef.current) {
+      abortControllerRef.current.abort()
+      abortControllerRef.current = null
+    }
+    isStreamingRef.current = false
+    thinkingStartTimeRef.current = null
+    setLoadingState('idle')
+    setRetryInfo(null)
+    setIsThinking(false)
+    setIsWaitingForResponse(false)
+    setIsStreaming(false)
+  }, [])
+
+  const reset = useCallback(() => {
+    cancel()
+    setMessages([])
+    setQuote(null)
+  }, [cancel])
+
+  const askQuote = useCallback(
+    (quoteText: string) => {
+      if (!quoteText) return
+
+      // Discard any in-flight stream and any previous sidebar conversation.
+      cancel()
+      setMessages([])
+      setQuote(quoteText)
+
+      const model = models.find((m) => m.modelName === selectedModel)
+      if (!model) {
+        logError('Cannot start sidebar ask: model not found', undefined, {
+          component: 'useSidebarChat',
+          metadata: { selectedModel },
+        })
+        return
+      }
+
+      const userMessage: Message = {
+        role: 'user',
+        content: '',
+        quote: quoteText,
+        timestamp: new Date(),
+      }
+      const updatedMessages: Message[] = [userMessage]
+      setMessages(updatedMessages)
+
+      const controller = new AbortController()
+      abortControllerRef.current = controller
+      setLoadingState('loading')
+      setIsWaitingForResponse(true)
+      setIsStreaming(true)
+
+      // In-memory shim for updateChatWithHistoryCheck. The streaming processor
+      // expects (setChats, chatSnapshot, setCurrentChat, chatId, newMessages).
+      // We map that onto our single messages state.
+      const inMemoryUpdate = (
+        _setChats: unknown,
+        _chatSnapshot: unknown,
+        _setCurrentChat: unknown,
+        _chatId: string,
+        newMessages: Message[],
+      ) => {
+        setMessages(newMessages)
+      }
+
+      // Minimal Chat-shaped object; only id is really used by the processor.
+      const ephemeralChat = {
+        id: EPHEMERAL_CHAT_ID,
+        title: '',
+        messages: updatedMessages,
+        createdAt: new Date(),
+      }
+
+      ;(async () => {
+        try {
+          const response = await sendChatStream({
+            model,
+            systemPrompt,
+            rules,
+            onRetry: (attempt, max, error) => {
+              setLoadingState('retrying')
+              setRetryInfo({ attempt, maxRetries: max, error })
+            },
+            updatedMessages,
+            maxMessages,
+            signal: controller.signal,
+            reasoningEffort,
+            webSearchEnabled,
+            piiCheckEnabled,
+          })
+
+          isStreamingRef.current = true
+          const assistantMessage = await processStreamingResponse(response, {
+            updatedChat: ephemeralChat as never,
+            updatedMessages,
+            isFirstMessage: true,
+            modelsLength: models.length,
+            currentChatIdRef,
+            isStreamingRef,
+            thinkingStartTimeRef,
+            setIsThinking,
+            setIsWaitingForResponse,
+            setIsStreaming,
+            updateChatWithHistoryCheck: inMemoryUpdate as never,
+            setChats: (() => {}) as never,
+            setCurrentChat: (() => {}) as never,
+            setLoadingState: setLoadingState as never,
+            storeHistory: false,
+            startingChatId: EPHEMERAL_CHAT_ID,
+          })
+
+          if (assistantMessage && abortControllerRef.current === controller) {
+            setMessages([...updatedMessages, assistantMessage])
+          }
+        } catch (error) {
+          if (error instanceof DOMException && error.name === 'AbortError') {
+            return
+          }
+          // Ignore errors from a superseded request; the active request owns
+          // the visible messages state.
+          if (abortControllerRef.current !== controller) {
+            return
+          }
+          logError('Sidebar ask streaming failed', error, {
+            component: 'useSidebarChat',
+          })
+          const errMsg =
+            error instanceof Error ? error.message : 'Unknown error'
+          setMessages([
+            ...updatedMessages,
+            {
+              role: 'assistant',
+              content: `Error: ${errMsg}`,
+              timestamp: new Date(),
+              isError: true,
+            },
+          ])
+        } finally {
+          // Only clear streaming state if this request is still the active one.
+          // Otherwise a newer askQuote() call has already taken over the refs
+          // and setting them here would stomp on its flags.
+          if (abortControllerRef.current === controller) {
+            setLoadingState('idle')
+            setRetryInfo(null)
+            setIsWaitingForResponse(false)
+            setIsStreaming(false)
+            isStreamingRef.current = false
+            thinkingStartTimeRef.current = null
+            abortControllerRef.current = null
+          }
+        }
+      })()
+    },
+    [
+      cancel,
+      models,
+      selectedModel,
+      systemPrompt,
+      rules,
+      maxMessages,
+      reasoningEffort,
+      webSearchEnabled,
+      piiCheckEnabled,
+    ],
+  )
+
+  return {
+    messages,
+    quote,
+    loadingState,
+    retryInfo,
+    isThinking,
+    isWaitingForResponse,
+    isStreaming,
+    askQuote,
+    cancel,
+    reset,
+  }
+}

--- a/src/components/chat/quote-selection-popover.tsx
+++ b/src/components/chat/quote-selection-popover.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { PiQuotes } from 'react-icons/pi'
+import { PiChatCircleText, PiQuotes } from 'react-icons/pi'
 
 type PopoverPosition = {
   top: number
@@ -9,6 +9,7 @@ type PopoverPosition = {
 type QuoteSelectionPopoverProps = {
   containerRef: React.RefObject<HTMLElement>
   onQuote: (text: string) => void
+  onAsk?: (text: string) => void
 }
 
 // Minimum number of characters required for the popover to appear.
@@ -20,6 +21,7 @@ const POPOVER_VERTICAL_OFFSET = 40
 export function QuoteSelectionPopover({
   containerRef,
   onQuote,
+  onAsk,
 }: QuoteSelectionPopoverProps) {
   const [position, setPosition] = useState<PopoverPosition | null>(null)
   const [selectedText, setSelectedText] = useState<string>('')
@@ -122,13 +124,25 @@ export function QuoteSelectionPopover({
     [selectedText, onQuote, hidePopover],
   )
 
+  const handleAskClick = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault()
+      e.stopPropagation()
+      if (!selectedText || !onAsk) return
+      onAsk(selectedText)
+      window.getSelection()?.removeAllRanges()
+      hidePopover()
+    },
+    [selectedText, onAsk, hidePopover],
+  )
+
   if (!position) return null
 
   return (
     <div
       ref={popoverRef}
       role="dialog"
-      aria-label="Quote selection"
+      aria-label="Selection actions"
       style={{
         position: 'fixed',
         top: position.top,
@@ -140,15 +154,26 @@ export function QuoteSelectionPopover({
         // Prevent losing the selection when clicking the popover.
         e.preventDefault()
       }}
+      className="flex items-center gap-1 rounded-full border border-border-subtle bg-surface-chat p-0.5 shadow-md"
     >
       <button
         type="button"
         onClick={handleQuoteClick}
-        className="flex items-center gap-1.5 rounded-full border border-border-subtle bg-surface-chat px-3 py-1.5 text-sm font-medium text-content-primary shadow-md transition-colors hover:bg-surface-chat-background"
+        className="flex items-center gap-1.5 rounded-full px-3 py-1.5 text-sm font-medium text-content-primary transition-colors hover:bg-surface-chat-background"
       >
         <PiQuotes className="h-4 w-4" />
         <span>Quote</span>
       </button>
+      {onAsk && (
+        <button
+          type="button"
+          onClick={handleAskClick}
+          className="flex items-center gap-1.5 rounded-full px-3 py-1.5 text-sm font-medium text-content-primary transition-colors hover:bg-surface-chat-background"
+        >
+          <PiChatCircleText className="h-4 w-4" />
+          <span>Ask</span>
+        </button>
+      )}
     </div>
   )
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds an "Ask" sidebar for side questions from highlighted text. It runs a disposable side conversation, cancels any prior Ask stream, and lets you promote it to a full chat.

- New Features
  - Added an “Ask” action to the selection popover that opens a right-side `AskSidebar`.
  - Streams answers using the existing chat pipeline and renderers; nothing is saved.
  - “Open as chat” creates a new chat (session or cloud), then generates a title from the first exchange.
  - Automatically closes other right-side panels, respects mobile breakpoints with an overlay, reserves width via `ASK_SIDEBAR_WIDTH_PX`, and offsets right-side controls and Share modal when open.
  - UX polish: shows loading dots while waiting, disables “Open as chat” until an assistant reply, supports dark mode, and resets the ephemeral thread on each new Ask.

<sup>Written for commit ffa603c38a9237402e1f3f126e206a5d8673acd3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

