### PR TITLE
Fix cloud backup modal persistence and UI

### DIFF
--- a/src/components/modals/passkey-setup-prompt-modal.tsx
+++ b/src/components/modals/passkey-setup-prompt-modal.tsx
@@ -1,9 +1,5 @@
 import { Dialog, Transition } from '@headlessui/react'
-import {
-  CloudArrowUpIcon,
-  KeyIcon,
-  ShieldCheckIcon,
-} from '@heroicons/react/24/outline'
+import { CloudArrowUpIcon, KeyIcon } from '@heroicons/react/24/outline'
 import { Fragment } from 'react'
 
 interface PasskeySetupPromptModalProps {
@@ -66,12 +62,6 @@ export function PasskeySetupPromptModal({
                     Tinfoil can encrypt and back up your chats with a passkey so
                     you can access them across devices.
                   </p>
-                  <div className="flex items-start gap-2">
-                    <ShieldCheckIcon className="mt-0.5 h-4 w-4 flex-shrink-0 text-content-primary" />
-                    <span>
-                      End-to-end encrypted — only you can decrypt your chats.
-                    </span>
-                  </div>
                 </div>
 
                 <div className="mt-5 space-y-2">

--- a/src/constants/storage-keys.ts
+++ b/src/constants/storage-keys.ts
@@ -47,17 +47,19 @@ export const SETTINGS_LOCAL_ONLY_MODE_ENABLED =
 // passkey or manual backup.
 export const SETTINGS_PASSKEY_RECOVERY_DISMISSED =
   'tinfoil-settings-passkey-recovery-dismissed'
+// Persists across sessions: set when the brand-new-user first-time setup
+// prompt was dismissed via "Not Now". While set, the prompt is not
+// auto-opened on page load so the user isn't pestered on every new tab.
+// Cleared automatically when the user signs in as a different user, or
+// when they explicitly re-enable cloud sync from settings.
+export const SETTINGS_PASSKEY_FIRST_TIME_PROMPT_DISMISSED =
+  'tinfoil-settings-passkey-first-time-prompt-dismissed'
 
 // --- sessionStorage: Passkey setup failure ---------------------------------
 // Tracks whether the user has dismissed the "passkey backup failed" warning
 // during the current session so we don't re-prompt on every re-init.
 export const SETTINGS_PASSKEY_SETUP_WARNING_DISMISSED =
   'tinfoil-settings-passkey-setup-warning-dismissed'
-// Tracks whether the brand-new-user first-time setup prompt was dismissed
-// via "Not Now" during the current session so we don't re-show it on every
-// reload within the same tab. Cleared on tab close.
-export const SETTINGS_PASSKEY_FIRST_TIME_PROMPT_DISMISSED =
-  'tinfoil-settings-passkey-first-time-prompt-dismissed'
 
 // --- localStorage: User personalization preferences ------------------------
 export const USER_PREFS_NICKNAME = 'tinfoil-user-prefs-nickname'

--- a/src/hooks/use-passkey-backup.ts
+++ b/src/hooks/use-passkey-backup.ts
@@ -184,7 +184,7 @@ const passkeyRecoveryDismissedFlag = createStorageFlag(
 )
 
 const firstTimePromptDismissedFlag = createStorageFlag(
-  () => sessionStorage,
+  () => localStorage,
   SETTINGS_PASSKEY_FIRST_TIME_PROMPT_DISMISSED,
 )
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Persist the passkey/cloud backup prompt dismissal across tabs and sessions so new users aren’t repeatedly prompted. Also simplified the modal UI by removing the extra encryption note and icon.

- **Bug Fixes**
  - Store `SETTINGS_PASSKEY_FIRST_TIME_PROMPT_DISMISSED` in `localStorage` (via `createStorageFlag`) so “Not now” persists across tabs and reloads.

<sup>Written for commit 236ed34685333223ecacc6e1af352b2619d3515e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

