### PR TITLE
Improve websearch UX and UI

### DIFF
--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -591,6 +591,23 @@ export function ChatInterface({
   // State for scroll button - define early so it can be used in useChatState
   const [showScrollButton, setShowScrollButton] = useState(false)
   const scrollContainerRef = useRef<HTMLDivElement | null>(null)
+  const inputAreaObserverRef = useRef<ResizeObserver | null>(null)
+  const [inputAreaHeight, setInputAreaHeight] = useState(0)
+  const inputAreaRef = useCallback((node: HTMLDivElement | null) => {
+    inputAreaObserverRef.current?.disconnect()
+    inputAreaObserverRef.current = null
+    if (!node) {
+      setInputAreaHeight(0)
+      return
+    }
+    setInputAreaHeight(node.offsetHeight)
+    if (typeof ResizeObserver === 'undefined') return
+    const observer = new ResizeObserver(() => {
+      setInputAreaHeight(node.offsetHeight)
+    })
+    observer.observe(node)
+    inputAreaObserverRef.current = observer
+  }, [])
   const scrollCheckTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
     null,
   )
@@ -2572,7 +2589,32 @@ export function ChatInterface({
               ref={scrollContainerRef}
               onScroll={handleScroll}
               data-scroll-container="main"
-              className="relative flex flex-1 overflow-y-auto bg-surface-chat-background"
+              className="relative flex-1 overflow-y-auto bg-surface-chat-background"
+              style={
+                inputAreaHeight
+                  ? ({
+                      paddingBottom: inputAreaHeight + 32,
+                      '--input-area-height': `${inputAreaHeight}px`,
+                      '--mask-fade-start': `calc(100% - ${inputAreaHeight + 32}px)`,
+                      '--mask-fade-end': `calc(100% - ${inputAreaHeight}px)`,
+                      maskImage:
+                        'linear-gradient(to bottom, black 0, black var(--mask-fade-start), transparent var(--mask-fade-end)), linear-gradient(black, black)',
+                      maskSize:
+                        'calc(100% - var(--scrollbar-gutter, 14px)) 100%, var(--scrollbar-gutter, 14px) 100%',
+                      maskPosition: '0 0, 100% 0',
+                      maskRepeat: 'no-repeat, no-repeat',
+                      WebkitMaskImage:
+                        'linear-gradient(to bottom, black 0, black var(--mask-fade-start), transparent var(--mask-fade-end)), linear-gradient(black, black)',
+                      WebkitMaskSize:
+                        'calc(100% - var(--scrollbar-gutter, 14px)) 100%, var(--scrollbar-gutter, 14px) 100%',
+                      WebkitMaskPosition: '0 0, 100% 0',
+                      WebkitMaskRepeat: 'no-repeat, no-repeat',
+                    } as React.CSSProperties)
+                  : ({
+                      paddingBottom: inputAreaHeight + 32,
+                      '--input-area-height': `${inputAreaHeight}px`,
+                    } as React.CSSProperties)
+              }
             >
               <div className="flex min-w-0 flex-1 [container-type:inline-size]">
                 <ChatMessages
@@ -2614,7 +2656,8 @@ export function ChatInterface({
             (windowWidth < CONSTANTS.MOBILE_BREAKPOINT ||
               (currentChat?.messages && currentChat.messages.length > 0)) && (
               <div
-                className="relative flex-shrink-0 bg-surface-chat-background px-4 pb-4"
+                ref={inputAreaRef}
+                className="pointer-events-none absolute inset-x-0 bottom-0 z-10 px-4 pb-4"
                 style={{
                   minHeight: '80px',
                   maxHeight: '50vh',
@@ -2623,7 +2666,7 @@ export function ChatInterface({
               >
                 <form
                   onSubmit={handleSubmit}
-                  className="mx-auto max-w-3xl px-1 md:px-8"
+                  className="pointer-events-auto relative mx-auto max-w-3xl px-1 md:px-8"
                 >
                   <ChatInput
                     input={input}
@@ -2714,7 +2757,7 @@ export function ChatInterface({
 
                 {/* Scroll to bottom button - absolutely positioned in parent */}
                 {showScrollButton && currentChat?.messages?.length > 0 && (
-                  <div className="absolute -top-[50px] left-1/2 z-10 -translate-x-1/2">
+                  <div className="pointer-events-auto absolute -top-[50px] left-1/2 z-10 -translate-x-1/2">
                     <button
                       onClick={() => scrollToLastMessage()}
                       className="flex h-10 w-10 items-center justify-center rounded-full border border-border-subtle bg-surface-sidebar-button shadow-md transition-colors hover:bg-surface-sidebar-button-hover"

--- a/src/components/chat/chat-messages.tsx
+++ b/src/components/chat/chat-messages.tsx
@@ -118,11 +118,17 @@ const ChatMessage = memo(
 
     // Always re-render if this is the streaming message and content/thoughts changed
     if (nextProps.isStreaming && nextProps.isLastMessage) {
-      // Only re-render if content, thoughts, or expanded state actually changed
+      // Only re-render if content, thoughts, streaming tool-call state, or
+      // expanded state actually changed.
       return (
         prevProps.message.content === nextProps.message.content &&
         prevProps.message.thoughts === nextProps.message.thoughts &&
         prevProps.message.isThinking === nextProps.message.isThinking &&
+        prevProps.message.segments === nextProps.message.segments &&
+        prevProps.message.webSearches === nextProps.message.webSearches &&
+        prevProps.message.webSearch === nextProps.message.webSearch &&
+        prevProps.message.urlFetches === nextProps.message.urlFetches &&
+        prevProps.message.annotations === nextProps.message.annotations &&
         prevExpanded === nextExpanded
       )
     }
@@ -134,6 +140,11 @@ const ChatMessage = memo(
         prevProps.message.content === nextProps.message.content &&
         prevProps.message.thoughts === nextProps.message.thoughts &&
         prevProps.message.isThinking === nextProps.message.isThinking &&
+        prevProps.message.segments === nextProps.message.segments &&
+        prevProps.message.webSearches === nextProps.message.webSearches &&
+        prevProps.message.webSearch === nextProps.message.webSearch &&
+        prevProps.message.urlFetches === nextProps.message.urlFetches &&
+        prevProps.message.annotations === nextProps.message.annotations &&
         prevProps.message.attachments === nextProps.message.attachments &&
         prevProps.message.documentContent ===
           nextProps.message.documentContent &&
@@ -153,6 +164,11 @@ const ChatMessage = memo(
     return (
       prevProps.message.content === nextProps.message.content &&
       prevProps.message.thoughts === nextProps.message.thoughts &&
+      prevProps.message.segments === nextProps.message.segments &&
+      prevProps.message.webSearches === nextProps.message.webSearches &&
+      prevProps.message.webSearch === nextProps.message.webSearch &&
+      prevProps.message.urlFetches === nextProps.message.urlFetches &&
+      prevProps.message.annotations === nextProps.message.annotations &&
       prevProps.message.attachments === nextProps.message.attachments &&
       prevProps.message.documentContent === nextProps.message.documentContent &&
       prevProps.message.documents === nextProps.message.documents &&
@@ -467,11 +483,18 @@ export function ChatMessages({
           retryInfo={retryInfo}
         />
       )}
-      {/* Spacer allows scrollIntoView to bring user message to top of viewport */}
+      {/* Spacer allows scrollIntoView to bring user message to top of viewport.
+          Subtracts the composer height (set on the scroll container as
+          --input-area-height) so the total over-scroll is just enough for the
+          fade above the input area, not a full 70dvh of empty space. */}
       {showSpacer && (
         <div
           data-spacer
-          className="h-[70dvh] flex-shrink-0"
+          className="flex-shrink-0"
+          style={{
+            height:
+              'max(0px, calc(70dvh - var(--input-area-height, 0px) - 32px))',
+          }}
           aria-hidden="true"
         />
       )}

--- a/src/components/chat/hooks/streaming-processor.ts
+++ b/src/components/chat/hooks/streaming-processor.ts
@@ -19,7 +19,9 @@ import type {
   Annotation,
   Chat,
   Message,
+  MessageSegment,
   URLFetchState,
+  WebSearchInstance,
   WebSearchSource,
   WebSearchState,
 } from '../types'
@@ -108,6 +110,66 @@ export async function processStreamingResponse(
     let webSearchStarted = false
     let thinkingStarted = false
 
+    // Ordered content segments (text + inline event refs) that preserve the
+    // exact order in which the router surfaced events relative to the
+    // streamed text. The aggregate `webSearch`/`urlFetches` fields are kept
+    // in sync for legacy consumers (SourcesButton, title generation).
+    let segments: MessageSegment[] = []
+    let webSearches: WebSearchInstance[] = []
+    let nextSearchId = 0
+
+    const allocateSearchId = () => `ws-${nextSearchId++}`
+
+    const appendText = (text: string) => {
+      if (!text) return
+      const last = segments[segments.length - 1]
+      if (last && last.type === 'text') {
+        segments = [
+          ...segments.slice(0, -1),
+          { type: 'text', text: last.text + text },
+        ]
+      } else {
+        segments = [...segments, { type: 'text', text }]
+      }
+    }
+
+    const upsertWebSearchInstance = (instance: WebSearchInstance) => {
+      const idx = webSearches.findIndex((w) => w.id === instance.id)
+      if (idx >= 0) {
+        webSearches = [
+          ...webSearches.slice(0, idx),
+          instance,
+          ...webSearches.slice(idx + 1),
+        ]
+      } else {
+        webSearches = [...webSearches, instance]
+        segments = [...segments, { type: 'web_search', searchId: instance.id }]
+      }
+    }
+
+    const setContentAndRebuildTrailingText = (newContent: string) => {
+      // Strip any trailing text segment(s) and rebuild from the full content
+      // string. This keeps segments consistent when code paths replace the
+      // full `content` instead of appending deltas (e.g. initial chunk
+      // buffer flush, <think>/</think> splits).
+      let lastEventIdx = -1
+      for (let i = segments.length - 1; i >= 0; i--) {
+        if (segments[i].type !== 'text') {
+          lastEventIdx = i
+          break
+        }
+      }
+      const prefix = segments.slice(0, lastEventIdx + 1)
+      const eventContentLength = prefix.reduce((acc, seg) => {
+        if (seg.type === 'text') return acc + seg.text.length
+        return acc
+      }, 0)
+      const trailingText = newContent.slice(eventContentLength)
+      segments = trailingText
+        ? [...prefix, { type: 'text', text: trailingText }]
+        : prefix
+    }
+
     // The router delivers citations as standard markdown links inside the
     // assistant content, so the UI can forward the message through the
     // markdown renderer unchanged.
@@ -164,6 +226,27 @@ export async function processStreamingResponse(
     // the legacy top-level SSE path used.
     const tinfoilEventParser = createTinfoilEventParser()
 
+    const normalizeEventSources = (
+      sources:
+        | Array<{
+            title?: string
+            url?: string
+          }>
+        | undefined,
+    ): WebSearchSource[] | undefined => {
+      if (!sources || sources.length === 0) return undefined
+      const normalized = sources.flatMap((source) => {
+        if (!source?.url) return []
+        return [
+          {
+            title: source.title || source.url,
+            url: source.url,
+          },
+        ]
+      })
+      return normalized.length > 0 ? normalized : undefined
+    }
+
     /**
      * Dispatches a normalized web_search_call event into the live
      * streaming state. Callers normalize to a common shape so the
@@ -174,6 +257,7 @@ export async function processStreamingResponse(
       id?: string
       status: string
       action?: { type?: string; query?: string; url?: string }
+      sources?: WebSearchSource[]
       reason?: string
     }) => {
       // `assistantMessage` is typed `Message | null` at the outer scope
@@ -194,6 +278,7 @@ export async function processStreamingResponse(
               ...urlFetches,
               { id: fetchId, url: fetchUrl, status: 'fetching' },
             ]
+            segments = [...segments, { type: 'url_fetch', fetchId }]
           }
         } else if (
           fetchStatus === 'completed' ||
@@ -217,6 +302,7 @@ export async function processStreamingResponse(
         assistantMessage = {
           ...current,
           urlFetches: [...urlFetches],
+          segments: [...segments],
         }
         if (isSameChat()) {
           scheduleStreamingUpdate()
@@ -227,18 +313,38 @@ export async function processStreamingResponse(
       const searchQuery = event.action?.query
       const searchStatus = event.status
 
+      // Resolve which in-flight WebSearchInstance this event refers to.
+      // The router may or may not provide a stable id; when it doesn't,
+      // status updates address the most recent instance.
+      const findInstance = (): WebSearchInstance | undefined => {
+        if (event.id) {
+          const hit = webSearches.find((w) => w.id === event.id)
+          if (hit) return hit
+        }
+        return webSearches[webSearches.length - 1]
+      }
+
       if (searchStatus === 'in_progress' && searchQuery) {
         if (!webSearchStarted) {
           webSearchStarted = true
         }
-        webSearchState = {
+        const id = event.id || allocateSearchId()
+        const instance: WebSearchInstance = {
+          id,
           query: searchQuery,
           status: 'searching',
+        }
+        upsertWebSearchInstance(instance)
+        webSearchState = {
+          query: instance.query,
+          status: instance.status,
         }
         assistantMessage = {
           ...current,
           webSearch: webSearchState,
           webSearchBeforeThinking: !thinkingStarted,
+          segments: [...segments],
+          webSearches: [...webSearches],
         }
         if (isSameChat()) {
           const chatId = ctx.currentChatIdRef.current
@@ -255,38 +361,69 @@ export async function processStreamingResponse(
           )
           ctx.setIsWaitingForResponse(false)
         }
-      } else if (searchStatus === 'completed' && webSearchState) {
-        webSearchState = {
-          query: webSearchState.query,
-          status: 'completed',
-          sources: webSearchState.sources,
+      } else if (searchStatus === 'completed') {
+        const existing = findInstance()
+        if (existing) {
+          const updated: WebSearchInstance = {
+            ...existing,
+            status: 'completed',
+            sources: event.sources ?? existing.sources,
+          }
+          upsertWebSearchInstance(updated)
+          webSearchState = {
+            query: updated.query,
+            status: 'completed',
+            sources: updated.sources,
+          }
+          assistantMessage = {
+            ...current,
+            webSearch: webSearchState,
+            segments: [...segments],
+            webSearches: [...webSearches],
+          }
+          if (isSameChat()) {
+            scheduleStreamingUpdate()
+          }
         }
-        assistantMessage = {
-          ...current,
-          webSearch: webSearchState,
-        }
-        if (isSameChat()) {
-          scheduleStreamingUpdate()
-        }
-      } else if (searchStatus === 'failed' && webSearchState) {
-        webSearchState = {
-          query: webSearchState.query,
-          status: 'failed',
-          sources: [],
-        }
-        assistantMessage = {
-          ...current,
-          webSearch: webSearchState,
-        }
-        if (isSameChat()) {
-          scheduleStreamingUpdate()
+      } else if (searchStatus === 'failed') {
+        const existing = findInstance()
+        if (existing) {
+          const updated: WebSearchInstance = {
+            ...existing,
+            status: 'failed',
+            sources: event.sources ?? [],
+          }
+          upsertWebSearchInstance(updated)
+          webSearchState = {
+            query: updated.query,
+            status: 'failed',
+            sources: updated.sources,
+          }
+          assistantMessage = {
+            ...current,
+            webSearch: webSearchState,
+            segments: [...segments],
+            webSearches: [...webSearches],
+          }
+          if (isSameChat()) {
+            scheduleStreamingUpdate()
+          }
         }
       } else if (searchStatus === 'blocked') {
         if (!webSearchStarted) {
           webSearchStarted = true
         }
+        const existing = findInstance()
+        const id = existing?.id || event.id || allocateSearchId()
+        const updated: WebSearchInstance = {
+          id,
+          query: searchQuery ?? existing?.query,
+          status: 'blocked',
+          reason: event.reason,
+        }
+        upsertWebSearchInstance(updated)
         webSearchState = {
-          query: searchQuery,
+          query: updated.query,
           status: 'blocked',
           reason: event.reason,
         }
@@ -294,6 +431,8 @@ export async function processStreamingResponse(
           ...current,
           webSearch: webSearchState,
           webSearchBeforeThinking: !thinkingStarted,
+          segments: [...segments],
+          webSearches: [...webSearches],
         }
         if (isSameChat()) {
           scheduleStreamingUpdate()
@@ -312,6 +451,7 @@ export async function processStreamingResponse(
         id: event.item_id,
         status: event.status,
         action: event.action,
+        sources: normalizeEventSources(event.sources),
         reason: event.error?.code,
       })
     }
@@ -333,12 +473,15 @@ export async function processStreamingResponse(
         }
 
         if (isFirstChunk && initialContentBuffer.trim()) {
+          const finalContent = initialContentBuffer.trim()
+          setContentAndRebuildTrailingText(finalContent)
           assistantMessage = {
             ...assistantMessage,
             role: 'assistant',
-            content: initialContentBuffer.trim(),
+            content: finalContent,
             timestamp: assistantMessage?.timestamp || new Date(),
             isThinking: false,
+            segments: [...segments],
           }
           if (isSameChat()) {
             const newMessages = [...ctx.updatedMessages, assistantMessage]
@@ -418,6 +561,11 @@ export async function processStreamingResponse(
               id: typeof json.id === 'string' ? json.id : undefined,
               status: String(json.status ?? ''),
               action: json.action,
+              sources: normalizeEventSources(
+                Array.isArray(json.sources)
+                  ? (json.sources as Array<{ title?: string; url?: string }>)
+                  : undefined,
+              ),
               reason: typeof json.reason === 'string' ? json.reason : undefined,
             })
             continue
@@ -468,9 +616,22 @@ export async function processStreamingResponse(
                   status: webSearchState.status,
                   sources: [...collectedSources],
                 }
+                // Legacy annotation streams don't identify which web-search
+                // instance a source belongs to. Only mirror them onto an
+                // inline search pill when there's exactly one search, so
+                // multi-search turns don't incorrectly attach every favicon
+                // cluster to the last search row.
+                const lastInstance = webSearches[webSearches.length - 1]
+                if (lastInstance && webSearches.length === 1) {
+                  upsertWebSearchInstance({
+                    ...lastInstance,
+                    sources: [...collectedSources],
+                  })
+                }
                 assistantMessage = {
                   ...assistantMessage,
                   webSearch: webSearchState,
+                  webSearches: [...webSearches],
                   annotations: [...collectedAnnotations],
                 }
               } else {
@@ -570,12 +731,14 @@ export async function processStreamingResponse(
               const thinkingDuration = getThinkingDuration(
                 ctx.thinkingStartTimeRef,
               )
+              appendText(content)
               assistantMessage = {
                 ...assistantMessage,
                 thoughts: thoughtsBuffer.trim() || undefined,
                 content: content,
                 isThinking: false,
                 thinkingDuration,
+                segments: [...segments],
               }
               if (isSameChat()) {
                 scheduleStreamingUpdate()
@@ -605,10 +768,12 @@ export async function processStreamingResponse(
               )
               assistantMessage = { ...assistantMessage, thinkingDuration }
             }
+            appendText(content)
             assistantMessage = {
               ...assistantMessage,
               content: (assistantMessage.content || '') + content,
               isThinking: false,
+              segments: [...segments],
             }
             if (isSameChat()) {
               scheduleStreamingUpdate()
@@ -660,9 +825,11 @@ export async function processStreamingResponse(
                       thinkingDuration,
                     }
                     if (remaining.trim()) {
+                      appendText(remaining)
                       assistantMessage = {
                         ...assistantMessage,
                         content: (assistantMessage.content || '') + remaining,
+                        segments: [...segments],
                       }
                     }
 
@@ -750,8 +917,12 @@ export async function processStreamingResponse(
               thinkingDuration,
             }
             if (remainingContent.trim()) {
-              assistantMessage.content =
-                (assistantMessage.content || '') + remainingContent
+              appendText(remainingContent)
+              assistantMessage = {
+                ...assistantMessage,
+                content: (assistantMessage.content || '') + remainingContent,
+                segments: [...segments],
+              }
             }
             if (isSameChat()) {
               scheduleStreamingUpdate()
@@ -774,10 +945,12 @@ export async function processStreamingResponse(
               content = content.replace(/<think>|<\/think>/g, '')
             }
             if (content) {
+              appendText(content)
               assistantMessage = {
                 ...assistantMessage,
                 content: (assistantMessage.content || '') + content,
                 isThinking: false,
+                segments: [...segments],
               }
               if (isSameChat()) {
                 scheduleStreamingUpdate()
@@ -804,9 +977,11 @@ export async function processStreamingResponse(
     const tail = tinfoilEventParser.flush()
     if (tail) {
       const safeTail = tail.replace(/<\/?tinfoil-event>/g, '')
+      appendText(safeTail)
       assistantMessage = {
         ...assistantMessage,
         content: (assistantMessage.content || '') + safeTail,
+        segments: [...segments],
       }
     }
   } finally {

--- a/src/components/chat/renderers/components/MessageContent.tsx
+++ b/src/components/chat/renderers/components/MessageContent.tsx
@@ -51,9 +51,11 @@ export const MessageContent = memo(function MessageContent({
   citationUrlTitles,
 }: MessageContentProps) {
   const { remarkPlugins, rehypePlugins } = useMathPlugins()
-  const preprocessed = preprocessMarkdown(content)
-  const processedContent = processLatexTags(preprocessed)
-  const sanitizedContent = sanitizeUnsupportedMathBlocks(processedContent)
+  const sanitizedContent = useMemo(() => {
+    const preprocessed = preprocessMarkdown(content)
+    const processedContent = processLatexTags(preprocessed)
+    return sanitizeUnsupportedMathBlocks(processedContent)
+  }, [content])
 
   const showMarkdownTablePlaceholder = useMemo(() => {
     if (!isStreaming) return false

--- a/src/components/chat/renderers/components/SourcesButton.tsx
+++ b/src/components/chat/renderers/components/SourcesButton.tsx
@@ -1,0 +1,183 @@
+import type { WebSearchSource } from '@/components/chat/types'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { sanitizeUrl } from '@braintree/sanitize-url'
+import { ArrowUpRight } from 'lucide-react'
+import { memo, useMemo, useState } from 'react'
+
+const MAX_PREVIEW_FAVICONS = 4
+
+function getFaviconUrl(url: string): string {
+  try {
+    const parsedUrl = new URL(url)
+    return `https://icons.duckduckgo.com/ip3/${parsedUrl.hostname}.ico`
+  } catch {
+    return ''
+  }
+}
+
+function getDomain(url: string): string {
+  try {
+    const parsedUrl = new URL(url)
+    return parsedUrl.hostname.replace(/^www\./, '')
+  } catch {
+    return url
+  }
+}
+
+const faviconCache = new Map<string, { loaded: boolean; error: boolean }>()
+
+function Favicon({
+  url,
+  size,
+  className,
+}: {
+  url: string
+  size: number
+  className?: string
+}) {
+  const faviconUrl = getFaviconUrl(url)
+  const cached = faviconCache.get(faviconUrl)
+  const [loaded, setLoaded] = useState(cached?.loaded ?? false)
+  const [error, setError] = useState(cached?.error ?? false)
+
+  const handleLoad = () => {
+    setLoaded(true)
+    faviconCache.set(faviconUrl, { loaded: true, error: false })
+  }
+
+  const handleError = () => {
+    setError(true)
+    faviconCache.set(faviconUrl, { loaded: false, error: true })
+  }
+
+  if (error || !faviconUrl) {
+    return (
+      <span
+        className={`bg-surface-secondary inline-flex items-center justify-center rounded-full text-content-muted ${className ?? ''}`}
+        style={{ width: size, height: size }}
+        aria-hidden="true"
+      >
+        <span
+          className="block rounded-full bg-current"
+          style={{ width: size * 0.35, height: size * 0.35 }}
+        />
+      </span>
+    )
+  }
+
+  return (
+    <img
+      src={faviconUrl}
+      alt=""
+      width={size}
+      height={size}
+      className={`shrink-0 rounded-full bg-white p-[1px] transition-opacity ${loaded ? 'opacity-100' : 'opacity-0'} ${className ?? ''}`}
+      onLoad={handleLoad}
+      onError={handleError}
+    />
+  )
+}
+
+interface SourcesButtonProps {
+  sources: WebSearchSource[]
+}
+
+export const SourcesButton = memo(function SourcesButton({
+  sources,
+}: SourcesButtonProps) {
+  const [isOpen, setIsOpen] = useState(false)
+
+  const uniqueSources = useMemo(() => {
+    const seen = new Set<string>()
+    const unique: WebSearchSource[] = []
+    for (const source of sources) {
+      if (seen.has(source.url)) continue
+      seen.add(source.url)
+      unique.push(source)
+    }
+    return unique
+  }, [sources])
+
+  const previewDomains = useMemo(() => {
+    const seen = new Set<string>()
+    const domains: string[] = []
+    for (const source of uniqueSources) {
+      const domain = getDomain(source.url)
+      if (seen.has(domain)) continue
+      seen.add(domain)
+      domains.push(source.url)
+      if (domains.length >= MAX_PREVIEW_FAVICONS) break
+    }
+    return domains
+  }, [uniqueSources])
+
+  if (uniqueSources.length === 0) return null
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setIsOpen(true)}
+        className="flex items-center gap-2 rounded-full border border-border-subtle px-3 py-1.5 text-xs font-medium text-content-secondary transition-colors hover:bg-surface-chat-background hover:text-content-primary"
+        aria-label={`Show ${uniqueSources.length} source${uniqueSources.length === 1 ? '' : 's'}`}
+      >
+        <span>Sources</span>
+        <span className="inline-flex items-center">
+          {previewDomains.map((url, index) => (
+            <Favicon
+              key={`${url}-${index}`}
+              url={url}
+              size={16}
+              className={
+                index === 0
+                  ? 'border border-surface-chat'
+                  : '-ml-1.5 border border-surface-chat'
+              }
+            />
+          ))}
+        </span>
+      </button>
+
+      <Dialog open={isOpen} onOpenChange={setIsOpen}>
+        <DialogContent className="max-h-[80vh] max-w-lg overflow-hidden p-0">
+          <DialogHeader className="border-b border-border-subtle px-6 py-4">
+            <DialogTitle>Sources</DialogTitle>
+          </DialogHeader>
+          <div className="max-h-[60vh] overflow-y-auto px-2 py-2">
+            <ul className="flex flex-col">
+              {uniqueSources.map((source, index) => (
+                <li key={`${source.url}-${index}`}>
+                  <a
+                    href={sanitizeUrl(source.url)}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="group flex items-start gap-3 rounded-md px-3 py-2.5 transition-colors hover:bg-surface-chat-background"
+                  >
+                    <Favicon url={source.url} size={20} className="mt-0.5" />
+                    <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+                      <span className="truncate text-sm font-medium text-content-primary">
+                        {source.title || source.url}
+                      </span>
+                      <span className="truncate text-xs text-content-muted">
+                        {getDomain(source.url)}
+                      </span>
+                    </div>
+                    <ArrowUpRight
+                      className="mt-1 h-3.5 w-3.5 shrink-0 text-content-muted opacity-0 transition-opacity group-hover:opacity-100"
+                      aria-hidden="true"
+                    />
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+})

--- a/src/components/chat/renderers/components/StreamingChunkedText.tsx
+++ b/src/components/chat/renderers/components/StreamingChunkedText.tsx
@@ -16,6 +16,9 @@ interface ContentChunk {
   isComplete: boolean
 }
 
+const LIVE_TAIL_MASK =
+  'linear-gradient(to bottom, black calc(100% - 1.5em), transparent 100%)'
+
 // Check if a line looks like a markdown table separator (|---|---|)
 function isTableSeparator(line: string): boolean {
   const trimmed = line.trim()
@@ -373,9 +376,20 @@ const ChunkRenderer = memo(
       return <GeneratingTable />
     }
 
+    const isLiveTail = !!isStreaming && !chunk.isComplete && !isTable
+    const liveTailMaskStyle = isLiveTail
+      ? {
+          WebkitMaskImage: LIVE_TAIL_MASK,
+          maskImage: LIVE_TAIL_MASK,
+        }
+      : undefined
+
     // Render content, with fade-in animation for tables that just completed
     return (
-      <div className={shouldAnimate ? 'animate-fadeIn' : ''}>
+      <div
+        className={shouldAnimate ? 'animate-fadeIn' : ''}
+        style={liveTailMaskStyle}
+      >
         <MessageContent
           content={chunk.content}
           isDarkMode={isDarkMode}

--- a/src/components/chat/renderers/components/StreamingContentWrapper.tsx
+++ b/src/components/chat/renderers/components/StreamingContentWrapper.tsx
@@ -20,7 +20,6 @@ export const StreamingContentWrapper = memo(function StreamingContentWrapper({
   const contentRef = useRef<HTMLDivElement>(null)
   const [minHeight, setMinHeight] = useState<number | undefined>(undefined)
   const maxHeightRef = useRef<number>(0)
-  const measurementFrameRef = useRef<number | null>(null)
   const hasEverStreamedRef = useRef<boolean>(false)
   const holdTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const [isHolding, setIsHolding] = useState<boolean>(false)
@@ -61,37 +60,7 @@ export const StreamingContentWrapper = memo(function StreamingContentWrapper({
       }
     }
 
-    if (!isStreaming) {
-      return
-    }
-
-    if (!contentRef.current) return
-
-    // Function to measure and update minimum height
-    const measureHeight = () => {
-      if (contentRef.current && isStreaming) {
-        const currentHeight = contentRef.current.scrollHeight
-
-        // Only increase, never decrease during streaming
-        if (currentHeight > maxHeightRef.current) {
-          maxHeightRef.current = currentHeight
-          setMinHeight(currentHeight)
-        }
-
-        // Continue measuring while streaming
-        measurementFrameRef.current = requestAnimationFrame(measureHeight)
-      }
-    }
-
-    // Start measuring
-    measureHeight()
-
-    // Cleanup
     return () => {
-      if (measurementFrameRef.current) {
-        cancelAnimationFrame(measurementFrameRef.current)
-        measurementFrameRef.current = null
-      }
       // Clear hold timeout on unmount or when effect re-runs
       if (holdTimeoutRef.current) {
         clearTimeout(holdTimeoutRef.current)
@@ -99,6 +68,36 @@ export const StreamingContentWrapper = memo(function StreamingContentWrapper({
       }
     }
   }, [isStreaming, holdAfterStopMs])
+
+  useEffect(() => {
+    if (
+      !contentRef.current ||
+      typeof ResizeObserver === 'undefined' ||
+      (!isStreaming && !isHolding)
+    ) {
+      return
+    }
+
+    const node = contentRef.current
+    const measureHeight = () => {
+      const currentHeight = node.scrollHeight
+      if (currentHeight > maxHeightRef.current) {
+        maxHeightRef.current = currentHeight
+        setMinHeight(currentHeight)
+      }
+    }
+
+    measureHeight()
+
+    const resizeObserver = new ResizeObserver(() => {
+      measureHeight()
+    })
+    resizeObserver.observe(node)
+
+    return () => {
+      resizeObserver.disconnect()
+    }
+  }, [isStreaming, isHolding])
 
   // Cleanup timeout on unmount
   useEffect(() => {
@@ -114,6 +113,7 @@ export const StreamingContentWrapper = memo(function StreamingContentWrapper({
     <div
       ref={contentRef}
       style={{
+        overflowAnchor: 'none',
         minHeight:
           (isStreaming || isHolding) && minHeight
             ? `${minHeight}px`

--- a/src/components/chat/renderers/components/ThoughtProcess.tsx
+++ b/src/components/chat/renderers/components/ThoughtProcess.tsx
@@ -305,7 +305,7 @@ export const ThoughtProcess = memo(function ThoughtProcess({
               ) : (
                 <div className="flex items-center gap-1.5 text-content-primary/50">
                   <span className="text-base font-medium">Thinking</span>
-                  <LoadingDots isThinking={true} />
+                  <LoadingDots isThinking={true} size="small" />
                 </div>
               )}
             </div>

--- a/src/components/chat/renderers/components/URLFetchProcess.tsx
+++ b/src/components/chat/renderers/components/URLFetchProcess.tsx
@@ -1,5 +1,6 @@
 import type { URLFetchState } from '@/components/chat/types'
 import { memo, useMemo, useState } from 'react'
+import { PiSpinner } from 'react-icons/pi'
 
 interface URLFetchProcessProps {
   urlFetches: URLFetchState[]
@@ -34,22 +35,7 @@ function getFaviconUrl(url: string): string {
 
 function FetchSpinner() {
   return (
-    <svg
-      className="h-3.5 w-3.5 shrink-0 animate-spin text-content-primary/50"
-      viewBox="0 0 16 16"
-      fill="none"
-    >
-      <circle
-        cx="8"
-        cy="8"
-        r="6"
-        stroke="currentColor"
-        strokeWidth="2"
-        strokeLinecap="round"
-        strokeDasharray="28"
-        strokeDashoffset="8"
-      />
-    </svg>
+    <PiSpinner className="h-3.5 w-3.5 shrink-0 animate-spin text-content-primary/50" />
   )
 }
 

--- a/src/components/chat/renderers/components/URLFetchProcess.tsx
+++ b/src/components/chat/renderers/components/URLFetchProcess.tsx
@@ -1,8 +1,15 @@
 import type { URLFetchState } from '@/components/chat/types'
-import { memo, useMemo } from 'react'
+import { memo, useMemo, useState } from 'react'
 
 interface URLFetchProcessProps {
   urlFetches: URLFetchState[]
+  /**
+   * When true and `urlFetches` contains more than one entry, the component
+   * renders a collapsed "Read N links" row that expands on click, instead
+   * of stacking one row per URL. Keeps long fetch runs from vertically
+   * polluting the chat.
+   */
+  grouped?: boolean
 }
 
 function getDisplayUrl(url: string): string {
@@ -46,69 +53,156 @@ function FetchSpinner() {
   )
 }
 
+/// Single row rendering one fetched URL. Used by both the flat and
+/// grouped (collapsed) URL-fetch views so presentation tweaks stay in
+/// one place. `compact` drops the verb prefix ("Read ", "Reading ") that
+/// only makes sense when the row stands alone; the grouped header
+/// already conveys that state for its children.
+function URLFetchRow({
+  fetch,
+  compact,
+}: {
+  fetch: URLFetchState
+  compact: boolean
+}) {
+  const textSize = compact ? 'text-sm' : 'text-base'
+  const textTone = compact
+    ? 'text-content-primary/60'
+    : 'text-content-primary/50'
+
+  return (
+    <div className={`flex min-h-7 items-center gap-2 ${textSize}`}>
+      {fetch.status === 'fetching' ? (
+        <FetchSpinner />
+      ) : (
+        <img
+          src={getFaviconUrl(fetch.url)}
+          alt=""
+          className="h-3.5 w-3.5 shrink-0 rounded-sm"
+          onError={(e) => {
+            ;(e.target as HTMLImageElement).style.display = 'none'
+          }}
+        />
+      )}
+      <span
+        className={`min-w-0 truncate ${
+          fetch.status === 'failed'
+            ? 'text-content-primary/40 line-through'
+            : textTone
+        }`}
+      >
+        {compact ? (
+          getDisplayUrl(fetch.url)
+        ) : fetch.status === 'fetching' ? (
+          <>
+            <span className="font-medium text-content-primary/50">
+              Reading{' '}
+            </span>
+            {getDisplayUrl(fetch.url)}
+          </>
+        ) : fetch.status === 'completed' ? (
+          <>
+            <span className="font-medium text-content-primary/50">Read </span>
+            {getDisplayUrl(fetch.url)}
+          </>
+        ) : (
+          <>
+            <span className="font-medium">Failed to read </span>
+            {getDisplayUrl(fetch.url)}
+          </>
+        )}
+      </span>
+    </div>
+  )
+}
+
 export const URLFetchProcess = memo(function URLFetchProcess({
   urlFetches,
+  grouped,
 }: URLFetchProcessProps) {
   const anyFetching = useMemo(
     () => urlFetches.some((f) => f.status === 'fetching'),
     [urlFetches],
   )
 
+  const shouldCollapse = !!grouped && urlFetches.length > 1
+  if (shouldCollapse) {
+    return <GroupedURLFetchProcess urlFetches={urlFetches} />
+  }
+
   return (
     <div>
       <div className="flex flex-col gap-0.5 px-1 py-1">
         {urlFetches.map((fetch) => (
-          <div
-            key={fetch.id}
-            className="flex min-h-7 items-center gap-2 text-base"
-          >
-            {fetch.status === 'fetching' ? (
-              <FetchSpinner />
-            ) : (
-              <img
-                src={getFaviconUrl(fetch.url)}
-                alt=""
-                className="h-3.5 w-3.5 shrink-0 rounded-sm"
-                onError={(e) => {
-                  ;(e.target as HTMLImageElement).style.display = 'none'
-                }}
-              />
-            )}
-            <span
-              className={`min-w-0 truncate ${
-                fetch.status === 'failed'
-                  ? 'text-content-primary/40 line-through'
-                  : 'text-content-primary/50'
-              }`}
-            >
-              {fetch.status === 'fetching' ? (
-                <>
-                  <span className="font-medium text-content-primary/50">
-                    Reading{' '}
-                  </span>
-                  {getDisplayUrl(fetch.url)}
-                </>
-              ) : fetch.status === 'completed' ? (
-                <>
-                  <span className="font-medium text-content-primary/50">
-                    Read{' '}
-                  </span>
-                  {getDisplayUrl(fetch.url)}
-                </>
-              ) : (
-                <>
-                  <span className="font-medium">Failed to read </span>
-                  {getDisplayUrl(fetch.url)}
-                </>
-              )}
-            </span>
-          </div>
+          <URLFetchRow key={fetch.id} fetch={fetch} compact={false} />
         ))}
         {anyFetching && urlFetches.length === 1 && (
           <span className="text-xs text-content-primary/40">
             Fetching page contents...
           </span>
         )}
+      </div>
+    </div>
+  )
+})
+
+const GroupedURLFetchProcess = memo(function GroupedURLFetchProcess({
+  urlFetches,
+}: {
+  urlFetches: URLFetchState[]
+}) {
+  const [isExpanded, setIsExpanded] = useState(false)
+  const anyFetching = useMemo(
+    () => urlFetches.some((f) => f.status === 'fetching'),
+    [urlFetches],
+  )
+  const completedCount = useMemo(
+    () => urlFetches.filter((f) => f.status === 'completed').length,
+    [urlFetches],
+  )
+  const count = urlFetches.length
+  const label = anyFetching
+    ? `Reading ${count} link${count === 1 ? '' : 's'}`
+    : `Read ${completedCount} link${completedCount === 1 ? '' : 's'}`
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => setIsExpanded((v) => !v)}
+        className="hover:bg-surface-secondary/50 group flex cursor-pointer items-start gap-1.5 rounded-md px-1 py-1 text-left transition-colors"
+      >
+        <span className="mt-[5px] h-3.5 w-3.5 shrink-0" aria-hidden="true">
+          <svg
+            className={`h-3.5 w-3.5 transform text-content-primary/40 transition-transform ${isExpanded ? 'rotate-90' : ''}`}
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M9 5l7 7-7 7"
+            />
+          </svg>
+        </span>
+        <span className="min-w-0 text-base text-content-primary/50">
+          <span className="font-medium">{label}</span>
+        </span>
+      </button>
+
+      <div
+        className="grid overflow-hidden transition-[grid-template-rows] duration-300 ease-out"
+        style={{ gridTemplateRows: isExpanded ? '1fr' : '0fr' }}
+      >
+        <div className="min-h-0 overflow-hidden">
+          <div className="ml-2 flex flex-col gap-0.5 border-l-2 border-border-subtle py-2 pl-3 pr-1">
+            {urlFetches.map((fetch) => (
+              <URLFetchRow key={fetch.id} fetch={fetch} compact />
+            ))}
+          </div>
+        </div>
       </div>
     </div>
   )

--- a/src/components/chat/renderers/components/WebSearchProcess.tsx
+++ b/src/components/chat/renderers/components/WebSearchProcess.tsx
@@ -5,6 +5,7 @@ import type {
 } from '@/components/chat/types'
 import { sanitizeUrl } from '@braintree/sanitize-url'
 import { memo, useMemo, useState } from 'react'
+import { PiSpinner } from 'react-icons/pi'
 
 const webSearchFaviconCache = new Map<
   string,
@@ -143,28 +144,11 @@ const SingleWebSearchProcess = memo(function SingleWebSearchProcess({
           aria-hidden="true"
         >
           {isSearching ? (
-            <svg
+            <PiSpinner
               className="h-3.5 w-3.5 animate-spin text-content-primary/50"
-              viewBox="0 0 24 24"
-              fill="none"
               aria-hidden="true"
               focusable="false"
-            >
-              <circle
-                cx="12"
-                cy="12"
-                r="10"
-                stroke="currentColor"
-                strokeOpacity="0.25"
-                strokeWidth="3"
-              />
-              <path
-                d="M22 12a10 10 0 0 1-10 10"
-                stroke="currentColor"
-                strokeWidth="3"
-                strokeLinecap="round"
-              />
-            </svg>
+            />
           ) : hasSources ? (
             <svg
               className={`h-3.5 w-3.5 transform text-content-primary/40 transition-transform ${isExpanded ? 'rotate-90' : ''}`}
@@ -325,28 +309,11 @@ const GroupedWebSearchProcess = memo(function GroupedWebSearchProcess({
       >
         <span className="mt-[5px] h-3.5 w-3.5 shrink-0" aria-hidden="true">
           {aggregateStatus === 'searching' ? (
-            <svg
+            <PiSpinner
               className="h-3.5 w-3.5 animate-spin text-content-primary/50"
-              viewBox="0 0 24 24"
-              fill="none"
               aria-hidden="true"
               focusable="false"
-            >
-              <circle
-                cx="12"
-                cy="12"
-                r="10"
-                stroke="currentColor"
-                strokeOpacity="0.25"
-                strokeWidth="3"
-              />
-              <path
-                d="M22 12a10 10 0 0 1-10 10"
-                stroke="currentColor"
-                strokeWidth="3"
-                strokeLinecap="round"
-              />
-            </svg>
+            />
           ) : (
             <svg
               className={`h-3.5 w-3.5 transform text-content-primary/40 transition-transform ${isExpanded ? 'rotate-90' : ''}`}

--- a/src/components/chat/renderers/components/WebSearchProcess.tsx
+++ b/src/components/chat/renderers/components/WebSearchProcess.tsx
@@ -1,4 +1,8 @@
-import type { WebSearchState } from '@/components/chat/types'
+import type {
+  WebSearchInstance,
+  WebSearchSource,
+  WebSearchState,
+} from '@/components/chat/types'
 import { sanitizeUrl } from '@braintree/sanitize-url'
 import { memo, useMemo, useState } from 'react'
 
@@ -9,6 +13,13 @@ const webSearchFaviconCache = new Map<
 
 interface WebSearchProcessProps {
   webSearch: WebSearchState
+  /**
+   * When provided with more than one entry, the component renders a
+   * collapsed "Searched the web on N queries" row that expands to list
+   * each query (and, within each query, its own sources). Lets adjacent
+   * tool-call runs stay inline without stacking one pill per search.
+   */
+  groupInstances?: WebSearchInstance[]
 }
 
 function getFaviconUrl(url: string): string {
@@ -72,7 +83,24 @@ function FadeInFavicon({
 
 export const WebSearchProcess = memo(function WebSearchProcess({
   webSearch,
+  groupInstances,
 }: WebSearchProcessProps) {
+  const isGrouped = !!groupInstances && groupInstances.length > 1
+  if (isGrouped) {
+    return (
+      <GroupedWebSearchProcess
+        instances={groupInstances as WebSearchInstance[]}
+      />
+    )
+  }
+  return <SingleWebSearchProcess webSearch={webSearch} />
+})
+
+const SingleWebSearchProcess = memo(function SingleWebSearchProcess({
+  webSearch,
+}: {
+  webSearch: WebSearchState
+}) {
   const [isExpanded, setIsExpanded] = useState(false)
   const isSearching = webSearch.status === 'searching'
   const isFailed = webSearch.status === 'failed'
@@ -110,23 +138,51 @@ export const WebSearchProcess = memo(function WebSearchProcess({
             : 'cursor-default'
         }`}
       >
-        {hasSources && (
-          <svg
-            className={`mt-[5px] h-3.5 w-3.5 shrink-0 transform text-content-primary/40 transition-transform ${isExpanded ? 'rotate-90' : ''}`}
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-            aria-hidden="true"
-            focusable="false"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M9 5l7 7-7 7"
-            />
-          </svg>
-        )}
+        <span
+          className={`mt-[5px] h-3.5 w-3.5 shrink-0 ${hasSources || isSearching ? '' : 'invisible'}`}
+          aria-hidden="true"
+        >
+          {isSearching ? (
+            <svg
+              className="h-3.5 w-3.5 animate-spin text-content-primary/50"
+              viewBox="0 0 24 24"
+              fill="none"
+              aria-hidden="true"
+              focusable="false"
+            >
+              <circle
+                cx="12"
+                cy="12"
+                r="10"
+                stroke="currentColor"
+                strokeOpacity="0.25"
+                strokeWidth="3"
+              />
+              <path
+                d="M22 12a10 10 0 0 1-10 10"
+                stroke="currentColor"
+                strokeWidth="3"
+                strokeLinecap="round"
+              />
+            </svg>
+          ) : hasSources ? (
+            <svg
+              className={`h-3.5 w-3.5 transform text-content-primary/40 transition-transform ${isExpanded ? 'rotate-90' : ''}`}
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              aria-hidden="true"
+              focusable="false"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M9 5l7 7-7 7"
+              />
+            </svg>
+          ) : null}
+        </span>
         <span className="min-w-0 text-base text-content-primary/50">
           {isSearching ? (
             <>
@@ -180,33 +236,35 @@ export const WebSearchProcess = memo(function WebSearchProcess({
 
       {hasSources && (
         <div
-          className="overflow-hidden transition-all duration-300 ease-out"
-          style={{
-            maxHeight: isExpanded ? '1000px' : '0px',
-          }}
+          className="grid overflow-hidden transition-[grid-template-rows] duration-300 ease-out"
+          style={{ gridTemplateRows: isExpanded ? '1fr' : '0fr' }}
         >
-          <div className="ml-2 border-l-2 border-border-subtle py-2 pl-3 pr-1">
-            <div className="flex flex-col gap-2">
-              {uniqueSources.map((source, index) => (
-                <a
-                  key={`${source.url}-${index}`}
-                  href={sanitizeUrl(source.url)}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="hover:bg-surface-secondary/50 flex items-start gap-3 rounded-md px-2 py-1.5 text-sm text-content-primary/70 transition-colors"
-                >
-                  <FadeInFavicon
-                    url={source.url}
-                    className="mt-0.5 h-4 w-4 shrink-0 rounded-full"
-                  />
-                  <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-                    <span className="text-xs opacity-50">
-                      {getDomainName(source.url)}
-                    </span>
-                    <span className="truncate font-medium">{source.title}</span>
-                  </div>
-                </a>
-              ))}
+          <div className="min-h-0 overflow-hidden">
+            <div className="ml-2 border-l-2 border-border-subtle py-2 pl-3 pr-1">
+              <div className="flex flex-col gap-2">
+                {uniqueSources.map((source, index) => (
+                  <a
+                    key={`${source.url}-${index}`}
+                    href={sanitizeUrl(source.url)}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="hover:bg-surface-secondary/50 flex items-start gap-3 rounded-md px-2 py-1.5 text-sm text-content-primary/70 transition-colors"
+                  >
+                    <FadeInFavicon
+                      url={source.url}
+                      className="mt-0.5 h-4 w-4 shrink-0 rounded-full"
+                    />
+                    <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+                      <span className="text-xs opacity-50">
+                        {getDomainName(source.url)}
+                      </span>
+                      <span className="truncate font-medium">
+                        {source.title}
+                      </span>
+                    </div>
+                  </a>
+                ))}
+              </div>
             </div>
           </div>
         </div>
@@ -214,3 +272,192 @@ export const WebSearchProcess = memo(function WebSearchProcess({
     </div>
   )
 })
+
+const GroupedWebSearchProcess = memo(function GroupedWebSearchProcess({
+  instances,
+}: {
+  instances: WebSearchInstance[]
+}) {
+  const [isExpanded, setIsExpanded] = useState(false)
+  const count = instances.length
+
+  const aggregateStatus: WebSearchState['status'] = useMemo(() => {
+    if (instances.some((i) => i.status === 'searching')) return 'searching'
+    if (instances.some((i) => i.status === 'failed')) return 'failed'
+    if (instances.some((i) => i.status === 'blocked')) return 'blocked'
+    return 'completed'
+  }, [instances])
+
+  const mergedSources = useMemo(() => {
+    const seen = new Set<string>()
+    const out: WebSearchSource[] = []
+    for (const instance of instances) {
+      for (const source of instance.sources ?? []) {
+        if (seen.has(source.url)) continue
+        seen.add(source.url)
+        out.push(source)
+      }
+    }
+    return out
+  }, [instances])
+
+  const faviconsToShow = mergedSources.slice(0, 5)
+  const queriesNoun = `${count} quer${count === 1 ? 'y' : 'ies'}`
+  const label: string = (() => {
+    switch (aggregateStatus) {
+      case 'searching':
+        return `Searching the web on ${queriesNoun}`
+      case 'failed':
+        return `Failed to search the web on ${queriesNoun}`
+      case 'blocked':
+        return `Web search blocked on ${queriesNoun}`
+      case 'completed':
+        return `Searched the web on ${queriesNoun}`
+    }
+  })()
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => setIsExpanded((v) => !v)}
+        className="hover:bg-surface-secondary/50 group flex cursor-pointer items-start gap-1.5 rounded-md px-1 py-1 text-left transition-colors"
+      >
+        <span className="mt-[5px] h-3.5 w-3.5 shrink-0" aria-hidden="true">
+          {aggregateStatus === 'searching' ? (
+            <svg
+              className="h-3.5 w-3.5 animate-spin text-content-primary/50"
+              viewBox="0 0 24 24"
+              fill="none"
+              aria-hidden="true"
+              focusable="false"
+            >
+              <circle
+                cx="12"
+                cy="12"
+                r="10"
+                stroke="currentColor"
+                strokeOpacity="0.25"
+                strokeWidth="3"
+              />
+              <path
+                d="M22 12a10 10 0 0 1-10 10"
+                stroke="currentColor"
+                strokeWidth="3"
+                strokeLinecap="round"
+              />
+            </svg>
+          ) : (
+            <svg
+              className={`h-3.5 w-3.5 transform text-content-primary/40 transition-transform ${isExpanded ? 'rotate-90' : ''}`}
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              aria-hidden="true"
+              focusable="false"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M9 5l7 7-7 7"
+              />
+            </svg>
+          )}
+        </span>
+        <span className="min-w-0 text-base text-content-primary/50">
+          <span className="font-medium">{label}</span>
+          {mergedSources.length > 0 && (
+            <span
+              className="inline-flex items-center align-middle"
+              style={{ marginLeft: 6 }}
+            >
+              {faviconsToShow.map((source, index) => (
+                <FadeInFavicon
+                  key={`${source.url}-${index}`}
+                  url={source.url}
+                  className="h-4 w-4 shrink-0 rounded-full border border-surface-chat bg-surface-chat"
+                  style={{ marginLeft: index === 0 ? 0 : -6 }}
+                />
+              ))}
+            </span>
+          )}
+        </span>
+      </button>
+
+      <div
+        className="grid overflow-hidden transition-[grid-template-rows] duration-300 ease-out"
+        style={{ gridTemplateRows: isExpanded ? '1fr' : '0fr' }}
+      >
+        <div className="min-h-0 overflow-hidden">
+          <div className="ml-2 flex flex-col gap-3 border-l-2 border-border-subtle py-2 pl-3 pr-1">
+            {instances.map((instance) => (
+              <GroupedWebSearchRow key={instance.id} instance={instance} />
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+})
+
+function GroupedWebSearchRow({ instance }: { instance: WebSearchInstance }) {
+  const sources = useMemo(() => {
+    const seen = new Set<string>()
+    return (instance.sources ?? []).filter((s) => {
+      if (seen.has(s.url)) return false
+      seen.add(s.url)
+      return true
+    })
+  }, [instance.sources])
+  const hasSources = sources.length > 0
+  const label = instance.query || 'Web search'
+
+  return (
+    <div className="flex flex-col gap-1">
+      <div className="flex items-start gap-1.5 px-1 text-sm text-content-primary/70">
+        <span className="min-w-0">
+          <span className="font-medium">{label}</span>
+          {instance.status === 'searching' && (
+            <span className="text-content-primary/40"> — searching…</span>
+          )}
+          {instance.status === 'failed' && (
+            <span className="text-content-primary/40"> — failed</span>
+          )}
+          {instance.status === 'blocked' && (
+            <span className="text-content-primary/40"> — blocked</span>
+          )}
+          {instance.status === 'completed' && hasSources && (
+            <span className="text-content-primary/40">
+              {' '}
+              — {sources.length} source{sources.length === 1 ? '' : 's'}
+            </span>
+          )}
+        </span>
+      </div>
+
+      {hasSources && (
+        <div className="flex flex-col gap-0.5">
+          {sources.map((source, index) => (
+            <a
+              key={`${source.url}-${index}`}
+              href={sanitizeUrl(source.url)}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hover:bg-surface-secondary/50 flex items-start gap-2 rounded-md px-2 py-1 text-xs text-content-primary/70 transition-colors"
+            >
+              <FadeInFavicon
+                url={source.url}
+                className="mt-0.5 h-3.5 w-3.5 shrink-0 rounded-full"
+              />
+              <div className="flex min-w-0 flex-1 flex-col">
+                <span className="opacity-50">{getDomainName(source.url)}</span>
+                <span className="truncate font-medium">{source.title}</span>
+              </div>
+            </a>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/chat/renderers/components/markdown-components.tsx
+++ b/src/components/chat/renderers/components/markdown-components.tsx
@@ -57,7 +57,7 @@ function CitationPill({ url, title }: { url: string; title?: string }) {
           href={sanitizedHref}
           target="_blank"
           rel="noopener noreferrer"
-          className="mx-0.5 inline-flex h-[1.5em] items-center gap-1.5 whitespace-nowrap rounded-full bg-blue-500/10 pl-1 pr-2 !align-baseline text-[10px] font-medium text-blue-500 transition-colors hover:bg-blue-500/20"
+          className="mx-0.5 inline-flex h-[1.5em] items-center gap-1.5 whitespace-nowrap rounded-full bg-blue-500/10 pl-1 pr-2 align-middle text-[10px] font-medium leading-none text-blue-500 transition-colors hover:bg-blue-500/20"
         >
           <span
             className="inline-flex h-[1.1em] w-[1.1em] shrink-0 items-center justify-center rounded-full bg-white"
@@ -73,7 +73,7 @@ function CitationPill({ url, title }: { url: string; title?: string }) {
               />
             )}
           </span>
-          <span>{domain}</span>
+          <span className="leading-none">{domain}</span>
         </a>
       </TooltipTrigger>
       <TooltipContent side="top" className="max-w-xs">

--- a/src/components/chat/renderers/components/markdown-components.tsx
+++ b/src/components/chat/renderers/components/markdown-components.tsx
@@ -59,15 +59,20 @@ function CitationPill({ url, title }: { url: string; title?: string }) {
           rel="noopener noreferrer"
           className="mx-0.5 inline-flex h-[1.5em] items-center gap-1.5 whitespace-nowrap rounded-full bg-blue-500/10 pl-1 pr-2 !align-baseline text-[10px] font-medium text-blue-500 transition-colors hover:bg-blue-500/20"
         >
-          {!imgError && (
-            <img
-              src={faviconUrl}
-              alt=""
-              className={`h-[1.1em] w-[1.1em] shrink-0 rounded-full bg-white p-[1px] transition-opacity ${imgLoaded ? 'opacity-100' : 'opacity-0'}`}
-              onLoad={handleLoad}
-              onError={handleError}
-            />
-          )}
+          <span
+            className="inline-flex h-[1.1em] w-[1.1em] shrink-0 items-center justify-center rounded-full bg-white"
+            aria-hidden="true"
+          >
+            {!imgError && (
+              <img
+                src={faviconUrl}
+                alt=""
+                className={`h-full w-full rounded-full p-[1px] transition-opacity ${imgLoaded ? 'opacity-100' : 'opacity-0'}`}
+                onLoad={handleLoad}
+                onError={handleError}
+              />
+            )}
+          </span>
           <span>{domain}</span>
         </a>
       </TooltipTrigger>

--- a/src/components/chat/renderers/default/DefaultMessageRenderer.tsx
+++ b/src/components/chat/renderers/default/DefaultMessageRenderer.tsx
@@ -1,3 +1,4 @@
+import { StreamingTracer } from '@/components/streaming-tracer'
 import { cn } from '@/components/ui/utils'
 import {
   ArrowPathIcon,
@@ -138,6 +139,9 @@ const DefaultMessageComponent = ({
     message.quote && shouldTruncateQuote && !isQuoteExpanded
       ? `${message.quote.slice(0, QUOTE_PREVIEW_MAX_LENGTH).trimEnd()}…`
       : (message.quote ?? '')
+  const hasInlineTextSegments =
+    !isUser &&
+    (message.segments?.some((segment) => segment.type === 'text') ?? false)
 
   React.useEffect(() => {
     if (isUser && userMessageContentRef.current) {
@@ -253,47 +257,243 @@ const DefaultMessageComponent = ({
         />
       )}
 
-      {/* Show URL fetch status for assistant messages */}
-      {!isUser && message.urlFetches && message.urlFetches.length > 0 && (
-        <div className="no-scroll-anchoring w-full px-4">
-          <URLFetchProcess urlFetches={message.urlFetches} />
-        </div>
-      )}
+      {/* Render inline segments (events interleaved in the order they
+          streamed) when present; fall back to the legacy fixed layout for
+          older messages without segments. Thoughts render once at the top
+          since a message has at most one thoughts stream and it always
+          precedes the content segments. */}
+      {!isUser && message.segments && message.segments.length > 0 ? (
+        <>
+          {(message.isThinking ||
+            (typeof message.thoughts === 'string' &&
+              message.thoughts.trim().length > 0)) && (
+            <div className="no-scroll-anchoring w-full px-4">
+              <ThoughtProcess
+                thoughts={message.thoughts || ''}
+                isDarkMode={isDarkMode}
+                isThinking={message.isThinking}
+                thinkingDuration={message.thinkingDuration}
+                messageId={messageUniqueId}
+                expandedThoughtsState={expandedThoughtsState}
+                setExpandedThoughtsState={setExpandedThoughtsState}
+              />
+            </div>
+          )}
+          {(() => {
+            // Group adjacent same-kind event segments so long runs of
+            // tool calls collapse into a single summary row instead of
+            // stacking one full pill per event.
+            type Run =
+              | { kind: 'text'; index: number }
+              | {
+                  kind: 'web_search'
+                  index: number
+                  instances: NonNullable<typeof message.webSearches>
+                }
+              | {
+                  kind: 'url_fetch'
+                  index: number
+                  fetches: NonNullable<typeof message.urlFetches>
+                }
+            const runs: Run[] = []
+            message.segments.forEach((segment, i) => {
+              if (segment.type === 'text') {
+                runs.push({ kind: 'text', index: i })
+                return
+              }
+              if (segment.type === 'web_search') {
+                const instance = message.webSearches?.find(
+                  (w) => w.id === segment.searchId,
+                )
+                if (!instance) return
+                const last = runs[runs.length - 1]
+                if (last && last.kind === 'web_search') {
+                  last.instances.push(instance)
+                } else {
+                  runs.push({
+                    kind: 'web_search',
+                    index: i,
+                    instances: [instance],
+                  })
+                }
+                return
+              }
+              if (segment.type === 'url_fetch') {
+                const fetchState = message.urlFetches?.find(
+                  (f) => f.id === segment.fetchId,
+                )
+                if (!fetchState) return
+                const last = runs[runs.length - 1]
+                if (last && last.kind === 'url_fetch') {
+                  last.fetches.push(fetchState)
+                } else {
+                  runs.push({
+                    kind: 'url_fetch',
+                    index: i,
+                    fetches: [fetchState],
+                  })
+                }
+              }
+            })
 
-      {/* Show web search for assistant messages - before thoughts if it started first */}
-      {!isUser && message.webSearch && message.webSearchBeforeThinking && (
-        <div className="no-scroll-anchoring w-full px-4">
-          <WebSearchProcess webSearch={message.webSearch} />
-        </div>
-      )}
+            return runs.map((run, runIndex) => {
+              if (run.kind === 'text') {
+                const segment = message.segments?.[run.index]
+                if (!segment || segment.type !== 'text' || !segment.text) {
+                  return null
+                }
 
-      {/* Show thoughts for assistant messages */}
-      {!isUser &&
-        (message.isThinking ||
-          (typeof message.thoughts === 'string' &&
-            message.thoughts.trim().length > 0)) && (
-          <div className="no-scroll-anchoring w-full px-4">
-            <ThoughtProcess
-              thoughts={message.thoughts || ''}
-              isDarkMode={isDarkMode}
-              isThinking={message.isThinking}
-              thinkingDuration={message.thinkingDuration}
-              messageId={messageUniqueId}
-              expandedThoughtsState={expandedThoughtsState}
-              setExpandedThoughtsState={setExpandedThoughtsState}
-            />
-          </div>
-        )}
+                const textIsStreaming =
+                  !!isStreaming &&
+                  !!isLastMessage &&
+                  runIndex === runs.length - 1 &&
+                  !message.isThinking
 
-      {/* Show web search for assistant messages - after thoughts if it started after */}
-      {!isUser && message.webSearch && !message.webSearchBeforeThinking && (
-        <div className="no-scroll-anchoring w-full px-4">
-          <WebSearchProcess webSearch={message.webSearch} />
-        </div>
+                return (
+                  <div
+                    key={`run-${run.index}`}
+                    className="no-scroll-anchoring w-full px-4 py-2"
+                  >
+                    <div
+                      className={cn(
+                        'prose w-full max-w-none text-base prose-pre:bg-transparent prose-pre:p-0',
+                        'text-content-primary prose-headings:text-content-primary prose-strong:text-content-primary prose-code:text-content-primary',
+                        'prose-a:text-blue-500 hover:prose-a:text-blue-600',
+                      )}
+                    >
+                      {textIsStreaming ? (
+                        <StreamingContentWrapper isStreaming={true}>
+                          <StreamingChunkedText
+                            content={segment.text}
+                            isDarkMode={isDarkMode}
+                            isUser={false}
+                            isStreaming={true}
+                            citationUrlTitles={citationUrlTitles}
+                          />
+                        </StreamingContentWrapper>
+                      ) : (
+                        <StreamingChunkedText
+                          content={segment.text}
+                          isDarkMode={isDarkMode}
+                          isUser={false}
+                          isStreaming={false}
+                          citationUrlTitles={citationUrlTitles}
+                        />
+                      )}
+                    </div>
+                    {textIsStreaming && (
+                      <div
+                        role="status"
+                        aria-label="Response still streaming"
+                        className="mt-1 text-content-primary"
+                      >
+                        <StreamingTracer />
+                      </div>
+                    )}
+                  </div>
+                )
+              }
+              const isTrailingRun =
+                !!isStreaming &&
+                !!isLastMessage &&
+                runIndex === runs.length - 1 &&
+                !message.isThinking
+              if (run.kind === 'web_search') {
+                const aggregate = run.instances[run.instances.length - 1]
+                return (
+                  <div
+                    key={`run-${run.index}`}
+                    className="no-scroll-anchoring w-full px-4"
+                  >
+                    <WebSearchProcess
+                      webSearch={aggregate}
+                      groupInstances={
+                        run.instances.length > 1 ? run.instances : undefined
+                      }
+                    />
+                    {isTrailingRun && (
+                      <div
+                        role="status"
+                        aria-label="Response still streaming"
+                        className="mt-1 text-content-primary"
+                      >
+                        <StreamingTracer />
+                      </div>
+                    )}
+                  </div>
+                )
+              }
+              if (run.kind === 'url_fetch') {
+                return (
+                  <div
+                    key={`run-${run.index}`}
+                    className="no-scroll-anchoring w-full px-4"
+                  >
+                    <URLFetchProcess
+                      urlFetches={run.fetches}
+                      grouped={run.fetches.length > 1}
+                    />
+                    {isTrailingRun && (
+                      <div
+                        role="status"
+                        aria-label="Response still streaming"
+                        className="mt-1 text-content-primary"
+                      >
+                        <StreamingTracer />
+                      </div>
+                    )}
+                  </div>
+                )
+              }
+              return null
+            })
+          })()}
+        </>
+      ) : (
+        <>
+          {/* Show URL fetch status for assistant messages */}
+          {!isUser && message.urlFetches && message.urlFetches.length > 0 && (
+            <div className="no-scroll-anchoring w-full px-4">
+              <URLFetchProcess urlFetches={message.urlFetches} />
+            </div>
+          )}
+
+          {/* Show web search for assistant messages - before thoughts if it started first */}
+          {!isUser && message.webSearch && message.webSearchBeforeThinking && (
+            <div className="no-scroll-anchoring w-full px-4">
+              <WebSearchProcess webSearch={message.webSearch} />
+            </div>
+          )}
+
+          {/* Show thoughts for assistant messages */}
+          {!isUser &&
+            (message.isThinking ||
+              (typeof message.thoughts === 'string' &&
+                message.thoughts.trim().length > 0)) && (
+              <div className="no-scroll-anchoring w-full px-4">
+                <ThoughtProcess
+                  thoughts={message.thoughts || ''}
+                  isDarkMode={isDarkMode}
+                  isThinking={message.isThinking}
+                  thinkingDuration={message.thinkingDuration}
+                  messageId={messageUniqueId}
+                  expandedThoughtsState={expandedThoughtsState}
+                  setExpandedThoughtsState={setExpandedThoughtsState}
+                />
+              </div>
+            )}
+
+          {/* Show web search for assistant messages - after thoughts if it started after */}
+          {!isUser && message.webSearch && !message.webSearchBeforeThinking && (
+            <div className="no-scroll-anchoring w-full px-4">
+              <WebSearchProcess webSearch={message.webSearch} />
+            </div>
+          )}
+        </>
       )}
 
       {/* Message content */}
-      {message.content && (
+      {message.content && (!hasInlineTextSegments || isUser) && (
         <>
           {/* Hide message when editing for user messages */}
           {!(isUser && isEditing) && (
@@ -354,8 +554,10 @@ const DefaultMessageComponent = ({
                             'prose-a:text-blue-500 hover:prose-a:text-blue-600',
                           )}
                         >
-                          {!isUser && isStreaming && isLastMessage ? (
-                            <StreamingContentWrapper isStreaming={true}>
+                          {!isUser && isLastMessage ? (
+                            <StreamingContentWrapper
+                              isStreaming={isStreaming ?? false}
+                            >
                               <StreamingChunkedText
                                 content={message.content}
                                 isDarkMode={isDarkMode}
@@ -374,6 +576,18 @@ const DefaultMessageComponent = ({
                             />
                           )}
                         </div>
+                        {!isUser &&
+                          isLastMessage &&
+                          isStreaming &&
+                          !message.isThinking && (
+                            <div
+                              role="status"
+                              aria-label="Response still streaming"
+                              className="mt-1 text-content-primary"
+                            >
+                              <StreamingTracer />
+                            </div>
+                          )}
                       </div>
 
                       {isUser &&
@@ -524,40 +738,41 @@ const DefaultMessageComponent = ({
               </div>
             </div>
           )}
-
-          {/* Actions for assistant messages - fade in/out during streaming */}
-          {!isUser && (
-            <div
-              className={`flex items-center gap-1 px-4 transition-opacity duration-500 ease-in-out ${
-                showActions ? 'opacity-100' : 'pointer-events-none opacity-0'
-              }`}
-            >
-              <MessageActions
-                content={message.content}
-                isDarkMode={isDarkMode}
-              />
-              {message.webSearch?.sources &&
-                message.webSearch.sources.length > 0 &&
-                !(isStreaming && isLastMessage) && (
-                  <SourcesButton sources={message.webSearch.sources} />
-                )}
-              {/* Regenerate button - only on last assistant message */}
-              {isLastMessage && onRegenerateMessage && messageIndex > 0 && (
-                <div className="group/regen relative">
-                  <button
-                    onClick={() => onRegenerateMessage(messageIndex - 1)}
-                    className="flex items-center gap-1.5 rounded px-2 py-1.5 text-xs font-medium text-content-secondary transition-all hover:bg-surface-chat-background hover:text-content-primary"
-                  >
-                    <ArrowPathIcon className="h-3.5 w-3.5" />
-                  </button>
-                  <span className="pointer-events-none absolute -bottom-8 left-1/2 -translate-x-1/2 whitespace-nowrap rounded border border-border-subtle bg-surface-chat-background px-2 py-1 text-xs text-content-primary opacity-0 shadow-sm transition-opacity group-hover/regen:opacity-100">
-                    Regenerate
-                  </span>
-                </div>
-              )}
-            </div>
-          )}
         </>
+      )}
+
+      {/* Actions for assistant messages - hidden while streaming the last response */}
+      {!isUser && message.content && !(isStreaming && isLastMessage) && (
+        <div
+          className={`flex items-center justify-between gap-3 px-4 transition-opacity duration-500 ease-in-out ${
+            showActions ? 'opacity-100' : 'pointer-events-none opacity-0'
+          }`}
+        >
+          <div className="flex items-center gap-1">
+            <MessageActions content={message.content} isDarkMode={isDarkMode} />
+            {/* Regenerate button - only on last assistant message */}
+            {isLastMessage && onRegenerateMessage && messageIndex > 0 && (
+              <div className="group/regen relative">
+                <button
+                  onClick={() => onRegenerateMessage(messageIndex - 1)}
+                  className="flex items-center gap-1.5 rounded px-2 py-1.5 text-xs font-medium text-content-secondary transition-all hover:bg-surface-chat-background hover:text-content-primary"
+                >
+                  <ArrowPathIcon className="h-3.5 w-3.5" />
+                </button>
+                <span className="pointer-events-none absolute -bottom-8 left-1/2 -translate-x-1/2 whitespace-nowrap rounded border border-border-subtle bg-surface-chat-background px-2 py-1 text-xs text-content-primary opacity-0 shadow-sm transition-opacity group-hover/regen:opacity-100">
+                  Regenerate
+                </span>
+              </div>
+            )}
+          </div>
+          {message.webSearch?.sources &&
+            message.webSearch.sources.length > 0 &&
+            !(isStreaming && isLastMessage) && (
+              <div className="ml-auto flex items-center">
+                <SourcesButton sources={message.webSearch.sources} />
+              </div>
+            )}
+        </div>
       )}
     </div>
   )

--- a/src/components/chat/renderers/default/DefaultMessageRenderer.tsx
+++ b/src/components/chat/renderers/default/DefaultMessageRenderer.tsx
@@ -749,6 +749,11 @@ const DefaultMessageComponent = ({
           }`}
         >
           <div className="flex items-center gap-1">
+            {message.webSearch?.sources &&
+              message.webSearch.sources.length > 0 &&
+              !(isStreaming && isLastMessage) && (
+                <SourcesButton sources={message.webSearch.sources} />
+              )}
             <MessageActions content={message.content} isDarkMode={isDarkMode} />
             {/* Regenerate button - only on last assistant message */}
             {isLastMessage && onRegenerateMessage && messageIndex > 0 && (
@@ -765,13 +770,6 @@ const DefaultMessageComponent = ({
               </div>
             )}
           </div>
-          {message.webSearch?.sources &&
-            message.webSearch.sources.length > 0 &&
-            !(isStreaming && isLastMessage) && (
-              <div className="ml-auto flex items-center">
-                <SourcesButton sources={message.webSearch.sources} />
-              </div>
-            )}
         </div>
       )}
     </div>

--- a/src/components/chat/renderers/default/DefaultMessageRenderer.tsx
+++ b/src/components/chat/renderers/default/DefaultMessageRenderer.tsx
@@ -23,6 +23,11 @@ import { URLFetchProcess } from '../components/URLFetchProcess'
 import { WebSearchProcess } from '../components/WebSearchProcess'
 import type { MessageRenderer, MessageRenderProps } from '../types'
 
+// Vertical rhythm between consecutive event/content rows (thoughts,
+// web searches, URL fetches, streamed text). Kept in one place so all
+// rows stay visually in sync.
+const EVENT_STACK_CLASSES = 'flex flex-col gap-2'
+
 const DefaultMessageComponent = ({
   message,
   messageIndex,
@@ -263,7 +268,7 @@ const DefaultMessageComponent = ({
           since a message has at most one thoughts stream and it always
           precedes the content segments. */}
       {!isUser && message.segments && message.segments.length > 0 ? (
-        <>
+        <div className={EVENT_STACK_CLASSES}>
           {(message.isThinking ||
             (typeof message.thoughts === 'string' &&
               message.thoughts.trim().length > 0)) && (
@@ -352,13 +357,15 @@ const DefaultMessageComponent = ({
                 return (
                   <div
                     key={`run-${run.index}`}
-                    className="no-scroll-anchoring w-full px-4 py-2"
+                    className="no-scroll-anchoring w-full px-4"
                   >
                     <div
                       className={cn(
                         'prose w-full max-w-none text-base prose-pre:bg-transparent prose-pre:p-0',
                         'text-content-primary prose-headings:text-content-primary prose-strong:text-content-primary prose-code:text-content-primary',
                         'prose-a:text-blue-500 hover:prose-a:text-blue-600',
+                        '[&>*:first-child_p:first-child]:mt-0 [&>p:first-child]:mt-0',
+                        '[&>*:last-child_p:last-child]:mb-0 [&>p:last-child]:mb-0',
                       )}
                     >
                       {textIsStreaming ? (
@@ -448,9 +455,9 @@ const DefaultMessageComponent = ({
               return null
             })
           })()}
-        </>
+        </div>
       ) : (
-        <>
+        <div className={EVENT_STACK_CLASSES}>
           {/* Show URL fetch status for assistant messages */}
           {!isUser && message.urlFetches && message.urlFetches.length > 0 && (
             <div className="no-scroll-anchoring w-full px-4">
@@ -489,7 +496,7 @@ const DefaultMessageComponent = ({
               <WebSearchProcess webSearch={message.webSearch} />
             </div>
           )}
-        </>
+        </div>
       )}
 
       {/* Message content */}
@@ -744,7 +751,7 @@ const DefaultMessageComponent = ({
       {/* Actions for assistant messages - hidden while streaming the last response */}
       {!isUser && message.content && !(isStreaming && isLastMessage) && (
         <div
-          className={`flex items-center justify-between gap-3 px-4 transition-opacity duration-500 ease-in-out ${
+          className={`mt-4 flex items-center justify-between gap-3 px-4 transition-opacity duration-500 ease-in-out ${
             showActions ? 'opacity-100' : 'pointer-events-none opacity-0'
           }`}
         >

--- a/src/components/chat/renderers/default/DefaultMessageRenderer.tsx
+++ b/src/components/chat/renderers/default/DefaultMessageRenderer.tsx
@@ -14,6 +14,7 @@ import { hasMessageAttachments } from '../../attachment-helpers'
 import { CHAT_FONT_CLASSES, useChatFont } from '../../hooks/use-chat-font'
 import { DocumentList } from '../components/DocumentList'
 import { MessageActions } from '../components/MessageActions'
+import { SourcesButton } from '../components/SourcesButton'
 import { StreamingChunkedText } from '../components/StreamingChunkedText'
 import { StreamingContentWrapper } from '../components/StreamingContentWrapper'
 import { ThoughtProcess } from '../components/ThoughtProcess'
@@ -535,6 +536,11 @@ const DefaultMessageComponent = ({
                 content={message.content}
                 isDarkMode={isDarkMode}
               />
+              {message.webSearch?.sources &&
+                message.webSearch.sources.length > 0 &&
+                !(isStreaming && isLastMessage) && (
+                  <SourcesButton sources={message.webSearch.sources} />
+                )}
               {/* Regenerate button - only on last assistant message */}
               {isLastMessage && onRegenerateMessage && messageIndex > 0 && (
                 <div className="group/regen relative">

--- a/src/components/chat/types.ts
+++ b/src/components/chat/types.ts
@@ -22,11 +22,20 @@ export type WebSearchState = {
   reason?: string
 }
 
+export type WebSearchInstance = WebSearchState & {
+  id: string
+}
+
 export type URLFetchState = {
   id: string
   url: string
   status: 'fetching' | 'completed' | 'failed'
 }
+
+export type MessageSegment =
+  | { type: 'text'; text: string }
+  | { type: 'web_search'; searchId: string }
+  | { type: 'url_fetch'; fetchId: string }
 
 export type Attachment = {
   id: string
@@ -63,6 +72,12 @@ export type Message = {
   annotations?: Annotation[] // URL citations from web search
   searchReasoning?: string // Search agent's reasoning for multi-turn context
   quote?: string // Highlighted text the user is replying to
+  // Ordered list of content/event segments so web-search and URL-fetch events
+  // render inline with the assistant text in the exact order they streamed.
+  // Optional for backward compatibility; legacy messages fall back to the
+  // aggregate fields above.
+  segments?: MessageSegment[]
+  webSearches?: WebSearchInstance[]
 }
 
 export type TitleState = 'placeholder' | 'generated' | 'manual'

--- a/src/components/loading-dots.tsx
+++ b/src/components/loading-dots.tsx
@@ -1,17 +1,23 @@
 import { memo } from 'react'
 
+const DEFAULT_WIDTH_PX = 36
+const SMALL_WIDTH_PX = 22
+
 export const LoadingDots = memo(function LoadingDots({
   isThinking = false,
+  size = 'default',
 }: {
   isThinking?: boolean
+  size?: 'default' | 'small'
 }) {
   const dotColor = isThinking ? 'currentColor' : 'hsl(var(--content-secondary))'
+  const widthPx = size === 'small' ? SMALL_WIDTH_PX : DEFAULT_WIDTH_PX
 
   return (
     <div
       style={
         {
-          width: '36px',
+          width: `${widthPx}px`,
           aspectRatio: '4',
           '--_g': `no-repeat radial-gradient(circle closest-side,${dotColor} 90%,transparent)`,
           background: 'var(--_g) 0% 50%, var(--_g) 50% 50%, var(--_g) 100% 50%',

--- a/src/components/streaming-tracer.tsx
+++ b/src/components/streaming-tracer.tsx
@@ -1,0 +1,18 @@
+import { memo } from 'react'
+
+export const StreamingTracer = memo(function StreamingTracer() {
+  return (
+    <div
+      aria-hidden="true"
+      style={
+        {
+          width: '36px',
+          aspectRatio: '4',
+          background:
+            'radial-gradient(circle closest-side, currentColor 90%, transparent) 0 / calc(100% / 3) 100% no-repeat',
+          animation: 'streaming-tracer 1s steps(3) infinite',
+        } as React.CSSProperties
+      }
+    />
+  )
+})

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -13,15 +13,17 @@ const TooltipContent = React.forwardRef<
   React.ElementRef<typeof TooltipPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
 >(({ className, sideOffset = 4, ...props }, ref) => (
-  <TooltipPrimitive.Content
-    ref={ref}
-    sideOffset={sideOffset}
-    className={cn(
-      'z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
-      className,
-    )}
-    {...props}
-  />
+  <TooltipPrimitive.Portal>
+    <TooltipPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        'z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+        className,
+      )}
+      {...props}
+    />
+  </TooltipPrimitive.Portal>
 ))
 TooltipContent.displayName = TooltipPrimitive.Content.displayName
 

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -11,6 +11,12 @@
   }
 }
 
+@keyframes streaming-tracer {
+  to {
+    background-position: 150%;
+  }
+}
+
 @keyframes loading-dots {
   33% {
     background-size:

--- a/src/utils/tinfoil-events.ts
+++ b/src/utils/tinfoil-events.ts
@@ -96,18 +96,24 @@ export function createTinfoilEventParser(): {
    * Given a non-marker chunk suffix, return how many trailing bytes
    * might be the start of an opening tag. The parser holds those bytes
    * back until the next chunk arrives so `<tinfoil-event` split across
-   * a boundary is still detected. A match is only plausible if the
-   * suffix is a proper prefix of OPEN_TAG; everything shorter is
-   * consumed as visible text.
+   * a boundary is still detected.
+   *
+   * Only the bytes starting at the last `<` in the buffer are eligible
+   * to be a partial open tag. If those bytes match the corresponding
+   * prefix of OPEN_TAG exactly, hold them back; otherwise release
+   * everything. This avoids stalling visible text whenever the model
+   * emits any `<` character (e.g. `<think>`, HTML, `x < y`, generics)
+   * which would otherwise batch up to 14 bytes per stall.
    */
   const openTagPrefixSuffixLength = (s: string): number => {
-    const max = Math.min(s.length, OPEN_TAG.length - 1)
-    for (let len = max; len > 0; len--) {
-      if (OPEN_TAG.startsWith(s.slice(s.length - len))) {
-        return len
-      }
+    const lastLt = s.lastIndexOf('<')
+    if (lastLt < 0) return 0
+    const tail = s.length - lastLt
+    if (tail >= OPEN_TAG.length) return 0
+    for (let i = 0; i < tail; i++) {
+      if (s.charCodeAt(lastLt + i) !== OPEN_TAG.charCodeAt(i)) return 0
     }
-    return 0
+    return tail
   }
 
   const consume = (chunk: string): TinfoilEventConsumeResult => {

--- a/src/utils/tinfoil-events.ts
+++ b/src/utils/tinfoil-events.ts
@@ -53,6 +53,10 @@ export interface TinfoilWebSearchCallEvent {
     query?: string
     url?: string
   }
+  sources?: Array<{
+    title?: string
+    url?: string
+  }>
   error?: { code?: string }
 }
 

--- a/tests/components/chat/markdown-components.test.tsx
+++ b/tests/components/chat/markdown-components.test.tsx
@@ -1,0 +1,57 @@
+import { createMarkdownComponents } from '@/components/chat/renderers/components/markdown-components'
+import { TooltipProvider } from '@/components/ui/tooltip'
+import { render, screen } from '@testing-library/react'
+import { createElement, type ElementType } from 'react'
+import { describe, expect, it } from 'vitest'
+
+describe('createMarkdownComponents citations', () => {
+  const citationUrlTitles = new Map([['https://a.test', 'Example']])
+
+  it('renders citation links as pills while streaming', () => {
+    const components = createMarkdownComponents({
+      isDarkMode: false,
+      isStreaming: true,
+      showMarkdownTablePlaceholder: false,
+      citationUrlTitles,
+    })
+
+    render(
+      createElement(
+        TooltipProvider,
+        null,
+        createElement(
+          components.a as ElementType,
+          { href: 'https://a.test' },
+          'source',
+        ),
+      ),
+    )
+
+    expect(screen.getByRole('link')).toHaveTextContent('a')
+    expect(screen.getByRole('link')).toHaveClass('align-middle', 'leading-none')
+  })
+
+  it('renders citation links as pills after streaming finishes', () => {
+    const components = createMarkdownComponents({
+      isDarkMode: false,
+      isStreaming: false,
+      showMarkdownTablePlaceholder: false,
+      citationUrlTitles,
+    })
+
+    render(
+      createElement(
+        TooltipProvider,
+        null,
+        createElement(
+          components.a as ElementType,
+          { href: 'https://a.test' },
+          'source',
+        ),
+      ),
+    )
+
+    expect(screen.getByRole('link')).toHaveTextContent('a')
+    expect(screen.getByRole('link')).toHaveClass('align-middle', 'leading-none')
+  })
+})

--- a/tests/components/chat/web-search-process.test.tsx
+++ b/tests/components/chat/web-search-process.test.tsx
@@ -1,0 +1,25 @@
+import { WebSearchProcess } from '@/components/chat/renderers/components/WebSearchProcess'
+import { render, screen } from '@testing-library/react'
+import { createElement } from 'react'
+import { describe, expect, it } from 'vitest'
+
+describe('WebSearchProcess', () => {
+  it('reserves chevron spacing for failed searches without sources', () => {
+    const { container } = render(
+      createElement(WebSearchProcess, {
+        webSearch: {
+          query: 'xxx',
+          status: 'failed',
+          sources: [],
+        },
+      }),
+    )
+
+    expect(screen.getByRole('button')).toHaveTextContent(
+      'Search failed for "xxx"',
+    )
+    expect(
+      container.querySelector('button > span[aria-hidden="true"]'),
+    ).toHaveClass('invisible')
+  })
+})

--- a/tests/utils/tinfoil-events.test.ts
+++ b/tests/utils/tinfoil-events.test.ts
@@ -27,6 +27,25 @@ describe('createTinfoilEventParser', () => {
     expect(parser.flush()).toBe('')
   })
 
+  it('preserves per-search sources attached to a marker payload', () => {
+    const parser = createTinfoilEventParser()
+    const payload = {
+      type: TINFOIL_WEB_SEARCH_CALL_TYPE,
+      item_id: 'ws_1',
+      status: 'completed',
+      action: { type: 'search', query: 'q' },
+      sources: [
+        {
+          title: 'Example',
+          url: 'https://example.com/article',
+        },
+      ],
+    }
+    const result = parser.consume(markerFor(payload))
+    expect(result.events).toHaveLength(1)
+    expect(result.events[0].sources).toEqual(payload.sources)
+  })
+
   it('stitches a marker split across an arbitrary byte boundary', () => {
     const parser = createTinfoilEventParser()
     const payload = {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Revamped the web search experience with inline event streaming, grouped runs, and a Sources modal. Streaming is smoother and the layout is stable; the tracer stays visible and actions wait until streams finish.

- **New Features**
  - Inline web search and URL fetch events inside assistant text; preserves stream order, supports multi-search with stable IDs and per-query sources.
  - Groups adjacent web searches and link reads into one collapsible row per run with shared spinners and favicon previews.
  - Sources button on the last assistant message; opens a modal of deduped, sanitized links.

- **Bug Fixes**
  - Unified spacing for thoughts/searches/fetches/text and a live-tail fade; no stalls around '<'; tracer visible during tool calls; actions appear only after streams finish.
  - Stable scroll/composer layout: input-aware bottom padding, fade excludes the scrollbar, last message never clips, scroll-to-bottom stays clickable; smaller thinking dots.
  - Tool-call updates stream reliably; per-search sources (including marker-supplied) propagate and dedupe; citation pills keep shape and align with text; tooltips render in a portal; fewer re-renders while streaming.
  - Align Sources button to the left of assistant actions; shared spinner icon across web search and URL fetch rows.

<sup>Written for commit 6d5841fb869082758f57afac6752b8f9caf41e6a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

