### PR TITLE
Page and new chat via URL extensions

### DIFF
--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -162,6 +162,14 @@ type ChatInterfaceProps = {
   initialChatId?: string | null
   initialProjectId?: string | null
   isLocalChatUrl?: boolean
+  /**
+   * When true, suppresses auto-opening intro/setup modals on this mount
+   * (onboarding, passkey setup/recovery prompts, cloud sync setup, and the
+   * "passkey setup failed" warning). Used by routes like /newchat where the
+   * user explicitly wants to start chatting without interruptions. The user
+   * can still open these flows manually from settings.
+   */
+  suppressIntroModals?: boolean
 }
 
 // Short delay before showing the "Chats Are Not Being Backed Up" warning so
@@ -268,6 +276,7 @@ export function ChatInterface({
   initialChatId,
   initialProjectId,
   isLocalChatUrl: isLocalChatUrlProp,
+  suppressIntroModals = false,
 }: ChatInterfaceProps) {
   const { toast } = useToast()
   const { isSignedIn, isLoaded: isAuthLoaded } = useAuth()
@@ -422,10 +431,11 @@ export function ChatInterface({
 
   // Show onboarding once models are loaded for new users
   useEffect(() => {
+    if (suppressIntroModals) return
     if (onboardingNeeded && models.length > 0) {
       setShowOnboarding(true)
     }
-  }, [onboardingNeeded, models.length])
+  }, [onboardingNeeded, models.length, suppressIntroModals])
 
   // State for right sidebar
   const [isVerifierSidebarOpen, setIsVerifierSidebarOpen] = useState(false)
@@ -463,6 +473,7 @@ export function ChatInterface({
   const [cloudSyncSetupModalKey, setCloudSyncSetupModalKey] = useState(0)
 
   useEffect(() => {
+    if (suppressIntroModals) return
     // Passkey-based recovery always auto-opens: a remote passkey credential
     // means the user *has* chats backed up and can't see them on this device
     // until they unlock, regardless of whether the local sync toggle is on.
@@ -475,10 +486,10 @@ export function ChatInterface({
     if (manualRecoveryNeeded && isCloudSyncEnabled()) {
       setShowCloudSyncSetupModal(true)
     }
-  }, [manualRecoveryNeeded, passkeyRecoveryNeeded])
+  }, [manualRecoveryNeeded, passkeyRecoveryNeeded, suppressIntroModals])
 
   useEffect(() => {
-    if (!passkeySetupFailed) {
+    if (!passkeySetupFailed || suppressIntroModals) {
       setShowPasskeySetupFailed(false)
       return
     }
@@ -486,7 +497,7 @@ export function ChatInterface({
       setShowPasskeySetupFailed(true)
     }, PASSKEY_SETUP_FAILED_MODAL_DELAY_MS)
     return () => clearTimeout(timer)
-  }, [passkeySetupFailed])
+  }, [passkeySetupFailed, suppressIntroModals])
 
   // State for add-to-project-context modal
   const [showAddToProjectModal, setShowAddToProjectModal] = useState(false)
@@ -2957,7 +2968,7 @@ export function ChatInterface({
 
       {/* First-time passkey setup confirmation - shown to brand-new users so
           we never invoke the native WebAuthn dialog without an explicit click. */}
-      {passkeyFirstTimePromptAvailable && (
+      {passkeyFirstTimePromptAvailable && !suppressIntroModals && (
         <PasskeySetupPromptModal
           isOpen={passkeyFirstTimePromptAvailable}
           isBusy={isFirstTimePasskeySetupBusy}

--- a/src/components/url-hash-message-handler.tsx
+++ b/src/components/url-hash-message-handler.tsx
@@ -7,10 +7,46 @@ interface UrlHashMessageHandlerProps {
   isReady: boolean
 }
 
+const MAX_MESSAGE_LENGTH = 50000
+const CONTROL_CHARS_REGEX = /[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/
+
+function sanitizeMessage(decodedMessage: string): string | null {
+  if (!decodedMessage) {
+    return null
+  }
+
+  if (decodedMessage.length > MAX_MESSAGE_LENGTH) {
+    logWarning('URL message exceeds maximum length', {
+      component: 'UrlHashMessageHandler',
+      metadata: {
+        messageLength: decodedMessage.length,
+        maxLength: MAX_MESSAGE_LENGTH,
+      },
+    })
+    return null
+  }
+
+  if (CONTROL_CHARS_REGEX.test(decodedMessage)) {
+    logWarning('URL message contains invalid control characters', {
+      component: 'UrlHashMessageHandler',
+    })
+    return null
+  }
+
+  // Normalize smart quotes to regular quotes for better compatibility
+  return decodedMessage
+    .replace(/[\u201C\u201D]/g, '"') // Replace " and "
+    .replace(/[\u2018\u2019]/g, "'") // Replace ' and '
+}
+
 /**
- * Handles URL fragments with format: #send=<base64-encoded-message>
- * Example: #send=V2hhdCBpcyAyKzI/
- * This format distinguishes message sending from other fragment uses like #settings/<tab>
+ * Handles two URL formats for prefilling a message:
+ * 1. URL fragment: #send=<base64-encoded-message> (e.g., #send=V2hhdCBpcyAyKzI/)
+ * 2. Query string: ?q=<url-encoded-message> (e.g., ?q=hello+world)
+ *
+ * The hash format distinguishes message sending from other fragment uses
+ * like #settings/<tab>. The query format mirrors the convention used by
+ * other chat tools (e.g., ChatGPT's ?q=).
  */
 export function UrlHashMessageHandler({
   onMessageReady,
@@ -27,12 +63,8 @@ export function UrlHashMessageHandler({
       try {
         const hash = window.location.hash
 
-        if (!hash || hash.length <= 1) {
-          return
-        }
-
-        if (!hash.startsWith('#send=')) {
-          return
+        if (!hash || hash.length <= 1 || !hash.startsWith('#send=')) {
+          return false
         }
 
         const encodedMessage = hash.slice(6)
@@ -42,36 +74,10 @@ export function UrlHashMessageHandler({
           const bytes = base64ToUint8Array(encodedMessage)
           const decodedMessage = new TextDecoder('utf-8').decode(bytes)
 
-          if (!decodedMessage) {
-            return
+          const normalizedMessage = sanitizeMessage(decodedMessage)
+          if (!normalizedMessage) {
+            return false
           }
-
-          const maxMessageLength = 50000
-          if (decodedMessage.length > maxMessageLength) {
-            logWarning('URL hash message exceeds maximum length', {
-              component: 'UrlHashMessageHandler',
-              metadata: {
-                messageLength: decodedMessage.length,
-                maxLength: maxMessageLength,
-              },
-            })
-            return
-          }
-
-          const hasControlChars = /[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/.test(
-            decodedMessage,
-          )
-          if (hasControlChars) {
-            logWarning('URL hash message contains invalid control characters', {
-              component: 'UrlHashMessageHandler',
-            })
-            return
-          }
-
-          // Normalize smart quotes to regular quotes for better compatibility
-          const normalizedMessage = decodedMessage
-            .replace(/[\u201C\u201D]/g, '"') // Replace " and "
-            .replace(/[\u2018\u2019]/g, "'") // Replace ' and '
 
           logInfo('Processing message from URL hash', {
             component: 'UrlHashMessageHandler',
@@ -86,6 +92,7 @@ export function UrlHashMessageHandler({
             '',
             window.location.pathname + window.location.search,
           )
+          return true
         } catch (decodeError) {
           logWarning('Invalid base64 encoding in URL hash', {
             component: 'UrlHashMessageHandler',
@@ -96,15 +103,57 @@ export function UrlHashMessageHandler({
                   : 'Unknown error',
             },
           })
+          return false
         }
       } catch (error) {
         logError('Failed to process URL hash message', error, {
           component: 'UrlHashMessageHandler',
         })
+        return false
       }
     }
 
-    processHashMessage()
+    const processQueryMessage = () => {
+      try {
+        const params = new URLSearchParams(window.location.search)
+        const rawMessage = params.get('q')
+
+        if (!rawMessage) {
+          return false
+        }
+
+        const normalizedMessage = sanitizeMessage(rawMessage)
+        if (!normalizedMessage) {
+          return false
+        }
+
+        logInfo('Processing message from URL query', {
+          component: 'UrlHashMessageHandler',
+          metadata: { messageLength: normalizedMessage.length },
+        })
+
+        hasProcessed.current = true
+        onMessageReady(normalizedMessage)
+
+        params.delete('q')
+        const remainingQuery = params.toString()
+        const newUrl =
+          window.location.pathname +
+          (remainingQuery ? `?${remainingQuery}` : '') +
+          window.location.hash
+        window.history.replaceState(null, '', newUrl)
+        return true
+      } catch (error) {
+        logError('Failed to process URL query message', error, {
+          component: 'UrlHashMessageHandler',
+        })
+        return false
+      }
+    }
+
+    if (!processHashMessage()) {
+      processQueryMessage()
+    }
   }, [isReady, onMessageReady])
 
   return null

--- a/src/components/url-hash-message-handler.tsx
+++ b/src/components/url-hash-message-handler.tsx
@@ -10,6 +10,25 @@ interface UrlHashMessageHandlerProps {
 const MAX_MESSAGE_LENGTH = 50000
 const CONTROL_CHARS_REGEX = /[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/
 
+/**
+ * Rewrites the current URL to remove any markers that would cause the message
+ * handler to re-fire on a future reload. Strips both `?q=` and `#send=` so a
+ * URL like `/?q=foo#send=<b64>` can't auto-send the leftover query param later.
+ */
+function clearMessageMarkersFromUrl() {
+  const params = new URLSearchParams(window.location.search)
+  params.delete('q')
+  const remainingQuery = params.toString()
+  const hash = window.location.hash.startsWith('#send=')
+    ? ''
+    : window.location.hash
+  const newUrl =
+    window.location.pathname +
+    (remainingQuery ? `?${remainingQuery}` : '') +
+    hash
+  window.history.replaceState(null, '', newUrl)
+}
+
 function sanitizeMessage(decodedMessage: string): string | null {
   if (!decodedMessage) {
     return null
@@ -87,11 +106,7 @@ export function UrlHashMessageHandler({
           hasProcessed.current = true
           onMessageReady(normalizedMessage)
 
-          window.history.replaceState(
-            null,
-            '',
-            window.location.pathname + window.location.search,
-          )
+          clearMessageMarkersFromUrl()
           return true
         } catch (decodeError) {
           logWarning('Invalid base64 encoding in URL hash', {
@@ -135,13 +150,7 @@ export function UrlHashMessageHandler({
         hasProcessed.current = true
         onMessageReady(normalizedMessage)
 
-        params.delete('q')
-        const remainingQuery = params.toString()
-        const newUrl =
-          window.location.pathname +
-          (remainingQuery ? `?${remainingQuery}` : '') +
-          window.location.hash
-        window.history.replaceState(null, '', newUrl)
+        clearMessageMarkersFromUrl()
         return true
       } catch (error) {
         logError('Failed to process URL query message', error, {

--- a/src/pages/newchat.tsx
+++ b/src/pages/newchat.tsx
@@ -1,0 +1,19 @@
+'use client'
+
+import { ChatInterface } from '@/components/chat'
+import { ProjectProvider } from '@/components/project'
+
+/**
+ * Entry point for starting a new chat without any auto-opening intro/setup
+ * modals. Pairs nicely with the `?q=` query parameter to send a prefilled
+ * message immediately (e.g. /newchat?q=hello+world).
+ */
+export default function NewChatPage() {
+  return (
+    <div className="h-screen font-aeonik">
+      <ProjectProvider>
+        <ChatInterface suppressIntroModals />
+      </ProjectProvider>
+    </div>
+  )
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a distraction‑free `/newchat` route and supports prefilled messages via `?q=` (plain text) and `#send=` (base64). Prevents duplicate sends by processing once and clearing URL markers.

- **New Features**
  - New `/newchat` page renders `ChatInterface` with `suppressIntroModals` to skip onboarding, passkey, and cloud‑sync modals.
  - URL handler accepts `?q=` and `#send=`; processes once and strips both markers to avoid re-sends on reload.
  - Message sanitization: max 50k chars, control‑char rejection, and smart‑quote normalization. Adds structured logs for errors.
  - `ChatInterface` gets `suppressIntroModals` prop and guards related effects and the first‑time passkey prompt.

<sup>Written for commit a54e67aff8b391dc2450380baf3acfc00ae0ae14. Summary will update on new commits. <a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/359?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

