### PR TITLE
Improve chat deletion robustness logic

### DIFF
--- a/src/components/chat/hooks/chat-operations.ts
+++ b/src/components/chat/hooks/chat-operations.ts
@@ -81,7 +81,7 @@ export async function deleteChat(
   isSignedIn: boolean,
 ): Promise<void> {
   if (isSignedIn) {
-    await chatStorage.deleteChat(chatId)
+    await chatStorage.deleteChat(chatId, { requireCloudDelete: true })
   } else {
     sessionChatStorage.deleteChat(chatId)
   }

--- a/src/components/chat/hooks/chat-operations.ts
+++ b/src/components/chat/hooks/chat-operations.ts
@@ -80,20 +80,10 @@ export async function deleteChat(
   chatId: string,
   isSignedIn: boolean,
 ): Promise<void> {
-  deletedChatsTracker.markAsDeleted(chatId)
-
-  try {
-    if (isSignedIn) {
-      await chatStorage.deleteChat(chatId)
-    } else {
-      sessionChatStorage.deleteChat(chatId)
-    }
-  } catch (error) {
-    logError('Failed to delete chat', error, {
-      component: 'chat-operations',
-      action: 'deleteChat',
-      metadata: { chatId },
-    })
+  if (isSignedIn) {
+    await chatStorage.deleteChat(chatId)
+  } else {
+    sessionChatStorage.deleteChat(chatId)
   }
 }
 

--- a/src/components/chat/hooks/use-chat-storage.ts
+++ b/src/components/chat/hooks/use-chat-storage.ts
@@ -241,25 +241,27 @@ export function useChatStorage({
   // Delete chat
   const deleteChat = useCallback(
     (chatId: string) => {
-      setChats((prevChats) => {
-        const filtered = prevChats.filter((c) => c.id !== chatId)
-        const newChats = ensureAtLeastOneChat(filtered)
-
-        // Switch to another chat if we deleted the current one
-        if (currentChat?.id === chatId && newChats.length > 0) {
-          setCurrentChat(newChats[0])
-        }
-
-        return newChats
-      })
-
       // Delete from storage
-      deleteChatFromStorage(chatId, !!isSignedIn).catch((error) => {
-        logError('Failed to delete chat', error, {
-          component: 'useChatStorage',
-          metadata: { chatId },
+      deleteChatFromStorage(chatId, !!isSignedIn)
+        .then(() => {
+          setChats((prevChats) => {
+            const filtered = prevChats.filter((c) => c.id !== chatId)
+            const newChats = ensureAtLeastOneChat(filtered)
+
+            // Switch to another chat if we deleted the current one
+            if (currentChat?.id === chatId && newChats.length > 0) {
+              setCurrentChat(newChats[0])
+            }
+
+            return newChats
+          })
         })
-      })
+        .catch((error) => {
+          logError('Failed to delete chat', error, {
+            component: 'useChatStorage',
+            metadata: { chatId },
+          })
+        })
     },
     [currentChat?.id, isSignedIn],
   )

--- a/src/components/chat/hooks/use-chat-storage.ts
+++ b/src/components/chat/hooks/use-chat-storage.ts
@@ -249,9 +249,11 @@ export function useChatStorage({
             const newChats = ensureAtLeastOneChat(filtered)
 
             // Switch to another chat if we deleted the current one
-            if (currentChat?.id === chatId && newChats.length > 0) {
-              setCurrentChat(newChats[0])
-            }
+            setCurrentChat((prevCurrent) =>
+              prevCurrent?.id === chatId && newChats.length > 0
+                ? newChats[0]
+                : prevCurrent,
+            )
 
             return newChats
           })
@@ -263,7 +265,7 @@ export function useChatStorage({
           })
         })
     },
-    [currentChat?.id, isSignedIn],
+    [isSignedIn],
   )
 
   // Update chat title

--- a/src/services/cloud/chat-ingestion.ts
+++ b/src/services/cloud/chat-ingestion.ts
@@ -183,6 +183,7 @@ export async function syncRemoteDeletions(
     const successfulIds: string[] = []
     for (const id of deletedIds) {
       try {
+        deletedChatsTracker.markAsDeleted(id)
         await indexedDBStorage.deleteChat(id)
         successfulIds.push(id)
       } catch (error) {

--- a/src/services/cloud/cloud-sync.ts
+++ b/src/services/cloud/cloud-sync.ts
@@ -338,11 +338,6 @@ export class CloudSyncService {
     }
 
     try {
-      // First, backup any unsynced local changes
-      const backupResult = await this.backupUnsyncedChats()
-      result.uploaded = backupResult.uploaded
-      result.errors.push(...backupResult.errors)
-
       // Get cached sync status to determine what changed
       const cachedStatus = this.chatSyncCache.load()
 
@@ -350,6 +345,14 @@ export class CloudSyncService {
         // No cached status, fall back to full sync (first page only)
         return await this.doSyncAllChats()
       }
+
+      // Delete local chats that were deleted on another device
+      await syncRemoteDeletions(cachedStatus.lastUpdated, 'syncChangedChats')
+
+      // First, backup any unsynced local changes
+      const backupResult = await this.backupUnsyncedChats()
+      result.uploaded = backupResult.uploaded
+      result.errors.push(...backupResult.errors)
 
       // Fetch chats updated since our last sync, paginating through all results
       let continuationToken: string | undefined
@@ -409,11 +412,6 @@ export class CloudSyncService {
         hasMore =
           updatedChats.hasMore === true && !!updatedChats.nextContinuationToken
         continuationToken = updatedChats.nextContinuationToken
-      }
-
-      // Delete local chats that were deleted on another device
-      if (cachedStatus?.lastUpdated) {
-        await syncRemoteDeletions(cachedStatus.lastUpdated, 'syncChangedChats')
       }
 
       // Update cached sync status
@@ -705,6 +703,12 @@ export class CloudSyncService {
     }
 
     try {
+      const cachedStatus = this.chatSyncCache.load()
+      if (cachedStatus?.lastUpdated) {
+        // Delete local chats that were deleted on another device
+        await syncRemoteDeletions(cachedStatus.lastUpdated, 'syncAllChats')
+      }
+
       // First, backup any unsynced local changes
       const backupResult = await this.backupUnsyncedChats()
       result.uploaded = backupResult.uploaded
@@ -740,12 +744,6 @@ export class CloudSyncService {
       })
       result.downloaded += ingestResult.downloaded
       result.errors.push(...ingestResult.errors)
-
-      // Delete local chats that were deleted on another device
-      const cachedStatus = this.chatSyncCache.load()
-      if (cachedStatus?.lastUpdated) {
-        await syncRemoteDeletions(cachedStatus.lastUpdated, 'syncAllChats')
-      }
 
       // Update cached sync status after successful sync
       try {
@@ -828,8 +826,10 @@ export class CloudSyncService {
   async deleteFromCloud(chatId: string): Promise<void> {
     // Don't attempt deletion if not authenticated
     if (!(await cloudStorage.isAuthenticated())) {
-      return
+      throw new Error('Authentication token not set')
     }
+
+    deletedChatsTracker.markAsDeleted(chatId)
 
     try {
       await cloudStorage.deleteChat(chatId)
@@ -844,13 +844,7 @@ export class CloudSyncService {
         metadata: { chatId },
       })
     } catch (error) {
-      // Silently fail if no auth token set
-      if (
-        error instanceof Error &&
-        error.message.includes('Authentication token not set')
-      ) {
-        return
-      }
+      deletedChatsTracker.removeFromDeleted(chatId)
       throw error
     }
   }
@@ -1062,6 +1056,11 @@ export class CloudSyncService {
     }
 
     try {
+      const cachedStatus = this.getProjectSyncCache(projectId).load()
+      if (cachedStatus?.lastUpdated) {
+        await syncRemoteDeletions(cachedStatus.lastUpdated, 'syncProjectChats')
+      }
+
       const localChats = await indexedDBStorage.getAllChats()
       const localChatMap = new Map(localChats.map((c) => [c.id, c]))
 
@@ -1174,6 +1173,19 @@ export class CloudSyncService {
     }
 
     try {
+      // Get cached sync status to determine what changed
+      const cachedStatus = this.getProjectSyncCache(projectId).load()
+
+      if (!cachedStatus?.lastUpdated) {
+        // No cached status, fall back to full sync
+        return await this.doSyncProjectChats(projectId)
+      }
+
+      await syncRemoteDeletions(
+        cachedStatus.lastUpdated,
+        'syncProjectChatsChanged',
+      )
+
       // First, backup any unsynced local project chats
       const unsyncedChats = await indexedDBStorage.getUnsyncedChats()
       const projectChatsToSync = unsyncedChats.filter(
@@ -1192,14 +1204,6 @@ export class CloudSyncService {
             `Failed to backup project chat ${chat.id}: ${error instanceof Error ? error.message : String(error)}`,
           )
         }
-      }
-
-      // Get cached sync status to determine what changed
-      const cachedStatus = this.getProjectSyncCache(projectId).load()
-
-      if (!cachedStatus?.lastUpdated) {
-        // No cached status, fall back to full sync
-        return await this.doSyncProjectChats(projectId)
       }
 
       // Fetch and process chats updated since our last sync, with pagination

--- a/src/services/storage/chat-storage.ts
+++ b/src/services/storage/chat-storage.ts
@@ -142,15 +142,21 @@ export class ChatStorageService {
     }
   }
 
-  async deleteChat(id: string): Promise<void> {
+  async deleteChat(
+    id: string,
+    options: { requireCloudDelete?: boolean } = {},
+  ): Promise<void> {
     await this.initialize()
 
     const chat = await indexedDBStorage.getChat(id)
     if (chat?.isLocalOnly !== true) {
-      if (!(await cloudStorage.isAuthenticated())) {
+      const isAuthenticated = await cloudStorage.isAuthenticated()
+      if (!isAuthenticated && options.requireCloudDelete === true) {
         throw new Error('Authentication token not set')
       }
-      await cloudSync.deleteFromCloud(id)
+      if (isAuthenticated) {
+        await cloudSync.deleteFromCloud(id)
+      }
     }
 
     // Mark as deleted to prevent re-sync

--- a/src/services/storage/chat-storage.ts
+++ b/src/services/storage/chat-storage.ts
@@ -145,20 +145,19 @@ export class ChatStorageService {
   async deleteChat(id: string): Promise<void> {
     await this.initialize()
 
+    const chat = await indexedDBStorage.getChat(id)
+    if (chat?.isLocalOnly !== true) {
+      if (!(await cloudStorage.isAuthenticated())) {
+        throw new Error('Authentication token not set')
+      }
+      await cloudSync.deleteFromCloud(id)
+    }
+
     // Mark as deleted to prevent re-sync
     deletedChatsTracker.markAsDeleted(id)
 
     await indexedDBStorage.deleteChat(id)
     chatEvents.emit({ reason: 'delete', ids: [id] })
-
-    // Also delete from cloud storage (non-blocking)
-    cloudSync.deleteFromCloud(id).catch((error: unknown) => {
-      logError('Failed to delete chat from cloud', error, {
-        component: 'ChatStorageService',
-        action: 'deleteChat',
-        metadata: { chatId: id },
-      })
-    })
   }
 
   async deleteAllNonLocalChats(): Promise<number> {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make chat deletion reliable across devices so deleted chats don’t come back during sync.

- **Bug Fixes**
  - Apply remote deletions at the start of sync (`syncChangedChats`, `syncAllChats`, and project sync) to prevent “resurrected” chats.
  - Require auth and delete from cloud first for non-local chats; roll back the deletion tracker if cloud delete fails.
  - Centralize deletion marking via `deletedChatsTracker` during cloud deletes and remote ingestion (no pre-marking in UI).
  - Update UI to remove a chat only after storage deletion succeeds; errors are logged instead of swallowed.

<sup>Written for commit dd6f7be0d1b4482c12cab603779d6c8cca5e73e6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

