### PR TITLE
fix: route /newchat through static export rewrite

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -33,7 +33,9 @@
     {
       "source": "/share/:path*",
       "destination": "/share/%5B%5B...slug%5D%5D.html"
-    }
+    },
+    { "source": "/newchat", "destination": "/newchat.html" },
+    { "source": "/newchat/", "destination": "/newchat.html" }
   ],
   "headers": [
     {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Route /newchat through the static export rewrite. Both /newchat and /newchat/ now serve /newchat.html to avoid 404s on static deployments.

<sup>Written for commit 9a976603d42b235ec0d69d6308a24c7cf62ea86c. Summary will update on new commits. <a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/360?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

