### PR TITLE
Fix some minor signin and signout ux issues 

### DIFF
--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -15,6 +15,8 @@ import { useSubscriptionStatus } from '@/hooks/use-subscription-status'
 import { useToast } from '@/hooks/use-toast'
 import {
   getRateLimitInfo,
+  getSessionToken,
+  invalidateAnonymousSessionCache,
   snapshotAndDecrementRemaining,
   type RateLimitInfo,
 } from '@/services/inference/tinfoil-client'
@@ -899,6 +901,18 @@ export function ChatInterface({
       window.removeEventListener('rateLimitUpdated', handleRateLimitUpdate)
     }
   }, [])
+
+  // Once the user signs in (and the auth token manager has been
+  // initialized via useCloudSync), discard any anonymous session token /
+  // free-tier rate-limit info cached before sign-in and force a fresh
+  // fetch so the banner reflects the authenticated user's quota.
+  useEffect(() => {
+    if (!isSignedIn || !cloudSyncInitialized) return
+    invalidateAnonymousSessionCache()
+    void getSessionToken().catch(() => {
+      // best-effort; the next real request will retry
+    })
+  }, [isSignedIn, cloudSyncInitialized])
 
   // Handle upgrade requests from error CTA buttons
   useEffect(() => {

--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -237,6 +237,7 @@ export function SettingsModal({
   const [isKeyVisible, setIsKeyVisible] = useState(false)
   const [isSettingUpPasskey, setIsSettingUpPasskey] = useState(false)
   const [showSignOutConfirm, setShowSignOutConfirm] = useState(false)
+  const [isSigningOut, setIsSigningOut] = useState(false)
   const [isHowItWorksOpen, setIsHowItWorksOpen] = useState(false)
   const [isEncryptionKeyOpen, setIsEncryptionKeyOpen] = useState(false)
   const [primaryKeyMode, setPrimaryKeyMode] = useState<
@@ -934,6 +935,24 @@ export function SettingsModal({
       setBillingLoading(false)
     }
   }, [getToken])
+
+  const handleSignOut = useCallback(async () => {
+    setIsSigningOut(true)
+    try {
+      await signOut()
+    } catch (error) {
+      logError('Sign out failed', error, {
+        component: 'SettingsModal',
+        action: 'handleSignOut',
+      })
+    } finally {
+      // Always reset the flag so the button is re-enabled — on success
+      // the component typically unmounts before this matters, and on
+      // failure the user can retry instead of being stuck on a
+      // permanently-disabled control.
+      setIsSigningOut(false)
+    }
+  }, [signOut])
 
   // Import handlers
   const generateChatId = (createdAt?: Date) => {
@@ -3517,18 +3536,23 @@ ${encryptionKey.replace('key_', '')}
                               if (isLocalOnlyModeEnabled()) {
                                 setShowSignOutConfirm(true)
                               } else {
-                                signOut()
+                                void handleSignOut()
                               }
                             }}
+                            disabled={isSigningOut}
                             className={cn(
-                              'rounded-lg px-3 py-1.5 text-sm font-medium transition-colors',
+                              'flex items-center justify-center gap-2 rounded-lg px-3 py-1.5 text-sm font-medium transition-colors',
                               'w-full border md:w-auto md:border-0',
+                              'disabled:cursor-not-allowed disabled:opacity-70',
                               isDarkMode
                                 ? 'border-red-500/30 bg-red-950/20 text-red-400 hover:bg-red-950/40 md:bg-transparent md:hover:bg-red-500/10'
                                 : 'border-red-300 bg-red-50 text-red-600 hover:bg-red-100 md:bg-transparent md:text-red-500 md:hover:bg-red-500/10',
                             )}
                           >
-                            Sign out
+                            {isSigningOut && (
+                              <ArrowPathIcon className="h-4 w-4 animate-spin" />
+                            )}
+                            {isSigningOut ? 'Signing out...' : 'Sign out'}
                           </button>
                         </div>
                       </div>
@@ -3719,16 +3743,21 @@ ${encryptionKey.replace('key_', '')}
               <button
                 onClick={() => {
                   setShowSignOutConfirm(false)
-                  signOut()
+                  void handleSignOut()
                 }}
+                disabled={isSigningOut}
                 className={cn(
-                  'flex-1 rounded-lg border px-4 py-2.5 text-sm font-medium transition-colors',
+                  'flex flex-1 items-center justify-center gap-2 rounded-lg border px-4 py-2.5 text-sm font-medium transition-colors',
+                  'disabled:cursor-not-allowed disabled:opacity-70',
                   isDarkMode
                     ? 'border-red-500/30 bg-red-950/30 text-red-400 hover:bg-red-950/50'
                     : 'border-red-300 bg-red-50 text-red-600 hover:bg-red-100',
                 )}
               >
-                Sign Out
+                {isSigningOut && (
+                  <ArrowPathIcon className="h-4 w-4 animate-spin" />
+                )}
+                {isSigningOut ? 'Signing out...' : 'Sign Out'}
               </button>
             </div>
           </div>

--- a/src/components/onboarding/onboarding-modal.tsx
+++ b/src/components/onboarding/onboarding-modal.tsx
@@ -638,7 +638,7 @@ function OnboardingModelsPage({
           </h2>
           <p className="text-base text-content-secondary">
             Access leading AI models, all running inside secure hardware
-            enclaves with fully verified privacy.
+            enclaves with verified privacy.
           </p>
         </div>
 

--- a/src/services/inference/tinfoil-client.ts
+++ b/src/services/inference/tinfoil-client.ts
@@ -22,6 +22,7 @@ let clientInstance: TinfoilAI | OpenAI | null = null
 let lastSessionToken: string | null = null
 let cachedSessionToken: string | null = null
 let cachedSessionTokenExpiresAt: number | null = null
+let cachedSessionTokenWasAuthenticated = false
 let cachedRateLimit: RateLimitInfo | null = null
 let remainingBeforeRequest: number | null = null
 let refreshInFlight: Promise<void> | null = null
@@ -37,17 +38,6 @@ async function fetchSessionToken(): Promise<string> {
     return DEV_API_KEY
   }
 
-  if (cachedSessionToken) {
-    const isExpired =
-      cachedSessionTokenExpiresAt !== null &&
-      Date.now() > cachedSessionTokenExpiresAt - SESSION_TOKEN_EXPIRY_BUFFER_MS
-    if (!isExpired) {
-      return cachedSessionToken
-    }
-    cachedSessionToken = null
-    cachedSessionTokenExpiresAt = null
-  }
-
   // If the user was previously signed in, wait for Clerk to initialize
   // the auth token manager before fetching — otherwise we'd get an
   // anonymous free-tier key that gets cached until expiry.
@@ -59,12 +49,14 @@ async function fetchSessionToken(): Promise<string> {
     await authTokenManager.waitForInit(AUTH_INIT_WAIT_MS)
   }
 
-  // Build request headers: include auth if signed in, omit for anonymous users
-  const headers: Record<string, string> = {}
+  // Resolve the auth bearer (if any) up front so the cache-validity
+  // check and the actual request use the same authenticated/anonymous
+  // decision.  This avoids a stale-cache loop when getValidToken()
+  // intermittently fails for a signed-in user.
+  let authBearer: string | null = null
   if (authTokenManager.isInitialized()) {
     try {
-      const token = await authTokenManager.getValidToken()
-      headers['Authorization'] = `Bearer ${token}`
+      authBearer = await authTokenManager.getValidToken()
     } catch (error) {
       logError(
         'Failed to get auth token, falling back to anonymous key',
@@ -75,6 +67,39 @@ async function fetchSessionToken(): Promise<string> {
         },
       )
     }
+  }
+  const usedAuthHeader = authBearer !== null
+
+  // If the cached token was fetched anonymously but we now have an
+  // authenticated bearer, discard it so the next fetch goes out with
+  // the user's token and returns the correct (possibly premium) rate
+  // limit info.
+  if (
+    cachedSessionToken &&
+    !cachedSessionTokenWasAuthenticated &&
+    usedAuthHeader
+  ) {
+    cachedSessionToken = null
+    cachedSessionTokenExpiresAt = null
+    cachedRateLimit = null
+    dispatchRateLimitUpdate()
+  }
+
+  if (cachedSessionToken) {
+    const isExpired =
+      cachedSessionTokenExpiresAt !== null &&
+      Date.now() > cachedSessionTokenExpiresAt - SESSION_TOKEN_EXPIRY_BUFFER_MS
+    if (!isExpired) {
+      return cachedSessionToken
+    }
+    cachedSessionToken = null
+    cachedSessionTokenExpiresAt = null
+  }
+
+  // Build request headers: include auth if we resolved a bearer above
+  const headers: Record<string, string> = {}
+  if (authBearer) {
+    headers['Authorization'] = `Bearer ${authBearer}`
   }
 
   const response = await fetch(`${API_BASE_URL}/api/keys/chat`, {
@@ -97,6 +122,7 @@ async function fetchSessionToken(): Promise<string> {
 
   const data = await response.json()
   cachedSessionToken = data.key
+  cachedSessionTokenWasAuthenticated = usedAuthHeader
   if (data.expires_at) {
     cachedSessionTokenExpiresAt = new Date(data.expires_at).getTime()
   }
@@ -183,9 +209,26 @@ export function resetTinfoilClient(): void {
   lastSessionToken = null
   cachedSessionToken = null
   cachedSessionTokenExpiresAt = null
+  cachedSessionTokenWasAuthenticated = false
   cachedRateLimit = null
   remainingBeforeRequest = null
   refreshInFlight = null
+}
+
+/**
+ * Discards any cached anonymous session token + rate limit so the next
+ * request fetches a fresh authenticated token from the server.  Called
+ * after sign-in transitions so a leftover anonymous free-tier banner
+ * does not persist for a now-authenticated user.
+ */
+export function invalidateAnonymousSessionCache(): void {
+  if (cachedSessionTokenWasAuthenticated) return
+  cachedSessionToken = null
+  cachedSessionTokenExpiresAt = null
+  if (cachedRateLimit !== null) {
+    cachedRateLimit = null
+    dispatchRateLimitUpdate()
+  }
 }
 
 async function initClient(sessionToken: string): Promise<TinfoilAI | OpenAI> {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Show a spinner and disable Settings sign-out buttons while signing out, and simplify onboarding copy to "verified privacy."
After sign-in, invalidate anonymous session cache and prefetch a session token so the chat quota banner reflects the user's limits.

<sup>Written for commit b22c2b09c614a65598689b436e36d025c204f12c. Summary will update on new commits. <a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/357?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

