### PR TITLE
Fix PDF export in light mode

### DIFF
--- a/src/components/code-block.tsx
+++ b/src/components/code-block.tsx
@@ -1,4 +1,5 @@
 import { toast } from '@/hooks/use-toast'
+import { downloadMarkdownAsPdf } from '@/utils/markdown-pdf-export'
 import DOMPurify from 'isomorphic-dompurify'
 import { memo, useEffect, useId, useMemo, useRef, useState } from 'react'
 import { BsFiletypeMd, BsFiletypePdf } from 'react-icons/bs'
@@ -1003,72 +1004,11 @@ export const CodeBlock = memo(function CodeBlock({
     if (!markdownRef.current || isGeneratingPdf) return
 
     setIsGeneratingPdf(true)
-
-    // html2pdf internally clones the target and reparents it under document.body
-    // while the live <html> still carries the `dark` class, so Tailwind's
-    // `dark:` rules (e.g. `dark:prose-invert`) keep resolving and the PDF comes
-    // out with white-on-white text. To avoid that (and to pin the font to
-    // Helvetica) we clone the preview ourselves into a detached, off-screen
-    // wrapper, stamp inline styles that override the theme, and hand that clone
-    // to html2pdf instead of the live node.
-    const originalEl = markdownRef.current
-    const wrapper = document.createElement('div')
-    wrapper.style.position = 'fixed'
-    wrapper.style.top = '-10000px'
-    wrapper.style.left = '0'
-    wrapper.style.width = `${originalEl.scrollWidth}px`
-    wrapper.style.backgroundColor = '#ffffff'
-    wrapper.style.color = '#000000'
-    wrapper.style.padding = '0'
-    // Detach from any dark-mode ancestor so `:where(.dark *)` selectors miss.
-    wrapper.className = ''
-
-    const clone = originalEl.cloneNode(true) as HTMLElement
-    wrapper.appendChild(clone)
-    document.body.appendChild(wrapper)
-
-    // Remove overflow clipping inside the clone so wide tables capture fully.
-    clone
-      .querySelectorAll<HTMLElement>('.overflow-x-auto')
-      .forEach((el) => (el.style.overflow = 'visible'))
-
-    // Force a light palette + Helvetica on the clone via inline styles, which
-    // override any theme-driven class rules inherited from the stylesheet.
-    const PDF_FONT_FAMILY = 'Helvetica, Arial, sans-serif'
-    const PDF_MONO_FAMILY = 'ui-monospace, Menlo, Consolas, monospace'
-    const allEls: HTMLElement[] = [
-      clone,
-      ...Array.from(clone.querySelectorAll<HTMLElement>('*')),
-    ]
-    for (const el of allEls) {
-      const tag = el.tagName
-      const isMono =
-        tag === 'CODE' || tag === 'PRE' || tag === 'KBD' || tag === 'SAMP'
-      el.style.fontFamily = isMono ? PDF_MONO_FAMILY : PDF_FONT_FAMILY
-      el.style.color = tag === 'A' ? '#1d4ed8' : '#000000'
-      el.style.backgroundColor = el === clone ? '#ffffff' : 'transparent'
-      el.style.borderColor = '#e5e7eb'
-    }
-
     try {
-      const html2pdf = (await import('html2pdf.js')).default
-      await html2pdf()
-        .set({
-          margin: [10, 10, 10, 10],
-          filename: 'document.pdf',
-          image: { type: 'jpeg', quality: 0.98 },
-          html2canvas: {
-            scale: 2,
-            backgroundColor: '#ffffff',
-          },
-          jsPDF: { unit: 'mm', format: 'a4', orientation: 'portrait' },
-        })
-        .from(clone)
-        .save()
+      await downloadMarkdownAsPdf(markdownRef.current)
     } catch {
       toast({ title: 'Failed to generate PDF', variant: 'destructive' })
     } finally {
-      wrapper.remove()
       setIsGeneratingPdf(false)
     }
   }

--- a/src/utils/markdown-pdf-export.ts
+++ b/src/utils/markdown-pdf-export.ts
@@ -1,0 +1,185 @@
+/**
+ * Exports a rendered markdown subtree as a PDF with a forced light theme.
+ *
+ * Why this exists:
+ *   The markdown preview uses the Tailwind Typography plugin (`prose`) and a
+ *   pile of app-specific rules in `globals.css` that colour everything via
+ *   `color: hsl(var(--content-primary)) !important`. In dark mode
+ *   `--content-primary` resolves to near-white, so a naive capture produces a
+ *   PDF with ghost-white text on a white background.
+ *
+ *   Rather than fighting every rule individually, we clone the subtree and
+ *   override the handful of CSS custom properties those rules actually read.
+ *   Everything else (prose spacing, heading scale, list indentation, code
+ *   block chrome, etc.) continues to render exactly as on screen.
+ *
+ * Guarantees:
+ *   - Body text resolves dark on a white background.
+ *   - Fonts are pinned to Helvetica (body) and a monospace stack (code).
+ *   - The live preview is not mutated.
+ */
+
+// Light-theme HSL triplets (H S% L%) for the theme tokens that drive text and
+// surface colours in the markdown preview. These mirror the `:root` values in
+// `src/styles/tailwind.css`.
+const LIGHT_THEME_TOKENS: Record<string, string> = {
+  '--content-primary': '221 39.3% 11%',
+  '--content-secondary': '221 20% 20%',
+  '--content-muted': '221 14% 34%',
+  '--content-inverse': '0 0% 100%',
+  '--border-subtle': '220 13% 91%',
+  '--border-strong': '217 19.1% 26.7%',
+  '--muted': '220 14% 95%',
+  '--surface-chat-background': '0 0% 100%',
+  '--surface-card': '0 0% 100%',
+  '--surface-input': '220 14% 95%',
+}
+
+const PDF_BODY_FONT = 'Helvetica, Arial, sans-serif'
+const PDF_MONO_FONT = 'ui-monospace, Menlo, Consolas, monospace'
+
+const MONO_TAGS = new Set(['CODE', 'PRE', 'KBD', 'SAMP'])
+const LAYOUT_SETTLE_MS = 30
+
+type PdfMargin = number | [number, number] | [number, number, number, number]
+
+type Html2PdfOptions = {
+  filename?: string
+  margin?: PdfMargin
+}
+
+/**
+ * Render `source` into a PDF file and trigger a download.
+ *
+ * The source element must be attached to the live DOM (so we can measure its
+ * intrinsic width). Its classes, content, and inline styles are preserved in
+ * an off-screen clone; only a small number of theme-related CSS variables are
+ * overridden so the clone always renders in light mode.
+ */
+export async function downloadMarkdownAsPdf(
+  source: HTMLElement,
+  {
+    filename = 'document.pdf',
+    margin = [10, 10, 10, 10],
+  }: Html2PdfOptions = {},
+): Promise<void> {
+  const wrapper = createLightThemeWrapper(source.scrollWidth)
+  const clone = source.cloneNode(true) as HTMLElement
+
+  applyLightThemeTokens(clone)
+  applyPdfFonts(clone)
+  expandOverflowingContainers(clone)
+
+  wrapper.appendChild(clone)
+  document.body.appendChild(wrapper)
+
+  try {
+    // Let layout settle (fonts, images, etc.) before html2canvas measures.
+    await new Promise((resolve) => setTimeout(resolve, LAYOUT_SETTLE_MS))
+
+    const html2pdf = (await import('html2pdf.js')).default
+    // Keep block-level elements intact across page boundaries so headings,
+    // paragraphs, list items, tables, and code blocks aren't sliced in half.
+    // `pagebreak` is a real html2pdf option but its published TS typings omit
+    // it, hence the cast below.
+    const opts = {
+      margin,
+      filename,
+      image: { type: 'jpeg', quality: 0.98 },
+      html2canvas: { scale: 2, backgroundColor: '#ffffff' },
+      jsPDF: { unit: 'mm', format: 'a4', orientation: 'portrait' },
+      pagebreak: {
+        mode: ['css', 'legacy'],
+        avoid: [
+          'h1',
+          'h2',
+          'h3',
+          'h4',
+          'h5',
+          'h6',
+          'p',
+          'li',
+          'tr',
+          'thead',
+          'blockquote',
+          'pre',
+          'img',
+          'figure',
+        ],
+      },
+    }
+    const pdfUrl = await (
+      html2pdf() as unknown as {
+        set: (opts: unknown) => {
+          from: (el: HTMLElement) => {
+            output: (type: 'bloburl') => Promise<string>
+          }
+        }
+      }
+    )
+      .set(opts)
+      .from(clone)
+      .output('bloburl')
+    window.open(pdfUrl, '_blank', 'noopener,noreferrer')
+  } finally {
+    wrapper.remove()
+  }
+}
+
+function createLightThemeWrapper(sourceWidth: number): HTMLDivElement {
+  const wrapper = document.createElement('div')
+  wrapper.setAttribute('aria-hidden', 'true')
+
+  const style = wrapper.style
+  style.setProperty('position', 'fixed', 'important')
+  style.setProperty('top', '-10000px', 'important')
+  style.setProperty('left', '0', 'important')
+  style.setProperty('width', `${Math.max(sourceWidth, 800)}px`, 'important')
+  style.setProperty('padding', '16px', 'important')
+  style.setProperty('background-color', '#ffffff', 'important')
+  style.setProperty('color-scheme', 'light', 'important')
+
+  // Pin every theme token that app CSS resolves via `hsl(var(--...))`. Because
+  // these are inline on the wrapper with !important, they win over both the
+  // `:root` defaults and the `.dark { ... }` overrides on `<html>`, for
+  // everything inside the wrapper.
+  for (const [name, value] of Object.entries(LIGHT_THEME_TOKENS)) {
+    style.setProperty(name, value, 'important')
+  }
+
+  return wrapper
+}
+
+function applyLightThemeTokens(clone: HTMLElement): void {
+  // Re-apply on the clone itself as well so CSS rules that specifically match
+  // the `.prose` root (e.g. `.prose { color: hsl(var(--content-primary)) }`)
+  // pick up the light palette even when the rule's selector doesn't see the
+  // wrapper.
+  for (const [name, value] of Object.entries(LIGHT_THEME_TOKENS)) {
+    clone.style.setProperty(name, value, 'important')
+  }
+}
+
+function applyPdfFonts(clone: HTMLElement): void {
+  const elements: HTMLElement[] = [
+    clone,
+    ...Array.from(clone.querySelectorAll<HTMLElement>('*')),
+  ]
+  for (const el of elements) {
+    const isMono = MONO_TAGS.has(el.tagName)
+    el.style.setProperty(
+      'font-family',
+      isMono ? PDF_MONO_FONT : PDF_BODY_FONT,
+      'important',
+    )
+  }
+}
+
+function expandOverflowingContainers(clone: HTMLElement): void {
+  // html2canvas captures the element's layout box, so overflow:auto/hidden
+  // regions get clipped. Force them visible on the clone so wide tables and
+  // code blocks render in full.
+  clone
+    .querySelectorAll<HTMLElement>('table, [style*="overflow"]')
+    .forEach((el) => el.style.setProperty('overflow', 'visible', 'important'))
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes unreadable PDFs in dark mode by exporting a forced light‑mode clone of the markdown preview. PDFs now show dark text on white with Helvetica, better page breaks, and open in a new tab for preview/save.

- **Bug Fixes**
  - Force light mode via theme CSS variables and `color-scheme: light` (no class stripping); keep `prose` spacing/scale.
  - Pin fonts (Helvetica for body, monospace for code).
  - Reduce clipping and bad splits: expand overflow, avoid breaking common block elements, and wait briefly before capture.
  - Open the generated PDF in a new tab instead of forcing an immediate download.

- **Refactors**
  - Extracted export logic to `src/utils/markdown-pdf-export.ts` as `downloadMarkdownAsPdf()` and used it in `code-block.tsx`.

<sup>Written for commit 86e657f656b355b40614bb679fdcd13e02a6f9df. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

