### PR TITLE
Better cloud sync prompting and passkey issue handling

### DIFF
--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -103,6 +103,20 @@ const CloudSyncSetupModal = dynamic(
     ),
   { ssr: false },
 )
+const PasskeySetupFailedModal = dynamic(
+  () =>
+    import('../modals/passkey-setup-failed-modal').then(
+      (m) => m.PasskeySetupFailedModal,
+    ),
+  { ssr: false },
+)
+const PasskeySetupPromptModal = dynamic(
+  () =>
+    import('../modals/passkey-setup-prompt-modal').then(
+      (m) => m.PasskeySetupPromptModal,
+    ),
+  { ssr: false },
+)
 const AddToProjectContextModal = dynamic(
   () =>
     import('../modals/add-to-project-context-modal').then(
@@ -345,10 +359,18 @@ export function ChatInterface({
     passkeyRecoveryNeeded,
     manualRecoveryNeeded,
     passkeySetupAvailable,
+    passkeySetupFailed,
+    passkeyFirstTimePromptAvailable,
     setupPasskey,
+    setupFirstTimePasskey,
+    showFirstTimePasskeyPrompt,
+    dismissFirstTimePasskeyPrompt,
     recoverWithPasskey,
     setupNewKeySplit,
     updatePasskeyBackup,
+    dismissPasskeySetupFailed,
+    skipPasskeyRecovery,
+    retryPasskeySetup,
   } = usePasskeyBackup({
     encryptionKey,
     initialized: cloudSyncInitialized && !showOnboarding,
@@ -402,15 +424,36 @@ export function ChatInterface({
 
   // State for cloud sync setup modal
   const [showCloudSyncSetupModal, setShowCloudSyncSetupModal] = useState(false)
+  // When the user falls back to manual backup from the passkey-setup-failed
+  // modal, we force the cloud sync setup modal onto the non-passkey path.
+  const [forceManualCloudSyncFlow, setForceManualCloudSyncFlow] =
+    useState(false)
+  // Tracks the in-flight first-time passkey setup call so the modal can
+  // disable its buttons while the native dialog is showing.
+  const [isFirstTimePasskeySetupBusy, setIsFirstTimePasskeySetupBusy] =
+    useState(false)
+  // Tracks an in-flight retry triggered from the setup-failed warning modal.
+  const [isRetryingPasskey, setIsRetryingPasskey] = useState(false)
+  // Bumped whenever we need CloudSyncSetupModal to remount (e.g. switching
+  // from passkey-recovery step to forced manual flow after the user dismisses
+  // the setup-failed warning). The modal derives initialStep from props only
+  // once, so a remount is required to pick up the new starting step.
+  const [cloudSyncSetupModalKey, setCloudSyncSetupModalKey] = useState(0)
 
   useEffect(() => {
-    // Only auto-open the recovery modal when the user actually has cloud sync
-    // turned on. Signed-in users with cloud sync disabled should not see it
-    // pop up on every load - they can still trigger it manually from settings.
+    // Passkey-based recovery always auto-opens: a remote passkey credential
+    // means the user *has* chats backed up and can't see them on this device
+    // until they unlock, regardless of whether the local sync toggle is on.
+    // Manual recovery still respects the sync toggle — if the user has
+    // explicitly disabled sync, we don't force a manual-key prompt.
+    if (passkeyRecoveryNeeded) {
+      setShowCloudSyncSetupModal(true)
+      return
+    }
     if (manualRecoveryNeeded && isCloudSyncEnabled()) {
       setShowCloudSyncSetupModal(true)
     }
-  }, [manualRecoveryNeeded])
+  }, [manualRecoveryNeeded, passkeyRecoveryNeeded])
 
   // State for add-to-project-context modal
   const [showAddToProjectModal, setShowAddToProjectModal] = useState(false)
@@ -1129,10 +1172,17 @@ export function ChatInterface({
     }
   }
 
-  // Handler for cloud sync setup
-  const handleOpenCloudSyncSetup = () => {
+  // Handler for cloud sync setup. Prefer the friendly "Back Up Your Chats"
+  // prompt for brand-new signed-in users so they don't get dropped into the
+  // raw key-generator UI; fall back to the manual cloud-sync setup modal
+  // otherwise (existing key, remote data, or PRF unsupported).
+  const handleOpenCloudSyncSetup = useCallback(async () => {
+    if (!encryptionService.getKey()) {
+      const routed = await showFirstTimePasskeyPrompt()
+      if (routed) return
+    }
     setShowCloudSyncSetupModal(true)
-  }
+  }, [showFirstTimePasskeyPrompt])
 
   const handleKeyChanged = useCallback(
     async (
@@ -2684,9 +2734,11 @@ export function ChatInterface({
       {/* Cloud Sync Setup Modal - manually triggered from settings */}
       {showCloudSyncSetupModal && (
         <CloudSyncSetupModal
+          key={cloudSyncSetupModalKey}
           isOpen={showCloudSyncSetupModal}
           onClose={() => {
             setShowCloudSyncSetupModal(false)
+            setForceManualCloudSyncFlow(false)
             // If no key was set, turn off cloud sync
             if (!encryptionService.getKey()) {
               setCloudSyncEnabled(false)
@@ -2696,6 +2748,7 @@ export function ChatInterface({
             try {
               await handleKeyChanged(key, { mode })
               setShowCloudSyncSetupModal(false)
+              setForceManualCloudSyncFlow(false)
               return true
             } catch {
               return false
@@ -2708,6 +2761,12 @@ export function ChatInterface({
           }
           passkeyRecoveryNeeded={passkeyRecoveryNeeded}
           manualRecoveryNeeded={manualRecoveryNeeded}
+          forceManualFlow={forceManualCloudSyncFlow}
+          onSkipRecovery={() => {
+            skipPasskeyRecovery()
+            setShowCloudSyncSetupModal(false)
+            setForceManualCloudSyncFlow(false)
+          }}
           onRecoverWithPasskey={async () => {
             const key = await recoverWithPasskey()
             if (!key) return false
@@ -2729,6 +2788,59 @@ export function ChatInterface({
             }
             setShowCloudSyncSetupModal(false)
             return true
+          }}
+        />
+      )}
+
+      {/* Passkey Setup Failed Warning - shown when the user's passkey
+          provider can't do PRF, so chats aren't being backed up. */}
+      {passkeySetupFailed && (
+        <PasskeySetupFailedModal
+          isOpen={passkeySetupFailed}
+          isRetryingPasskey={isRetryingPasskey}
+          onRetryPasskey={async () => {
+            setIsRetryingPasskey(true)
+            try {
+              await retryPasskeySetup()
+            } finally {
+              setIsRetryingPasskey(false)
+            }
+          }}
+          onEnableManualBackup={() => {
+            dismissPasskeySetupFailed()
+            setForceManualCloudSyncFlow(true)
+            // Force a remount so CloudSyncSetupModal picks up the new
+            // forceManualFlow prop in its initialStep calculation.
+            setCloudSyncSetupModalKey((k) => k + 1)
+            setShowCloudSyncSetupModal(true)
+          }}
+          onDismiss={() => {
+            dismissPasskeySetupFailed()
+            setCloudSyncEnabled(false)
+            // Also close any auto-opened recovery modal since the user has
+            // explicitly opted out of backups this session.
+            setShowCloudSyncSetupModal(false)
+          }}
+        />
+      )}
+
+      {/* First-time passkey setup confirmation - shown to brand-new users so
+          we never invoke the native WebAuthn dialog without an explicit click. */}
+      {passkeyFirstTimePromptAvailable && (
+        <PasskeySetupPromptModal
+          isOpen={passkeyFirstTimePromptAvailable}
+          isBusy={isFirstTimePasskeySetupBusy}
+          onEnable={async () => {
+            setIsFirstTimePasskeySetupBusy(true)
+            try {
+              await setupFirstTimePasskey()
+            } finally {
+              setIsFirstTimePasskeySetupBusy(false)
+            }
+          }}
+          onDismiss={() => {
+            dismissFirstTimePasskeyPrompt()
+            setCloudSyncEnabled(false)
           }}
         />
       )}

--- a/src/components/modals/cloud-sync-setup-modal.tsx
+++ b/src/components/modals/cloud-sync-setup-modal.tsx
@@ -40,6 +40,19 @@ interface CloudSyncSetupModalBaseProps {
   initialCloudSyncEnabled?: boolean
   prfSupported?: boolean
   manualRecoveryNeeded?: boolean
+  /**
+   * When true, the modal skips the passkey-based flow entirely and opens
+   * directly on the manual "generate or restore key" step. Used when the
+   * user's passkey provider doesn't support PRF and they opt into manual
+   * backup from the {@link PasskeySetupFailedModal} warning.
+   */
+  forceManualFlow?: boolean
+  /**
+   * Called when the user clicks "Skip for Now" on the passkey-recovery step.
+   * Lets the caller persist a "don't auto-reopen" flag. When omitted, the
+   * button falls back to plain {@link onClose}.
+   */
+  onSkipRecovery?: () => void
 }
 type CloudSyncSetupModalProps = CloudSyncSetupModalBaseProps &
   (
@@ -72,16 +85,20 @@ export function CloudSyncSetupModal({
   passkeyRecoveryNeeded = false,
   prfSupported = false,
   manualRecoveryNeeded = false,
+  forceManualFlow = false,
+  onSkipRecovery,
   onRecoverWithPasskey,
   onSetupNewKey,
 }: CloudSyncSetupModalProps) {
-  const initialStep: SetupStep = passkeyRecoveryNeeded
-    ? 'passkey-recovery'
-    : manualRecoveryNeeded
-      ? 'generate-or-restore'
-      : prfSupported
+  const initialStep: SetupStep = forceManualFlow
+    ? 'generate-or-restore'
+    : passkeyRecoveryNeeded
+      ? 'passkey-recovery'
+      : manualRecoveryNeeded
         ? 'generate-or-restore'
-        : 'intro'
+        : prfSupported
+          ? 'generate-or-restore'
+          : 'intro'
   const [currentStep, setCurrentStep] = useState<SetupStep>(initialStep)
   const [cloudSyncEnabled, setCloudSyncEnabled] = useState(
     initialCloudSyncEnabled,
@@ -805,7 +822,7 @@ ${generatedKey.replace('key_', '')}
       )}
 
       <button
-        onClick={onClose}
+        onClick={onSkipRecovery ?? onClose}
         disabled={isRecovering || isStartingFresh}
         className="w-full text-center text-sm text-content-muted transition-colors hover:text-content-secondary"
       >

--- a/src/components/modals/passkey-setup-failed-modal.tsx
+++ b/src/components/modals/passkey-setup-failed-modal.tsx
@@ -1,0 +1,144 @@
+import { Dialog, Transition } from '@headlessui/react'
+import {
+  ArrowPathIcon,
+  ChevronDownIcon,
+  ExclamationTriangleIcon,
+  KeyIcon,
+} from '@heroicons/react/24/outline'
+import { Fragment, useState } from 'react'
+
+interface PasskeySetupFailedModalProps {
+  isOpen: boolean
+  /** User chose to retry the passkey flow. */
+  onRetryPasskey: () => void
+  /** User chose to fall back to the manual encryption-key backup flow. */
+  onEnableManualBackup: () => void
+  /** User dismissed the warning and chose to continue without backups. */
+  onDismiss: () => void
+  /** Passkey retry is currently in-flight; disables the buttons. */
+  isRetryingPasskey?: boolean
+}
+
+export function PasskeySetupFailedModal({
+  isOpen,
+  onRetryPasskey,
+  onEnableManualBackup,
+  onDismiss,
+  isRetryingPasskey = false,
+}: PasskeySetupFailedModalProps) {
+  const [isDetailsExpanded, setIsDetailsExpanded] = useState(false)
+  return (
+    <Transition appear show={isOpen} as={Fragment}>
+      <Dialog as="div" className="relative z-50" onClose={() => {}}>
+        <Transition.Child
+          as={Fragment}
+          enter="ease-out duration-300"
+          enterFrom="opacity-0"
+          enterTo="opacity-100"
+          leave="ease-in duration-200"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <div className="fixed inset-0 bg-black/50" />
+        </Transition.Child>
+
+        <div className="fixed inset-0 overflow-y-auto">
+          <div className="flex min-h-full items-center justify-center p-4 text-center">
+            <Transition.Child
+              as={Fragment}
+              enter="ease-out duration-300"
+              enterFrom="opacity-0 scale-95"
+              enterTo="opacity-100 scale-100"
+              leave="ease-in duration-200"
+              leaveFrom="opacity-100 scale-100"
+              leaveTo="opacity-0 scale-95"
+            >
+              <Dialog.Panel className="w-full max-w-md transform overflow-hidden rounded-2xl border border-border-subtle bg-surface-card p-6 text-left align-middle shadow-xl transition-all">
+                <div className="flex items-center justify-center">
+                  <div className="rounded-full bg-amber-500/20 p-3">
+                    <ExclamationTriangleIcon className="h-8 w-8 text-amber-500" />
+                  </div>
+                </div>
+
+                <Dialog.Title
+                  as="h2"
+                  className="mt-4 text-center font-aeonik text-xl font-bold text-content-primary"
+                >
+                  Chats Are Not Being Backed Up
+                </Dialog.Title>
+
+                <div className="mt-4 space-y-3 text-sm text-content-secondary">
+                  <p>
+                    Tinfoil needs a passkey or a manually managed encryption key
+                    to back up your chats.
+                  </p>
+                  <p className="font-semibold text-content-primary">
+                    Your chats will only exist on this device.
+                  </p>
+
+                  <div className="rounded-lg border border-border-subtle">
+                    <button
+                      type="button"
+                      onClick={() => setIsDetailsExpanded((prev) => !prev)}
+                      aria-expanded={isDetailsExpanded}
+                      className="flex w-full items-center justify-between p-3 text-sm font-medium text-content-secondary transition-colors hover:bg-surface-chat/50"
+                    >
+                      <span>Why is this happening?</span>
+                      <ChevronDownIcon
+                        className={`h-4 w-4 transition-transform ${
+                          isDetailsExpanded ? 'rotate-180' : ''
+                        }`}
+                      />
+                    </button>
+                    {isDetailsExpanded && (
+                      <div className="space-y-2 border-t border-border-subtle bg-surface-card p-3 text-sm text-content-secondary">
+                        <p>
+                          Tinfoil works best with built-in passkey managers like
+                          iCloud Keychain, Google Password Manager, or the
+                          Passwords app in your device settings.
+                        </p>
+                        <p>
+                          However, you can also create an encryption key that
+                          you&apos;ll have to manage and copy across your
+                          devices manually (don&apos;t lose your key!).
+                        </p>
+                      </div>
+                    )}
+                  </div>
+                </div>
+
+                <div className="mt-5 space-y-2">
+                  <button
+                    onClick={onRetryPasskey}
+                    disabled={isRetryingPasskey}
+                    className="flex w-full items-center justify-center gap-2 rounded-lg bg-brand-accent-dark px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-brand-accent-dark/90 disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    <ArrowPathIcon className="h-4 w-4" />
+                    {isRetryingPasskey ? 'Trying...' : 'Try Again with Passkey'}
+                  </button>
+
+                  <button
+                    onClick={onEnableManualBackup}
+                    disabled={isRetryingPasskey}
+                    className="flex w-full items-center justify-center gap-2 rounded-lg border border-border-subtle bg-surface-chat px-4 py-2 text-sm font-medium text-content-primary transition-colors hover:bg-surface-chat/80 disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    <KeyIcon className="h-4 w-4" />
+                    Enable Manual Backup
+                  </button>
+
+                  <button
+                    onClick={onDismiss}
+                    disabled={isRetryingPasskey}
+                    className="w-full text-center text-sm text-content-muted transition-colors hover:text-content-secondary disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    Continue Without Backup
+                  </button>
+                </div>
+              </Dialog.Panel>
+            </Transition.Child>
+          </div>
+        </div>
+      </Dialog>
+    </Transition>
+  )
+}

--- a/src/components/modals/passkey-setup-prompt-modal.tsx
+++ b/src/components/modals/passkey-setup-prompt-modal.tsx
@@ -1,0 +1,102 @@
+import { Dialog, Transition } from '@headlessui/react'
+import {
+  CloudArrowUpIcon,
+  KeyIcon,
+  ShieldCheckIcon,
+} from '@heroicons/react/24/outline'
+import { Fragment } from 'react'
+
+interface PasskeySetupPromptModalProps {
+  isOpen: boolean
+  isBusy?: boolean
+  /** User confirmed they want to enable passkey-backed cloud sync. */
+  onEnable: () => void
+  /** User dismissed the prompt (cloud sync stays off). */
+  onDismiss: () => void
+}
+
+export function PasskeySetupPromptModal({
+  isOpen,
+  isBusy = false,
+  onEnable,
+  onDismiss,
+}: PasskeySetupPromptModalProps) {
+  return (
+    <Transition appear show={isOpen} as={Fragment}>
+      <Dialog as="div" className="relative z-50" onClose={() => {}}>
+        <Transition.Child
+          as={Fragment}
+          enter="ease-out duration-300"
+          enterFrom="opacity-0"
+          enterTo="opacity-100"
+          leave="ease-in duration-200"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <div className="fixed inset-0 bg-black/50" />
+        </Transition.Child>
+
+        <div className="fixed inset-0 overflow-y-auto">
+          <div className="flex min-h-full items-center justify-center p-4 text-center">
+            <Transition.Child
+              as={Fragment}
+              enter="ease-out duration-300"
+              enterFrom="opacity-0 scale-95"
+              enterTo="opacity-100 scale-100"
+              leave="ease-in duration-200"
+              leaveFrom="opacity-100 scale-100"
+              leaveTo="opacity-0 scale-95"
+            >
+              <Dialog.Panel className="w-full max-w-md transform overflow-hidden rounded-2xl border border-border-subtle bg-surface-card p-6 text-left align-middle shadow-xl transition-all">
+                <div className="flex items-center justify-center">
+                  <div className="rounded-full bg-brand-accent-dark/15 p-3">
+                    <CloudArrowUpIcon className="h-8 w-8 text-brand-accent-dark" />
+                  </div>
+                </div>
+
+                <Dialog.Title
+                  as="h2"
+                  className="mt-4 text-center font-aeonik text-xl font-bold text-content-primary"
+                >
+                  Back Up Your Chats
+                </Dialog.Title>
+
+                <div className="mt-4 space-y-3 text-sm text-content-secondary">
+                  <p>
+                    Tinfoil can encrypt and back up your chats with a passkey so
+                    you can access them across devices.
+                  </p>
+                  <div className="flex items-start gap-2">
+                    <ShieldCheckIcon className="mt-0.5 h-4 w-4 flex-shrink-0 text-content-primary" />
+                    <span>
+                      End-to-end encrypted — only you can decrypt your chats.
+                    </span>
+                  </div>
+                </div>
+
+                <div className="mt-5 space-y-2">
+                  <button
+                    onClick={onEnable}
+                    disabled={isBusy}
+                    className="flex w-full items-center justify-center gap-2 rounded-lg bg-brand-accent-dark px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-brand-accent-dark/90 disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    <KeyIcon className="h-4 w-4" />
+                    {isBusy ? 'Setting up...' : 'Enable with Passkey'}
+                  </button>
+
+                  <button
+                    onClick={onDismiss}
+                    disabled={isBusy}
+                    className="w-full rounded-lg border border-border-subtle bg-surface-chat px-4 py-2 text-sm font-medium text-content-primary transition-colors hover:bg-surface-chat/80 disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    Not Now
+                  </button>
+                </div>
+              </Dialog.Panel>
+            </Transition.Child>
+          </div>
+        </div>
+      </Dialog>
+    </Transition>
+  )
+}

--- a/src/constants/storage-keys.ts
+++ b/src/constants/storage-keys.ts
@@ -40,6 +40,24 @@ export const SETTINGS_HAS_SEEN_WEB_SEARCH_INTRO =
   'tinfoil-settings-has-seen-web-search-intro'
 export const SETTINGS_LOCAL_ONLY_MODE_ENABLED =
   'tinfoil-settings-local-only-mode-enabled'
+// Persists across sessions: set when the user explicitly dismisses the
+// recovery / setup-failed warning after a cancelled passkey recovery attempt.
+// While set, the recovery modal is not auto-opened on page load so the user
+// isn't pestered on every reload. Cleared when they successfully unlock via
+// passkey or manual backup.
+export const SETTINGS_PASSKEY_RECOVERY_DISMISSED =
+  'tinfoil-settings-passkey-recovery-dismissed'
+
+// --- sessionStorage: Passkey setup failure ---------------------------------
+// Tracks whether the user has dismissed the "passkey backup failed" warning
+// during the current session so we don't re-prompt on every re-init.
+export const SETTINGS_PASSKEY_SETUP_WARNING_DISMISSED =
+  'tinfoil-settings-passkey-setup-warning-dismissed'
+// Tracks whether the brand-new-user first-time setup prompt was dismissed
+// via "Not Now" during the current session so we don't re-show it on every
+// reload within the same tab. Cleared on tab close.
+export const SETTINGS_PASSKEY_FIRST_TIME_PROMPT_DISMISSED =
+  'tinfoil-settings-passkey-first-time-prompt-dismissed'
 
 // --- localStorage: User personalization preferences ------------------------
 export const USER_PREFS_NICKNAME = 'tinfoil-user-prefs-nickname'

--- a/src/hooks/use-passkey-backup.ts
+++ b/src/hooks/use-passkey-backup.ts
@@ -2,6 +2,9 @@ import {
   PASSKEY_BUNDLE_VERSION,
   PASSKEY_SYNC_VERSION,
   SECRET_PASSKEY_BACKED_UP,
+  SETTINGS_PASSKEY_FIRST_TIME_PROMPT_DISMISSED,
+  SETTINGS_PASSKEY_RECOVERY_DISMISSED,
+  SETTINGS_PASSKEY_SETUP_WARNING_DISMISSED,
 } from '@/constants/storage-keys'
 import type { CloudKeyAuthorizationMode } from '@/services/cloud/cloud-key-authorization'
 import {
@@ -22,6 +25,7 @@ import {
   getPasskeyCredentialState,
   loadPasskeyCredentials,
   PasskeyCredentialConflictError,
+  PasskeyTimeoutError,
   PrfNotSupportedError,
   retrieveEncryptedKeys,
   storeEncryptedKeys,
@@ -41,6 +45,19 @@ export interface PasskeyBackupState {
   manualRecoveryNeeded: boolean
   /** PRF supported + keys exist locally; user can register a passkey backup from settings */
   passkeySetupAvailable: boolean
+  /**
+   * Passkey backup setup was attempted but failed because the user's passkey
+   * provider doesn't actually support PRF or hung. Surfaces the
+   * "your chats are not backed up" warning modal.
+   */
+  passkeySetupFailed: boolean
+  /**
+   * First-time user with no local key, no remote backup, and PRF support
+   * available. Surfaces a confirmation modal asking whether to enable
+   * passkey-backed cloud sync — we no longer invoke the native passkey
+   * prompt automatically on page load.
+   */
+  passkeyFirstTimePromptAvailable: boolean
 }
 
 export interface UsePasskeyBackupOptions {
@@ -110,6 +127,59 @@ function setLocalBundleVersion(version: number): void {
   }
 }
 
+interface StorageFlag {
+  isSet: () => boolean
+  set: () => void
+  clear: () => void
+}
+
+// Build a best-effort boolean flag backed by a web Storage bucket. All
+// operations swallow errors so Safari ITP / quota / private-mode failures
+// never crash the hook.
+function createStorageFlag(
+  getStorage: () => Storage,
+  key: string,
+): StorageFlag {
+  return {
+    isSet: () => {
+      try {
+        return getStorage().getItem(key) === 'true'
+      } catch {
+        return false
+      }
+    },
+    set: () => {
+      try {
+        getStorage().setItem(key, 'true')
+      } catch {
+        // best-effort
+      }
+    },
+    clear: () => {
+      try {
+        getStorage().removeItem(key)
+      } catch {
+        // best-effort
+      }
+    },
+  }
+}
+
+const setupWarningDismissedFlag = createStorageFlag(
+  () => sessionStorage,
+  SETTINGS_PASSKEY_SETUP_WARNING_DISMISSED,
+)
+
+const passkeyRecoveryDismissedFlag = createStorageFlag(
+  () => localStorage,
+  SETTINGS_PASSKEY_RECOVERY_DISMISSED,
+)
+
+const firstTimePromptDismissedFlag = createStorageFlag(
+  () => sessionStorage,
+  SETTINGS_PASSKEY_FIRST_TIME_PROMPT_DISMISSED,
+)
+
 export function usePasskeyBackup({
   encryptionKey,
   initialized,
@@ -122,6 +192,8 @@ export function usePasskeyBackup({
     passkeyRecoveryNeeded: false,
     manualRecoveryNeeded: false,
     passkeySetupAvailable: false,
+    passkeySetupFailed: false,
+    passkeyFirstTimePromptAvailable: false,
   })
 
   const isMountedRef = useRef(true)
@@ -131,6 +203,7 @@ export function usePasskeyBackup({
   const onEncryptionKeyRecoveredRef = useRef(onEncryptionKeyRecovered)
   onEncryptionKeyRecoveredRef.current = onEncryptionKeyRecovered
   const hasInitializedPasskeyRef = useRef(false)
+  const previousUserIdRef = useRef<string | null | undefined>(undefined)
 
   // Cleanup on unmount
   useEffect(() => {
@@ -138,6 +211,43 @@ export function usePasskeyBackup({
       isMountedRef.current = false
     }
   }, [])
+
+  // When the signed-in user changes *after* the initial sign-in hydration
+  // (sign-out-then-sign-in on the same tab, or a user switch), reset the
+  // init guard and per-user state so the passkey init effect re-runs for
+  // the new session. Also clear any previous-session recovery dismissal so
+  // we never inherit a prior user's "don't prompt me" choice.
+  //
+  // The ref starts as `undefined` and is only populated once we've observed
+  // a real user ID. This way, the initial Clerk hydration sequence
+  // (`undefined → null → <id>` on reload, or `undefined → <id>` directly)
+  // does not trip the reset and wipe legitimate same-user dismissals.
+  useEffect(() => {
+    const currentUserId = isSignedIn ? (user?.id ?? null) : null
+    if (previousUserIdRef.current === undefined) {
+      if (currentUserId !== null) {
+        previousUserIdRef.current = currentUserId
+      }
+      return
+    }
+    if (currentUserId !== null && currentUserId !== previousUserIdRef.current) {
+      hasInitializedPasskeyRef.current = false
+      passkeyRecoveryDismissedFlag.clear()
+      firstTimePromptDismissedFlag.clear()
+      setupWarningDismissedFlag.clear()
+      if (isMountedRef.current) {
+        setState({
+          passkeyActive: false,
+          passkeyRecoveryNeeded: false,
+          manualRecoveryNeeded: false,
+          passkeySetupAvailable: false,
+          passkeySetupFailed: false,
+          passkeyFirstTimePromptAvailable: false,
+        })
+      }
+      previousUserIdRef.current = currentUserId
+    }
+  }, [isSignedIn, user?.id])
 
   /**
    * Build the (userId, userName, displayName) tuple for createPrfPasskey
@@ -597,6 +707,10 @@ export function usePasskeyBackup({
    * Returns the recovered primary key on success, null on failure.
    */
   const recoverWithPasskey = useCallback(async (): Promise<string | null> => {
+    // Each explicit user-initiated passkey action resets the session
+    // "warning dismissed" flag, so a dismissal from an earlier failure
+    // flow doesn't silently suppress the warning on a new attempt.
+    setupWarningDismissedFlag.clear()
     try {
       const previousKeys = encryptionService.getAllKeys()
       const recovery = await performPasskeyRecovery()
@@ -609,6 +723,7 @@ export function usePasskeyBackup({
       if (!appliedMode) return null
 
       applyRecoveredKeys(recovery)
+      passkeyRecoveryDismissedFlag.clear()
 
       logInfo('Recovered encryption keys via passkey retry', {
         component: 'usePasskeyBackup',
@@ -617,6 +732,26 @@ export function usePasskeyBackup({
       })
       return recovery.keyBundle.primary
     } catch (error) {
+      if (
+        error instanceof PrfNotSupportedError ||
+        error instanceof PasskeyTimeoutError
+      ) {
+        logInfo('Passkey provider cannot complete PRF recovery', {
+          component: 'usePasskeyBackup',
+          action: 'recoverWithPasskey',
+          metadata: { reason: error.name },
+        })
+        if (isMountedRef.current) {
+          const alreadyDismissed = setupWarningDismissedFlag.isSet()
+          setState((prev) => ({
+            ...prev,
+            passkeySetupFailed: alreadyDismissed
+              ? prev.passkeySetupFailed
+              : true,
+          }))
+        }
+        return null
+      }
       logError('Passkey recovery retry failed', error, {
         component: 'usePasskeyBackup',
         action: 'recoverWithPasskey',
@@ -632,7 +767,25 @@ export function usePasskeyBackup({
 
     const initializePasskey = async () => {
       const prfSupported = await isPrfSupported()
-      if (!prfSupported) return
+
+      if (!prfSupported) {
+        // The device/provider can't do PRF, so passkey-backed cloud sync is
+        // unavailable here. If the user has no local key and no remote data
+        // we warn them that their chats will only exist on this device and
+        // offer the manual-backup fallback. If remote data exists, they need
+        // the manual recovery flow to decrypt it. Users who already have a
+        // local key stay silent — local storage works fine even without PRF.
+        if (!encryptionKey) {
+          const remoteState = await inspectRemoteEncryptedState()
+          if (!isMountedRef.current) return
+          if (remoteState === 'empty') {
+            setState((prev) => ({ ...prev, passkeySetupFailed: true }))
+          } else {
+            setState((prev) => ({ ...prev, manualRecoveryNeeded: true }))
+          }
+        }
+        return
+      }
 
       if (encryptionKey) {
         // User has local keys — check for existing backup
@@ -660,12 +813,20 @@ export function usePasskeyBackup({
           }
         }
       } else {
-        // No localStorage keys — try passkey recovery
+        // No localStorage keys — check backend state but do not auto-prompt
+        // the user with a native passkey dialog. We surface the appropriate
+        // UI state flag instead and let the user trigger the WebAuthn call
+        // explicitly from a confirmation or recovery modal.
         const credentialState = await getPasskeyCredentialState()
 
         if (credentialState === 'exists') {
-          const recovered = await tryPasskeyRecovery()
-          if (!recovered && isMountedRef.current) {
+          // If the user explicitly dismissed the recovery prompt on a
+          // previous visit, stay silent on reload — they can re-trigger
+          // recovery from Settings when they're ready.
+          if (passkeyRecoveryDismissedFlag.isSet()) {
+            return
+          }
+          if (isMountedRef.current) {
             setState((prev) => ({
               ...prev,
               passkeyRecoveryNeeded: true,
@@ -675,7 +836,12 @@ export function usePasskeyBackup({
           const remoteState = await inspectRemoteEncryptedState()
 
           if (remoteState === 'empty') {
-            await setupFirstTimePasskeyUser()
+            if (isMountedRef.current && !firstTimePromptDismissedFlag.isSet()) {
+              setState((prev) => ({
+                ...prev,
+                passkeyFirstTimePromptAvailable: true,
+              }))
+            }
           } else if (isMountedRef.current) {
             setState((prev) => ({
               ...prev,
@@ -691,103 +857,20 @@ export function usePasskeyBackup({
       }
     }
 
-    /**
-     * Attempt to recover keys from backend using passkey authentication.
-     * Delegates to recoverWithPasskey (stable useCallback) and forwards
-     * the recovered key to the onEncryptionKeyRecovered callback.
-     */
-    const tryPasskeyRecovery = async (): Promise<boolean> => {
-      const key = await recoverWithPasskey()
-      if (key) {
-        onEncryptionKeyRecoveredRef.current?.(key)
-        return true
-      }
-      return false
-    }
-
-    /**
-     * First-time user with PRF support: generate key in memory, only persist
-     * after passkey creation succeeds. If passkey is cancelled, key is discarded
-     * and cloud sync stays OFF.
-     */
-    const setupFirstTimePasskeyUser = async (): Promise<void> => {
-      try {
-        const previousKeys = encryptionService.getAllKeys()
-        const newKey = await generateKeyWithPasskeyBackup('validated')
-
-        if (newKey) {
-          const appliedMode = await applyRecoveredKeyBundle(
-            {
-              primary: newKey,
-              alternatives: [],
-              authorizationMode: 'validated',
-            },
-            previousKeys,
-          )
-          if (!appliedMode) {
-            if (isMountedRef.current) {
-              setState((prev) => ({
-                ...prev,
-                manualRecoveryNeeded: true,
-              }))
-            }
-            return
-          }
-
-          applyNewPasskeyKey()
-          onEncryptionKeyRecoveredRef.current?.(newKey)
-
-          logInfo('First-time passkey setup complete', {
-            component: 'usePasskeyBackup',
-            action: 'setupFirstTimePasskeyUser',
-          })
-        } else {
-          // User cancelled — discard key, cloud sync stays OFF
-          if (isMountedRef.current) {
-            setState((prev) => ({
-              ...prev,
-              passkeySetupAvailable: true,
-            }))
-          }
-
-          logInfo('Passkey creation cancelled, key discarded', {
-            component: 'usePasskeyBackup',
-            action: 'setupFirstTimePasskeyUser',
-          })
-        }
-      } catch (error) {
-        if (error instanceof PrfNotSupportedError) {
-          logInfo(
-            'Authenticator does not support PRF during first-time setup',
-            {
-              component: 'usePasskeyBackup',
-              action: 'setupFirstTimePasskeyUser',
-            },
-          )
-          if (isMountedRef.current) {
-            setState((prev) => ({
-              ...prev,
-              passkeySetupAvailable: true,
-            }))
-          }
-          return
-        }
-        logError('First-time passkey user setup failed', error, {
-          component: 'usePasskeyBackup',
-          action: 'setupFirstTimePasskeyUser',
-        })
-      }
-    }
-
     initializePasskey()
-  }, [
-    applyRecoveredKeyBundle,
-    initialized,
-    isSignedIn,
-    encryptionKey,
-    generateKeyWithPasskeyBackup,
-    recoverWithPasskey,
-  ])
+  }, [initialized, isSignedIn, encryptionKey])
+
+  // Clear the persistent "recovery dismissed" flag and the session
+  // first-time-prompt flag once the user has a key again (via passkey
+  // recovery, successful manual-key apply, or completed first-time setup).
+  // The modals will be allowed to auto-open again on a future visit if they
+  // ever land back in the no-key state.
+  useEffect(() => {
+    if (encryptionKey) {
+      passkeyRecoveryDismissedFlag.clear()
+      firstTimePromptDismissedFlag.clear()
+    }
+  }, [encryptionKey])
 
   // --- Periodic sync_version check ---
   useEffect(() => {
@@ -809,6 +892,7 @@ export function usePasskeyBackup({
     const userInfo = getPasskeyUserInfo()
     if (!userInfo) return false
 
+    setupWarningDismissedFlag.clear()
     try {
       let authorizationMode = await getCurrentCloudKeyAuthorizationMode()
       if (!authorizationMode) {
@@ -853,6 +937,7 @@ export function usePasskeyBackup({
       return true
     } catch (error) {
       if (error instanceof PrfNotSupportedError) throw error
+      if (error instanceof PasskeyTimeoutError) throw error
       logError('Passkey setup failed', error, {
         component: 'usePasskeyBackup',
         action: 'setupPasskey',
@@ -867,6 +952,7 @@ export function usePasskeyBackup({
    * Returns the new primary key on success, null on failure/cancel.
    */
   const setupNewKeySplit = useCallback(async (): Promise<string | null> => {
+    setupWarningDismissedFlag.clear()
     const previousKeys = encryptionService.getAllKeys()
     let didSetNewKey = false
 
@@ -891,6 +977,7 @@ export function usePasskeyBackup({
       return newKey
     } catch (error) {
       if (error instanceof PrfNotSupportedError) throw error
+      if (error instanceof PasskeyTimeoutError) throw error
       if (didSetNewKey) {
         await rollbackToPreviousKeys(previousKeys)
       }
@@ -902,11 +989,236 @@ export function usePasskeyBackup({
     }
   }, [generateKeyWithPasskeyBackup, rollbackToPreviousKeys])
 
+  const dismissPasskeySetupFailed = useCallback((): void => {
+    setupWarningDismissedFlag.set()
+    if (isMountedRef.current) {
+      setState((prev) => {
+        // If the warning is being dismissed while we're in the recovery
+        // flow (remote passkey exists but this device can't use it),
+        // persist a localStorage flag so the recovery modal doesn't
+        // re-open on every reload. It's cleared when the user successfully
+        // unlocks with a passkey or applies a manual key.
+        if (prev.passkeyRecoveryNeeded) {
+          passkeyRecoveryDismissedFlag.set()
+        }
+        return {
+          ...prev,
+          passkeySetupFailed: false,
+          // Also hide the recovery-needed flag so chat-interface closes the
+          // auto-opened recovery modal. It stays recoverable via Settings.
+          passkeyRecoveryNeeded: false,
+        }
+      })
+    }
+  }, [])
+
+  /**
+   * Brand-new user flow (no local key, no remote backup, PRF supported):
+   * generate a key in memory, create a passkey to back it up, and persist the
+   * key only after passkey creation succeeds. Invoked from the first-time
+   * confirmation modal — we intentionally do not auto-trigger the native
+   * passkey dialog on page load.
+   */
+  const setupFirstTimePasskey = useCallback(async (): Promise<boolean> => {
+    setupWarningDismissedFlag.clear()
+    // Single exit point for every non-success branch: close the prompt
+    // modal and surface the "chats are not being backed up" warning so the
+    // user always has a clear next step (manual backup or continue without).
+    const markFailedAndClosePrompt = (): void => {
+      if (!isMountedRef.current) return
+      setState((prev) => ({
+        ...prev,
+        passkeyFirstTimePromptAvailable: false,
+        passkeySetupFailed: true,
+      }))
+    }
+
+    try {
+      const previousKeys = encryptionService.getAllKeys()
+      const newKey = await generateKeyWithPasskeyBackup('validated')
+
+      if (newKey) {
+        const appliedMode = await applyRecoveredKeyBundle(
+          {
+            primary: newKey,
+            alternatives: [],
+            authorizationMode: 'validated',
+          },
+          previousKeys,
+        )
+        if (!appliedMode) {
+          if (isMountedRef.current) {
+            setState((prev) => ({
+              ...prev,
+              manualRecoveryNeeded: true,
+              passkeyFirstTimePromptAvailable: false,
+            }))
+          }
+          return false
+        }
+
+        applyNewPasskeyKey()
+        onEncryptionKeyRecoveredRef.current?.(newKey)
+        if (isMountedRef.current) {
+          setState((prev) => ({
+            ...prev,
+            passkeyActive: true,
+            passkeyFirstTimePromptAvailable: false,
+          }))
+        }
+
+        logInfo('First-time passkey setup complete', {
+          component: 'usePasskeyBackup',
+          action: 'setupFirstTimePasskey',
+        })
+        return true
+      }
+
+      markFailedAndClosePrompt()
+      logInfo('Passkey creation cancelled, key discarded', {
+        component: 'usePasskeyBackup',
+        action: 'setupFirstTimePasskey',
+      })
+      return false
+    } catch (error) {
+      if (
+        error instanceof PrfNotSupportedError ||
+        error instanceof PasskeyTimeoutError
+      ) {
+        logInfo(
+          'Passkey provider cannot support PRF backup during first-time setup',
+          {
+            component: 'usePasskeyBackup',
+            action: 'setupFirstTimePasskey',
+            metadata: { reason: error.name },
+          },
+        )
+      } else {
+        logError('First-time passkey setup failed', error, {
+          component: 'usePasskeyBackup',
+          action: 'setupFirstTimePasskey',
+        })
+      }
+      markFailedAndClosePrompt()
+      return false
+    }
+  }, [applyRecoveredKeyBundle, generateKeyWithPasskeyBackup])
+
+  const dismissFirstTimePasskeyPrompt = useCallback((): void => {
+    firstTimePromptDismissedFlag.set()
+    if (!isMountedRef.current) return
+    setState((prev) => ({
+      ...prev,
+      passkeyFirstTimePromptAvailable: false,
+      // Surface the "chats are not being backed up" warning so the user has
+      // a clear next step (manual backup or continue without). Respect the
+      // session dismiss so we don't reopen it after they've already seen
+      // and dismissed it this session.
+      passkeySetupFailed: setupWarningDismissedFlag.isSet()
+        ? prev.passkeySetupFailed
+        : true,
+    }))
+  }, [])
+
+  // Ask the hook to re-show the first-time setup prompt modal. Used when
+  // the user clicks "Enable Cloud Sync" from the sidebar/settings after
+  // previously dismissing the prompt. Only succeeds when PRF is supported
+  // AND the backend has no remote passkey credential or encrypted data —
+  // first-time setup would otherwise generate a new key that couldn't
+  // decrypt anything already stored remotely. Returns true if the prompt
+  // was made available; false if the caller should route through the
+  // manual-key flow instead.
+  const showFirstTimePasskeyPrompt = useCallback(async (): Promise<boolean> => {
+    const prfSupported = await isPrfSupported()
+    if (!prfSupported) return false
+    try {
+      const [credentialState, remoteState] = await Promise.all([
+        getPasskeyCredentialState(),
+        inspectRemoteEncryptedState(),
+      ])
+      if (credentialState !== 'empty' || remoteState !== 'empty') {
+        return false
+      }
+    } catch {
+      return false
+    }
+    firstTimePromptDismissedFlag.clear()
+    if (isMountedRef.current) {
+      setState((prev) => ({
+        ...prev,
+        passkeyFirstTimePromptAvailable: true,
+      }))
+    }
+    return true
+  }, [])
+
+  // User explicitly opted out of passkey recovery (e.g. "Skip for Now" on
+  // the recovery modal). Persist the dismiss so we don't auto-reopen the
+  // recovery modal on every reload, and clear the recovery-needed flag so
+  // chat-interface closes the currently open modal. Cleared automatically
+  // once the user regains an encryption key via any path.
+  const skipPasskeyRecovery = useCallback((): void => {
+    passkeyRecoveryDismissedFlag.set()
+    if (!isMountedRef.current) return
+    setState((prev) => ({
+      ...prev,
+      passkeyRecoveryNeeded: false,
+      // Surface the "chats are not being backed up" warning so the user
+      // has a clear next step (manual backup or continue without). Respect
+      // the session dismiss so we don't keep reopening it.
+      passkeySetupFailed: setupWarningDismissedFlag.isSet()
+        ? prev.passkeySetupFailed
+        : true,
+    }))
+  }, [])
+
+  // Called from the "Try Again with Passkey" button on the setup-failed
+  // warning modal. Picks the right passkey flow based on current state:
+  // - local key + no backup → retry `setupPasskey` (backup-existing-key)
+  // - no key + remote credential → retry `recoverWithPasskey`
+  // - no key + no remote → retry `setupFirstTimePasskey`
+  // Returns true on success, false on any failure path (caller keeps the
+  // warning dismissed and the user can try again manually).
+  const retryPasskeySetup = useCallback(async (): Promise<boolean> => {
+    setupWarningDismissedFlag.clear()
+    passkeyRecoveryDismissedFlag.clear()
+    firstTimePromptDismissedFlag.clear()
+    if (isMountedRef.current) {
+      setState((prev) => ({ ...prev, passkeySetupFailed: false }))
+    }
+
+    const hasLocalKey = Boolean(encryptionService.getKey())
+    if (hasLocalKey) {
+      return await setupPasskey()
+    }
+
+    try {
+      const credentialState = await getPasskeyCredentialState()
+      if (credentialState === 'exists') {
+        const key = await recoverWithPasskey()
+        return Boolean(key)
+      }
+      return await setupFirstTimePasskey()
+    } catch (error) {
+      logError('Retry passkey setup failed', error, {
+        component: 'usePasskeyBackup',
+        action: 'retryPasskeySetup',
+      })
+      return false
+    }
+  }, [setupPasskey, recoverWithPasskey, setupFirstTimePasskey])
+
   return {
     ...state,
     setupPasskey,
+    setupFirstTimePasskey,
+    showFirstTimePasskeyPrompt,
+    dismissFirstTimePasskeyPrompt,
     recoverWithPasskey,
     setupNewKeySplit,
     updatePasskeyBackup,
+    dismissPasskeySetupFailed,
+    skipPasskeyRecovery,
+    retryPasskeySetup,
   }
 }

--- a/src/services/passkey/index.ts
+++ b/src/services/passkey/index.ts
@@ -16,6 +16,7 @@ export type {
   StoreEncryptedKeysOptions,
 } from './passkey-key-storage'
 export {
+  PasskeyTimeoutError,
   PrfNotSupportedError,
   authenticatePrfPasskey,
   clearCachedPrfResult,

--- a/src/services/passkey/passkey-service.ts
+++ b/src/services/passkey/passkey-service.ts
@@ -29,6 +29,42 @@ export class PrfNotSupportedError extends Error {
   }
 }
 
+export class PasskeyTimeoutError extends Error {
+  constructor() {
+    super(
+      "Your passkey provider took too long to respond. This can happen with some browser extension password managers. Try using iCloud Keychain, Chrome's built-in passkey manager, or the Passwords app in your device settings.",
+    )
+    this.name = 'PasskeyTimeoutError'
+  }
+}
+
+// Timeout passed to the WebAuthn API (some browsers ignore this).
+const WEBAUTHN_TIMEOUT_MS = 30_000
+
+// Internal hard timeout to guard against providers (e.g. some password-manager
+// browser extensions) that never resolve the credentials.create/get promise.
+// Kept tight so users aren't left staring at an indefinite spinner; the
+// WebAuthn flow itself should complete well within this window once the
+// provider actually prompts.
+const STUCK_WEBAUTHN_TIMEOUT_MS = 10_000
+
+async function withStuckTimeout<T>(promise: Promise<T>): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_, reject) => {
+        timer = setTimeout(
+          () => reject(new PasskeyTimeoutError()),
+          STUCK_WEBAUTHN_TIMEOUT_MS,
+        )
+      }),
+    ])
+  } finally {
+    if (timer !== undefined) clearTimeout(timer)
+  }
+}
+
 // Salt passed to PRF eval.first — the client internally computes:
 // SHA-256("WebAuthn PRF" || 0x00 || PRF_EVAL_FIRST)
 const PRF_EVAL_FIRST = new TextEncoder().encode('tinfoil-chat-key-encryption')
@@ -109,28 +145,31 @@ export async function createPrfPasskey(
   const userIdBytes = new TextEncoder().encode(userId)
 
   try {
-    const credential = (await navigator.credentials.create({
-      publicKey: {
-        challenge: crypto.getRandomValues(new Uint8Array(32)),
-        rp: { id: RP_ID, name: RP_NAME },
-        user: {
-          id: userIdBytes,
-          name: userEmail,
-          displayName: displayName || userEmail,
+    const credential = (await withStuckTimeout(
+      navigator.credentials.create({
+        publicKey: {
+          challenge: crypto.getRandomValues(new Uint8Array(32)),
+          rp: { id: RP_ID, name: RP_NAME },
+          user: {
+            id: userIdBytes,
+            name: userEmail,
+            displayName: displayName || userEmail,
+          },
+          pubKeyCredParams: [
+            { type: 'public-key', alg: -7 }, // ES256
+            { type: 'public-key', alg: -257 }, // RS256 (broader compat)
+          ],
+          authenticatorSelection: {
+            residentKey: 'preferred',
+            userVerification: 'required',
+          },
+          timeout: WEBAUTHN_TIMEOUT_MS,
+          extensions: {
+            prf: { eval: { first: PRF_EVAL_FIRST } },
+          },
         },
-        pubKeyCredParams: [
-          { type: 'public-key', alg: -7 }, // ES256
-          { type: 'public-key', alg: -257 }, // RS256 (broader compat)
-        ],
-        authenticatorSelection: {
-          residentKey: 'preferred',
-          userVerification: 'required',
-        },
-        extensions: {
-          prf: { eval: { first: PRF_EVAL_FIRST } },
-        },
-      },
-    })) as PublicKeyCredential | null
+      }),
+    )) as PublicKeyCredential | null
 
     if (!credential) {
       return null
@@ -170,9 +209,23 @@ export async function createPrfPasskey(
         action: 'createPrfPasskey',
       },
     )
-    return await authenticatePrfPasskey([credentialId])
+    // Pass throwOnCancel so a user-cancelled assertion surfaces as a
+    // DOMException we can handle below — otherwise a `null` return would
+    // be indistinguishable from "provider returned no PRF output" and we'd
+    // show the misleading "PRF not supported" error for a plain cancel.
+    const postCreateAuth = await authenticatePrfPasskey([credentialId], {
+      throwOnCancel: true,
+    })
+    if (!postCreateAuth) {
+      // The provider claimed PRF support during creation but didn't deliver
+      // a PRF output on the immediately-following assertion. Treat this as
+      // a lack of real PRF support rather than a silent failure.
+      throw new PrfNotSupportedError()
+    }
+    return postCreateAuth
   } catch (error) {
     if (error instanceof PrfNotSupportedError) throw error
+    if (error instanceof PasskeyTimeoutError) throw error
 
     // DOMException with name "NotAllowedError" means the user cancelled
     if (error instanceof DOMException && error.name === 'NotAllowedError') {
@@ -200,7 +253,9 @@ export async function createPrfPasskey(
  */
 export async function authenticatePrfPasskey(
   credentialIds: string[],
+  options: { throwOnCancel?: boolean } = {},
 ): Promise<PrfPasskeyResult | null> {
+  const { throwOnCancel = false } = options
   const allowCredentials: PublicKeyCredentialDescriptor[] = credentialIds.map(
     (id) => ({
       id: base64UrlToUint8Array(id),
@@ -209,17 +264,20 @@ export async function authenticatePrfPasskey(
   )
 
   try {
-    const assertion = (await navigator.credentials.get({
-      publicKey: {
-        challenge: crypto.getRandomValues(new Uint8Array(32)),
-        rpId: RP_ID,
-        allowCredentials,
-        userVerification: 'required',
-        extensions: {
-          prf: { eval: { first: PRF_EVAL_FIRST } },
+    const assertion = (await withStuckTimeout(
+      navigator.credentials.get({
+        publicKey: {
+          challenge: crypto.getRandomValues(new Uint8Array(32)),
+          rpId: RP_ID,
+          allowCredentials,
+          userVerification: 'required',
+          timeout: WEBAUTHN_TIMEOUT_MS,
+          extensions: {
+            prf: { eval: { first: PRF_EVAL_FIRST } },
+          },
         },
-      },
-    })) as PublicKeyCredential | null
+      }),
+    )) as PublicKeyCredential | null
 
     if (!assertion) {
       return null
@@ -243,11 +301,14 @@ export async function authenticatePrfPasskey(
     cachePrfResult(result)
     return result
   } catch (error) {
+    if (error instanceof PasskeyTimeoutError) throw error
+
     if (error instanceof DOMException && error.name === 'NotAllowedError') {
       logInfo('User cancelled passkey authentication', {
         component: 'PasskeyService',
         action: 'authenticatePrfPasskey',
       })
+      if (throwOnCancel) throw error
       return null
     }
 

--- a/tests/components/passkey-setup-failed-modal.test.tsx
+++ b/tests/components/passkey-setup-failed-modal.test.tsx
@@ -1,0 +1,124 @@
+import { PasskeySetupFailedModal } from '@/components/modals/passkey-setup-failed-modal'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { createElement } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+describe('PasskeySetupFailedModal', () => {
+  const baseProps = {
+    isOpen: true,
+    onRetryPasskey: () => {},
+    onEnableManualBackup: () => {},
+    onDismiss: () => {},
+  }
+
+  it('renders the backup-failure warning text', () => {
+    render(createElement(PasskeySetupFailedModal, baseProps))
+
+    expect(
+      screen.getByRole('heading', { name: /chats are not being backed up/i }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(/your chats will only exist on this device/i),
+    ).toBeInTheDocument()
+  })
+
+  it('invokes onRetryPasskey when the primary button is clicked', () => {
+    const onRetryPasskey = vi.fn()
+    render(
+      createElement(PasskeySetupFailedModal, { ...baseProps, onRetryPasskey }),
+    )
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /try again with passkey/i }),
+    )
+
+    expect(onRetryPasskey).toHaveBeenCalledTimes(1)
+  })
+
+  it('invokes onEnableManualBackup when the manual-backup button is clicked', () => {
+    const onEnableManualBackup = vi.fn()
+    render(
+      createElement(PasskeySetupFailedModal, {
+        ...baseProps,
+        onEnableManualBackup,
+      }),
+    )
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /enable manual backup/i }),
+    )
+
+    expect(onEnableManualBackup).toHaveBeenCalledTimes(1)
+  })
+
+  it('invokes onDismiss when the user chooses to continue without backup', () => {
+    const onDismiss = vi.fn()
+    render(createElement(PasskeySetupFailedModal, { ...baseProps, onDismiss }))
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /continue without backup/i }),
+    )
+
+    expect(onDismiss).toHaveBeenCalledTimes(1)
+  })
+
+  it('disables every action while a passkey retry is in flight', () => {
+    const onRetryPasskey = vi.fn()
+    const onEnableManualBackup = vi.fn()
+    const onDismiss = vi.fn()
+    render(
+      createElement(PasskeySetupFailedModal, {
+        ...baseProps,
+        isRetryingPasskey: true,
+        onRetryPasskey,
+        onEnableManualBackup,
+        onDismiss,
+      }),
+    )
+
+    const retryButton = screen.getByRole('button', { name: /trying/i })
+    const manualButton = screen.getByRole('button', {
+      name: /enable manual backup/i,
+    })
+    const dismissButton = screen.getByRole('button', {
+      name: /continue without backup/i,
+    })
+
+    expect(retryButton).toBeDisabled()
+    expect(manualButton).toBeDisabled()
+    expect(dismissButton).toBeDisabled()
+
+    fireEvent.click(retryButton)
+    fireEvent.click(manualButton)
+    fireEvent.click(dismissButton)
+    expect(onRetryPasskey).not.toHaveBeenCalled()
+    expect(onEnableManualBackup).not.toHaveBeenCalled()
+    expect(onDismiss).not.toHaveBeenCalled()
+  })
+
+  it('does not render its content when closed', () => {
+    render(
+      createElement(PasskeySetupFailedModal, { ...baseProps, isOpen: false }),
+    )
+
+    expect(
+      screen.queryByRole('heading', { name: /chats are not being backed up/i }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('hides the provider-recommendation details by default and reveals them when the dropdown is expanded', () => {
+    render(createElement(PasskeySetupFailedModal, baseProps))
+
+    expect(
+      screen.queryByText(/tinfoil works best with built-in passkey managers/i),
+    ).not.toBeInTheDocument()
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /why is this happening/i }),
+    )
+
+    expect(
+      screen.getByText(/tinfoil works best with built-in passkey managers/i),
+    ).toBeInTheDocument()
+  })
+})

--- a/tests/components/passkey-setup-prompt-modal.test.tsx
+++ b/tests/components/passkey-setup-prompt-modal.test.tsx
@@ -1,0 +1,93 @@
+import { PasskeySetupPromptModal } from '@/components/modals/passkey-setup-prompt-modal'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { createElement } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+describe('PasskeySetupPromptModal', () => {
+  it('renders the primary heading and passkey copy', () => {
+    render(
+      createElement(PasskeySetupPromptModal, {
+        isOpen: true,
+        onEnable: () => {},
+        onDismiss: () => {},
+      }),
+    )
+
+    expect(
+      screen.getByRole('heading', { name: /back up your chats/i }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(/encrypt and back up your chats with a passkey/i),
+    ).toBeInTheDocument()
+  })
+
+  it('invokes onEnable when the user clicks the primary button', () => {
+    const onEnable = vi.fn()
+    render(
+      createElement(PasskeySetupPromptModal, {
+        isOpen: true,
+        onEnable,
+        onDismiss: () => {},
+      }),
+    )
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /enable with passkey/i }),
+    )
+
+    expect(onEnable).toHaveBeenCalledTimes(1)
+  })
+
+  it('invokes onDismiss when the user clicks not now', () => {
+    const onDismiss = vi.fn()
+    render(
+      createElement(PasskeySetupPromptModal, {
+        isOpen: true,
+        onEnable: () => {},
+        onDismiss,
+      }),
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /not now/i }))
+
+    expect(onDismiss).toHaveBeenCalledTimes(1)
+  })
+
+  it('disables both buttons while a setup is in progress', () => {
+    const onEnable = vi.fn()
+    const onDismiss = vi.fn()
+    render(
+      createElement(PasskeySetupPromptModal, {
+        isOpen: true,
+        isBusy: true,
+        onEnable,
+        onDismiss,
+      }),
+    )
+
+    const enableButton = screen.getByRole('button', { name: /setting up/i })
+    const dismissButton = screen.getByRole('button', { name: /not now/i })
+
+    expect(enableButton).toBeDisabled()
+    expect(dismissButton).toBeDisabled()
+
+    fireEvent.click(enableButton)
+    fireEvent.click(dismissButton)
+    expect(onEnable).not.toHaveBeenCalled()
+    expect(onDismiss).not.toHaveBeenCalled()
+  })
+
+  it('does not render anything when closed', () => {
+    render(
+      createElement(PasskeySetupPromptModal, {
+        isOpen: false,
+        onEnable: () => {},
+        onDismiss: () => {},
+      }),
+    )
+
+    expect(
+      screen.queryByRole('heading', { name: /back up your chats/i }),
+    ).not.toBeInTheDocument()
+  })
+})

--- a/tests/services/passkey/passkey-service.test.ts
+++ b/tests/services/passkey/passkey-service.test.ts
@@ -1,5 +1,11 @@
-import { deriveKeyEncryptionKey } from '@/services/passkey/passkey-service'
-import { describe, expect, it } from 'vitest'
+import {
+  authenticatePrfPasskey,
+  createPrfPasskey,
+  deriveKeyEncryptionKey,
+  PasskeyTimeoutError,
+  PrfNotSupportedError,
+} from '@/services/passkey/passkey-service'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 describe('passkey-service', () => {
   describe('deriveKeyEncryptionKey', () => {
@@ -67,6 +73,155 @@ describe('passkey-service', () => {
       await expect(
         crypto.subtle.decrypt({ name: 'AES-GCM', iv }, kek2, ciphertext),
       ).rejects.toThrow()
+    })
+  })
+
+  describe('PRF failure handling', () => {
+    const originalCredentials = navigator.credentials
+
+    beforeEach(() => {
+      vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+      Object.defineProperty(navigator, 'credentials', {
+        value: originalCredentials,
+        writable: true,
+        configurable: true,
+      })
+    })
+
+    function installCredentialsMock(stub: {
+      create?: (...args: any[]) => unknown
+      get?: (...args: any[]) => unknown
+    }): void {
+      Object.defineProperty(navigator, 'credentials', {
+        value: stub,
+        writable: true,
+        configurable: true,
+      })
+    }
+
+    function fakePublicKeyCredential(options?: {
+      prfEnabled?: boolean
+      prfFirst?: ArrayBuffer | null
+    }): any {
+      const rawId = crypto.getRandomValues(new Uint8Array(16)).buffer
+      return {
+        rawId,
+        getClientExtensionResults: () => {
+          if (!options?.prfEnabled) return {}
+          const prf: {
+            enabled: boolean
+            results?: { first: ArrayBuffer }
+          } = { enabled: true }
+          if (options.prfFirst) {
+            prf.results = { first: options.prfFirst }
+          }
+          return { prf }
+        },
+      }
+    }
+
+    it('createPrfPasskey throws PrfNotSupportedError when prf.enabled is false', async () => {
+      installCredentialsMock({
+        create: vi.fn(async () =>
+          fakePublicKeyCredential({ prfEnabled: false }),
+        ),
+      })
+
+      await expect(
+        createPrfPasskey('user-id', 'user@example.com', 'Test User'),
+      ).rejects.toBeInstanceOf(PrfNotSupportedError)
+    })
+
+    it('createPrfPasskey throws PrfNotSupportedError when the post-create assertion yields no PRF output', async () => {
+      installCredentialsMock({
+        create: vi.fn(async () =>
+          fakePublicKeyCredential({ prfEnabled: true, prfFirst: null }),
+        ),
+        get: vi.fn(async () => fakePublicKeyCredential({ prfEnabled: false })),
+      })
+
+      await expect(
+        createPrfPasskey('user-id', 'user@example.com', 'Test User'),
+      ).rejects.toBeInstanceOf(PrfNotSupportedError)
+    })
+
+    it('createPrfPasskey returns the result when PRF output is provided on creation', async () => {
+      const prfFirst = crypto.getRandomValues(new Uint8Array(32))
+        .buffer as ArrayBuffer
+      installCredentialsMock({
+        create: vi.fn(async () =>
+          fakePublicKeyCredential({ prfEnabled: true, prfFirst }),
+        ),
+      })
+
+      const result = await createPrfPasskey(
+        'user-id',
+        'user@example.com',
+        'Test User',
+      )
+
+      expect(result).not.toBeNull()
+      expect(result?.prfOutput.byteLength).toBe(32)
+    })
+
+    it('createPrfPasskey returns null when the user cancels (NotAllowedError)', async () => {
+      installCredentialsMock({
+        create: vi.fn(async () => {
+          throw new DOMException('User cancelled', 'NotAllowedError')
+        }),
+      })
+
+      const result = await createPrfPasskey(
+        'user-id',
+        'user@example.com',
+        'Test User',
+      )
+      expect(result).toBeNull()
+    })
+
+    it('createPrfPasskey throws PasskeyTimeoutError when the provider hangs', async () => {
+      installCredentialsMock({
+        create: vi.fn(() => new Promise(() => {})),
+      })
+
+      const resultPromise = createPrfPasskey(
+        'user-id',
+        'user@example.com',
+        'Test User',
+      )
+      // Swallow the rejection while we advance time so Node doesn't flag
+      // this as an unhandled rejection between fake-timer ticks.
+      resultPromise.catch(() => {})
+
+      await vi.advanceTimersByTimeAsync(15_000)
+
+      await expect(resultPromise).rejects.toBeInstanceOf(PasskeyTimeoutError)
+    })
+
+    it('authenticatePrfPasskey throws PasskeyTimeoutError when the provider hangs', async () => {
+      installCredentialsMock({
+        get: vi.fn(() => new Promise(() => {})),
+      })
+
+      const resultPromise = authenticatePrfPasskey(['AAAA'])
+      resultPromise.catch(() => {})
+
+      await vi.advanceTimersByTimeAsync(15_000)
+
+      await expect(resultPromise).rejects.toBeInstanceOf(PasskeyTimeoutError)
+    })
+
+    it('authenticatePrfPasskey returns null when PRF output is missing from assertion', async () => {
+      installCredentialsMock({
+        get: vi.fn(async () => fakePublicKeyCredential({ prfEnabled: false })),
+      })
+
+      const result = await authenticatePrfPasskey(['AAAA'])
+      expect(result).toBeNull()
     })
   })
 })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,9 @@ import path from 'path'
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
+  esbuild: {
+    jsx: 'automatic',
+  },
   test: {
     environment: 'happy-dom',
     globals: true,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Improves cloud sync UX with a first‑time passkey setup prompt and a clear “backup failed” warning when PRF is unsupported or a provider hangs. Adds WebAuthn timeouts and safe fallbacks to manual backup, with smarter auto‑open, dismissal, and user‑switch behavior.

- **New Features**
  - Passkey setup modals:
    - `PasskeySetupPromptModal` for first‑time users; never auto‑opens native dialogs; disables buttons while busy.
    - `PasskeySetupFailedModal` when PRF is unsupported, missing post‑create PRF output, or times out; offers “Try Again with Passkey”, “Enable Manual Backup”, or “Continue Without Backup”.
  - `use-passkey-backup`:
    - State: `passkeySetupFailed`, `passkeyFirstTimePromptAvailable`.
    - Helpers: `setupFirstTimePasskey`, `showFirstTimePasskeyPrompt`, `dismissFirstTimePasskeyPrompt`, `dismissPasskeySetupFailed`, `skipPasskeyRecovery`, `retryPasskeySetup`.
    - Auto‑open rules: passkey recovery always opens; manual recovery respects the sync toggle. Dismissals persist across reloads, clear when a key is regained, and reset on user switch.
  - Cloud sync flow:
    - `CloudSyncSetupModal` adds `forceManualFlow` and `onSkipRecovery`; “Skip for Now” persists a dismissal; modal can remount via a key to pick up new initial steps.
    - `ChatInterface` prefers the first‑time prompt when opening cloud sync from settings (no local key), wires the new modals, tracks busy/retry state, forces manual flow from the warning, and turns sync off and closes recovery when warnings are dismissed.

- **Bug Fixes**
  - Added `PasskeyTimeoutError`, a 10s stuck guard, and a 30s WebAuthn timeout on create/auth; shows the failure modal instead of hanging.
  - Treats “PRF advertised but not delivered” as unsupported; post‑create auth uses `throwOnCancel` to distinguish cancels from PRF failures.
  - Never auto‑trigger native dialogs on load; “Skip for Now” and dismissing the warning persist flags so modals don’t auto‑reopen until a key is restored or the user changes.
  - Storage flags: `SETTINGS_PASSKEY_RECOVERY_DISMISSED` (local), `SETTINGS_PASSKEY_SETUP_WARNING_DISMISSED` (session), `SETTINGS_PASSKEY_FIRST_TIME_PROMPT_DISMISSED` (session). Tests cover new modals, PRF edge cases, and timeout paths; `vitest` config uses `jsx: 'automatic'`.

<sup>Written for commit efc5c896440eb748ddc7888d2ab960d21ca50a54. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

