### PR TITLE
Support new websearch streaming event parsing

### DIFF
--- a/src/components/chat/hooks/streaming-processor.ts
+++ b/src/components/chat/hooks/streaming-processor.ts
@@ -203,11 +203,22 @@ export async function processStreamingResponse(
               { id: fetchId, url: fetchUrl, status: 'fetching' },
             ]
           }
-        } else if (fetchStatus === 'completed' || fetchStatus === 'failed') {
+        } else if (
+          fetchStatus === 'completed' ||
+          fetchStatus === 'failed' ||
+          fetchStatus === 'blocked'
+        ) {
+          // URLFetchState has no distinct `blocked` status slot, so a
+          // safety-block on a URL fetch is collapsed onto `failed` in
+          // the UI. The router's richer `blocked` signal still surfaces
+          // on the separate webSearchState when the whole search is
+          // blocked; per-URL blocks are rare and the fallback keeps
+          // the UI consistent with the spec-defined URLFetchStatus
+          // enum.
+          const next: URLFetchState['status'] =
+            fetchStatus === 'blocked' ? 'failed' : fetchStatus
           urlFetches = urlFetches.map((f) =>
-            f.id === fetchId
-              ? { ...f, status: fetchStatus as 'completed' | 'failed' }
-              : f,
+            f.id === fetchId ? { ...f, status: next } : f,
           )
         }
 

--- a/src/components/chat/hooks/streaming-processor.ts
+++ b/src/components/chat/hooks/streaming-processor.ts
@@ -12,6 +12,10 @@
 import { streamingTracker } from '@/services/cloud/streaming-tracker'
 import { processCitationMarkers } from '@/utils/citation-processing'
 import { logError } from '@/utils/error-handling'
+import {
+  createTinfoilEventParser,
+  type TinfoilWebSearchCallEvent,
+} from '@/utils/tinfoil-events'
 import type {
   Annotation,
   Chat,
@@ -160,6 +164,155 @@ export async function processStreamingResponse(
             }, 16)
     }
 
+    // Parser for `<tinfoil-event>...</tinfoil-event>` progress markers
+    // the router inlines into delta.content when the client opts in via
+    // the X-Tinfoil-Events header. Markers are stripped from the
+    // visible text before it reaches the assistant message; decoded
+    // events drive the same webSearchState / urlFetches state machine
+    // the legacy top-level SSE path used.
+    const tinfoilEventParser = createTinfoilEventParser()
+
+    /**
+     * Dispatches a normalized web_search_call event into the live
+     * streaming state. Callers normalize to a common shape so the
+     * legacy top-level SSE branch and the new marker-extracted events
+     * share one code path.
+     */
+    const applyWebSearchCallEvent = (event: {
+      id?: string
+      status: string
+      action?: { type?: string; query?: string; url?: string }
+      reason?: string
+    }) => {
+      // `assistantMessage` is typed `Message | null` at the outer scope
+      // but is never reassigned to `null` once streaming begins. The
+      // helper runs exclusively inside the streaming loop, so force
+      // the narrowing here instead of threading the field through
+      // another parameter.
+      const current = assistantMessage as Message
+      // URL fetch events surface as action.type === 'open_page'.
+      if (event.action?.type === 'open_page' && event.action?.url) {
+        const fetchUrl = event.action.url
+        const fetchId = event.id || fetchUrl
+        const fetchStatus = event.status
+
+        if (fetchStatus === 'in_progress') {
+          if (!urlFetches.some((f) => f.id === fetchId)) {
+            urlFetches = [
+              ...urlFetches,
+              { id: fetchId, url: fetchUrl, status: 'fetching' },
+            ]
+          }
+        } else if (fetchStatus === 'completed' || fetchStatus === 'failed') {
+          urlFetches = urlFetches.map((f) =>
+            f.id === fetchId
+              ? { ...f, status: fetchStatus as 'completed' | 'failed' }
+              : f,
+          )
+        }
+
+        assistantMessage = {
+          ...current,
+          urlFetches: [...urlFetches],
+        }
+        if (isSameChat()) {
+          scheduleStreamingUpdate()
+        }
+        return
+      }
+
+      const searchQuery = event.action?.query
+      const searchStatus = event.status
+
+      if (searchStatus === 'in_progress' && searchQuery) {
+        if (!webSearchStarted) {
+          webSearchStarted = true
+        }
+        webSearchState = {
+          query: searchQuery,
+          status: 'searching',
+        }
+        assistantMessage = {
+          ...current,
+          webSearch: webSearchState,
+          webSearchBeforeThinking: !thinkingStarted,
+        }
+        if (isSameChat()) {
+          const chatId = ctx.currentChatIdRef.current
+          const messageToSave = assistantMessage as Message
+          const newMessages = [...ctx.updatedMessages, messageToSave]
+          ctx.updateChatWithHistoryCheck(
+            ctx.setChats,
+            { ...ctx.updatedChat, id: chatId },
+            ctx.setCurrentChat,
+            chatId,
+            newMessages,
+            false,
+            true,
+          )
+          ctx.setIsWaitingForResponse(false)
+        }
+      } else if (searchStatus === 'completed' && webSearchState) {
+        webSearchState = {
+          query: webSearchState.query,
+          status: 'completed',
+          sources: webSearchState.sources,
+        }
+        assistantMessage = {
+          ...current,
+          webSearch: webSearchState,
+        }
+        if (isSameChat()) {
+          scheduleStreamingUpdate()
+        }
+      } else if (searchStatus === 'failed' && webSearchState) {
+        webSearchState = {
+          query: webSearchState.query,
+          status: 'failed',
+          sources: [],
+        }
+        assistantMessage = {
+          ...current,
+          webSearch: webSearchState,
+        }
+        if (isSameChat()) {
+          scheduleStreamingUpdate()
+        }
+      } else if (searchStatus === 'blocked') {
+        if (!webSearchStarted) {
+          webSearchStarted = true
+        }
+        webSearchState = {
+          query: searchQuery,
+          status: 'blocked',
+          reason: event.reason,
+        }
+        assistantMessage = {
+          ...current,
+          webSearch: webSearchState,
+          webSearchBeforeThinking: !thinkingStarted,
+        }
+        if (isSameChat()) {
+          scheduleStreamingUpdate()
+        }
+      }
+    }
+
+    /**
+     * Adapts a marker-shaped payload to the normalized dispatch shape.
+     * Marker payloads carry `item_id` and `error.code`; the legacy
+     * top-level SSE events carry `id` and `reason`. Everything else is
+     * structurally identical so we just re-key the two fields.
+     */
+    const dispatchMarkerEvent = (event: TinfoilWebSearchCallEvent) => {
+      applyWebSearchCallEvent({
+        id: event.item_id,
+        status: event.status,
+        action: event.action,
+        reason: event.error?.code,
+      })
+    }
+
     while (true) {
       const { done, value } = await reader!.read()
       if (done || !isSameChat()) {
@@ -252,115 +405,18 @@ export async function processStreamingResponse(
           const jsonData = line.replace(/^data:\s*/i, '')
           const json = JSON.parse(jsonData)
 
-          // Handle web_search_call events
+          // Legacy top-level `web_search_call` SSE records. Current
+          // routers surface the same progression through inline
+          // `<tinfoil-event>` markers on delta.content; this branch
+          // stays so older router builds that still emit the legacy
+          // record shape keep the same UX.
           if (json.type === 'web_search_call') {
-            // Handle URL fetch events (action.type === 'open_page')
-            if (json.action?.type === 'open_page' && json.action?.url) {
-              const fetchUrl = json.action.url as string
-              const fetchId = (json.id as string) || fetchUrl
-              const fetchStatus = json.status as string
-
-              if (fetchStatus === 'in_progress') {
-                urlFetches = [
-                  ...urlFetches,
-                  { id: fetchId, url: fetchUrl, status: 'fetching' },
-                ]
-              } else if (
-                fetchStatus === 'completed' ||
-                fetchStatus === 'failed'
-              ) {
-                urlFetches = urlFetches.map((f) =>
-                  f.id === fetchId
-                    ? { ...f, status: fetchStatus as 'completed' | 'failed' }
-                    : f,
-                )
-              }
-
-              assistantMessage = {
-                ...assistantMessage,
-                urlFetches: [...urlFetches],
-              }
-              if (isSameChat()) {
-                scheduleStreamingUpdate()
-              }
-              continue
-            }
-
-            const searchQuery = json.action?.query
-            const searchStatus = json.status
-
-            if (searchStatus === 'in_progress' && searchQuery) {
-              if (!webSearchStarted) {
-                webSearchStarted = true
-              }
-              webSearchState = {
-                query: searchQuery,
-                status: 'searching',
-              }
-              assistantMessage = {
-                ...assistantMessage,
-                webSearch: webSearchState,
-                webSearchBeforeThinking: !thinkingStarted,
-              }
-              if (isSameChat()) {
-                const chatId = ctx.currentChatIdRef.current
-                const messageToSave = assistantMessage as Message
-                const newMessages = [...ctx.updatedMessages, messageToSave]
-                ctx.updateChatWithHistoryCheck(
-                  ctx.setChats,
-                  { ...ctx.updatedChat, id: chatId },
-                  ctx.setCurrentChat,
-                  chatId,
-                  newMessages,
-                  false,
-                  true,
-                )
-                ctx.setIsWaitingForResponse(false)
-              }
-            } else if (searchStatus === 'completed' && webSearchState) {
-              webSearchState = {
-                query: webSearchState.query,
-                status: 'completed',
-                sources: webSearchState.sources,
-              }
-              assistantMessage = {
-                ...assistantMessage,
-                webSearch: webSearchState,
-              }
-              if (isSameChat()) {
-                scheduleStreamingUpdate()
-              }
-            } else if (searchStatus === 'failed' && webSearchState) {
-              webSearchState = {
-                query: webSearchState.query,
-                status: 'failed',
-                sources: [],
-              }
-              assistantMessage = {
-                ...assistantMessage,
-                webSearch: webSearchState,
-              }
-              if (isSameChat()) {
-                scheduleStreamingUpdate()
-              }
-            } else if (searchStatus === 'blocked') {
-              if (!webSearchStarted) {
-                webSearchStarted = true
-              }
-              webSearchState = {
-                query: searchQuery,
-                status: 'blocked',
-                reason: json.reason,
-              }
-              assistantMessage = {
-                ...assistantMessage,
-                webSearch: webSearchState,
-                webSearchBeforeThinking: !thinkingStarted,
-              }
-              if (isSameChat()) {
-                scheduleStreamingUpdate()
-              }
-            }
+            applyWebSearchCallEvent({
+              id: typeof json.id === 'string' ? json.id : undefined,
+              status: String(json.status ?? ''),
+              action: json.action,
+              reason: typeof json.reason === 'string' ? json.reason : undefined,
+            })
             continue
           }
 
@@ -441,6 +497,22 @@ export async function processStreamingResponse(
             json.choices?.[0]?.delta?.reasoning ||
             ''
           let content = json.choices?.[0]?.delta?.content || ''
+
+          // Strip any `<tinfoil-event>` progress markers the router
+          // embeds in delta.content when the caller opts into the
+          // event stream. Dispatched events drive the same
+          // webSearchState / urlFetches machinery as the legacy SSE
+          // records; the cleaned text flows through the rest of the
+          // pipeline so the assistant message never contains raw
+          // marker tags.
+          if (content) {
+            const { text: cleaned, events } =
+              tinfoilEventParser.consume(content)
+            for (const event of events) {
+              dispatchMarkerEvent(event)
+            }
+            content = cleaned
+          }
 
           if (
             hasReasoningContent &&
@@ -715,6 +787,22 @@ export async function processStreamingResponse(
           })
           continue
         }
+      }
+    }
+
+    // Drain any bytes the tinfoil-event parser was holding back at
+    // the byte boundary of the final delta. Anything left over is
+    // either an unterminated marker body (router bug) or a trailing
+    // fragment of what could have been an open tag. Surface it as
+    // plain text so no assistant characters are lost, and strip any
+    // residual marker tags defensively so the UI never renders raw
+    // `<tinfoil-event>` bytes.
+    const tail = tinfoilEventParser.flush()
+    if (tail) {
+      const safeTail = tail.replace(/<\/?tinfoil-event>/g, '')
+      assistantMessage = {
+        ...assistantMessage,
+        content: (assistantMessage.content || '') + safeTail,
       }
     }
 

--- a/src/services/inference/tinfoil-client.ts
+++ b/src/services/inference/tinfoil-client.ts
@@ -1,6 +1,10 @@
 import { API_BASE_URL } from '@/config'
 import { AUTH_ACTIVE_USER_ID } from '@/constants/storage-keys'
 import { logError } from '@/utils/error-handling'
+import {
+  TINFOIL_EVENTS_HEADER,
+  TINFOIL_EVENTS_VALUE_WEB_SEARCH,
+} from '@/utils/tinfoil-events'
 import { AuthenticationError, TinfoilAI } from 'tinfoil'
 import { authTokenManager } from '../auth'
 
@@ -184,6 +188,13 @@ async function initClient(sessionToken: string): Promise<TinfoilAI> {
     clientInstance = new TinfoilAI({
       apiKey: sessionToken,
       dangerouslyAllowBrowser: true,
+      // Opt into the router's inline progress-marker stream so the
+      // chat UI can surface live web_search and URL-fetch status while
+      // the underlying SSE stream stays spec-conformant for any other
+      // OpenAI-compatible consumer.
+      defaultHeaders: {
+        [TINFOIL_EVENTS_HEADER]: TINFOIL_EVENTS_VALUE_WEB_SEARCH,
+      },
     })
     lastSessionToken = sessionToken
     return clientInstance

--- a/src/utils/tinfoil-events.ts
+++ b/src/utils/tinfoil-events.ts
@@ -81,6 +81,16 @@ export function createTinfoilEventParser(): {
   // bounded by the largest in-flight marker.
   let buffer = ''
   let insideMarker = false
+  // True when the most recently-consumed close tag landed at the very
+  // end of a chunk. In that case the router's trailing pad `\n` is
+  // still in the next chunk; we strip the first byte of that chunk
+  // below instead of checking buffer[0] synchronously.
+  let pendingStripLeadingNewline = false
+  // True when the last byte we emitted to the output `text` was `\n`.
+  // If the next chunk starts with `<tinfoil-event>`, that `\n` was the
+  // router's leading pad and must be retroactively removed from `text`
+  // (we only know it was a pad after seeing the open tag).
+  let trailingNewlineOnText = false
 
   /**
    * Given a non-marker chunk suffix, return how many trailing bytes
@@ -105,6 +115,16 @@ export function createTinfoilEventParser(): {
     let text = ''
     const events: TinfoilWebSearchCallEvent[] = []
 
+    // Drain a deferred trailing-pad `\n` left over from the previous
+    // `consume` call. Only applies to the very first byte so we do not
+    // accidentally eat model-emitted newlines further downstream.
+    if (pendingStripLeadingNewline) {
+      pendingStripLeadingNewline = false
+      if (buffer.charCodeAt(0) === 0x0a) {
+        buffer = buffer.slice(1)
+      }
+    }
+
     while (buffer.length > 0) {
       if (!insideMarker) {
         const openIdx = buffer.indexOf(OPEN_TAG)
@@ -112,7 +132,11 @@ export function createTinfoilEventParser(): {
           // No full open tag yet. Emit everything except any trailing
           // bytes that could still grow into `<tinfoil-event>`.
           const holdBack = openTagPrefixSuffixLength(buffer)
-          text += buffer.slice(0, buffer.length - holdBack)
+          const emit = buffer.slice(0, buffer.length - holdBack)
+          text += emit
+          if (emit.length > 0) {
+            trailingNewlineOnText = emit.charCodeAt(emit.length - 1) === 0x0a
+          }
           buffer = buffer.slice(buffer.length - holdBack)
           break
         }
@@ -120,12 +144,24 @@ export function createTinfoilEventParser(): {
         // captures stay readable. Drop a single `\n` directly abutting
         // the open tag so the marker round-trips invisibly in the
         // rendered text instead of producing an empty line where the
-        // marker used to be.
-        const preTag =
-          openIdx > 0 && buffer.charCodeAt(openIdx - 1) === 0x0a /* \n */
-            ? buffer.slice(0, openIdx - 1)
-            : buffer.slice(0, openIdx)
-        text += preTag
+        // marker used to be. The `\n` can live either in the current
+        // buffer (same chunk) or at the end of what we already emitted
+        // on a prior chunk; handle both cases.
+        let preTagEnd = openIdx
+        if (preTagEnd > 0 && buffer.charCodeAt(preTagEnd - 1) === 0x0a) {
+          preTagEnd -= 1
+        } else if (preTagEnd === 0 && trailingNewlineOnText) {
+          // Pad `\n` already sits at the tail of `text` from a prior
+          // chunk. Retroactively drop it so the rendered text has no
+          // orphan blank line where the marker used to be.
+          text = text.slice(0, -1)
+        }
+        text += buffer.slice(0, preTagEnd)
+        if (text.length > 0) {
+          trailingNewlineOnText = text.charCodeAt(text.length - 1) === 0x0a
+        } else {
+          trailingNewlineOnText = false
+        }
         buffer = buffer.slice(openIdx + OPEN_TAG.length)
         insideMarker = true
         continue
@@ -139,10 +175,20 @@ export function createTinfoilEventParser(): {
       const payload = buffer.slice(0, closeIdx)
       buffer = buffer.slice(closeIdx + CLOSE_TAG.length)
       // Match the leading-newline strip on the trailing side so a
-      // `\n<marker>\n` pad collapses to nothing, not to `\n`.
-      if (buffer.charCodeAt(0) === 0x0a) {
+      // `\n<marker>\n` pad collapses to nothing, not to `\n`. The pad
+      // might have already arrived (same chunk) or still be pending
+      // (close tag was at the chunk boundary) — defer the strip to the
+      // next call if the buffer is empty here.
+      if (buffer.length === 0) {
+        pendingStripLeadingNewline = true
+      } else if (buffer.charCodeAt(0) === 0x0a) {
         buffer = buffer.slice(1)
       }
+      // The open tag we just finished reset `trailingNewlineOnText` to
+      // whatever `text` ended with; re-confirm that state so leading
+      // strips for subsequent markers in the same chunk still work.
+      trailingNewlineOnText =
+        text.length > 0 && text.charCodeAt(text.length - 1) === 0x0a
       insideMarker = false
       const event = parseMarkerPayload(payload)
       if (event) events.push(event)
@@ -159,6 +205,8 @@ export function createTinfoilEventParser(): {
     const tail = buffer
     buffer = ''
     insideMarker = false
+    pendingStripLeadingNewline = false
+    trailingNewlineOnText = false
     return tail
   }
 

--- a/src/utils/tinfoil-events.ts
+++ b/src/utils/tinfoil-events.ts
@@ -116,7 +116,16 @@ export function createTinfoilEventParser(): {
           buffer = buffer.slice(buffer.length - holdBack)
           break
         }
-        text += buffer.slice(0, openIdx)
+        // The router pads each marker with a leading newline so raw SSE
+        // captures stay readable. Drop a single `\n` directly abutting
+        // the open tag so the marker round-trips invisibly in the
+        // rendered text instead of producing an empty line where the
+        // marker used to be.
+        const preTag =
+          openIdx > 0 && buffer.charCodeAt(openIdx - 1) === 0x0a /* \n */
+            ? buffer.slice(0, openIdx - 1)
+            : buffer.slice(0, openIdx)
+        text += preTag
         buffer = buffer.slice(openIdx + OPEN_TAG.length)
         insideMarker = true
         continue
@@ -129,6 +138,11 @@ export function createTinfoilEventParser(): {
       }
       const payload = buffer.slice(0, closeIdx)
       buffer = buffer.slice(closeIdx + CLOSE_TAG.length)
+      // Match the leading-newline strip on the trailing side so a
+      // `\n<marker>\n` pad collapses to nothing, not to `\n`.
+      if (buffer.charCodeAt(0) === 0x0a) {
+        buffer = buffer.slice(1)
+      }
       insideMarker = false
       const event = parseMarkerPayload(payload)
       if (event) events.push(event)

--- a/src/utils/tinfoil-events.ts
+++ b/src/utils/tinfoil-events.ts
@@ -1,0 +1,184 @@
+/**
+ * Streaming parser for `<tinfoil-event>...</tinfoil-event>` markers.
+ *
+ * The router rides opt-in web_search / fetch progress events inline with
+ * the model's assistant text when the client sets the `X-Tinfoil-Events`
+ * request header. Strict OpenAI SDKs render the tags as literal text; we
+ * intercept them here so the UI can drive the existing webSearchState
+ * and urlFetches surfaces without the raw tags leaking into the rendered
+ * message.
+ *
+ * The parser is deliberately chunk-tolerant: markers can be split across
+ * any byte boundary (inside the opening tag, inside the JSON body, or
+ * inside the closing tag) because the upstream stream is not
+ * newline-aligned. Callers feed each delta through `consume` and collect
+ * (1) the visible text with every completed marker removed and
+ * (2) the decoded event payloads. On stream end `flush` returns whatever
+ * tail text remained. The buffer always carries forward only the minimal
+ * unresolved suffix so the memory footprint stays O(marker size).
+ */
+
+/**
+ * Name of the request header clients set to opt into the tinfoil-event
+ * marker stream. Exported so the one place that builds the TinfoilAI
+ * options can reference the same string as the parser.
+ */
+export const TINFOIL_EVENTS_HEADER = 'X-Tinfoil-Events'
+
+/**
+ * Value to send on the header to enable the router's web-search marker
+ * stream. Forward compat: the header is comma-separated so additional
+ * families can be added later.
+ */
+export const TINFOIL_EVENTS_VALUE_WEB_SEARCH = 'web_search'
+
+/** The `type` value on every web_search_call marker payload. */
+export const TINFOIL_WEB_SEARCH_CALL_TYPE = 'tinfoil.web_search_call'
+
+const OPEN_TAG = '<tinfoil-event>'
+const CLOSE_TAG = '</tinfoil-event>'
+
+/**
+ * Parsed web_search_call marker payload. Mirrors what the router
+ * serializes: `item_id`, `status`, `action` (with optional `query` /
+ * `url` / `type`) and an optional `error` object with a machine-readable
+ * `code` describing the failure or safety block.
+ */
+export interface TinfoilWebSearchCallEvent {
+  type: typeof TINFOIL_WEB_SEARCH_CALL_TYPE
+  item_id?: string
+  status: 'in_progress' | 'searching' | 'completed' | 'failed' | 'blocked'
+  action?: {
+    type?: 'search' | 'open_page'
+    query?: string
+    url?: string
+  }
+  error?: { code?: string }
+}
+
+/**
+ * Result of consuming a single content chunk. `text` is the chunk with
+ * every complete marker removed; `events` is the zero-or-more decoded
+ * payloads the router emitted inside those markers.
+ */
+export interface TinfoilEventConsumeResult {
+  text: string
+  events: TinfoilWebSearchCallEvent[]
+}
+
+/**
+ * Create a stateful parser bound to a single assistant turn. Chunks must
+ * be fed through `consume` in order; at stream end callers should drain
+ * any unterminated tail via `flush` so no characters are lost.
+ */
+export function createTinfoilEventParser(): {
+  consume: (chunk: string) => TinfoilEventConsumeResult
+  flush: () => string
+} {
+  // Holds any bytes we could not yet classify: either a partial open
+  // tag being sniffed, or everything between an open tag and the
+  // eventual close tag. Kept as a plain string so the memory cost is
+  // bounded by the largest in-flight marker.
+  let buffer = ''
+  let insideMarker = false
+
+  /**
+   * Given a non-marker chunk suffix, return how many trailing bytes
+   * might be the start of an opening tag. The parser holds those bytes
+   * back until the next chunk arrives so `<tinfoil-event` split across
+   * a boundary is still detected. A match is only plausible if the
+   * suffix is a proper prefix of OPEN_TAG; everything shorter is
+   * consumed as visible text.
+   */
+  const openTagPrefixSuffixLength = (s: string): number => {
+    const max = Math.min(s.length, OPEN_TAG.length - 1)
+    for (let len = max; len > 0; len--) {
+      if (OPEN_TAG.startsWith(s.slice(s.length - len))) {
+        return len
+      }
+    }
+    return 0
+  }
+
+  const consume = (chunk: string): TinfoilEventConsumeResult => {
+    buffer += chunk
+    let text = ''
+    const events: TinfoilWebSearchCallEvent[] = []
+
+    while (buffer.length > 0) {
+      if (!insideMarker) {
+        const openIdx = buffer.indexOf(OPEN_TAG)
+        if (openIdx < 0) {
+          // No full open tag yet. Emit everything except any trailing
+          // bytes that could still grow into `<tinfoil-event>`.
+          const holdBack = openTagPrefixSuffixLength(buffer)
+          text += buffer.slice(0, buffer.length - holdBack)
+          buffer = buffer.slice(buffer.length - holdBack)
+          break
+        }
+        text += buffer.slice(0, openIdx)
+        buffer = buffer.slice(openIdx + OPEN_TAG.length)
+        insideMarker = true
+        continue
+      }
+
+      const closeIdx = buffer.indexOf(CLOSE_TAG)
+      if (closeIdx < 0) {
+        // Full payload has not landed yet; wait for more bytes.
+        break
+      }
+      const payload = buffer.slice(0, closeIdx)
+      buffer = buffer.slice(closeIdx + CLOSE_TAG.length)
+      insideMarker = false
+      const event = parseMarkerPayload(payload)
+      if (event) events.push(event)
+    }
+
+    return { text, events }
+  }
+
+  const flush = (): string => {
+    // If we ended inside a marker the router emitted garbage — surface
+    // the raw tail as plain text so at least the user sees something
+    // rather than silently dropping bytes. Callers can still decide
+    // whether to strip residual tags before display.
+    const tail = buffer
+    buffer = ''
+    insideMarker = false
+    return tail
+  }
+
+  return { consume, flush }
+}
+
+function parseMarkerPayload(raw: string): TinfoilWebSearchCallEvent | null {
+  const trimmed = raw.trim()
+  if (!trimmed) return null
+  try {
+    const decoded = JSON.parse(trimmed) as unknown
+    if (!decoded || typeof decoded !== 'object') return null
+    const obj = decoded as Record<string, unknown>
+    if (obj.type !== TINFOIL_WEB_SEARCH_CALL_TYPE) return null
+    if (typeof obj.status !== 'string') return null
+    return obj as unknown as TinfoilWebSearchCallEvent
+  } catch {
+    return null
+  }
+}
+
+/**
+ * One-shot helper for non-streaming content: runs a fresh parser across
+ * the full string and returns both the cleaned text and the decoded
+ * events. Use this for final assistant messages returned by the
+ * non-streaming chat / responses paths, where the whole payload lands
+ * in one chunk.
+ */
+export function extractTinfoilEventsFromText(input: string): {
+  text: string
+  events: TinfoilWebSearchCallEvent[]
+} {
+  const parser = createTinfoilEventParser()
+  const { text, events } = parser.consume(input)
+  const tail = parser.flush()
+  return { text: text + tail, events }
+}

--- a/tests/utils/tinfoil-events.test.ts
+++ b/tests/utils/tinfoil-events.test.ts
@@ -130,6 +130,53 @@ describe('createTinfoilEventParser', () => {
     expect(tail).not.toContain('<tinfoil-event>')
     expect(tail).toBe('{"type":"')
   })
+
+  it('strips trailing pad newline that arrives in the next chunk', () => {
+    const parser = createTinfoilEventParser()
+    const payload = {
+      type: TINFOIL_WEB_SEARCH_CALL_TYPE,
+      item_id: 'ws_1',
+      status: 'completed',
+      action: { type: 'search', query: 'q' },
+    }
+    // Close tag lands at the exact end of chunk 1; the router's
+    // trailing pad `\n` arrives at the start of chunk 2. Both must be
+    // suppressed so the concatenated text has no orphan blank line.
+    const first = parser.consume(`hello\n${markerFor(payload)}`)
+    expect(first.text).toBe('hello')
+    expect(first.events).toHaveLength(1)
+    const second = parser.consume('\nAnswer.')
+    expect(second.text).toBe('Answer.')
+    expect(second.events).toEqual([])
+  })
+
+  it('strips leading pad newline when the open tag starts the next chunk', () => {
+    const parser = createTinfoilEventParser()
+    const payload = {
+      type: TINFOIL_WEB_SEARCH_CALL_TYPE,
+      item_id: 'ws_1',
+      status: 'in_progress',
+      action: { type: 'search', query: 'q' },
+    }
+    // Leading pad `\n` is in chunk 1 before the open tag arrives in
+    // chunk 2. The parser must retroactively drop it from the emitted
+    // text so no orphan blank line surfaces above the marker.
+    const first = parser.consume('hello\n')
+    expect(first.text).toBe('hello\n')
+    const second = parser.consume(`${markerFor(payload)}\nAnswer.`)
+    expect(second.text).toBe('Answer.')
+    expect(second.events).toHaveLength(1)
+  })
+
+  it('preserves a real model newline when no marker follows it', () => {
+    const parser = createTinfoilEventParser()
+    // A `\n` emitted by the model that is NOT followed by an open tag
+    // in the next chunk must survive verbatim.
+    const first = parser.consume('line1\n')
+    expect(first.text).toBe('line1\n')
+    const second = parser.consume('line2')
+    expect(second.text).toBe('line2')
+  })
 })
 
 describe('extractTinfoilEventsFromText', () => {

--- a/tests/utils/tinfoil-events.test.ts
+++ b/tests/utils/tinfoil-events.test.ts
@@ -140,9 +140,13 @@ describe('extractTinfoilEventsFromText', () => {
       status: 'completed',
       action: { type: 'search', query: 'q' },
     }
+    // Router emits `\n<marker>\n` so raw SSE captures stay readable.
+    // The parser collapses those pad newlines on each side so the
+    // marker round-trips invisibly — the rendered text should have no
+    // orphan blank line where the marker used to be.
     const input = `\n${markerFor(payload)}\nAnswer.`
     const { text, events } = extractTinfoilEventsFromText(input)
-    expect(text).toBe('\n\nAnswer.')
+    expect(text).toBe('Answer.')
     expect(events).toHaveLength(1)
     expect(events[0].action?.query).toBe('q')
   })
@@ -153,5 +157,19 @@ describe('extractTinfoilEventsFromText', () => {
     )
     expect(text).toBe('plain answer without events')
     expect(events).toEqual([])
+  })
+
+  it('preserves non-pad whitespace adjacent to a marker', () => {
+    const payload = {
+      type: TINFOIL_WEB_SEARCH_CALL_TYPE,
+      item_id: 'ws_1',
+      status: 'completed',
+      action: { type: 'search', query: 'q' },
+    }
+    // Two `\n` before the marker: one is consumed as the pad, the
+    // other is real content the model intended to emit.
+    const input = `first\n\n${markerFor(payload)}\n\nsecond`
+    const { text } = extractTinfoilEventsFromText(input)
+    expect(text).toBe('first\n\nsecond')
   })
 })

--- a/tests/utils/tinfoil-events.test.ts
+++ b/tests/utils/tinfoil-events.test.ts
@@ -1,0 +1,157 @@
+import {
+  TINFOIL_WEB_SEARCH_CALL_TYPE,
+  createTinfoilEventParser,
+  extractTinfoilEventsFromText,
+} from '@/utils/tinfoil-events'
+import { describe, expect, it } from 'vitest'
+
+function markerFor(payload: Record<string, unknown>): string {
+  return `<tinfoil-event>${JSON.stringify(payload)}</tinfoil-event>`
+}
+
+describe('createTinfoilEventParser', () => {
+  it('extracts a marker delivered in a single chunk', () => {
+    const parser = createTinfoilEventParser()
+    const payload = {
+      type: TINFOIL_WEB_SEARCH_CALL_TYPE,
+      item_id: 'ws_1',
+      status: 'in_progress',
+      action: { type: 'search', query: 'q' },
+    }
+    const input = `prefix ${markerFor(payload)} suffix`
+    const result = parser.consume(input)
+    expect(result.text).toBe('prefix  suffix')
+    expect(result.events).toHaveLength(1)
+    expect(result.events[0].status).toBe('in_progress')
+    expect(result.events[0].action?.query).toBe('q')
+    expect(parser.flush()).toBe('')
+  })
+
+  it('stitches a marker split across an arbitrary byte boundary', () => {
+    const parser = createTinfoilEventParser()
+    const payload = {
+      type: TINFOIL_WEB_SEARCH_CALL_TYPE,
+      item_id: 'ws_1',
+      status: 'completed',
+      action: { type: 'search', query: 'hello world' },
+    }
+    const full = markerFor(payload)
+    // Split every single character — the parser must hold state across
+    // every boundary, including mid-tag, mid-JSON, and mid-close-tag.
+    const out: string[] = []
+    const events = []
+    for (const ch of full) {
+      const r = parser.consume(ch)
+      out.push(r.text)
+      events.push(...r.events)
+    }
+    out.push(parser.flush())
+    expect(out.join('')).toBe('')
+    expect(events).toHaveLength(1)
+    expect(events[0].status).toBe('completed')
+  })
+
+  it('does not emit a trailing partial open tag as visible text', () => {
+    const parser = createTinfoilEventParser()
+    // The suffix `<tinfoil-` could grow into a real open tag; the
+    // parser must hold it back rather than leak it to the UI.
+    const result = parser.consume('hello <tinfoil-')
+    expect(result.text).toBe('hello ')
+    expect(result.events).toEqual([])
+    // Completing the tag + payload emits the event, still suppressing
+    // the raw tags from the visible text.
+    const payload = {
+      type: TINFOIL_WEB_SEARCH_CALL_TYPE,
+      item_id: 'ws_1',
+      status: 'completed',
+      action: { type: 'search', query: 'q' },
+    }
+    const rest = `event>${JSON.stringify(payload)}</tinfoil-event>tail`
+    const second = parser.consume(rest)
+    expect(second.text).toBe('tail')
+    expect(second.events).toHaveLength(1)
+  })
+
+  it('handles multiple markers in one chunk with surrounding text', () => {
+    const parser = createTinfoilEventParser()
+    const a = markerFor({
+      type: TINFOIL_WEB_SEARCH_CALL_TYPE,
+      item_id: 'ws_1',
+      status: 'in_progress',
+      action: { type: 'search', query: 'a' },
+    })
+    const b = markerFor({
+      type: TINFOIL_WEB_SEARCH_CALL_TYPE,
+      item_id: 'ws_1',
+      status: 'completed',
+      action: { type: 'search', query: 'a' },
+    })
+    const result = parser.consume(`L${a}M${b}R`)
+    expect(result.text).toBe('LMR')
+    expect(result.events.map((e) => e.status)).toEqual([
+      'in_progress',
+      'completed',
+    ])
+  })
+
+  it('drops malformed JSON payloads without breaking later markers', () => {
+    const parser = createTinfoilEventParser()
+    const malformed = '<tinfoil-event>{not json}</tinfoil-event>'
+    const good = markerFor({
+      type: TINFOIL_WEB_SEARCH_CALL_TYPE,
+      item_id: 'ws_2',
+      status: 'completed',
+      action: { type: 'search', query: 'q' },
+    })
+    const result = parser.consume(`${malformed}keep${good}`)
+    expect(result.text).toBe('keep')
+    expect(result.events).toHaveLength(1)
+    expect(result.events[0].item_id).toBe('ws_2')
+  })
+
+  it('ignores foreign JSON payloads that are not tinfoil.web_search_call', () => {
+    const parser = createTinfoilEventParser()
+    const foreign = '<tinfoil-event>{"type":"other.kind"}</tinfoil-event>'
+    const result = parser.consume(foreign)
+    expect(result.text).toBe('')
+    expect(result.events).toEqual([])
+  })
+
+  it('flushes unterminated marker body without leaking the open tag', () => {
+    const parser = createTinfoilEventParser()
+    const first = parser.consume('hello <tinfoil-event>{"type":"')
+    // The chunk before the opening tag flows through verbatim.
+    expect(first.text).toBe('hello ')
+    // Stream ends mid-marker; the parser already consumed the opening
+    // tag and entered the marker body, so the flushed tail surfaces
+    // only the uninterpreted JSON fragment. The opening tag itself
+    // stays suppressed so the UI never renders raw `<tinfoil-event>`.
+    const tail = parser.flush()
+    expect(tail).not.toContain('<tinfoil-event>')
+    expect(tail).toBe('{"type":"')
+  })
+})
+
+describe('extractTinfoilEventsFromText', () => {
+  it('processes a full non-streaming message in one call', () => {
+    const payload = {
+      type: TINFOIL_WEB_SEARCH_CALL_TYPE,
+      item_id: 'ws_1',
+      status: 'completed',
+      action: { type: 'search', query: 'q' },
+    }
+    const input = `\n${markerFor(payload)}\nAnswer.`
+    const { text, events } = extractTinfoilEventsFromText(input)
+    expect(text).toBe('\n\nAnswer.')
+    expect(events).toHaveLength(1)
+    expect(events[0].action?.query).toBe('q')
+  })
+
+  it('returns the original text when no markers are present', () => {
+    const { text, events } = extractTinfoilEventsFromText(
+      'plain answer without events',
+    )
+    expect(text).toBe('plain answer without events')
+    expect(events).toEqual([])
+  })
+})


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds inline web search progress to streaming chats by parsing `<tinfoil-event>` markers and updating web search and URL fetch status live, while keeping assistant text clean. We also opt into these events by default via the `X-Tinfoil-Events` header.

- **New Features**
  - Added a chunk-tolerant `tinfoil-events` parser that removes markers and emits decoded events; includes one-shot `extractTinfoilEventsFromText`.
  - Integrated parser into the streaming processor to drive `webSearch` and `urlFetches`; legacy `web_search_call` SSE events now share the same normalized path.
  - `tinfoil-client` now sends `X-Tinfoil-Events: web_search` by default to enable router markers.

- **Bug Fixes**
  - Map per-URL `blocked` to `failed` for consistent UI status.
  - Keep markers invisible across chunk boundaries (mid-tag or mid-JSON); strip pad newlines that land in later chunks and flush tails without raw `<tinfoil-event>` bytes.

<sup>Written for commit add1f6166e9b926f983ea09c8cd162a0f3a93efd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

