### PR TITLE
Sidebar chat context

### DIFF
--- a/src/components/chat/ask-sidebar.tsx
+++ b/src/components/chat/ask-sidebar.tsx
@@ -1,17 +1,22 @@
 import { cn } from '@/components/ui/utils'
 import { type BaseModel } from '@/config/models'
 import { XMarkIcon } from '@heroicons/react/24/outline'
-import { memo } from 'react'
+import { memo, useRef } from 'react'
 import { PiChatCircleText } from 'react-icons/pi'
 import { LoadingDots } from '../loading-dots'
 import { CONSTANTS } from './constants'
 import type { SidebarChatState } from './hooks/use-sidebar-chat'
+import { QuoteSelectionPopover } from './quote-selection-popover'
 import { getRendererRegistry } from './renderers/client'
 import type { AIModel, Message } from './types'
 
 type AskSidebarProps = {
   isOpen: boolean
   onClose: () => void
+  // Fired when the user highlights text inside the sidebar and chooses
+  // "Quote". The quote is piped back into the main chat's input (the sidebar
+  // itself has no input of its own).
+  onQuote?: (text: string) => void
   state: SidebarChatState
   models: BaseModel[]
   selectedModel: AIModel
@@ -52,6 +57,7 @@ const SidebarMessage = memo(function SidebarMessage({
 export function AskSidebar({
   isOpen,
   onClose,
+  onQuote,
   state,
   models,
   selectedModel,
@@ -61,6 +67,7 @@ export function AskSidebar({
   const hasMessages = messages.length > 0
   const currentModel =
     models.find((m) => m.modelName === selectedModel) || models[0]
+  const sidebarScrollRef = useRef<HTMLDivElement>(null)
 
   const lastMessage = messages[messages.length - 1]
   const showLoadingDots =
@@ -98,7 +105,13 @@ export function AskSidebar({
         </div>
 
         {/* Messages area */}
-        <div className="flex flex-1 overflow-y-auto">
+        {isOpen && onQuote && (
+          <QuoteSelectionPopover
+            containerRef={sidebarScrollRef}
+            onQuote={onQuote}
+          />
+        )}
+        <div ref={sidebarScrollRef} className="flex flex-1 overflow-y-auto">
           {hasMessages && currentModel ? (
             <div className="flex-1 [container-type:inline-size]">
               <div className="flex flex-col gap-2 px-2 py-4">

--- a/src/components/chat/ask-sidebar.tsx
+++ b/src/components/chat/ask-sidebar.tsx
@@ -1,9 +1,6 @@
 import { cn } from '@/components/ui/utils'
 import { type BaseModel } from '@/config/models'
-import {
-  ArrowTopRightOnSquareIcon,
-  XMarkIcon,
-} from '@heroicons/react/24/outline'
+import { XMarkIcon } from '@heroicons/react/24/outline'
 import { memo } from 'react'
 import { PiChatCircleText } from 'react-icons/pi'
 import { LoadingDots } from '../loading-dots'
@@ -15,7 +12,6 @@ import type { AIModel, Message } from './types'
 type AskSidebarProps = {
   isOpen: boolean
   onClose: () => void
-  onOpenAsChat: () => void
   state: SidebarChatState
   models: BaseModel[]
   selectedModel: AIModel
@@ -56,16 +52,13 @@ const SidebarMessage = memo(function SidebarMessage({
 export function AskSidebar({
   isOpen,
   onClose,
-  onOpenAsChat,
   state,
   models,
   selectedModel,
   isDarkMode,
 }: AskSidebarProps) {
-  const { messages, isWaitingForResponse, isStreaming, loadingState } = state
+  const { messages, isWaitingForResponse, isStreaming } = state
   const hasMessages = messages.length > 0
-  const hasAssistantReply = messages.some((m) => m.role === 'assistant')
-  const canOpenAsChat = hasAssistantReply && loadingState === 'idle'
   const currentModel =
     models.find((m) => m.modelName === selectedModel) || models[0]
 
@@ -94,26 +87,14 @@ export function AskSidebar({
             <PiChatCircleText className="h-5 w-5" />
             <span className="text-sm font-medium">Ask</span>
           </div>
-          <div className="flex items-center gap-1">
-            <button
-              type="button"
-              onClick={onOpenAsChat}
-              disabled={!canOpenAsChat}
-              className="flex h-9 items-center gap-1.5 rounded-lg border border-border-subtle bg-surface-chat px-2.5 text-xs font-medium text-content-primary transition-colors hover:bg-surface-chat-background disabled:cursor-not-allowed disabled:opacity-40"
-              title="Open as a new chat"
-            >
-              <ArrowTopRightOnSquareIcon className="h-4 w-4" />
-              <span>Open as chat</span>
-            </button>
-            <button
-              type="button"
-              onClick={onClose}
-              className="flex h-9 w-9 items-center justify-center rounded-lg border border-border-subtle bg-surface-chat text-content-secondary transition-colors hover:bg-surface-chat-background"
-              aria-label="Close ask sidebar"
-            >
-              <XMarkIcon className="h-4 w-4" />
-            </button>
-          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="flex h-9 w-9 items-center justify-center rounded-lg border border-border-subtle bg-surface-chat text-content-secondary transition-colors hover:bg-surface-chat-background"
+            aria-label="Close ask sidebar"
+          >
+            <XMarkIcon className="h-4 w-4" />
+          </button>
         </div>
 
         {/* Messages area */}

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -2366,6 +2366,15 @@ export function ChatInterface({
           setIsAskSidebarOpen(false)
           sidebarChat.reset()
         }}
+        onQuote={(text) => {
+          // Highlighting text inside the sidebar quotes back into the main
+          // chat's input. The sidebar itself has no input.
+          setQuote(text)
+          setIsAskSidebarOpen(false)
+          sidebarChat.reset()
+          // Defer focus so the layout has settled after the sidebar closes.
+          setTimeout(() => inputRef.current?.focus(), 0)
+        }}
         state={sidebarChat}
         models={models}
         selectedModel={selectedModel}

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -48,10 +48,8 @@ import { useProfileSync } from '@/hooks/use-profile-sync'
 
 import { cloudSync } from '@/services/cloud/cloud-sync'
 import { encryptionService } from '@/services/encryption/encryption-service'
-import { generateTitle } from '@/services/inference/title'
 import { chatStorage } from '@/services/storage/chat-storage'
 import { indexedDBStorage } from '@/services/storage/indexed-db'
-import { sessionChatStorage } from '@/services/storage/session-storage'
 import {
   isCloudSyncEnabled,
   setCloudSyncEnabled,
@@ -62,7 +60,6 @@ import {
   getProjectUploadPreference,
   setProjectUploadPreference,
 } from '@/utils/project-upload-preference'
-import { generateReverseId } from '@/utils/reverse-id'
 import { TfTinSad } from '@tinfoilsh/tinfoil-icons'
 import dynamic from 'next/dynamic'
 import {
@@ -96,7 +93,7 @@ import { QuoteSelectionPopover } from './quote-selection-popover'
 import { initializeRenderers } from './renderers/client'
 import type { ProcessedDocument } from './renderers/types'
 import type { SettingsTab } from './settings-modal'
-import type { Attachment, Chat } from './types'
+import type { Attachment } from './types'
 // Lazy-load modals that aren't shown on initial load
 const CloudSyncSetupModal = dynamic(
   () =>
@@ -676,75 +673,6 @@ export function ChatInterface({
     webSearchEnabled,
     piiCheckEnabled,
   })
-
-  const handleOpenSidebarAsChat = useCallback(async () => {
-    const snapshotMessages = sidebarChat.messages
-    if (snapshotMessages.length === 0) return
-
-    const useCloudStorage = isSignedIn || !isCloudSyncEnabled()
-    const newChatId = generateReverseId().id
-    const newChat: Chat = {
-      id: newChatId,
-      title: 'Untitled',
-      titleState: 'placeholder',
-      messages: snapshotMessages,
-      createdAt: new Date(),
-      isLocalOnly: !isCloudSyncEnabled(),
-      projectId: isProjectMode && activeProject ? activeProject.id : undefined,
-    }
-
-    setIsAskSidebarOpen(false)
-    sidebarChat.reset()
-
-    try {
-      if (useCloudStorage) {
-        await chatStorage.saveChatAndSync(newChat)
-      } else {
-        sessionChatStorage.saveChat(newChat)
-      }
-    } catch (error) {
-      logError('Failed to persist sidebar chat as full chat', error, {
-        component: 'ChatInterface',
-        action: 'handleOpenSidebarAsChat',
-      })
-    }
-
-    // Title generation from the seeded conversation (best effort, non-blocking).
-    const firstUser = snapshotMessages.find((m) => m.role === 'user')
-    const firstAssistant = snapshotMessages.find((m) => m.role === 'assistant')
-    if (firstUser && firstAssistant) {
-      generateTitle([
-        {
-          role: 'user',
-          content: firstUser.quote
-            ? `In reply to:\n${firstUser.quote}\n\n${firstUser.content}`
-            : firstUser.content,
-        },
-        { role: 'assistant', content: firstAssistant.content },
-      ])
-        .then((title) => {
-          if (title && title !== 'Untitled') {
-            updateChatTitle(newChatId, title)
-          }
-        })
-        .catch(() => {})
-    }
-
-    try {
-      await reloadChats()
-    } catch {
-      // non-fatal
-    }
-    handleChatSelect(newChatId)
-  }, [
-    sidebarChat,
-    isSignedIn,
-    isProjectMode,
-    activeProject,
-    reloadChats,
-    handleChatSelect,
-    updateChatTitle,
-  ])
 
   // Sync URL with current chat state
   useEffect(() => {
@@ -2430,15 +2358,14 @@ export function ChatInterface({
         isClient={isClient}
       />
 
-      {/* Ask Sidebar - ephemeral side conversation seeded from highlighted text.
-          Discarded on close or on the next "Ask" click. */}
+      {/* Ask Sidebar - ephemeral, context-aware side conversation seeded from
+          highlighted text. Discarded on close or on the next "Ask" click. */}
       <AskSidebar
         isOpen={isAskSidebarOpen}
         onClose={() => {
           setIsAskSidebarOpen(false)
           sidebarChat.reset()
         }}
-        onOpenAsChat={handleOpenSidebarAsChat}
         state={sidebarChat}
         models={models}
         selectedModel={selectedModel}
@@ -2560,7 +2487,11 @@ export function ChatInterface({
                 setIsSidebarOpen(false)
               }
               setIsAskSidebarOpen(true)
-              sidebarChat.askQuote(text)
+              // Hand the current chat transcript to the sidebar so the model
+              // can reason about the highlighted snippet in context. The
+              // transcript is sent as a hidden user message; only the quote
+              // and assistant reply are shown in the sidebar UI.
+              sidebarChat.askQuote(text, currentChat?.messages ?? [])
             }}
           />
           <div

--- a/src/components/chat/hooks/use-sidebar-chat.ts
+++ b/src/components/chat/hooks/use-sidebar-chat.ts
@@ -41,7 +41,7 @@ export interface SidebarChatState {
 }
 
 interface UseSidebarChatReturn extends SidebarChatState {
-  askQuote: (quote: string) => void
+  askQuote: (quote: string, contextMessages?: Message[]) => void
   cancel: () => void
   reset: () => void
 }
@@ -49,6 +49,30 @@ interface UseSidebarChatReturn extends SidebarChatState {
 // A stable placeholder chat id used by the streaming processor. The id never
 // leaves this hook — nothing is saved under it.
 const EPHEMERAL_CHAT_ID = 'ask-sidebar-ephemeral'
+
+// Prompt prepended to the hidden user turn so the model understands that the
+// preceding transcript is the conversation the user highlighted from.
+const ASK_CONTEXT_INSTRUCTION =
+  'The following is the prior conversation the user was having. ' +
+  'They highlighted a snippet from it and want you to elaborate on, ' +
+  'clarify, or expand on that specific snippet. Use the conversation ' +
+  'above only as background context and focus your answer on the quoted ' +
+  'snippet in the user\u2019s next message.'
+
+// Render a Chat transcript as readable plain text for the hidden context turn.
+function serializeTranscript(messages: Message[]): string {
+  return messages
+    .filter((m) => m.role === 'user' || m.role === 'assistant')
+    .map((m) => {
+      const role = m.role === 'user' ? 'User' : 'Assistant'
+      const quotePrefix = m.quote
+        ? `[In reply to: ${m.quote.replace(/\s+/g, ' ').trim()}]\n`
+        : ''
+      const body = (m.content || '').trim()
+      return `${role}:\n${quotePrefix}${body}`.trim()
+    })
+    .join('\n\n')
+}
 
 export function useSidebarChat({
   systemPrompt,
@@ -100,7 +124,7 @@ export function useSidebarChat({
   }, [cancel])
 
   const askQuote = useCallback(
-    (quoteText: string) => {
+    (quoteText: string, contextMessages?: Message[]) => {
       if (!quoteText) return
 
       // Discard any in-flight stream and any previous sidebar conversation.
@@ -117,14 +141,34 @@ export function useSidebarChat({
         return
       }
 
-      const userMessage: Message = {
+      // Visible user message - shown in the sidebar UI. Content is empty so
+      // the default renderer only shows the quoted block.
+      const visibleUserMessage: Message = {
         role: 'user',
         content: '',
         quote: quoteText,
         timestamp: new Date(),
       }
-      const updatedMessages: Message[] = [userMessage]
-      setMessages(updatedMessages)
+      setMessages([visibleUserMessage])
+
+      // Hidden context message sent to the model but never shown in the UI.
+      // It carries the parent conversation transcript and tells the model to
+      // focus on the quote in the next user message.
+      const transcript = contextMessages?.length
+        ? serializeTranscript(contextMessages)
+        : ''
+      const hiddenContextMessage: Message | null = transcript
+        ? {
+            role: 'user',
+            content: `${ASK_CONTEXT_INSTRUCTION}\n\n----- Prior conversation -----\n${transcript}\n----- End of conversation -----`,
+            timestamp: new Date(),
+          }
+        : null
+
+      // What we actually send to the model.
+      const apiMessages: Message[] = hiddenContextMessage
+        ? [hiddenContextMessage, visibleUserMessage]
+        : [visibleUserMessage]
 
       const controller = new AbortController()
       abortControllerRef.current = controller
@@ -133,8 +177,10 @@ export function useSidebarChat({
       setIsStreaming(true)
 
       // In-memory shim for updateChatWithHistoryCheck. The streaming processor
-      // expects (setChats, chatSnapshot, setCurrentChat, chatId, newMessages).
-      // We map that onto our single messages state.
+      // calls this with `[...apiMessages, currentAssistantMessage]`. The UI
+      // must only show the visible user message plus the assistant reply, so
+      // we drop the hidden prefix and keep the tail.
+      const hiddenPrefixLength = hiddenContextMessage ? 1 : 0
       const inMemoryUpdate = (
         _setChats: unknown,
         _chatSnapshot: unknown,
@@ -142,14 +188,14 @@ export function useSidebarChat({
         _chatId: string,
         newMessages: Message[],
       ) => {
-        setMessages(newMessages)
+        setMessages(newMessages.slice(hiddenPrefixLength))
       }
 
       // Minimal Chat-shaped object; only id is really used by the processor.
       const ephemeralChat = {
         id: EPHEMERAL_CHAT_ID,
         title: '',
-        messages: updatedMessages,
+        messages: apiMessages,
         createdAt: new Date(),
       }
 
@@ -163,7 +209,7 @@ export function useSidebarChat({
               setLoadingState('retrying')
               setRetryInfo({ attempt, maxRetries: max, error })
             },
-            updatedMessages,
+            updatedMessages: apiMessages,
             maxMessages,
             signal: controller.signal,
             reasoningEffort,
@@ -174,7 +220,7 @@ export function useSidebarChat({
           isStreamingRef.current = true
           const assistantMessage = await processStreamingResponse(response, {
             updatedChat: ephemeralChat as never,
-            updatedMessages,
+            updatedMessages: apiMessages,
             isFirstMessage: true,
             modelsLength: models.length,
             currentChatIdRef,
@@ -192,7 +238,8 @@ export function useSidebarChat({
           })
 
           if (assistantMessage && abortControllerRef.current === controller) {
-            setMessages([...updatedMessages, assistantMessage])
+            // Only the visible messages go into the UI state.
+            setMessages([visibleUserMessage, assistantMessage])
           }
         } catch (error) {
           if (error instanceof DOMException && error.name === 'AbortError') {
@@ -209,7 +256,7 @@ export function useSidebarChat({
           const errMsg =
             error instanceof Error ? error.message : 'Unknown error'
           setMessages([
-            ...updatedMessages,
+            visibleUserMessage,
             {
               role: 'assistant',
               content: `Error: ${errMsg}`,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
The Ask sidebar now uses the full conversation as hidden context for better answers and lets you quote text from the sidebar back into the main chat input. The “Open as chat” action is removed; quoting is now the handoff path.

- **New Features**
  - Sidebar requests include the current chat transcript as a hidden user turn; the UI still shows only the quoted snippet and the assistant reply.
  - You can highlight text inside the sidebar and “Quote” it into the main input; the sidebar closes and focus moves to the input.

- **Refactors**
  - Removed the “Open as chat” flow and related persistence/title-generation code; the sidebar remains ephemeral.
  - `askQuote` now accepts optional context messages; `AskSidebar` supports an `onQuote` callback and integrates `QuoteSelectionPopover`.

<sup>Written for commit 4a1ba5f5a1a92ef521a13a78adf3e736459647af. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

