### PR TITLE
Add bulk chat delete option in settings

### DIFF
--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -25,6 +25,7 @@ import { projectStorage } from '@/services/cloud/project-storage'
 import { encryptionService } from '@/services/encryption/encryption-service'
 import { PrfNotSupportedError } from '@/services/passkey'
 import { chatStorage } from '@/services/storage/chat-storage'
+import { sessionChatStorage } from '@/services/storage/session-storage'
 import { TINFOIL_COLORS } from '@/theme/colors'
 import {
   parseChatGPTConversations,
@@ -339,6 +340,11 @@ export function SettingsModal({
   const [exportType, setExportType] = useState<'chats' | 'projects' | null>(
     null,
   )
+
+  // Danger zone state
+  const [showDeleteAllChatsConfirm, setShowDeleteAllChatsConfirm] =
+    useState(false)
+  const [isDeletingAllChats, setIsDeletingAllChats] = useState(false)
 
   // Available personality traits
   const availableTraits = [
@@ -1416,6 +1422,44 @@ export function SettingsModal({
     }
   }
 
+  // Delete every chat the user owns (local IndexedDB + cloud + session)
+  const handleDeleteAllChats = async () => {
+    setIsDeletingAllChats(true)
+    try {
+      if (isSignedIn) {
+        const result = await chatStorage.deleteAllChats()
+        const total = result.localDeleted + result.cloudDeleted
+        toast({
+          title: 'All chats deleted',
+          description: `Removed ${total} chat${total !== 1 ? 's' : ''} from this device${result.cloudDeleted > 0 ? ' and the cloud' : ''}.`,
+        })
+      } else {
+        sessionChatStorage.clearAll()
+        toast({
+          title: 'All chats deleted',
+          description: 'Removed all chats from this browser session.',
+        })
+      }
+
+      if (onChatsUpdated) {
+        onChatsUpdated()
+      }
+    } catch (error) {
+      logError('Failed to delete all chats', error, {
+        component: 'SettingsModal',
+        action: 'handleDeleteAllChats',
+      })
+      toast({
+        title: 'Delete failed',
+        description: 'Failed to delete all chats. Please try again.',
+        variant: 'destructive',
+      })
+    } finally {
+      setIsDeletingAllChats(false)
+      setShowDeleteAllChatsConfirm(false)
+    }
+  }
+
   // Export projects as projects.json
   const downloadProjects = async (
     projectsToExport: Array<{
@@ -1544,6 +1588,7 @@ export function SettingsModal({
     if (!isOpen) {
       setIsQRCodeExpanded(false)
       setShowSignOutConfirm(false)
+      setShowDeleteAllChatsConfirm(false)
       setPrimaryKeyMode('recoverExisting')
     }
   }, [isOpen])
@@ -2230,6 +2275,80 @@ ${encryptionKey.replace('key_', '')}
                         </div>
                       </div>
                     )}
+                  </div>
+
+                  {/* Danger Zone */}
+                  <div className="space-y-3">
+                    <h3 className="font-aeonik text-sm font-medium text-content-secondary">
+                      Danger Zone
+                    </h3>
+
+                    {/* Delete all saved chats */}
+                    <div
+                      className={cn(
+                        'rounded-lg border p-4',
+                        isDarkMode
+                          ? 'border-red-500/30 bg-red-950/10'
+                          : 'border-red-200 bg-red-50/50',
+                      )}
+                    >
+                      <div className="space-y-3">
+                        <div>
+                          <div className="font-aeonik text-sm font-medium text-content-primary">
+                            Delete all saved chats
+                          </div>
+                          <div className="font-aeonik-fono text-xs text-content-muted">
+                            {isSignedIn
+                              ? 'Permanently delete every chat from this device and your encrypted cloud backup. This cannot be undone.'
+                              : 'Permanently delete every chat from this browser. This cannot be undone.'}
+                          </div>
+                        </div>
+                        {showDeleteAllChatsConfirm ? (
+                          <div className="flex flex-col gap-2 sm:flex-row">
+                            <button
+                              onClick={handleDeleteAllChats}
+                              disabled={isDeletingAllChats}
+                              className={cn(
+                                'flex-1 rounded-md px-3 py-2 text-sm font-medium transition-colors',
+                                isDarkMode
+                                  ? 'bg-red-600 text-white hover:bg-red-500 disabled:bg-red-900 disabled:text-red-300'
+                                  : 'bg-red-600 text-white hover:bg-red-700 disabled:bg-red-300',
+                              )}
+                            >
+                              {isDeletingAllChats
+                                ? 'Deleting…'
+                                : 'Yes, delete all my chats'}
+                            </button>
+                            <button
+                              onClick={() =>
+                                setShowDeleteAllChatsConfirm(false)
+                              }
+                              disabled={isDeletingAllChats}
+                              className={cn(
+                                'flex-1 rounded-md border px-3 py-2 text-sm font-medium transition-colors',
+                                isDarkMode
+                                  ? 'border-border-strong bg-surface-chat text-content-secondary hover:bg-surface-chat/80'
+                                  : 'border-border-subtle bg-white text-content-primary hover:bg-surface-chat',
+                              )}
+                            >
+                              Cancel
+                            </button>
+                          </div>
+                        ) : (
+                          <button
+                            onClick={() => setShowDeleteAllChatsConfirm(true)}
+                            className={cn(
+                              'w-full rounded-md border px-3 py-2 text-sm font-medium transition-colors',
+                              isDarkMode
+                                ? 'border-red-500/40 bg-red-950/30 text-red-400 hover:bg-red-950/50'
+                                : 'border-red-300 bg-white text-red-600 hover:bg-red-100',
+                            )}
+                          >
+                            Delete all saved chats
+                          </button>
+                        )}
+                      </div>
+                    </div>
                   </div>
                 </>
               )}

--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -82,6 +82,9 @@ const CHARS = '0123456789ABCDEF!@#$%^&*()_+<>?/'
 
 const DASHBOARD_URL = 'https://dash.tinfoil.sh'
 
+const DELETE_ALL_CHATS_CONFIRM_PHRASE = 'delete all chats'
+const DELETE_ALL_PROJECTS_CONFIRM_PHRASE = 'delete all projects'
+
 const ScrambleText = ({
   text,
   className,
@@ -349,9 +352,12 @@ export function SettingsModal({
   const [showDeleteAllChatsConfirm, setShowDeleteAllChatsConfirm] =
     useState(false)
   const [isDeletingAllChats, setIsDeletingAllChats] = useState(false)
+  const [deleteAllChatsConfirmText, setDeleteAllChatsConfirmText] = useState('')
   const [showDeleteAllProjectsConfirm, setShowDeleteAllProjectsConfirm] =
     useState(false)
   const [isDeletingAllProjects, setIsDeletingAllProjects] = useState(false)
+  const [deleteAllProjectsConfirmText, setDeleteAllProjectsConfirmText] =
+    useState('')
 
   // Available personality traits
   const availableTraits = [
@@ -1429,8 +1435,18 @@ export function SettingsModal({
     }
   }
 
-  // Delete every chat the user owns (local IndexedDB + cloud + session)
+  // Delete every chat the user owns (local IndexedDB + cloud + session).
+  // Defense in depth: re-check the typed confirmation phrase here in addition
+  // to gating the submit button on it, so the destructive action cannot be
+  // triggered accidentally even if the UI layer is bypassed.
   const handleDeleteAllChats = async () => {
+    if (
+      deleteAllChatsConfirmText.trim().toLowerCase() !==
+      DELETE_ALL_CHATS_CONFIRM_PHRASE
+    ) {
+      return
+    }
+
     setIsDeletingAllChats(true)
     try {
       if (isSignedIn) {
@@ -1464,11 +1480,20 @@ export function SettingsModal({
     } finally {
       setIsDeletingAllChats(false)
       setShowDeleteAllChatsConfirm(false)
+      setDeleteAllChatsConfirmText('')
     }
   }
 
-  // Delete every project the user owns
+  // Delete every project the user owns. Same defense-in-depth confirmation
+  // gate as handleDeleteAllChats.
   const handleDeleteAllProjects = async () => {
+    if (
+      deleteAllProjectsConfirmText.trim().toLowerCase() !==
+      DELETE_ALL_PROJECTS_CONFIRM_PHRASE
+    ) {
+      return
+    }
+
     setIsDeletingAllProjects(true)
     try {
       const result = await projectStorage.deleteAllProjects()
@@ -1497,6 +1522,7 @@ export function SettingsModal({
     } finally {
       setIsDeletingAllProjects(false)
       setShowDeleteAllProjectsConfirm(false)
+      setDeleteAllProjectsConfirmText('')
     }
   }
 
@@ -1629,7 +1655,9 @@ export function SettingsModal({
       setIsQRCodeExpanded(false)
       setShowSignOutConfirm(false)
       setShowDeleteAllChatsConfirm(false)
+      setDeleteAllChatsConfirmText('')
       setShowDeleteAllProjectsConfirm(false)
+      setDeleteAllProjectsConfirmText('')
       setPrimaryKeyMode('recoverExisting')
     }
   }, [isOpen])
@@ -2345,35 +2373,72 @@ ${encryptionKey.replace('key_', '')}
                           </div>
                         </div>
                         {showDeleteAllChatsConfirm ? (
-                          <div className="flex flex-col gap-2 sm:flex-row">
-                            <button
-                              onClick={handleDeleteAllChats}
-                              disabled={isDeletingAllChats}
-                              className={cn(
-                                'flex-1 rounded-md px-3 py-2 text-sm font-medium transition-colors',
-                                isDarkMode
-                                  ? 'bg-red-600 text-white hover:bg-red-500 disabled:bg-red-900 disabled:text-red-300'
-                                  : 'bg-red-600 text-white hover:bg-red-700 disabled:bg-red-300',
-                              )}
-                            >
-                              {isDeletingAllChats
-                                ? 'Deleting…'
-                                : 'Yes, delete all my chats'}
-                            </button>
-                            <button
-                              onClick={() =>
-                                setShowDeleteAllChatsConfirm(false)
-                              }
-                              disabled={isDeletingAllChats}
-                              className={cn(
-                                'flex-1 rounded-md border px-3 py-2 text-sm font-medium transition-colors',
-                                isDarkMode
-                                  ? 'border-border-strong bg-surface-chat text-content-secondary hover:bg-surface-chat/80'
-                                  : 'border-border-subtle bg-white text-content-primary hover:bg-surface-chat',
-                              )}
-                            >
-                              Cancel
-                            </button>
+                          <div className="space-y-2">
+                            <label className="block">
+                              <span className="font-aeonik-fono text-xs text-content-muted">
+                                Type{' '}
+                                <code className="font-mono text-content-primary">
+                                  {DELETE_ALL_CHATS_CONFIRM_PHRASE}
+                                </code>{' '}
+                                to confirm.
+                              </span>
+                              <input
+                                type="text"
+                                autoComplete="off"
+                                autoCorrect="off"
+                                autoCapitalize="off"
+                                spellCheck={false}
+                                value={deleteAllChatsConfirmText}
+                                onChange={(e) =>
+                                  setDeleteAllChatsConfirmText(e.target.value)
+                                }
+                                disabled={isDeletingAllChats}
+                                placeholder={DELETE_ALL_CHATS_CONFIRM_PHRASE}
+                                className={cn(
+                                  'mt-1 w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-red-500 disabled:opacity-60',
+                                  isDarkMode
+                                    ? 'border-border-strong bg-surface-chat text-content-secondary placeholder:text-content-muted'
+                                    : 'border-border-subtle bg-white text-content-primary placeholder:text-content-muted',
+                                )}
+                              />
+                            </label>
+                            <div className="flex flex-col gap-2 sm:flex-row">
+                              <button
+                                onClick={handleDeleteAllChats}
+                                disabled={
+                                  isDeletingAllChats ||
+                                  deleteAllChatsConfirmText
+                                    .trim()
+                                    .toLowerCase() !==
+                                    DELETE_ALL_CHATS_CONFIRM_PHRASE
+                                }
+                                className={cn(
+                                  'flex-1 rounded-md px-3 py-2 text-sm font-medium transition-colors',
+                                  isDarkMode
+                                    ? 'bg-red-600 text-white hover:bg-red-500 disabled:bg-red-900 disabled:text-red-300'
+                                    : 'bg-red-600 text-white hover:bg-red-700 disabled:bg-red-300 disabled:text-white/70',
+                                )}
+                              >
+                                {isDeletingAllChats
+                                  ? 'Deleting…'
+                                  : 'Yes, delete all my chats'}
+                              </button>
+                              <button
+                                onClick={() => {
+                                  setShowDeleteAllChatsConfirm(false)
+                                  setDeleteAllChatsConfirmText('')
+                                }}
+                                disabled={isDeletingAllChats}
+                                className={cn(
+                                  'flex-1 rounded-md border px-3 py-2 text-sm font-medium transition-colors',
+                                  isDarkMode
+                                    ? 'border-border-strong bg-surface-chat text-content-secondary hover:bg-surface-chat/80'
+                                    : 'border-border-subtle bg-white text-content-primary hover:bg-surface-chat',
+                                )}
+                              >
+                                Cancel
+                              </button>
+                            </div>
                           </div>
                         ) : (
                           <button
@@ -2413,35 +2478,76 @@ ${encryptionKey.replace('key_', '')}
                             </div>
                           </div>
                           {showDeleteAllProjectsConfirm ? (
-                            <div className="flex flex-col gap-2 sm:flex-row">
-                              <button
-                                onClick={handleDeleteAllProjects}
-                                disabled={isDeletingAllProjects}
-                                className={cn(
-                                  'flex-1 rounded-md px-3 py-2 text-sm font-medium transition-colors',
-                                  isDarkMode
-                                    ? 'bg-red-600 text-white hover:bg-red-500 disabled:bg-red-900 disabled:text-red-300'
-                                    : 'bg-red-600 text-white hover:bg-red-700 disabled:bg-red-300',
-                                )}
-                              >
-                                {isDeletingAllProjects
-                                  ? 'Deleting…'
-                                  : 'Yes, delete all my projects'}
-                              </button>
-                              <button
-                                onClick={() =>
-                                  setShowDeleteAllProjectsConfirm(false)
-                                }
-                                disabled={isDeletingAllProjects}
-                                className={cn(
-                                  'flex-1 rounded-md border px-3 py-2 text-sm font-medium transition-colors',
-                                  isDarkMode
-                                    ? 'border-border-strong bg-surface-chat text-content-secondary hover:bg-surface-chat/80'
-                                    : 'border-border-subtle bg-white text-content-primary hover:bg-surface-chat',
-                                )}
-                              >
-                                Cancel
-                              </button>
+                            <div className="space-y-2">
+                              <label className="block">
+                                <span className="font-aeonik-fono text-xs text-content-muted">
+                                  Type{' '}
+                                  <code className="font-mono text-content-primary">
+                                    {DELETE_ALL_PROJECTS_CONFIRM_PHRASE}
+                                  </code>{' '}
+                                  to confirm.
+                                </span>
+                                <input
+                                  type="text"
+                                  autoComplete="off"
+                                  autoCorrect="off"
+                                  autoCapitalize="off"
+                                  spellCheck={false}
+                                  value={deleteAllProjectsConfirmText}
+                                  onChange={(e) =>
+                                    setDeleteAllProjectsConfirmText(
+                                      e.target.value,
+                                    )
+                                  }
+                                  disabled={isDeletingAllProjects}
+                                  placeholder={
+                                    DELETE_ALL_PROJECTS_CONFIRM_PHRASE
+                                  }
+                                  className={cn(
+                                    'mt-1 w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-red-500 disabled:opacity-60',
+                                    isDarkMode
+                                      ? 'border-border-strong bg-surface-chat text-content-secondary placeholder:text-content-muted'
+                                      : 'border-border-subtle bg-white text-content-primary placeholder:text-content-muted',
+                                  )}
+                                />
+                              </label>
+                              <div className="flex flex-col gap-2 sm:flex-row">
+                                <button
+                                  onClick={handleDeleteAllProjects}
+                                  disabled={
+                                    isDeletingAllProjects ||
+                                    deleteAllProjectsConfirmText
+                                      .trim()
+                                      .toLowerCase() !==
+                                      DELETE_ALL_PROJECTS_CONFIRM_PHRASE
+                                  }
+                                  className={cn(
+                                    'flex-1 rounded-md px-3 py-2 text-sm font-medium transition-colors',
+                                    isDarkMode
+                                      ? 'bg-red-600 text-white hover:bg-red-500 disabled:bg-red-900 disabled:text-red-300'
+                                      : 'bg-red-600 text-white hover:bg-red-700 disabled:bg-red-300 disabled:text-white/70',
+                                  )}
+                                >
+                                  {isDeletingAllProjects
+                                    ? 'Deleting…'
+                                    : 'Yes, delete all my projects'}
+                                </button>
+                                <button
+                                  onClick={() => {
+                                    setShowDeleteAllProjectsConfirm(false)
+                                    setDeleteAllProjectsConfirmText('')
+                                  }}
+                                  disabled={isDeletingAllProjects}
+                                  className={cn(
+                                    'flex-1 rounded-md border px-3 py-2 text-sm font-medium transition-colors',
+                                    isDarkMode
+                                      ? 'border-border-strong bg-surface-chat text-content-secondary hover:bg-surface-chat/80'
+                                      : 'border-border-subtle bg-white text-content-primary hover:bg-surface-chat',
+                                  )}
+                                >
+                                  Cancel
+                                </button>
+                              </div>
                             </div>
                           ) : (
                             <button

--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -221,7 +221,11 @@ export function SettingsModal({
   const { toast } = useToast()
 
   // Projects for export functionality
-  const { projects, loading: projectsLoading } = useProjects({
+  const {
+    projects,
+    loading: projectsLoading,
+    refresh: refreshProjects,
+  } = useProjects({
     autoLoad: isSignedIn && isPremium,
   })
   const [maxMessages, setMaxMessages] = useState<number>(
@@ -345,6 +349,9 @@ export function SettingsModal({
   const [showDeleteAllChatsConfirm, setShowDeleteAllChatsConfirm] =
     useState(false)
   const [isDeletingAllChats, setIsDeletingAllChats] = useState(false)
+  const [showDeleteAllProjectsConfirm, setShowDeleteAllProjectsConfirm] =
+    useState(false)
+  const [isDeletingAllProjects, setIsDeletingAllProjects] = useState(false)
 
   // Available personality traits
   const availableTraits = [
@@ -1460,6 +1467,39 @@ export function SettingsModal({
     }
   }
 
+  // Delete every project the user owns
+  const handleDeleteAllProjects = async () => {
+    setIsDeletingAllProjects(true)
+    try {
+      const result = await projectStorage.deleteAllProjects()
+      toast({
+        title: 'All projects deleted',
+        description: `Removed ${result.deleted} project${result.deleted !== 1 ? 's' : ''}.`,
+      })
+
+      await refreshProjects()
+
+      // Project deletion detaches chats from projects on the server, so the
+      // chat list in the sidebar may need to refresh too.
+      if (onChatsUpdated) {
+        onChatsUpdated()
+      }
+    } catch (error) {
+      logError('Failed to delete all projects', error, {
+        component: 'SettingsModal',
+        action: 'handleDeleteAllProjects',
+      })
+      toast({
+        title: 'Delete failed',
+        description: 'Failed to delete all projects. Please try again.',
+        variant: 'destructive',
+      })
+    } finally {
+      setIsDeletingAllProjects(false)
+      setShowDeleteAllProjectsConfirm(false)
+    }
+  }
+
   // Export projects as projects.json
   const downloadProjects = async (
     projectsToExport: Array<{
@@ -1589,6 +1629,7 @@ export function SettingsModal({
       setIsQRCodeExpanded(false)
       setShowSignOutConfirm(false)
       setShowDeleteAllChatsConfirm(false)
+      setShowDeleteAllProjectsConfirm(false)
       setPrimaryKeyMode('recoverExisting')
     }
   }, [isOpen])
@@ -2349,6 +2390,77 @@ ${encryptionKey.replace('key_', '')}
                         )}
                       </div>
                     </div>
+
+                    {/* Delete all projects (signed-in premium users only) */}
+                    {isSignedIn && isPremium && (
+                      <div
+                        className={cn(
+                          'rounded-lg border p-4',
+                          isDarkMode
+                            ? 'border-red-500/30 bg-red-950/10'
+                            : 'border-red-200 bg-red-50/50',
+                        )}
+                      >
+                        <div className="space-y-3">
+                          <div>
+                            <div className="font-aeonik text-sm font-medium text-content-primary">
+                              Delete all projects
+                            </div>
+                            <div className="font-aeonik-fono text-xs text-content-muted">
+                              Permanently delete every project and its
+                              documents. Chats inside projects will be detached
+                              but kept. This cannot be undone.
+                            </div>
+                          </div>
+                          {showDeleteAllProjectsConfirm ? (
+                            <div className="flex flex-col gap-2 sm:flex-row">
+                              <button
+                                onClick={handleDeleteAllProjects}
+                                disabled={isDeletingAllProjects}
+                                className={cn(
+                                  'flex-1 rounded-md px-3 py-2 text-sm font-medium transition-colors',
+                                  isDarkMode
+                                    ? 'bg-red-600 text-white hover:bg-red-500 disabled:bg-red-900 disabled:text-red-300'
+                                    : 'bg-red-600 text-white hover:bg-red-700 disabled:bg-red-300',
+                                )}
+                              >
+                                {isDeletingAllProjects
+                                  ? 'Deleting…'
+                                  : 'Yes, delete all my projects'}
+                              </button>
+                              <button
+                                onClick={() =>
+                                  setShowDeleteAllProjectsConfirm(false)
+                                }
+                                disabled={isDeletingAllProjects}
+                                className={cn(
+                                  'flex-1 rounded-md border px-3 py-2 text-sm font-medium transition-colors',
+                                  isDarkMode
+                                    ? 'border-border-strong bg-surface-chat text-content-secondary hover:bg-surface-chat/80'
+                                    : 'border-border-subtle bg-white text-content-primary hover:bg-surface-chat',
+                                )}
+                              >
+                                Cancel
+                              </button>
+                            </div>
+                          ) : (
+                            <button
+                              onClick={() =>
+                                setShowDeleteAllProjectsConfirm(true)
+                              }
+                              className={cn(
+                                'w-full rounded-md border px-3 py-2 text-sm font-medium transition-colors',
+                                isDarkMode
+                                  ? 'border-red-500/40 bg-red-950/30 text-red-400 hover:bg-red-950/50'
+                                  : 'border-red-300 bg-white text-red-600 hover:bg-red-100',
+                              )}
+                            >
+                              Delete all projects
+                            </button>
+                          )}
+                        </div>
+                      </div>
+                    )}
                   </div>
                 </>
               )}

--- a/src/services/cloud/cloud-storage.ts
+++ b/src/services/cloud/cloud-storage.ts
@@ -455,6 +455,19 @@ export class CloudStorageService {
     }
   }
 
+  async deleteAllChats(): Promise<{ deleted: number }> {
+    const response = await fetch(`${API_BASE_URL}/api/storage/conversations`, {
+      method: 'DELETE',
+      headers: await this.getHeaders(),
+    })
+
+    if (!response.ok) {
+      throw new Error(`Failed to delete all chats: ${response.statusText}`)
+    }
+
+    return response.json()
+  }
+
   async getChatSyncStatus(): Promise<ChatSyncStatus> {
     // Add cache-busting parameter to avoid stale CDN/browser cache
     const url = `${API_BASE_URL}/api/chats/sync-status?_t=${Date.now()}`

--- a/src/services/cloud/project-storage.ts
+++ b/src/services/cloud/project-storage.ts
@@ -189,6 +189,25 @@ export class ProjectStorageService {
     }
   }
 
+  async deleteAllProjects(): Promise<{ deleted: number }> {
+    if (!(await canWriteToCloud())) {
+      throw new Error(
+        'Cloud writes are blocked until your encryption key is verified',
+      )
+    }
+
+    const response = await fetch(`${API_BASE_URL}/api/storage/projects`, {
+      method: 'DELETE',
+      headers: await this.getHeaders(),
+    })
+
+    if (!response.ok) {
+      throw new Error(`Failed to delete all projects: ${response.statusText}`)
+    }
+
+    return response.json()
+  }
+
   async listProjects(options?: {
     limit?: number
     continuationToken?: string

--- a/src/services/storage/chat-storage.ts
+++ b/src/services/storage/chat-storage.ts
@@ -1,6 +1,7 @@
 import type { Chat } from '@/components/chat/types'
 import { isCloudSyncEnabled } from '@/utils/cloud-sync-settings'
 import { logError, logInfo } from '@/utils/error-handling'
+import { cloudStorage } from '../cloud/cloud-storage'
 import { cloudSync } from '../cloud/cloud-sync'
 import { streamingTracker } from '../cloud/streaming-tracker'
 import { chatEvents } from './chat-events'
@@ -174,6 +175,54 @@ export class ChatStorageService {
     }
 
     return deletedCount
+  }
+
+  async deleteAllChats(): Promise<{
+    localDeleted: number
+    cloudDeleted: number
+  }> {
+    await this.initialize()
+
+    // Snapshot local IDs up front so we know what to mark as deleted in the
+    // tracker after a successful wipe, but don't mark anything yet — if the
+    // cloud delete fails we must leave sync state untouched, otherwise we'd
+    // tombstone chats that still exist on the server and lose them on the
+    // next pull.
+    const localIds = await indexedDBStorage.getAllChatIds()
+
+    // Attempt the cloud bulk-delete first. If it fails, surface the error
+    // and skip both the tracker update and the local wipe so the user can
+    // retry without partial-deletion side effects.
+    let cloudDeleted = 0
+    if (await cloudStorage.isAuthenticated()) {
+      try {
+        const result = await cloudStorage.deleteAllChats()
+        cloudDeleted = result.deleted
+      } catch (error) {
+        logError('Failed to bulk-delete cloud chats', error, {
+          component: 'ChatStorageService',
+          action: 'deleteAllChats',
+        })
+        throw error
+      }
+    }
+
+    // Cloud delete succeeded (or user is anonymous); now it's safe to
+    // tombstone the IDs locally and wipe IndexedDB.
+    for (const id of localIds) {
+      if (id) deletedChatsTracker.markAsDeleted(id)
+    }
+
+    const localDeleted = await indexedDBStorage.deleteAllChats()
+    chatEvents.emit({ reason: 'delete', ids: [] })
+
+    logInfo('Deleted all chats', {
+      component: 'ChatStorageService',
+      action: 'deleteAllChats',
+      metadata: { localDeleted, cloudDeleted },
+    })
+
+    return { localDeleted, cloudDeleted }
   }
 
   async getAllChats(): Promise<Chat[]> {

--- a/src/services/storage/indexed-db.ts
+++ b/src/services/storage/indexed-db.ts
@@ -403,6 +403,68 @@ export class IndexedDBStorage {
     })
   }
 
+  async getAllChatIds(): Promise<string[]> {
+    await this.saveQueue.catch(() => {})
+    const db = await this.ensureDB()
+
+    return new Promise((resolve, reject) => {
+      const transaction = db.transaction([CHATS_STORE], 'readonly')
+      const store = transaction.objectStore(CHATS_STORE)
+      const request = store.getAllKeys()
+
+      request.onsuccess = () => {
+        resolve((request.result as IDBValidKey[]).map((k) => String(k)))
+      }
+      request.onerror = () => reject(new Error('Failed to list chat IDs'))
+    })
+  }
+
+  async deleteAllChats(): Promise<number> {
+    // Serialize through saveQueue so a clear() can't race with an in-flight
+    // saveChatInternal that would re-insert a row after the wipe.
+    let resolveResult!: (n: number) => void
+    let rejectResult!: (e: unknown) => void
+    const result = new Promise<number>((resolve, reject) => {
+      resolveResult = resolve
+      rejectResult = reject
+    })
+
+    this.saveQueue = this.saveQueue
+      .catch((error) => {
+        logError('Previous save operation failed, recovering queue', error, {
+          component: 'IndexedDBStorage',
+          action: 'deleteAllChats.queueRecovery',
+        })
+      })
+      .then(async () => {
+        try {
+          const db = await this.ensureDB()
+          const total = await new Promise<number>((resolve, reject) => {
+            const transaction = db.transaction([CHATS_STORE], 'readwrite')
+            const store = transaction.objectStore(CHATS_STORE)
+            const countRequest = store.count()
+
+            countRequest.onsuccess = () => {
+              const count = countRequest.result
+              const clearRequest = store.clear()
+              clearRequest.onsuccess = () => resolve(count)
+              clearRequest.onerror = () =>
+                reject(new Error('Failed to clear chats store'))
+            }
+
+            countRequest.onerror = () =>
+              reject(new Error('Failed to count chats'))
+          })
+          resolveResult(total)
+        } catch (error) {
+          rejectResult(error)
+          throw error
+        }
+      })
+
+    return result
+  }
+
   async getAllChats(): Promise<StoredChat[]> {
     await this.saveQueue.catch(() => {})
     const db = await this.ensureDB()


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a “Danger Zone” in Settings to bulk delete all saved chats and all projects with a typed confirmation. Deletes local IndexedDB, session data, and cloud backups where applicable, and keeps the sidebar lists in sync.

- **New Features**
  - Delete all saved chats: requires typing “delete all chats”. For signed-in users, removes local chats and encrypted cloud backups via `chatStorage.deleteAllChats`; for guests, clears session chats via `sessionChatStorage.clearAll`.
  - Delete all projects (signed-in premium only): requires typing “delete all projects”. Uses `projectStorage.deleteAllProjects`; projects and documents are removed, chats are detached but kept. Refreshes projects and the chat list.
  - Storage support: added `cloudStorage.deleteAllChats`, `projectStorage.deleteAllProjects`, `indexedDBStorage.getAllChatIds`, and `indexedDBStorage.deleteAllChats`. `chatStorage.deleteAllChats` deletes in the cloud first, then tombstones local IDs and emits a delete event to prevent sync resurrection.
  - Safety: destructive buttons are gated by confirmation phrases and re-validated on submit. Shows toasts for success/failure and resets state when the modal closes.

<sup>Written for commit 1e325a1027f5ce1fed857cff9c937938ff9ff40c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

