### PR TITLE
Fix reasoning menu and UI nits

### DIFF
--- a/src/components/chat/reasoning-effort-selector.tsx
+++ b/src/components/chat/reasoning-effort-selector.tsx
@@ -354,7 +354,7 @@ function ReasoningIcon({ active }: { active: boolean }) {
       {!active && (
         <span
           aria-hidden="true"
-          className="pointer-events-none absolute left-1/2 top-1/2 h-[2px] w-[18px] -translate-x-1/2 -translate-y-1/2 -rotate-45 rounded-full bg-current"
+          className="pointer-events-none absolute left-1/2 top-1/2 h-px w-[18px] -translate-x-1/2 -translate-y-1/2 -rotate-45 rounded-full bg-current"
         />
       )}
     </span>

--- a/src/components/chat/reasoning-effort-selector.tsx
+++ b/src/components/chat/reasoning-effort-selector.tsx
@@ -46,42 +46,22 @@ export function ReasoningEffortSelector({
     return null
   }
 
-  // Toggle-only models render as a single icon-only button that flips state
-  // on click; there is no popover to open.
-  if (supportsToggle && !supportsEffort) {
-    return (
-      <button
-        type="button"
-        data-reasoning-selector
-        onClick={(e) => {
-          e.preventDefault()
-          e.stopPropagation()
-          onThinkingEnabledChange(!thinkingEnabled)
-        }}
-        className={cn(
-          'flex items-center rounded-md px-3 py-1 transition-colors',
-          thinkingEnabled
-            ? 'text-content-primary'
-            : 'text-content-secondary hover:text-content-primary',
-        )}
-        title={thinkingEnabled ? 'Thinking on' : 'Thinking off'}
-        aria-label={thinkingEnabled ? 'Thinking on' : 'Thinking off'}
-      >
-        <ReasoningIcon active={thinkingEnabled} />
-      </button>
-    )
-  }
-
-  // Effort-supporting models render an icon button that opens a popover.
-  // When the model also supports a toggle, the popover includes an "Off"
-  // option. A chevron next to the lightbulb icon signals the dropdown;
-  // the active effort is surfaced via the popover's row highlighting.
+  // Both effort-supporting and toggle-only models render an icon button that
+  // opens a popover. Effort models list the graded options; toggle-only models
+  // expose On/Off rows. When a model supports both, the popover includes an
+  // additional "Off" option below the effort rows. A chevron next to the
+  // lightbulb icon signals the dropdown; the active selection is surfaced via
+  // the popover's row highlighting.
   const currentEffort =
     EFFORT_OPTIONS.find((o) => o.value === reasoningEffort) ?? EFFORT_OPTIONS[1]
   const isThinkingActive = !supportsToggle || thinkingEnabled
-  const buttonTitle = isThinkingActive
-    ? `Reasoning effort: ${currentEffort.label}`
-    : 'Thinking off'
+  const buttonTitle = supportsEffort
+    ? isThinkingActive
+      ? `Reasoning effort: ${currentEffort.label}`
+      : 'Thinking off'
+    : isThinkingActive
+      ? 'Thinking on'
+      : 'Thinking off'
 
   return (
     <div className="relative">
@@ -114,6 +94,7 @@ export function ReasoningEffortSelector({
 
       {isOpen && (
         <ReasoningPopover
+          supportsEffort={supportsEffort}
           supportsToggle={supportsToggle}
           thinkingEnabled={thinkingEnabled}
           reasoningEffort={reasoningEffort}
@@ -128,6 +109,7 @@ export function ReasoningEffortSelector({
 }
 
 type ReasoningPopoverProps = {
+  supportsEffort: boolean
   supportsToggle: boolean
   thinkingEnabled: boolean
   reasoningEffort: ReasoningEffort
@@ -138,6 +120,7 @@ type ReasoningPopoverProps = {
 }
 
 function ReasoningPopover({
+  supportsEffort,
   supportsToggle,
   thinkingEnabled,
   reasoningEffort,
@@ -254,46 +237,76 @@ function ReasoningPopover({
       onTouchEnd={(e) => e.stopPropagation()}
       onMouseDown={(e) => e.stopPropagation()}
     >
-      {EFFORT_OPTIONS.map((option) => {
-        const isActive =
-          (!supportsToggle || thinkingEnabled) &&
-          reasoningEffort === option.value
-        const handleSelect = () => {
-          if (supportsToggle && !thinkingEnabled) {
-            onThinkingEnabledChange(true)
+      {supportsEffort &&
+        EFFORT_OPTIONS.map((option) => {
+          const isActive =
+            (!supportsToggle || thinkingEnabled) &&
+            reasoningEffort === option.value
+          const handleSelect = () => {
+            if (supportsToggle && !thinkingEnabled) {
+              onThinkingEnabledChange(true)
+            }
+            onEffortChange(option.value)
+            onClose()
           }
-          onEffortChange(option.value)
-          onClose()
-        }
-        return (
-          <button
-            key={option.value}
-            type="button"
-            className={cn(
-              'flex w-full flex-col rounded-md border px-3 py-2 text-left text-sm transition-colors',
-              isActive
-                ? 'border-border-subtle bg-surface-card text-content-primary'
-                : 'border-transparent hover:bg-surface-card/70',
-            )}
-            onClick={(e) => {
-              e.preventDefault()
-              e.stopPropagation()
-              handleSelect()
-            }}
-            onTouchEnd={(e) => {
-              e.stopPropagation()
-              if (isScrollingRef.current) return
-              e.preventDefault()
-              handleSelect()
-            }}
-          >
-            <span className="font-medium">{option.label}</span>
-            <span className="text-xs text-content-muted">
-              {option.description}
-            </span>
-          </button>
-        )
-      })}
+          return (
+            <button
+              key={option.value}
+              type="button"
+              className={cn(
+                'flex w-full flex-col rounded-md border px-3 py-2 text-left text-sm transition-colors',
+                isActive
+                  ? 'border-border-subtle bg-surface-card text-content-primary'
+                  : 'border-transparent hover:bg-surface-card/70',
+              )}
+              onClick={(e) => {
+                e.preventDefault()
+                e.stopPropagation()
+                handleSelect()
+              }}
+              onTouchEnd={(e) => {
+                e.stopPropagation()
+                if (isScrollingRef.current) return
+                e.preventDefault()
+                handleSelect()
+              }}
+            >
+              <span className="font-medium">{option.label}</span>
+              <span className="text-xs text-content-muted">
+                {option.description}
+              </span>
+            </button>
+          )
+        })}
+      {supportsToggle && !supportsEffort && (
+        <button
+          type="button"
+          className={cn(
+            'flex w-full flex-col rounded-md border px-3 py-2 text-left text-sm transition-colors',
+            thinkingEnabled
+              ? 'border-border-subtle bg-surface-card text-content-primary'
+              : 'border-transparent hover:bg-surface-card/70',
+          )}
+          onClick={(e) => {
+            e.preventDefault()
+            e.stopPropagation()
+            onThinkingEnabledChange(true)
+            onClose()
+          }}
+          onTouchEnd={(e) => {
+            e.stopPropagation()
+            if (isScrollingRef.current) return
+            e.preventDefault()
+            onThinkingEnabledChange(true)
+            onClose()
+          }}
+        >
+          <span className="font-medium">On</span>
+          <span className="text-xs text-content-muted">
+            Enable thinking mode
+          </span>
+        </button>
+      )}
       {supportsToggle && (
         <button
           type="button"

--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -43,6 +43,7 @@ import { SignInButton, useAuth, useUser } from '@clerk/nextjs'
 import {
   ArrowDownTrayIcon,
   ArrowPathIcon,
+  ArrowTopRightOnSquareIcon,
   ArrowUpTrayIcon,
   ChatBubbleLeftRightIcon,
   CheckCircleIcon,
@@ -77,6 +78,8 @@ import { normalizeChatFont, type ChatFont } from './hooks/use-chat-font'
 import type { Chat } from './types'
 
 const CHARS = '0123456789ABCDEF!@#$%^&*()_+<>?/'
+
+const DASHBOARD_URL = 'https://dash.tinfoil.sh'
 
 const ScrambleText = ({
   text,
@@ -3618,6 +3621,38 @@ ${encryptionKey.replace('key_', '')}
                             {upgradeError}
                           </p>
                         )}
+                      </div>
+
+                      {/* Account Management */}
+                      <div className="space-y-3">
+                        <h3 className="font-aeonik text-sm font-medium text-content-secondary">
+                          Account Management
+                        </h3>
+                        <a
+                          href={DASHBOARD_URL}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className={cn(
+                            'flex w-full items-start justify-between rounded-lg border border-border-subtle p-4 transition-colors hover:bg-surface-chat',
+                            isDarkMode ? 'bg-surface-sidebar' : 'bg-white',
+                          )}
+                        >
+                          <div className="text-left">
+                            <div className="flex items-center gap-3">
+                              <UserCircleIcon className="h-5 w-5 text-content-muted" />
+                              <div className="font-aeonik text-sm font-medium text-content-primary">
+                                Dashboard
+                              </div>
+                            </div>
+                            <div className="mt-1 font-aeonik-fono text-xs text-content-muted">
+                              Manage your account at dash.tinfoil.sh
+                            </div>
+                          </div>
+                          <ArrowTopRightOnSquareIcon
+                            className="h-4 w-4 text-content-muted"
+                            aria-hidden="true"
+                          />
+                        </a>
                       </div>
                     </>
                   ) : (


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Unifies the reasoning selector so it always opens a popover and correctly supports toggle-only models. Adds an Account Management link in Settings that opens the dashboard.

- **Bug Fixes**
  - Show the reasoning menu for models that only support thinking On/Off; list effort levels when supported and include an Off option when applicable.
  - Fix button titles and active-row highlighting; make the off-state strike-through more subtle.

- **New Features**
  - Add "Dashboard" link in Settings > Account Management to `https://dash.tinfoil.sh` (opens in a new tab).

<sup>Written for commit 0e406915d12090cb07c79cd320323b1177fa1f22. Summary will update on new commits. <a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/356?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

