### PR TITLE
fix: restore passkey unlock when re-enabling cloud sync

### DIFF
--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -365,6 +365,7 @@ export function ChatInterface({
     setupPasskey,
     setupFirstTimePasskey,
     showFirstTimePasskeyPrompt,
+    showPasskeyRecoveryPrompt,
     dismissFirstTimePasskeyPrompt,
     recoverWithPasskey,
     setupNewKeySplit,
@@ -1173,17 +1174,26 @@ export function ChatInterface({
     }
   }
 
-  // Handler for cloud sync setup. Prefer the friendly "Back Up Your Chats"
-  // prompt for brand-new signed-in users so they don't get dropped into the
-  // raw key-generator UI; fall back to the manual cloud-sync setup modal
-  // otherwise (existing key, remote data, or PRF unsupported).
+  // Handler for cloud sync setup. When the user has no local key we first
+  // check if the backend already holds a passkey credential — if so, route
+  // them back to passkey recovery even if they previously dismissed it, so
+  // clicking "Enable Cloud Sync" is always a valid re-entry path. Next
+  // prefer the friendly "Back Up Your Chats" prompt for brand-new signed-in
+  // users so they don't get dropped into the raw key-generator UI. Fall
+  // back to the manual cloud-sync setup modal otherwise (existing key,
+  // remote data without a passkey, or PRF unsupported).
   const handleOpenCloudSyncSetup = useCallback(async () => {
     if (!encryptionService.getKey()) {
+      const recovered = await showPasskeyRecoveryPrompt()
+      if (recovered) {
+        setShowCloudSyncSetupModal(true)
+        return
+      }
       const routed = await showFirstTimePasskeyPrompt()
       if (routed) return
     }
     setShowCloudSyncSetupModal(true)
-  }, [showFirstTimePasskeyPrompt])
+  }, [showPasskeyRecoveryPrompt, showFirstTimePasskeyPrompt])
 
   const handleKeyChanged = useCallback(
     async (

--- a/src/hooks/use-passkey-backup.ts
+++ b/src/hooks/use-passkey-backup.ts
@@ -1161,6 +1161,39 @@ export function usePasskeyBackup({
     }))
   }, [])
 
+  // Ask the hook to re-surface the passkey-recovery modal. Used when the
+  // user clicks "Enable Cloud Sync" from the sidebar/settings after
+  // previously dismissing the recovery prompt. Only succeeds when PRF is
+  // supported, there is no local encryption key, and the backend has a
+  // registered passkey credential for this user. Clears the persistent
+  // dismiss flag so the recovery modal reopens, and flips
+  // `passkeyRecoveryNeeded` back to true so `chat-interface` routes the
+  // modal to the passkey-recovery step. Returns true if the recovery
+  // prompt was made available; false if the caller should fall through to
+  // another flow (first-time setup or manual key).
+  const showPasskeyRecoveryPrompt = useCallback(async (): Promise<boolean> => {
+    if (encryptionService.getKey()) return false
+    const prfSupported = await isPrfSupported()
+    if (!prfSupported) return false
+    try {
+      const credentialState = await getPasskeyCredentialState()
+      if (credentialState !== 'exists') return false
+    } catch {
+      return false
+    }
+    passkeyRecoveryDismissedFlag.clear()
+    setupWarningDismissedFlag.clear()
+    if (isMountedRef.current) {
+      setState((prev) => ({
+        ...prev,
+        passkeyRecoveryNeeded: true,
+        passkeySetupFailed: false,
+        passkeyRetryAvailable: true,
+      }))
+    }
+    return true
+  }, [])
+
   // Ask the hook to re-show the first-time setup prompt modal. Used when
   // the user clicks "Enable Cloud Sync" from the sidebar/settings after
   // previously dismissing the prompt. Only succeeds when PRF is supported
@@ -1257,6 +1290,7 @@ export function usePasskeyBackup({
     setupPasskey,
     setupFirstTimePasskey,
     showFirstTimePasskeyPrompt,
+    showPasskeyRecoveryPrompt,
     dismissFirstTimePasskeyPrompt,
     recoverWithPasskey,
     setupNewKeySplit,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Restores passkey unlock when re-enabling cloud sync after the recovery prompt was previously dismissed. Clicking “Enable Cloud Sync” now reopens passkey recovery if a server credential exists and PRF is supported; otherwise it falls back to first-time setup or the manual flow.

- **Bug Fixes**
  - Added `showPasskeyRecoveryPrompt` in `use-passkey-backup` to check PRF support and server credential, clear dismiss flags, and re-enable recovery.
  - Updated `ChatInterface` to call recovery first, then the first-time prompt, then the manual setup, ensuring the modal routes to the recovery step when eligible.

<sup>Written for commit 918e75a3823bc8c4e35317bb4f70d3997e0474d7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

