### PR TITLE
fix: warn users with cloud data but no passkey credential

### DIFF
--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -360,6 +360,7 @@ export function ChatInterface({
     manualRecoveryNeeded,
     passkeySetupAvailable,
     passkeySetupFailed,
+    passkeyRetryAvailable,
     passkeyFirstTimePromptAvailable,
     setupPasskey,
     setupFirstTimePasskey,
@@ -2798,6 +2799,7 @@ export function ChatInterface({
         <PasskeySetupFailedModal
           isOpen={passkeySetupFailed}
           isRetryingPasskey={isRetryingPasskey}
+          allowRetry={passkeyRetryAvailable}
           onRetryPasskey={async () => {
             setIsRetryingPasskey(true)
             try {

--- a/src/components/modals/passkey-setup-failed-modal.tsx
+++ b/src/components/modals/passkey-setup-failed-modal.tsx
@@ -17,6 +17,14 @@ interface PasskeySetupFailedModalProps {
   onDismiss: () => void
   /** Passkey retry is currently in-flight; disables the buttons. */
   isRetryingPasskey?: boolean
+  /**
+   * Whether retrying the passkey flow is a valid action in the current state.
+   * False when the warning was raised by a state where there is no passkey
+   * to retry against (e.g. remote data exists but the server has no
+   * passkey credential registered for this user). Hides the retry button
+   * and promotes "Enable Manual Backup" to the primary action.
+   */
+  allowRetry?: boolean
 }
 
 export function PasskeySetupFailedModal({
@@ -25,6 +33,7 @@ export function PasskeySetupFailedModal({
   onEnableManualBackup,
   onDismiss,
   isRetryingPasskey = false,
+  allowRetry = true,
 }: PasskeySetupFailedModalProps) {
   const [isDetailsExpanded, setIsDetailsExpanded] = useState(false)
   return (
@@ -64,17 +73,35 @@ export function PasskeySetupFailedModal({
                   as="h2"
                   className="mt-4 text-center font-aeonik text-xl font-bold text-content-primary"
                 >
-                  Chats Are Not Being Backed Up
+                  {allowRetry
+                    ? 'Chats Are Not Being Backed Up'
+                    : 'Unlock Your Chats'}
                 </Dialog.Title>
 
                 <div className="mt-4 space-y-3 text-sm text-content-secondary">
-                  <p>
-                    Tinfoil needs a passkey or a manually managed encryption key
-                    to back up your chats.
-                  </p>
-                  <p className="font-semibold text-content-primary">
-                    Your chats will only exist on this device.
-                  </p>
+                  {allowRetry ? (
+                    <>
+                      <p>
+                        Tinfoil needs a passkey or a manually managed encryption
+                        key to back up your chats.
+                      </p>
+                      <p className="font-semibold text-content-primary">
+                        Your chats will only exist on this device.
+                      </p>
+                    </>
+                  ) : (
+                    <>
+                      <p>
+                        We detected existing encrypted chats on your account.
+                        Enter the encryption key you saved when you first set up
+                        cloud sync to unlock them on this device.
+                      </p>
+                      <p className="font-semibold text-content-primary">
+                        Your chats will only exist on this device until
+                        unlocked.
+                      </p>
+                    </>
+                  )}
 
                   <div className="rounded-lg border border-border-subtle">
                     <button
@@ -83,7 +110,11 @@ export function PasskeySetupFailedModal({
                       aria-expanded={isDetailsExpanded}
                       className="flex w-full items-center justify-between p-3 text-sm font-medium text-content-secondary transition-colors hover:bg-surface-chat/50"
                     >
-                      <span>Why is this happening?</span>
+                      <span>
+                        {allowRetry
+                          ? 'Why is this happening?'
+                          : "Why isn't passkey available?"}
+                      </span>
                       <ChevronDownIcon
                         className={`h-4 w-4 transition-transform ${
                           isDetailsExpanded ? 'rotate-180' : ''
@@ -92,38 +123,68 @@ export function PasskeySetupFailedModal({
                     </button>
                     {isDetailsExpanded && (
                       <div className="space-y-2 border-t border-border-subtle bg-surface-card p-3 text-sm text-content-secondary">
-                        <p>
-                          Tinfoil works best with built-in passkey managers like
-                          iCloud Keychain, Google Password Manager, or the
-                          Passwords app in your device settings.
-                        </p>
-                        <p>
-                          However, you can also create an encryption key that
-                          you&apos;ll have to manage and copy across your
-                          devices manually (don&apos;t lose your key!).
-                        </p>
+                        {allowRetry ? (
+                          <>
+                            <p>
+                              Tinfoil works best with built-in passkey managers
+                              like iCloud Keychain, Google Password Manager, or
+                              the Passwords app in your device settings.
+                            </p>
+                            <p>
+                              However, you can also create an encryption key
+                              that you&apos;ll have to manage and copy across
+                              your devices manually (don&apos;t lose your key!).
+                            </p>
+                          </>
+                        ) : (
+                          <>
+                            <p>
+                              We detected existing encrypted chats that
+                              weren&apos;t backed up with a passkey. You&apos;ll
+                              need to enter the encryption key you saved when
+                              you first set up cloud sync. Once unlocked, you
+                              can add passkey backup from Settings.
+                            </p>
+                            <p>
+                              If you don&apos;t have your key, you can start
+                              fresh with a new one — but existing chats will be
+                              inaccessible (don&apos;t lose your key this
+                              time!).
+                            </p>
+                          </>
+                        )}
                       </div>
                     )}
                   </div>
                 </div>
 
                 <div className="mt-5 space-y-2">
-                  <button
-                    onClick={onRetryPasskey}
-                    disabled={isRetryingPasskey}
-                    className="flex w-full items-center justify-center gap-2 rounded-lg bg-brand-accent-dark px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-brand-accent-dark/90 disabled:cursor-not-allowed disabled:opacity-60"
-                  >
-                    <ArrowPathIcon className="h-4 w-4" />
-                    {isRetryingPasskey ? 'Trying...' : 'Try Again with Passkey'}
-                  </button>
+                  {allowRetry && (
+                    <button
+                      onClick={onRetryPasskey}
+                      disabled={isRetryingPasskey}
+                      className="flex w-full items-center justify-center gap-2 rounded-lg bg-brand-accent-dark px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-brand-accent-dark/90 disabled:cursor-not-allowed disabled:opacity-60"
+                    >
+                      <ArrowPathIcon className="h-4 w-4" />
+                      {isRetryingPasskey
+                        ? 'Trying...'
+                        : 'Try Again with Passkey'}
+                    </button>
+                  )}
 
                   <button
                     onClick={onEnableManualBackup}
                     disabled={isRetryingPasskey}
-                    className="flex w-full items-center justify-center gap-2 rounded-lg border border-border-subtle bg-surface-chat px-4 py-2 text-sm font-medium text-content-primary transition-colors hover:bg-surface-chat/80 disabled:cursor-not-allowed disabled:opacity-60"
+                    className={
+                      allowRetry
+                        ? 'flex w-full items-center justify-center gap-2 rounded-lg border border-border-subtle bg-surface-chat px-4 py-2 text-sm font-medium text-content-primary transition-colors hover:bg-surface-chat/80 disabled:cursor-not-allowed disabled:opacity-60'
+                        : 'flex w-full items-center justify-center gap-2 rounded-lg bg-brand-accent-dark px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-brand-accent-dark/90 disabled:cursor-not-allowed disabled:opacity-60'
+                    }
                   >
                     <KeyIcon className="h-4 w-4" />
-                    Enable Manual Backup
+                    {allowRetry
+                      ? 'Enable Manual Backup'
+                      : 'Enter Encryption Key'}
                   </button>
 
                   <button

--- a/src/hooks/use-passkey-backup.ts
+++ b/src/hooks/use-passkey-backup.ts
@@ -52,6 +52,14 @@ export interface PasskeyBackupState {
    */
   passkeySetupFailed: boolean
   /**
+   * Whether retrying the passkey flow makes sense given the current state.
+   * False when the warning was raised by a path where there is no passkey
+   * credential to retry against (e.g. remote data exists but the server
+   * has no registered passkey for this user). The warning modal hides the
+   * "Try Again with Passkey" button in that case.
+   */
+  passkeyRetryAvailable: boolean
+  /**
    * First-time user with no local key, no remote backup, and PRF support
    * available. Surfaces a confirmation modal asking whether to enable
    * passkey-backed cloud sync — we no longer invoke the native passkey
@@ -193,6 +201,7 @@ export function usePasskeyBackup({
     manualRecoveryNeeded: false,
     passkeySetupAvailable: false,
     passkeySetupFailed: false,
+    passkeyRetryAvailable: true,
     passkeyFirstTimePromptAvailable: false,
   })
 
@@ -242,6 +251,7 @@ export function usePasskeyBackup({
           manualRecoveryNeeded: false,
           passkeySetupAvailable: false,
           passkeySetupFailed: false,
+          passkeyRetryAvailable: true,
           passkeyFirstTimePromptAvailable: false,
         })
       }
@@ -779,9 +789,25 @@ export function usePasskeyBackup({
           const remoteState = await inspectRemoteEncryptedState()
           if (!isMountedRef.current) return
           if (remoteState === 'empty') {
-            setState((prev) => ({ ...prev, passkeySetupFailed: true }))
+            setState((prev) => ({
+              ...prev,
+              passkeySetupFailed: true,
+              passkeyRetryAvailable: false,
+            }))
           } else {
-            setState((prev) => ({ ...prev, manualRecoveryNeeded: true }))
+            // Remote data exists but PRF is unavailable on this device.
+            // Surface both the recovery-needed flag (so the unlock modal
+            // can open when sync is enabled) and the warning (so the user
+            // knows their chats aren't being backed up right now). Hide
+            // the retry button since there's nothing to retry with.
+            setState((prev) => ({
+              ...prev,
+              manualRecoveryNeeded: true,
+              passkeySetupFailed: setupWarningDismissedFlag.isSet()
+                ? prev.passkeySetupFailed
+                : true,
+              passkeyRetryAvailable: false,
+            }))
           }
         }
         return
@@ -843,9 +869,23 @@ export function usePasskeyBackup({
               }))
             }
           } else if (isMountedRef.current) {
+            // Remote encrypted data exists but the server has no passkey
+            // credential registered for this user, so we can't offer a
+            // passkey-driven unlock on this device. Surface both:
+            //  - manualRecoveryNeeded (existing): the recovery modal still
+            //    opens when the user enables cloud sync from settings.
+            //  - passkeySetupFailed (warning): tell the user their chats
+            //    aren't being backed up, with manual-backup as the primary
+            //    fallback. Hide the "Try Again with Passkey" button since
+            //    there's no passkey to retry against.
+            // Respect the session warning-dismiss flag.
             setState((prev) => ({
               ...prev,
               manualRecoveryNeeded: true,
+              passkeySetupFailed: setupWarningDismissedFlag.isSet()
+                ? prev.passkeySetupFailed
+                : true,
+              passkeyRetryAvailable: false,
             }))
           }
         } else if (isMountedRef.current) {
@@ -1030,6 +1070,7 @@ export function usePasskeyBackup({
         ...prev,
         passkeyFirstTimePromptAvailable: false,
         passkeySetupFailed: true,
+        passkeyRetryAvailable: true,
       }))
     }
 
@@ -1169,6 +1210,9 @@ export function usePasskeyBackup({
       passkeySetupFailed: setupWarningDismissedFlag.isSet()
         ? prev.passkeySetupFailed
         : true,
+      // A passkey credential is registered on the server, so retrying
+      // passkey recovery is a valid next step.
+      passkeyRetryAvailable: true,
     }))
   }, [])
 

--- a/tests/components/passkey-setup-failed-modal.test.tsx
+++ b/tests/components/passkey-setup-failed-modal.test.tsx
@@ -121,4 +121,51 @@ describe('PasskeySetupFailedModal', () => {
       screen.getByText(/tinfoil works best with built-in passkey managers/i),
     ).toBeInTheDocument()
   })
+
+  it('hides retry and swaps to unlock copy when allowRetry is false', () => {
+    render(
+      createElement(PasskeySetupFailedModal, {
+        ...baseProps,
+        allowRetry: false,
+      }),
+    )
+
+    expect(
+      screen.queryByRole('button', { name: /try again with passkey/i }),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', { name: /unlock your chats/i }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(/we detected existing encrypted chats on your account/i),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: /enter encryption key/i }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: /continue without backup/i }),
+    ).toBeInTheDocument()
+  })
+
+  it('shows the unlock-specific dropdown copy when allowRetry is false', () => {
+    render(
+      createElement(PasskeySetupFailedModal, {
+        ...baseProps,
+        allowRetry: false,
+      }),
+    )
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /why isn't passkey available/i }),
+    )
+
+    expect(
+      screen.getByText(
+        /we detected existing encrypted chats that weren't backed up with a passkey/i,
+      ),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(/you can start fresh with a new one/i),
+    ).toBeInTheDocument()
+  })
 })


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Warn users who have encrypted cloud data but no usable passkey (missing server credential or no PRF support), and route them to manual unlock instead of offering a dead-end retry. Hides the “Try Again with Passkey” button and makes “Enter Encryption Key” the primary action when retry isn’t valid.

- **Bug Fixes**
  - Added `passkeyRetryAvailable` to `use-passkey-backup`; set to false when remote data exists but no server passkey is registered or PRF isn’t available. Also sets `manualRecoveryNeeded` and respects the session dismissal flag before surfacing the warning.
  - Updated `PasskeySetupFailedModal` with `allowRetry`; conditionally hides the retry button, switches the title to “Unlock Your Chats,” updates the explainer (“Why isn’t passkey available?”), and promotes “Enter Encryption Key” to the primary action. `ChatInterface` now passes this flag.
  - Expanded tests to cover hidden retry, updated copy, and the “Enter Encryption Key” flow.

<sup>Written for commit 6f161b535c79844fe7f478edc25b38a86733f8fd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

