### PR TITLE
fix: render PDF exports in a detached light-mode clone with Helvetica

### DIFF
--- a/src/components/code-block.tsx
+++ b/src/components/code-block.tsx
@@ -1004,13 +1004,51 @@ export const CodeBlock = memo(function CodeBlock({
 
     setIsGeneratingPdf(true)
 
-    // Temporarily remove overflow clipping so html2canvas captures full table width
-    const overflowElements = markdownRef.current.querySelectorAll(
-      '.overflow-x-auto',
-    ) as NodeListOf<HTMLElement>
-    overflowElements.forEach((el) => {
-      el.style.overflow = 'visible'
-    })
+    // html2pdf internally clones the target and reparents it under document.body
+    // while the live <html> still carries the `dark` class, so Tailwind's
+    // `dark:` rules (e.g. `dark:prose-invert`) keep resolving and the PDF comes
+    // out with white-on-white text. To avoid that (and to pin the font to
+    // Helvetica) we clone the preview ourselves into a detached, off-screen
+    // wrapper, stamp inline styles that override the theme, and hand that clone
+    // to html2pdf instead of the live node.
+    const originalEl = markdownRef.current
+    const wrapper = document.createElement('div')
+    wrapper.style.position = 'fixed'
+    wrapper.style.top = '-10000px'
+    wrapper.style.left = '0'
+    wrapper.style.width = `${originalEl.scrollWidth}px`
+    wrapper.style.backgroundColor = '#ffffff'
+    wrapper.style.color = '#000000'
+    wrapper.style.padding = '0'
+    // Detach from any dark-mode ancestor so `:where(.dark *)` selectors miss.
+    wrapper.className = ''
+
+    const clone = originalEl.cloneNode(true) as HTMLElement
+    wrapper.appendChild(clone)
+    document.body.appendChild(wrapper)
+
+    // Remove overflow clipping inside the clone so wide tables capture fully.
+    clone
+      .querySelectorAll<HTMLElement>('.overflow-x-auto')
+      .forEach((el) => (el.style.overflow = 'visible'))
+
+    // Force a light palette + Helvetica on the clone via inline styles, which
+    // override any theme-driven class rules inherited from the stylesheet.
+    const PDF_FONT_FAMILY = 'Helvetica, Arial, sans-serif'
+    const PDF_MONO_FAMILY = 'ui-monospace, Menlo, Consolas, monospace'
+    const allEls: HTMLElement[] = [
+      clone,
+      ...Array.from(clone.querySelectorAll<HTMLElement>('*')),
+    ]
+    for (const el of allEls) {
+      const tag = el.tagName
+      const isMono =
+        tag === 'CODE' || tag === 'PRE' || tag === 'KBD' || tag === 'SAMP'
+      el.style.fontFamily = isMono ? PDF_MONO_FAMILY : PDF_FONT_FAMILY
+      el.style.color = tag === 'A' ? '#1d4ed8' : '#000000'
+      el.style.backgroundColor = el === clone ? '#ffffff' : 'transparent'
+      el.style.borderColor = '#e5e7eb'
+    }
 
     try {
       const html2pdf = (await import('html2pdf.js')).default
@@ -1022,27 +1060,15 @@ export const CodeBlock = memo(function CodeBlock({
           html2canvas: {
             scale: 2,
             backgroundColor: '#ffffff',
-            onclone: (clonedDoc: Document) => {
-              // Strip class-based dark mode so the PDF always renders with
-              // light-theme colors (prevents white text on white background).
-              clonedDoc.documentElement.classList.remove('dark')
-              clonedDoc.body.classList.remove('dark')
-              clonedDoc
-                .querySelectorAll('.dark')
-                .forEach((el) => el.classList.remove('dark'))
-            },
           },
           jsPDF: { unit: 'mm', format: 'a4', orientation: 'portrait' },
         })
-        .from(markdownRef.current)
+        .from(clone)
         .save()
     } catch {
       toast({ title: 'Failed to generate PDF', variant: 'destructive' })
     } finally {
-      // Restore overflow for UI scrolling
-      overflowElements.forEach((el) => {
-        el.style.overflow = ''
-      })
+      wrapper.remove()
       setIsGeneratingPdf(false)
     }
   }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes dark-mode PDFs by rendering from a detached, light-mode clone and standardizing fonts to Helvetica for consistent, readable exports. PDFs now use correct colors and typography.

- **Bug Fixes**
  - Clone the markdown preview into an off-screen wrapper and render from it to avoid `dark:` Tailwind rules.
  - Inline light palette colors and set fonts: body `Helvetica, Arial, sans-serif`; code uses a monospace stack.
  - Remove `.overflow-x-auto` clipping in the clone so wide tables are captured.
  - Pass the clone to `html2pdf.js` and remove the wrapper after save; drops the previous `onclone` dark-mode stripping.

<sup>Written for commit 3ab54b7388db2dfd1755cf7f477980b4cab42dca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

