### PR TITLE
Add UI for setting model reasoning and fix UX bugs

### DIFF
--- a/src/components/chat/WelcomeScreen.tsx
+++ b/src/components/chat/WelcomeScreen.tsx
@@ -7,7 +7,12 @@ import { BiSolidLock } from 'react-icons/bi'
 import { ChatInput } from './chat-input'
 import { CONSTANTS } from './constants'
 import { DataFlowDiagram } from './DataFlowDiagram'
+import {
+  isReasoningModel,
+  type ReasoningEffort,
+} from './hooks/use-reasoning-effort'
 import { ModelSelector } from './model-selector'
+import { ReasoningEffortSelector } from './reasoning-effort-selector'
 import type { ProcessedDocument } from './renderers/types'
 import type { LabelType, LoadingState } from './types'
 
@@ -197,6 +202,8 @@ interface WelcomeScreenProps {
   ) => void
   webSearchEnabled?: boolean
   onWebSearchToggle?: () => void
+  reasoningEffort?: ReasoningEffort
+  setReasoningEffort?: (effort: ReasoningEffort) => void
   onOpenVerifier?: () => void
 }
 
@@ -220,6 +227,8 @@ export const WelcomeScreen = memo(function WelcomeScreen({
   handleLabelClick,
   webSearchEnabled,
   onWebSearchToggle,
+  reasoningEffort,
+  setReasoningEffort,
   onOpenVerifier,
 }: WelcomeScreenProps) {
   const { user } = useUser()
@@ -504,6 +513,22 @@ export const WelcomeScreen = memo(function WelcomeScreen({
                           />
                         )}
                       </div>
+                    ) : undefined
+                  }
+                  reasoningSelectorButton={
+                    reasoningEffort &&
+                    setReasoningEffort &&
+                    handleLabelClick &&
+                    isReasoningModel(
+                      models?.find((m) => m.modelName === selectedModel),
+                    ) ? (
+                      <ReasoningEffortSelector
+                        reasoningEffort={reasoningEffort}
+                        onChange={setReasoningEffort}
+                        isOpen={expandedLabel === 'reasoning'}
+                        onToggle={() => handleLabelClick('reasoning', () => {})}
+                        onClose={() => handleLabelClick('reasoning', () => {})}
+                      />
                     ) : undefined
                   }
                   webSearchEnabled={webSearchEnabled}

--- a/src/components/chat/WelcomeScreen.tsx
+++ b/src/components/chat/WelcomeScreen.tsx
@@ -9,6 +9,8 @@ import { CONSTANTS } from './constants'
 import { DataFlowDiagram } from './DataFlowDiagram'
 import {
   isReasoningModel,
+  supportsReasoningEffort,
+  supportsThinkingToggle,
   type ReasoningEffort,
 } from './hooks/use-reasoning-effort'
 import { ModelSelector } from './model-selector'
@@ -204,6 +206,8 @@ interface WelcomeScreenProps {
   onWebSearchToggle?: () => void
   reasoningEffort?: ReasoningEffort
   setReasoningEffort?: (effort: ReasoningEffort) => void
+  thinkingEnabled?: boolean
+  setThinkingEnabled?: (enabled: boolean) => void
   onOpenVerifier?: () => void
 }
 
@@ -229,6 +233,8 @@ export const WelcomeScreen = memo(function WelcomeScreen({
   onWebSearchToggle,
   reasoningEffort,
   setReasoningEffort,
+  thinkingEnabled,
+  setThinkingEnabled,
   onOpenVerifier,
 }: WelcomeScreenProps) {
   const { user } = useUser()
@@ -515,22 +521,33 @@ export const WelcomeScreen = memo(function WelcomeScreen({
                       </div>
                     ) : undefined
                   }
-                  reasoningSelectorButton={
-                    reasoningEffort &&
-                    setReasoningEffort &&
-                    handleLabelClick &&
-                    isReasoningModel(
-                      models?.find((m) => m.modelName === selectedModel),
-                    ) ? (
+                  reasoningSelectorButton={(() => {
+                    if (
+                      !reasoningEffort ||
+                      !setReasoningEffort ||
+                      !handleLabelClick ||
+                      thinkingEnabled === undefined ||
+                      !setThinkingEnabled
+                    )
+                      return undefined
+                    const m = models?.find(
+                      (mm) => mm.modelName === selectedModel,
+                    )
+                    if (!isReasoningModel(m)) return undefined
+                    return (
                       <ReasoningEffortSelector
+                        supportsEffort={supportsReasoningEffort(m)}
+                        supportsToggle={supportsThinkingToggle(m)}
                         reasoningEffort={reasoningEffort}
-                        onChange={setReasoningEffort}
+                        onEffortChange={setReasoningEffort}
+                        thinkingEnabled={thinkingEnabled}
+                        onThinkingEnabledChange={setThinkingEnabled}
                         isOpen={expandedLabel === 'reasoning'}
                         onToggle={() => handleLabelClick('reasoning', () => {})}
                         onClose={() => handleLabelClick('reasoning', () => {})}
                       />
-                    ) : undefined
-                  }
+                    )
+                  })()}
                   webSearchEnabled={webSearchEnabled}
                   onWebSearchToggle={onWebSearchToggle}
                 />

--- a/src/components/chat/chat-input.tsx
+++ b/src/components/chat/chat-input.tsx
@@ -49,6 +49,7 @@ type ChatInputProps = {
   hasMessages?: boolean
   audioModel?: string
   modelSelectorButton?: React.ReactNode
+  reasoningSelectorButton?: React.ReactNode
   webSearchEnabled?: boolean
   onWebSearchToggle?: () => void
   quote?: string | null
@@ -75,6 +76,7 @@ export function ChatInput({
   hasMessages,
   audioModel,
   modelSelectorButton,
+  reasoningSelectorButton,
   webSearchEnabled,
   onWebSearchToggle,
   quote,
@@ -975,6 +977,7 @@ export function ChatInput({
 
             <div className="flex items-center gap-2">
               {modelSelectorButton && <div>{modelSelectorButton}</div>}
+              {reasoningSelectorButton && <div>{reasoningSelectorButton}</div>}
               {isPremium && audioModel && (
                 <button
                   type="button"

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -90,7 +90,10 @@ import { useCustomSystemPrompt } from './hooks/use-custom-system-prompt'
 import { useMaxMessages } from './hooks/use-max-messages'
 import {
   isReasoningModel,
+  supportsReasoningEffort,
+  supportsThinkingToggle,
   useReasoningEffort,
+  useThinkingEnabled,
 } from './hooks/use-reasoning-effort'
 import { useSidebarChat } from './hooks/use-sidebar-chat'
 import { ModelSelector } from './model-selector'
@@ -531,8 +534,11 @@ export function ChatInterface({
     autoLoad: isSignedIn && isCloudSyncEnabled() && isPremium,
   })
 
-  // Use reasoning effort hook for gpt-oss models
+  // Reasoning controls — graded effort for models that support it, on/off
+  // toggle for models that expose a thinking flag. Both are persisted globally
+  // (not per-model) and only surfaced for models whose reasoningConfig opts in.
   const { reasoningEffort, setReasoningEffort } = useReasoningEffort()
+  const { thinkingEnabled, setThinkingEnabled } = useThinkingEnabled()
 
   // Detect platform for keyboard shortcut display
   const isMac = useMemo(() => {
@@ -747,6 +753,7 @@ export function ChatInterface({
     // Scroll user message to top of viewport when sending
     scrollToBottom: scrollUserMessageToTop,
     reasoningEffort,
+    thinkingEnabled,
     initialChatId,
     isLocalChatUrl,
     webSearchEnabled,
@@ -764,6 +771,7 @@ export function ChatInterface({
     selectedModel,
     maxMessages: sidebarMaxMessages,
     reasoningEffort,
+    thinkingEnabled,
     webSearchEnabled,
     piiCheckEnabled,
   })
@@ -2684,6 +2692,8 @@ export function ChatInterface({
                   onWebSearchToggle={() => setWebSearchEnabled((prev) => !prev)}
                   reasoningEffort={reasoningEffort}
                   setReasoningEffort={setReasoningEffort}
+                  thinkingEnabled={thinkingEnabled}
+                  setThinkingEnabled={setThinkingEnabled}
                   onOpenVerifier={() => setIsVerifierSidebarOpen(true)}
                 />
               </div>
@@ -2787,13 +2797,19 @@ export function ChatInterface({
                         </div>
                       ) : undefined
                     }
-                    reasoningSelectorButton={
-                      isReasoningModel(
-                        models.find((m) => m.modelName === selectedModel),
-                      ) ? (
+                    reasoningSelectorButton={(() => {
+                      const m = models.find(
+                        (mm) => mm.modelName === selectedModel,
+                      )
+                      if (!isReasoningModel(m)) return undefined
+                      return (
                         <ReasoningEffortSelector
+                          supportsEffort={supportsReasoningEffort(m)}
+                          supportsToggle={supportsThinkingToggle(m)}
                           reasoningEffort={reasoningEffort}
-                          onChange={setReasoningEffort}
+                          onEffortChange={setReasoningEffort}
+                          thinkingEnabled={thinkingEnabled}
+                          onThinkingEnabledChange={setThinkingEnabled}
                           isOpen={expandedLabel === 'reasoning'}
                           onToggle={() =>
                             handleLabelClick('reasoning', () => {})
@@ -2802,8 +2818,8 @@ export function ChatInterface({
                             handleLabelClick('reasoning', () => {})
                           }
                         />
-                      ) : undefined
-                    }
+                      )
+                    })()}
                     webSearchEnabled={webSearchEnabled}
                     onWebSearchToggle={() =>
                       setWebSearchEnabled((prev) => !prev)

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -88,10 +88,14 @@ import { DragProvider } from './drag-context'
 import { useChatState } from './hooks/use-chat-state'
 import { useCustomSystemPrompt } from './hooks/use-custom-system-prompt'
 import { useMaxMessages } from './hooks/use-max-messages'
-import { useReasoningEffort } from './hooks/use-reasoning-effort'
+import {
+  isReasoningModel,
+  useReasoningEffort,
+} from './hooks/use-reasoning-effort'
 import { useSidebarChat } from './hooks/use-sidebar-chat'
 import { ModelSelector } from './model-selector'
 import { QuoteSelectionPopover } from './quote-selection-popover'
+import { ReasoningEffortSelector } from './reasoning-effort-selector'
 import { initializeRenderers } from './renderers/client'
 import type { ProcessedDocument } from './renderers/types'
 import type { SettingsTab } from './settings-modal'
@@ -2678,6 +2682,8 @@ export function ChatInterface({
                   showScrollButton={showScrollButton}
                   webSearchEnabled={webSearchEnabled}
                   onWebSearchToggle={() => setWebSearchEnabled((prev) => !prev)}
+                  reasoningEffort={reasoningEffort}
+                  setReasoningEffort={setReasoningEffort}
                   onOpenVerifier={() => setIsVerifierSidebarOpen(true)}
                 />
               </div>
@@ -2779,6 +2785,23 @@ export function ChatInterface({
                             />
                           )}
                         </div>
+                      ) : undefined
+                    }
+                    reasoningSelectorButton={
+                      isReasoningModel(
+                        models.find((m) => m.modelName === selectedModel),
+                      ) ? (
+                        <ReasoningEffortSelector
+                          reasoningEffort={reasoningEffort}
+                          onChange={setReasoningEffort}
+                          isOpen={expandedLabel === 'reasoning'}
+                          onToggle={() =>
+                            handleLabelClick('reasoning', () => {})
+                          }
+                          onClose={() =>
+                            handleLabelClick('reasoning', () => {})
+                          }
+                        />
                       ) : undefined
                     }
                     webSearchEnabled={webSearchEnabled}

--- a/src/components/chat/chat-messages.tsx
+++ b/src/components/chat/chat-messages.tsx
@@ -6,6 +6,7 @@ import { LoadingDots } from '../loading-dots'
 import { ensureTimeline } from './ensure-timeline'
 import { CHAT_FONT_CLASSES, useChatFont } from './hooks/use-chat-font'
 import { useMaxMessages } from './hooks/use-max-messages'
+import type { ReasoningEffort } from './hooks/use-reasoning-effort'
 import { PrintableChat } from './PrintableChat'
 import { getRendererRegistry } from './renderers/client'
 import type { LabelType, Message } from './types'
@@ -43,6 +44,8 @@ type ChatMessagesProps = {
   showScrollButton?: boolean
   webSearchEnabled?: boolean
   onWebSearchToggle?: () => void
+  reasoningEffort?: ReasoningEffort
+  setReasoningEffort?: (effort: ReasoningEffort) => void
   onOpenVerifier?: () => void
 }
 
@@ -210,6 +213,8 @@ export function ChatMessages({
   showScrollButton,
   webSearchEnabled,
   onWebSearchToggle,
+  reasoningEffort,
+  setReasoningEffort,
   onOpenVerifier,
 }: ChatMessagesProps) {
   const [mounted, setMounted] = useState(false)
@@ -311,6 +316,8 @@ export function ChatMessages({
             handleLabelClick={handleLabelClick}
             webSearchEnabled={webSearchEnabled}
             onWebSearchToggle={onWebSearchToggle}
+            reasoningEffort={reasoningEffort}
+            setReasoningEffort={setReasoningEffort}
             onOpenVerifier={onOpenVerifier}
           />
         </div>

--- a/src/components/chat/chat-messages.tsx
+++ b/src/components/chat/chat-messages.tsx
@@ -46,6 +46,8 @@ type ChatMessagesProps = {
   onWebSearchToggle?: () => void
   reasoningEffort?: ReasoningEffort
   setReasoningEffort?: (effort: ReasoningEffort) => void
+  thinkingEnabled?: boolean
+  setThinkingEnabled?: (enabled: boolean) => void
   onOpenVerifier?: () => void
 }
 
@@ -215,6 +217,8 @@ export function ChatMessages({
   onWebSearchToggle,
   reasoningEffort,
   setReasoningEffort,
+  thinkingEnabled,
+  setThinkingEnabled,
   onOpenVerifier,
 }: ChatMessagesProps) {
   const [mounted, setMounted] = useState(false)
@@ -318,6 +322,8 @@ export function ChatMessages({
             onWebSearchToggle={onWebSearchToggle}
             reasoningEffort={reasoningEffort}
             setReasoningEffort={setReasoningEffort}
+            thinkingEnabled={thinkingEnabled}
+            setThinkingEnabled={setThinkingEnabled}
             onOpenVerifier={onOpenVerifier}
           />
         </div>

--- a/src/components/chat/hooks/streaming/message-assembler.ts
+++ b/src/components/chat/hooks/streaming/message-assembler.ts
@@ -17,6 +17,12 @@ import type {
 
 export class MessageAssembler {
   private annotations: Annotation[] = []
+  // Frozen snapshot of `annotations` shared across every toMessage() call
+  // until a new annotation is added. Reusing the same reference lets
+  // downstream React memos (e.g. citationUrlTitles) skip rebuilding while
+  // streaming tokens arrive, which prevents citation pill favicons from
+  // remounting and flashing on every chunk.
+  private annotationsSnapshot: Annotation[] | undefined
   private sources: WebSearchSource[] = []
   private searchReasoning = ''
   private timestamp = new Date()
@@ -27,6 +33,7 @@ export class MessageAssembler {
       type: 'url_citation',
       url_citation: { title, url },
     })
+    this.annotationsSnapshot = undefined
   }
 
   addSearchReasoning(content: string): void {
@@ -85,10 +92,17 @@ export class MessageAssembler {
       webSearch,
       webSearchBeforeThinking: webSearchBeforeThinking || undefined,
       urlFetches: urlFetches.length > 0 ? urlFetches : undefined,
-      annotations:
-        this.annotations.length > 0 ? [...this.annotations] : undefined,
+      annotations: this.getAnnotationsSnapshot(),
       searchReasoning: this.searchReasoning || undefined,
       timeline: [...timeline],
     }
+  }
+
+  private getAnnotationsSnapshot(): Annotation[] | undefined {
+    if (this.annotations.length === 0) return undefined
+    if (!this.annotationsSnapshot) {
+      this.annotationsSnapshot = [...this.annotations]
+    }
+    return this.annotationsSnapshot
   }
 }

--- a/src/components/chat/hooks/use-chat-messaging.ts
+++ b/src/components/chat/hooks/use-chat-messaging.ts
@@ -50,6 +50,7 @@ interface UseChatMessagingProps {
   messagesEndRef: React.RefObject<HTMLDivElement>
   scrollToBottom?: () => void
   reasoningEffort?: ReasoningEffort
+  thinkingEnabled?: boolean
   webSearchEnabled?: boolean
   piiCheckEnabled?: boolean
 }
@@ -91,6 +92,7 @@ export function useChatMessaging({
   messagesEndRef,
   scrollToBottom,
   reasoningEffort,
+  thinkingEnabled,
   webSearchEnabled,
   piiCheckEnabled,
 }: UseChatMessagingProps): UseChatMessagingReturn {
@@ -515,6 +517,7 @@ export function useChatMessaging({
           maxMessages,
           signal: controller.signal,
           reasoningEffort,
+          thinkingEnabled,
           webSearchEnabled,
           piiCheckEnabled,
         })
@@ -738,6 +741,7 @@ export function useChatMessaging({
       updateChatWithHistoryCheck,
       scrollToBottom,
       reasoningEffort,
+      thinkingEnabled,
       isProjectMode,
       activeProject,
       webSearchEnabled,

--- a/src/components/chat/hooks/use-chat-state.ts
+++ b/src/components/chat/hooks/use-chat-state.ts
@@ -79,6 +79,7 @@ export function useChatState({
   models = [],
   scrollToBottom,
   reasoningEffort,
+  thinkingEnabled,
   initialChatId,
   isLocalChatUrl = false,
   webSearchEnabled,
@@ -90,6 +91,7 @@ export function useChatState({
   models?: BaseModel[]
   scrollToBottom?: () => void
   reasoningEffort?: ReasoningEffort
+  thinkingEnabled?: boolean
   initialChatId?: string | null
   isLocalChatUrl?: boolean
   webSearchEnabled?: boolean
@@ -191,6 +193,7 @@ export function useChatState({
     messagesEndRef,
     scrollToBottom,
     reasoningEffort,
+    thinkingEnabled,
     webSearchEnabled,
     piiCheckEnabled,
   })

--- a/src/components/chat/hooks/use-reasoning-effort.ts
+++ b/src/components/chat/hooks/use-reasoning-effort.ts
@@ -1,3 +1,4 @@
+import type { BaseModel } from '@/config/models'
 import { SETTINGS_REASONING_EFFORT } from '@/constants/storage-keys'
 import { useCallback, useEffect, useState } from 'react'
 
@@ -24,6 +25,6 @@ export function useReasoningEffort() {
   return { reasoningEffort, setReasoningEffort }
 }
 
-export function isReasoningModel(modelName: string): boolean {
-  return modelName.toLowerCase().startsWith('gpt-oss')
+export function isReasoningModel(model: BaseModel | undefined): boolean {
+  return !!model?.reasoning
 }

--- a/src/components/chat/hooks/use-reasoning-effort.ts
+++ b/src/components/chat/hooks/use-reasoning-effort.ts
@@ -1,5 +1,8 @@
 import type { BaseModel } from '@/config/models'
-import { SETTINGS_REASONING_EFFORT } from '@/constants/storage-keys'
+import {
+  SETTINGS_REASONING_EFFORT,
+  SETTINGS_THINKING_ENABLED,
+} from '@/constants/storage-keys'
 import { useCallback, useEffect, useState } from 'react'
 
 export type ReasoningEffort = 'low' | 'medium' | 'high'
@@ -25,6 +28,39 @@ export function useReasoningEffort() {
   return { reasoningEffort, setReasoningEffort }
 }
 
+/**
+ * Tracks whether the thinking-mode toggle is enabled, for models that expose
+ * an on/off thinking flag (rather than graded effort). Persisted globally to
+ * localStorage; not per-model. Reads from storage in the lazy initializer so
+ * the first render observes the persisted value and submits during the
+ * pre-mount window do not send a stale toggle.
+ */
+export function useThinkingEnabled() {
+  const [thinkingEnabled, setThinkingEnabledState] = useState<boolean>(() => {
+    if (typeof window === 'undefined') return true
+    const saved = window.localStorage.getItem(SETTINGS_THINKING_ENABLED)
+    if (saved === 'true' || saved === 'false') {
+      return saved === 'true'
+    }
+    return true
+  })
+
+  const setThinkingEnabled = useCallback((enabled: boolean) => {
+    setThinkingEnabledState(enabled)
+    localStorage.setItem(SETTINGS_THINKING_ENABLED, String(enabled))
+  }, [])
+
+  return { thinkingEnabled, setThinkingEnabled }
+}
+
 export function isReasoningModel(model: BaseModel | undefined): boolean {
-  return !!model?.reasoning
+  return !!model?.reasoningConfig
+}
+
+export function supportsReasoningEffort(model: BaseModel | undefined): boolean {
+  return !!model?.reasoningConfig?.supportsEffort
+}
+
+export function supportsThinkingToggle(model: BaseModel | undefined): boolean {
+  return !!model?.reasoningConfig?.supportsToggle
 }

--- a/src/components/chat/hooks/use-sidebar-chat.ts
+++ b/src/components/chat/hooks/use-sidebar-chat.ts
@@ -26,6 +26,7 @@ interface UseSidebarChatProps {
   selectedModel: AIModel
   maxMessages: number
   reasoningEffort?: ReasoningEffort
+  thinkingEnabled?: boolean
   webSearchEnabled?: boolean
   piiCheckEnabled?: boolean
 }
@@ -81,6 +82,7 @@ export function useSidebarChat({
   selectedModel,
   maxMessages,
   reasoningEffort,
+  thinkingEnabled,
   webSearchEnabled,
   piiCheckEnabled,
 }: UseSidebarChatProps): UseSidebarChatReturn {
@@ -213,6 +215,7 @@ export function useSidebarChat({
             maxMessages,
             signal: controller.signal,
             reasoningEffort,
+            thinkingEnabled,
             webSearchEnabled,
             piiCheckEnabled,
           })
@@ -288,6 +291,7 @@ export function useSidebarChat({
       rules,
       maxMessages,
       reasoningEffort,
+      thinkingEnabled,
       webSearchEnabled,
       piiCheckEnabled,
     ],

--- a/src/components/chat/reasoning-effort-selector.tsx
+++ b/src/components/chat/reasoning-effort-selector.tsx
@@ -1,0 +1,95 @@
+import { cn } from '@/components/ui/utils'
+import { PiSpeedometerLight } from 'react-icons/pi'
+import type { ReasoningEffort } from './hooks/use-reasoning-effort'
+
+const EFFORT_OPTIONS: {
+  value: ReasoningEffort
+  label: string
+  description: string
+}[] = [
+  { value: 'low', label: 'Low', description: 'Quick responses' },
+  { value: 'medium', label: 'Medium', description: 'Balanced reasoning' },
+  { value: 'high', label: 'High', description: 'Deep thinking' },
+]
+
+type ReasoningEffortSelectorProps = {
+  reasoningEffort: ReasoningEffort
+  onChange: (effort: ReasoningEffort) => void
+  isOpen: boolean
+  onToggle: () => void
+  onClose: () => void
+}
+
+export function ReasoningEffortSelector({
+  reasoningEffort,
+  onChange,
+  isOpen,
+  onToggle,
+  onClose,
+}: ReasoningEffortSelectorProps) {
+  const current =
+    EFFORT_OPTIONS.find((o) => o.value === reasoningEffort) ?? EFFORT_OPTIONS[1]
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        data-reasoning-selector
+        onClick={(e) => {
+          e.preventDefault()
+          e.stopPropagation()
+          onToggle()
+        }}
+        className="flex items-center gap-1 text-content-secondary transition-colors hover:text-content-primary"
+        title={`Reasoning effort: ${current.label}`}
+      >
+        <PiSpeedometerLight className="h-4 w-4" />
+        <span className="text-xs font-medium">{current.label}</span>
+        <svg
+          className="h-3 w-3"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M19 9l-7 7-7-7"
+          />
+        </svg>
+      </button>
+
+      {isOpen && (
+        <div
+          data-reasoning-menu
+          className="absolute bottom-full z-50 mb-2 w-[200px] overflow-hidden rounded-lg border border-border-subtle bg-surface-chat p-1 font-aeonik-fono text-content-secondary shadow-lg"
+        >
+          {EFFORT_OPTIONS.map((option) => (
+            <button
+              key={option.value}
+              type="button"
+              className={cn(
+                'flex w-full flex-col rounded-md border px-3 py-2 text-left text-sm transition-colors',
+                reasoningEffort === option.value
+                  ? 'border-border-subtle bg-surface-card text-content-primary'
+                  : 'border-transparent hover:bg-surface-card/70',
+              )}
+              onClick={(e) => {
+                e.preventDefault()
+                e.stopPropagation()
+                onChange(option.value)
+                onClose()
+              }}
+            >
+              <span className="font-medium">{option.label}</span>
+              <span className="text-xs text-content-muted">
+                {option.description}
+              </span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/chat/reasoning-effort-selector.tsx
+++ b/src/components/chat/reasoning-effort-selector.tsx
@@ -1,5 +1,5 @@
 import { cn } from '@/components/ui/utils'
-import { PiSpeedometerLight } from 'react-icons/pi'
+import { GiGearStickPattern } from 'react-icons/gi'
 import type { ReasoningEffort } from './hooks/use-reasoning-effort'
 
 const EFFORT_OPTIONS: {
@@ -13,22 +13,72 @@ const EFFORT_OPTIONS: {
 ]
 
 type ReasoningEffortSelectorProps = {
+  /** Whether the model exposes graded effort (low/medium/high). */
+  supportsEffort: boolean
+  /** Whether the model exposes an on/off thinking toggle. */
+  supportsToggle: boolean
   reasoningEffort: ReasoningEffort
-  onChange: (effort: ReasoningEffort) => void
+  onEffortChange: (effort: ReasoningEffort) => void
+  thinkingEnabled: boolean
+  onThinkingEnabledChange: (enabled: boolean) => void
   isOpen: boolean
   onToggle: () => void
   onClose: () => void
 }
 
 export function ReasoningEffortSelector({
+  supportsEffort,
+  supportsToggle,
   reasoningEffort,
-  onChange,
+  onEffortChange,
+  thinkingEnabled,
+  onThinkingEnabledChange,
   isOpen,
   onToggle,
   onClose,
 }: ReasoningEffortSelectorProps) {
-  const current =
+  if (!supportsEffort && !supportsToggle) {
+    return null
+  }
+
+  // Toggle-only models render as a single pill that flips state on click;
+  // there is no popover to open.
+  if (supportsToggle && !supportsEffort) {
+    return (
+      <button
+        type="button"
+        data-reasoning-selector
+        onClick={(e) => {
+          e.preventDefault()
+          e.stopPropagation()
+          onThinkingEnabledChange(!thinkingEnabled)
+        }}
+        className={cn(
+          'flex items-center gap-1 transition-colors',
+          thinkingEnabled
+            ? 'text-content-primary'
+            : 'text-content-secondary hover:text-content-primary',
+        )}
+        title={thinkingEnabled ? 'Thinking on' : 'Thinking off'}
+      >
+        <GiGearStickPattern className="h-4 w-4" />
+        <span className="text-xs font-medium">
+          {thinkingEnabled ? 'Thinking' : 'No thinking'}
+        </span>
+      </button>
+    )
+  }
+
+  // Effort-supporting models render a button that opens a popover. When the
+  // model also supports a toggle, the popover includes an "Off" option.
+  const currentEffort =
     EFFORT_OPTIONS.find((o) => o.value === reasoningEffort) ?? EFFORT_OPTIONS[1]
+  const buttonLabel =
+    supportsToggle && !thinkingEnabled ? 'Off' : currentEffort.label
+  const buttonTitle =
+    supportsToggle && !thinkingEnabled
+      ? 'Thinking off'
+      : `Reasoning effort: ${currentEffort.label}`
 
   return (
     <div className="relative">
@@ -41,10 +91,10 @@ export function ReasoningEffortSelector({
           onToggle()
         }}
         className="flex items-center gap-1 text-content-secondary transition-colors hover:text-content-primary"
-        title={`Reasoning effort: ${current.label}`}
+        title={buttonTitle}
       >
-        <PiSpeedometerLight className="h-4 w-4" />
-        <span className="text-xs font-medium">{current.label}</span>
+        <GiGearStickPattern className="h-4 w-4" />
+        <span className="text-xs font-medium">{buttonLabel}</span>
         <svg
           className="h-3 w-3"
           fill="none"
@@ -65,29 +115,59 @@ export function ReasoningEffortSelector({
           data-reasoning-menu
           className="absolute bottom-full z-50 mb-2 w-[200px] overflow-hidden rounded-lg border border-border-subtle bg-surface-chat p-1 font-aeonik-fono text-content-secondary shadow-lg"
         >
-          {EFFORT_OPTIONS.map((option) => (
+          {supportsToggle && (
             <button
-              key={option.value}
               type="button"
               className={cn(
                 'flex w-full flex-col rounded-md border px-3 py-2 text-left text-sm transition-colors',
-                reasoningEffort === option.value
+                !thinkingEnabled
                   ? 'border-border-subtle bg-surface-card text-content-primary'
                   : 'border-transparent hover:bg-surface-card/70',
               )}
               onClick={(e) => {
                 e.preventDefault()
                 e.stopPropagation()
-                onChange(option.value)
+                onThinkingEnabledChange(false)
                 onClose()
               }}
             >
-              <span className="font-medium">{option.label}</span>
+              <span className="font-medium">Off</span>
               <span className="text-xs text-content-muted">
-                {option.description}
+                Disable thinking mode
               </span>
             </button>
-          ))}
+          )}
+          {EFFORT_OPTIONS.map((option) => {
+            const isActive =
+              (!supportsToggle || thinkingEnabled) &&
+              reasoningEffort === option.value
+            return (
+              <button
+                key={option.value}
+                type="button"
+                className={cn(
+                  'flex w-full flex-col rounded-md border px-3 py-2 text-left text-sm transition-colors',
+                  isActive
+                    ? 'border-border-subtle bg-surface-card text-content-primary'
+                    : 'border-transparent hover:bg-surface-card/70',
+                )}
+                onClick={(e) => {
+                  e.preventDefault()
+                  e.stopPropagation()
+                  if (supportsToggle && !thinkingEnabled) {
+                    onThinkingEnabledChange(true)
+                  }
+                  onEffortChange(option.value)
+                  onClose()
+                }}
+              >
+                <span className="font-medium">{option.label}</span>
+                <span className="text-xs text-content-muted">
+                  {option.description}
+                </span>
+              </button>
+            )
+          })}
         </div>
       )}
     </div>

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -12,6 +12,7 @@ const DEV_MODELS: BaseModel[] = [
     type: 'chat',
     chat: true,
     multimodal: true,
+    reasoning: true,
     requestParams: { chat_template_kwargs: { enable_thinking: true } },
   },
   {
@@ -42,6 +43,8 @@ export type BaseModel = {
   chat?: boolean
   paid?: boolean
   multimodal?: boolean
+  toolCalling?: boolean
+  reasoning?: boolean
   endpoint?: string
   /** Extra fields merged into the chat completion request body */
   requestParams?: Record<string, unknown>

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -12,8 +12,20 @@ const DEV_MODELS: BaseModel[] = [
     type: 'chat',
     chat: true,
     multimodal: true,
-    reasoning: true,
-    requestParams: { chat_template_kwargs: { enable_thinking: true } },
+    reasoningConfig: {
+      supportsToggle: true,
+      defaultEnabled: true,
+      params: {
+        '/v1/chat/completions': {
+          enable: { chat_template_kwargs: { enable_thinking: true } },
+          disable: { chat_template_kwargs: { enable_thinking: false } },
+        },
+        '/v1/responses': {
+          enable: { chat_template_kwargs: { enable_thinking: true } },
+          disable: { chat_template_kwargs: { enable_thinking: false } },
+        },
+      },
+    },
   },
   {
     modelName: 'kimi-k2-6',
@@ -26,6 +38,44 @@ const DEV_MODELS: BaseModel[] = [
     multimodal: true,
   },
 ]
+
+/**
+ * Per-endpoint enable/disable parameter blocks for thinking mode.
+ * Keyed by full endpoint path (e.g. "/v1/chat/completions", "/v1/responses").
+ * Each block is shallow-merged into the request body when the toggle is in
+ * the corresponding state.
+ */
+export type ReasoningEndpointParams = {
+  enable?: Record<string, unknown>
+  disable?: Record<string, unknown>
+}
+
+/**
+ * Reasoning capability descriptor returned by the controlplane.
+ *
+ * - `supportsEffort: true` — model accepts a `reasoning_effort` (chat
+ *   completions) or `reasoning.effort` (responses) parameter with low/medium/high.
+ * - `supportsToggle: true` — thinking mode can be turned on or off per request
+ *   via `params[endpoint].enable` / `params[endpoint].disable`.
+ * - `defaultEnabled` — initial state of the toggle when `supportsToggle` is true.
+ *
+ * The presence of a `reasoningConfig` object is itself the capability flag
+ * — there is no separate boolean.
+ */
+export type ReasoningConfig = {
+  supportsEffort?: boolean
+  supportsToggle?: boolean
+  defaultEnabled?: boolean
+  /**
+   * Optional translation table from the UI's effort vocabulary
+   * (low | medium | high) to the model's actual accepted values. Used when
+   * a model's chat template only accepts a non-standard set, e.g. DeepSeek V4
+   * which accepts only "high" and "max". When unset, the UI value is
+   * substituted verbatim (correct for OpenAI-style models like GPT-OSS).
+   */
+  effortMap?: Record<string, string>
+  params?: Record<string, ReasoningEndpointParams>
+}
 
 // Base model type with all possible properties
 export type BaseModel = {
@@ -44,7 +94,7 @@ export type BaseModel = {
   paid?: boolean
   multimodal?: boolean
   toolCalling?: boolean
-  reasoning?: boolean
+  reasoningConfig?: ReasoningConfig
   endpoint?: string
   /** Extra fields merged into the chat completion request body */
   requestParams?: Record<string, unknown>

--- a/src/constants/storage-keys.ts
+++ b/src/constants/storage-keys.ts
@@ -27,6 +27,7 @@ export const SETTINGS_HAS_SEEN_CLOUD_SYNC_MODAL =
   'tinfoil-settings-has-seen-cloud-sync-modal'
 export const SETTINGS_SELECTED_MODEL = 'tinfoil-settings-selected-model'
 export const SETTINGS_REASONING_EFFORT = 'tinfoil-settings-reasoning-effort'
+export const SETTINGS_THINKING_ENABLED = 'tinfoil-settings-thinking-enabled'
 export const SETTINGS_MAX_PROMPT_MESSAGES =
   'tinfoil-settings-max-prompt-messages'
 export const SETTINGS_WEB_SEARCH_ENABLED = 'tinfoil-settings-web-search-enabled'

--- a/src/services/inference/inference-client.ts
+++ b/src/services/inference/inference-client.ts
@@ -2,6 +2,8 @@ import { ChatError } from '@/components/chat/chat-utils'
 import { CONSTANTS } from '@/components/chat/constants'
 import {
   isReasoningModel,
+  supportsReasoningEffort,
+  supportsThinkingToggle,
   type ReasoningEffort,
 } from '@/components/chat/hooks/use-reasoning-effort'
 import type { Message } from '@/components/chat/types'
@@ -10,6 +12,34 @@ import { shouldRetryTestFail } from '@/utils/dev-simulator'
 import { logError, logInfo } from '@/utils/error-handling'
 import { ChatQueryBuilder } from './chat-query-builder'
 import { getTinfoilClient } from './tinfoil-client'
+
+const CHAT_COMPLETIONS_ENDPOINT = '/v1/chat/completions'
+
+const EFFORT_PLACEHOLDER = '$EFFORT'
+
+/**
+ * Recursively clones an object, replacing any string equal to "$EFFORT" with
+ * the provided effort value. Used to splice the user-selected reasoning effort
+ * into the model's declarative `reasoningConfig.params[endpoint].enable` block
+ * without the inference layer needing to know which key the model expects it
+ * under (top-level `reasoning_effort`, nested `chat_template_kwargs`, etc.).
+ */
+function substituteEffort(value: unknown, effort: string): unknown {
+  if (typeof value === 'string') {
+    return value === EFFORT_PLACEHOLDER ? effort : value
+  }
+  if (Array.isArray(value)) {
+    return value.map((v) => substituteEffort(v, effort))
+  }
+  if (value && typeof value === 'object') {
+    const out: Record<string, unknown> = {}
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      out[k] = substituteEffort(v, effort)
+    }
+    return out
+  }
+  return value
+}
 
 function isOnline(): boolean {
   return typeof navigator !== 'undefined' ? navigator.onLine : true
@@ -80,6 +110,7 @@ export interface SendChatStreamParams {
   maxMessages: number
   signal: AbortSignal
   reasoningEffort?: ReasoningEffort
+  thinkingEnabled?: boolean
   webSearchEnabled?: boolean
   piiCheckEnabled?: boolean
 }
@@ -96,6 +127,7 @@ export async function sendChatStream(
     maxMessages,
     signal,
     reasoningEffort,
+    thinkingEnabled,
     webSearchEnabled,
     piiCheckEnabled,
   } = params
@@ -249,8 +281,41 @@ export async function sendChatStream(
         messages,
         stream: true,
       }
-      if (isReasoningModel(model) && reasoningEffort) {
-        requestBody.reasoning_effort = reasoningEffort
+      if (isReasoningModel(model)) {
+        const endpointParams =
+          model.reasoningConfig?.params?.[CHAT_COMPLETIONS_ENDPOINT]
+        if (endpointParams) {
+          // Pick enable vs disable based on the toggle. Models that don't
+          // support a toggle always take the enable block.
+          const rawBlock = supportsThinkingToggle(model)
+            ? thinkingEnabled
+              ? endpointParams.enable
+              : endpointParams.disable
+            : endpointParams.enable
+          if (rawBlock) {
+            // The config may embed "$EFFORT" anywhere inside the block; we
+            // splice in the user-selected effort here. Each model declares
+            // exactly which request key its backend expects the effort under
+            // (top-level reasoning_effort, chat_template_kwargs, etc.).
+            // When the model's chat template only accepts a non-standard set
+            // of effort values (e.g. DeepSeek V4 accepts only "high"/"max"),
+            // an effortMap on the reasoningConfig translates the UI value
+            // before substitution.
+            const uiEffort =
+              supportsReasoningEffort(model) && reasoningEffort
+                ? reasoningEffort
+                : 'medium'
+            const effort =
+              model.reasoningConfig?.effortMap?.[uiEffort] ?? uiEffort
+            const block = substituteEffort(rawBlock, effort) as Record<
+              string,
+              unknown
+            >
+            for (const [key, value] of Object.entries(block)) {
+              requestBody[key] = value
+            }
+          }
+        }
       }
       if (webSearchEnabled) {
         requestBody.web_search_options = {}

--- a/src/services/inference/inference-client.ts
+++ b/src/services/inference/inference-client.ts
@@ -249,7 +249,7 @@ export async function sendChatStream(
         messages,
         stream: true,
       }
-      if (isReasoningModel(model.modelName) && reasoningEffort) {
+      if (isReasoningModel(model) && reasoningEffort) {
         requestBody.reasoning_effort = reasoningEffort
       }
       if (webSearchEnabled) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds per-model reasoning controls (effort selector and thinking toggle) for models that opt in via `reasoningConfig`, wires the settings through chat, sidebar, and inference, and fixes citation favicon flicker while streaming.

- **New Features**
  - Reasoning selector next to the model picker in chat and on the welcome screen. Shown only for models with `reasoningConfig`.
  - Persist settings globally via `SETTINGS_REASONING_EFFORT` and `SETTINGS_THINKING_ENABLED`.
  - Expanded model schema with `reasoningConfig` (supportsEffort, supportsToggle, per-endpoint params, effortMap).
  - Inference client injects per-endpoint enable/disable blocks for `/v1/chat/completions`, substituting `$EFFORT` with the selected effort (after `effortMap` translation).
  - Plumbed `reasoningEffort` and `thinkingEnabled` through chat state, sidebar, and messaging to the inference client. Toggle-only models show a single on/off pill; effort models show a popover with Off/Low/Medium/High when supported.

- **Bug Fixes**
  - Stopped citation favicons flashing during streaming by snapshotting annotations to avoid unnecessary remounts.

<sup>Written for commit 9472d0afb5ccb21f408210198470d1ed82675bb7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

