### PR TITLE
Improve error UI and PDF rendering

### DIFF
--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -33,6 +33,7 @@ import {
   RateLimitBanner,
   shouldShowRateLimitBanner,
 } from '@/components/chat/rate-limit-banner'
+import { StreamErrorBanner } from '@/components/chat/stream-error-banner'
 import {
   ProjectModeBanner,
   ProjectSidebar,
@@ -617,6 +618,8 @@ export function ChatInterface({
     verificationSuccess,
     isWaitingForResponse,
     isStreaming,
+    streamError,
+    dismissStreamError,
     selectedModel,
     hasValidatedModel,
     expandedLabel,
@@ -2506,43 +2509,52 @@ export function ChatInterface({
               sidebarChat.askQuote(text, currentChat?.messages ?? [])
             }}
           />
-          <div
-            ref={scrollContainerRef}
-            onScroll={handleScroll}
-            data-scroll-container="main"
-            className="relative flex flex-1 overflow-y-auto bg-surface-chat-background"
-          >
-            <div className="flex min-w-0 flex-1 [container-type:inline-size]">
-              <ChatMessages
-                messages={currentChat?.messages || []}
+          <div className="relative flex min-h-0 flex-1">
+            {streamError && (
+              <StreamErrorBanner
+                message={streamError}
+                onDismiss={dismissStreamError}
                 isDarkMode={isDarkMode}
-                chatId={currentChat.id}
-                isWaitingForResponse={isWaitingForResponse}
-                isStreamingResponse={isStreaming}
-                isPremium={isPremium}
-                models={models}
-                onSubmit={handleSubmit}
-                input={input}
-                setInput={setInput}
-                loadingState={loadingState}
-                retryInfo={retryInfo}
-                cancelGeneration={cancelGeneration}
-                inputRef={inputRef}
-                handleInputFocus={handleInputFocus}
-                handleDocumentUpload={handleFileUpload}
-                processedDocuments={processedDocuments}
-                removeDocument={removeDocument}
-                selectedModel={selectedModel}
-                handleModelSelect={handleModelSelect}
-                expandedLabel={expandedLabel}
-                handleLabelClick={handleLabelClick}
-                onEditMessage={editMessage}
-                onRegenerateMessage={regenerateMessage}
-                showScrollButton={showScrollButton}
-                webSearchEnabled={webSearchEnabled}
-                onWebSearchToggle={() => setWebSearchEnabled((prev) => !prev)}
-                onOpenVerifier={() => setIsVerifierSidebarOpen(true)}
               />
+            )}
+            <div
+              ref={scrollContainerRef}
+              onScroll={handleScroll}
+              data-scroll-container="main"
+              className="relative flex flex-1 overflow-y-auto bg-surface-chat-background"
+            >
+              <div className="flex min-w-0 flex-1 [container-type:inline-size]">
+                <ChatMessages
+                  messages={currentChat?.messages || []}
+                  isDarkMode={isDarkMode}
+                  chatId={currentChat.id}
+                  isWaitingForResponse={isWaitingForResponse}
+                  isStreamingResponse={isStreaming}
+                  isPremium={isPremium}
+                  models={models}
+                  onSubmit={handleSubmit}
+                  input={input}
+                  setInput={setInput}
+                  loadingState={loadingState}
+                  retryInfo={retryInfo}
+                  cancelGeneration={cancelGeneration}
+                  inputRef={inputRef}
+                  handleInputFocus={handleInputFocus}
+                  handleDocumentUpload={handleFileUpload}
+                  processedDocuments={processedDocuments}
+                  removeDocument={removeDocument}
+                  selectedModel={selectedModel}
+                  handleModelSelect={handleModelSelect}
+                  expandedLabel={expandedLabel}
+                  handleLabelClick={handleLabelClick}
+                  onEditMessage={editMessage}
+                  onRegenerateMessage={regenerateMessage}
+                  showScrollButton={showScrollButton}
+                  webSearchEnabled={webSearchEnabled}
+                  onWebSearchToggle={() => setWebSearchEnabled((prev) => !prev)}
+                  onOpenVerifier={() => setIsVerifierSidebarOpen(true)}
+                />
+              </div>
             </div>
           </div>
 

--- a/src/components/chat/hooks/use-chat-messaging.ts
+++ b/src/components/chat/hooks/use-chat-messaging.ts
@@ -62,6 +62,8 @@ interface UseChatMessagingReturn {
   isThinking: boolean
   isWaitingForResponse: boolean
   isStreaming: boolean
+  streamError: string | null
+  dismissStreamError: () => void
   setInput: (input: string) => void
   handleSubmit: (e: React.FormEvent) => void
   handleQuery: (
@@ -108,6 +110,11 @@ export function useChatMessaging({
   const [isThinking, setIsThinking] = useState(false)
   const [isWaitingForResponse, setIsWaitingForResponse] = useState(false)
   const [isStreaming, setIsStreaming] = useState(false)
+  const [streamError, setStreamError] = useState<string | null>(null)
+
+  const dismissStreamError = useCallback(() => {
+    setStreamError(null)
+  }, [])
 
   const inputRef = useRef<HTMLTextAreaElement>(null)
   const currentChatIdRef = useRef<string>(currentChat?.id || '')
@@ -259,6 +266,7 @@ export function useChatMessaging({
       setLoadingState('loading')
       setIsWaitingForResponse(true)
       setIsStreaming(true)
+      setStreamError(null)
 
       // Only create a user message if there's actual query content
       // When using system prompt override with empty query, skip user message
@@ -678,24 +686,29 @@ export function useChatMessaging({
             lowerMsg.includes('request limit') ||
             lowerMsg.includes('insufficient_quota')
 
-          const errorMessage: Message = {
-            role: 'assistant',
-            content: `Error: ${errorMsg}`,
-            timestamp: new Date(),
-            isError: true,
-            isRateLimitError,
-          }
+          if (isRateLimitError) {
+            const errorMessage: Message = {
+              role: 'assistant',
+              content: `Error: ${errorMsg}`,
+              timestamp: new Date(),
+              isError: true,
+              isRateLimitError: true,
+            }
 
-          // Use the current chat ID from ref which has the correct (possibly server) ID
-          const currentId = currentChatIdRef.current || updatedChat.id
-          updateChatWithHistoryCheck(
-            setChats,
-            { ...updatedChat, id: currentId, pendingSave: false },
-            setCurrentChat,
-            currentId,
-            [...updatedMessages, errorMessage],
-            false,
-          )
+            // Use the current chat ID from ref which has the correct (possibly server) ID
+            const currentId = currentChatIdRef.current || updatedChat.id
+            updateChatWithHistoryCheck(
+              setChats,
+              { ...updatedChat, id: currentId, pendingSave: false },
+              setCurrentChat,
+              currentId,
+              [...updatedMessages, errorMessage],
+              false,
+            )
+          } else {
+            // Surface as a dismissable floating banner instead of a chat message
+            setStreamError(errorMsg)
+          }
         }
       } finally {
         // Refresh rate limit from server for free-tier users so the
@@ -797,6 +810,8 @@ export function useChatMessaging({
     isThinking,
     isWaitingForResponse,
     isStreaming,
+    streamError,
+    dismissStreamError,
     setInput,
     handleSubmit,
     handleQuery,

--- a/src/components/chat/hooks/use-chat-state.ts
+++ b/src/components/chat/hooks/use-chat-state.ts
@@ -27,6 +27,8 @@ interface UseChatStateReturn {
   verificationSuccess: boolean
   isWaitingForResponse: boolean
   isStreaming: boolean
+  streamError: string | null
+  dismissStreamError: () => void
   selectedModel: AIModel
   hasValidatedModel: boolean
   expandedLabel: LabelType
@@ -168,6 +170,8 @@ export function useChatState({
     isThinking,
     isWaitingForResponse,
     isStreaming,
+    streamError,
+    dismissStreamError,
     setInput,
     handleSubmit,
     handleQuery,
@@ -277,6 +281,8 @@ export function useChatState({
     verificationSuccess,
     isWaitingForResponse,
     isStreaming,
+    streamError,
+    dismissStreamError,
     selectedModel,
     hasValidatedModel,
     expandedLabel,

--- a/src/components/chat/renderers/default/DefaultMessageRenderer.tsx
+++ b/src/components/chat/renderers/default/DefaultMessageRenderer.tsx
@@ -304,9 +304,6 @@ const DefaultMessageComponent = ({
                   isUser ? 'max-w-[95%]' : 'w-full',
                   isUser &&
                     'rounded-2xl bg-surface-message-user/90 px-4 py-2 shadow-sm backdrop-blur-sm',
-                  message.isError &&
-                    !message.isRateLimitError &&
-                    'rounded-lg border-2 border-red-500/30 bg-red-500/5 px-4 py-3',
                   message.isRateLimitError &&
                     'rounded-lg border-2 border-brand-accent-dark/30 bg-brand-accent-dark/5 px-4 py-3',
                 )}
@@ -333,27 +330,6 @@ const DefaultMessageComponent = ({
                     </button>
                   </div>
                 )}
-                {message.isError && !message.isRateLimitError && (
-                  <div className="mb-3 flex items-center gap-2 border-b border-red-500/20 pb-2">
-                    <svg
-                      className="h-5 w-5 flex-shrink-0 text-red-500"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke="currentColor"
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth={2}
-                        d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
-                      />
-                    </svg>
-                    <span className="font-semibold text-red-500">
-                      Error occurred
-                    </span>
-                  </div>
-                )}
-
                 {!message.isRateLimitError && (
                   <>
                     <div className="relative">

--- a/src/components/chat/stream-error-banner.tsx
+++ b/src/components/chat/stream-error-banner.tsx
@@ -1,0 +1,99 @@
+'use client'
+
+import { cn } from '@/components/ui/utils'
+import { ChevronDownIcon, XMarkIcon } from '@heroicons/react/24/outline'
+import { useState } from 'react'
+
+interface StreamErrorBannerProps {
+  message: string
+  onDismiss: () => void
+  isDarkMode: boolean
+}
+
+const DEFAULT_ERROR_TITLE = 'Something went wrong'
+
+// Extract a short, human-friendly title from the raw error message while
+// keeping the full text available for the expanded view.
+function getErrorTitle(message: string): string {
+  const cleaned = message.replace(/^Error:\s*/i, '').trim()
+  if (!cleaned) return DEFAULT_ERROR_TITLE
+  const firstLine = cleaned.split('\n')[0]
+  const firstSentence = firstLine.split(/(?<=[.!?])\s/)[0]
+  return firstSentence.length > 120
+    ? `${firstSentence.slice(0, 117)}...`
+    : firstSentence
+}
+
+export function StreamErrorBanner({
+  message,
+  onDismiss,
+  isDarkMode,
+}: StreamErrorBannerProps) {
+  const [isExpanded, setIsExpanded] = useState(false)
+  const title = getErrorTitle(message)
+
+  const toggleExpanded = () => setIsExpanded((prev) => !prev)
+
+  const handleDismiss = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    onDismiss()
+  }
+
+  return (
+    <div className="pointer-events-none absolute left-0 right-0 top-2 z-10 flex w-full justify-center px-4">
+      <div
+        className={cn(
+          'pointer-events-auto w-full max-w-xl cursor-pointer overflow-hidden rounded-lg border shadow-lg backdrop-blur-sm transition-colors',
+          isDarkMode
+            ? 'border-red-500/40 bg-red-950/60 text-red-200'
+            : 'border-red-300 bg-red-50 text-red-700',
+        )}
+        role="button"
+        onClick={toggleExpanded}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault()
+            toggleExpanded()
+          }
+        }}
+        tabIndex={0}
+        aria-expanded={isExpanded}
+        aria-label={
+          isExpanded ? 'Collapse error details' : 'Expand error details'
+        }
+      >
+        <div className="flex items-center gap-2 px-3 py-2">
+          <ChevronDownIcon
+            className={cn(
+              'h-4 w-4 flex-shrink-0 transition-transform',
+              isExpanded && 'rotate-180',
+            )}
+            aria-hidden="true"
+          />
+          <span className="flex-1 truncate text-sm font-semibold">{title}</span>
+          <button
+            type="button"
+            onClick={handleDismiss}
+            aria-label="Dismiss error"
+            className={cn(
+              'rounded p-1 transition-colors',
+              isDarkMode ? 'hover:bg-red-500/20' : 'hover:bg-red-500/10',
+            )}
+          >
+            <XMarkIcon className="h-4 w-4" />
+          </button>
+        </div>
+        {isExpanded && (
+          <div
+            className={cn(
+              'border-t px-3 py-2 text-sm',
+              isDarkMode ? 'border-red-500/30' : 'border-red-300',
+            )}
+          >
+            <p className="whitespace-pre-wrap break-words">{message}</p>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/code-block.tsx
+++ b/src/components/code-block.tsx
@@ -1019,7 +1019,19 @@ export const CodeBlock = memo(function CodeBlock({
           margin: [10, 10, 10, 10],
           filename: 'document.pdf',
           image: { type: 'jpeg', quality: 0.98 },
-          html2canvas: { scale: 2 },
+          html2canvas: {
+            scale: 2,
+            backgroundColor: '#ffffff',
+            onclone: (clonedDoc: Document) => {
+              // Strip class-based dark mode so the PDF always renders with
+              // light-theme colors (prevents white text on white background).
+              clonedDoc.documentElement.classList.remove('dark')
+              clonedDoc.body.classList.remove('dark')
+              clonedDoc
+                .querySelectorAll('.dark')
+                .forEach((el) => el.classList.remove('dark'))
+            },
+          },
           jsPDF: { unit: 'mm', format: 'a4', orientation: 'portrait' },
         })
         .from(markdownRef.current)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Show non–rate limit stream errors as a dismissible floating banner and fix dark-mode PDF exports. Improves chat UX and ensures readable PDFs.

- **New Features**
  - Added `StreamErrorBanner` shown at the top of the chat for non–rate limit errors; expandable details and dismiss button.
  - Kept rate limit errors as inline chat messages.
  - Exposed `streamError` and `dismissStreamError` from `useChatMessaging` and wired them into `ChatInterface`; removed generic error UI from `DefaultMessageRenderer`.

- **Bug Fixes**
  - Forced light theme during PDF export by removing `dark` classes in `html2canvas.onclone` and setting a white background, preventing white text on white pages.

<sup>Written for commit 1f51fafb4ab746d34e43b9036cd18cc46e7f3b90. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

