### PR TITLE
Improve UI and add temporary chat mode

### DIFF
--- a/src/components/chat/WelcomeScreen.tsx
+++ b/src/components/chat/WelcomeScreen.tsx
@@ -209,7 +209,11 @@ interface WelcomeScreenProps {
   thinkingEnabled?: boolean
   setThinkingEnabled?: (enabled: boolean) => void
   onOpenVerifier?: () => void
+  isTemporaryMode?: boolean
 }
+
+// isTemporaryMode is forwarded to the embedded ChatInput so the input can
+// adopt the dashed border treatment when the parent is in temporary mode.
 
 export const WelcomeScreen = memo(function WelcomeScreen({
   isDarkMode,
@@ -236,6 +240,7 @@ export const WelcomeScreen = memo(function WelcomeScreen({
   thinkingEnabled,
   setThinkingEnabled,
   onOpenVerifier,
+  isTemporaryMode,
 }: WelcomeScreenProps) {
   const { user } = useUser()
   const [nickname, setNickname] = useState<string>('')
@@ -551,6 +556,7 @@ export const WelcomeScreen = memo(function WelcomeScreen({
                   })()}
                   webSearchEnabled={webSearchEnabled}
                   onWebSearchToggle={onWebSearchToggle}
+                  isTemporaryMode={isTemporaryMode}
                 />
               </motion.div>
             )}

--- a/src/components/chat/ask-sidebar.tsx
+++ b/src/components/chat/ask-sidebar.tsx
@@ -126,7 +126,7 @@ export function AskSidebar({
                 ))}
                 {showLoadingDots && (
                   <div className="mx-auto flex w-full max-w-3xl px-4">
-                    <LoadingDots isThinking={false} />
+                    <LoadingDots />
                   </div>
                 )}
               </div>

--- a/src/components/chat/chat-input.tsx
+++ b/src/components/chat/chat-input.tsx
@@ -54,6 +54,7 @@ type ChatInputProps = {
   onWebSearchToggle?: () => void
   quote?: string | null
   onClearQuote?: () => void
+  isTemporaryMode?: boolean
 }
 
 // Maximum number of characters displayed in the collapsed quote preview.
@@ -81,6 +82,7 @@ export function ChatInput({
   onWebSearchToggle,
   quote,
   onClearQuote,
+  isTemporaryMode,
 }: ChatInputProps) {
   const fileInputRef = useRef<HTMLInputElement>(null)
   const documentsScrollRef = useRef<HTMLDivElement>(null)
@@ -449,7 +451,10 @@ export function ChatInput({
         )}
         <div
           className={cn(
-            'rounded-3xl border border-border-subtle bg-surface-chat px-3 py-3 shadow-md transition-colors md:rounded-4xl md:px-6 md:py-4',
+            'rounded-3xl border bg-surface-chat px-3 py-3 shadow-md transition-colors md:rounded-4xl md:px-6 md:py-4',
+            isTemporaryMode
+              ? 'border-dashed border-content-muted'
+              : 'border-border-subtle',
           )}
         >
           <input

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -2661,291 +2661,306 @@ export function ChatInterface({
           top: 0,
         }}
       >
-        <div className="relative flex h-full flex-col bg-surface-chat-background">
-          {/* Project Mode Banner */}
-          {(isProjectMode && activeProject) || loadingProject ? (
-            <ProjectModeBanner
-              projectName={activeProject?.name || loadingProject?.name || ''}
-              isDarkMode={isDarkMode}
-            />
-          ) : null}
-
-          {/* Rate Limit Banner */}
-          {shouldShowRateLimitBanner(rateLimit) && (
-            <RateLimitBanner rateLimit={rateLimit} isDarkMode={isDarkMode} />
+        <div
+          className={cn(
+            'relative flex h-full flex-col transition-colors',
+            isTemporaryMode
+              ? 'bg-brand-accent-light/15 p-2'
+              : 'bg-surface-chat-background',
           )}
-
-          {/* Decryption Progress Banner */}
-          {decryptionProgress && decryptionProgress.isDecrypting && (
-            <div className="border-b border-border-subtle bg-surface-chat px-4 py-2 text-content-secondary">
-              <div className="flex items-center justify-between">
-                <div className="flex items-center gap-2">
-                  <PiSpinner className="h-4 w-4 animate-spin text-content-secondary" />
-                  <span className="text-sm">
-                    Decrypting chats with new key...
-                  </span>
-                </div>
-                {decryptionProgress.total > 0 && (
-                  <span className="text-sm">
-                    {decryptionProgress.current} / {decryptionProgress.total}
-                  </span>
-                )}
-              </div>
-            </div>
-          )}
-
-          {/* Messages Area */}
-          <QuoteSelectionPopover
-            containerRef={scrollContainerRef}
-            onQuote={(text) => {
-              setQuote(text)
-              inputRef.current?.focus()
-            }}
-            onAsk={(text) => {
-              setIsVerifierSidebarOpen(false)
-              setIsSettingsModalOpen(false)
-              if (
-                windowWidth < CONSTANTS.SINGLE_SIDEBAR_BREAKPOINT &&
-                isSidebarOpen
-              ) {
-                setIsSidebarOpen(false)
-              }
-              setIsAskSidebarOpen(true)
-              // Hand the current chat transcript to the sidebar so the model
-              // can reason about the highlighted snippet in context. The
-              // transcript is sent as a hidden user message; only the quote
-              // and assistant reply are shown in the sidebar UI.
-              sidebarChat.askQuote(text, currentChat?.messages ?? [])
-            }}
-          />
-          <div className="relative flex min-h-0 flex-1">
-            {isTemporaryMode && (
-              <div
-                aria-hidden="true"
-                className="pointer-events-none absolute inset-0 z-30 rounded-2xl border-2 border-brand-accent-light/60 ring-1 ring-inset ring-brand-accent-light/20"
-              />
+        >
+          <div
+            className={cn(
+              'relative flex h-full flex-col',
+              isTemporaryMode
+                ? 'overflow-hidden rounded-lg border border-brand-accent-light/40 bg-surface-chat-background shadow-[0_0_0_1px_rgba(0,0,0,0.04)_inset]'
+                : 'rounded-none border-0',
             )}
-            {streamError && (
-              <StreamErrorBanner
-                message={streamError}
-                onDismiss={dismissStreamError}
+          >
+            {/* Project Mode Banner */}
+            {(isProjectMode && activeProject) || loadingProject ? (
+              <ProjectModeBanner
+                projectName={activeProject?.name || loadingProject?.name || ''}
                 isDarkMode={isDarkMode}
               />
-            )}
-            <div
-              ref={scrollContainerRef}
-              onScroll={handleScroll}
-              data-scroll-container="main"
-              className="relative flex-1 overflow-y-auto bg-surface-chat-background"
-              style={
-                inputAreaHeight
-                  ? ({
-                      paddingBottom: inputAreaHeight + 32,
-                      '--input-area-height': `${inputAreaHeight}px`,
-                      '--mask-fade-start': `calc(100% - ${inputAreaHeight + 80}px)`,
-                      '--mask-fade-end': `calc(100% - ${inputAreaHeight + 8}px)`,
-                      maskImage:
-                        'linear-gradient(to bottom, black 0, black var(--mask-fade-start), transparent var(--mask-fade-end)), linear-gradient(black, black)',
-                      maskSize:
-                        'calc(100% - var(--scrollbar-gutter, 14px)) 100%, var(--scrollbar-gutter, 14px) 100%',
-                      maskPosition: '0 0, 100% 0',
-                      maskRepeat: 'no-repeat, no-repeat',
-                      WebkitMaskImage:
-                        'linear-gradient(to bottom, black 0, black var(--mask-fade-start), transparent var(--mask-fade-end)), linear-gradient(black, black)',
-                      WebkitMaskSize:
-                        'calc(100% - var(--scrollbar-gutter, 14px)) 100%, var(--scrollbar-gutter, 14px) 100%',
-                      WebkitMaskPosition: '0 0, 100% 0',
-                      WebkitMaskRepeat: 'no-repeat, no-repeat',
-                    } as React.CSSProperties)
-                  : ({
-                      paddingBottom: inputAreaHeight + 32,
-                      '--input-area-height': `${inputAreaHeight}px`,
-                    } as React.CSSProperties)
-              }
-            >
-              <div className="flex min-h-full min-w-0 flex-1 [container-type:inline-size]">
-                <ChatMessages
-                  messages={currentChat?.messages || []}
-                  isDarkMode={isDarkMode}
-                  chatId={currentChat.id}
-                  isWaitingForResponse={isWaitingForResponse}
-                  isStreamingResponse={isStreaming}
-                  isPremium={isPremium}
-                  models={models}
-                  onSubmit={handleSubmit}
-                  input={input}
-                  setInput={setInput}
-                  loadingState={loadingState}
-                  retryInfo={retryInfo}
-                  cancelGeneration={cancelGeneration}
-                  inputRef={inputRef}
-                  handleInputFocus={handleInputFocus}
-                  handleDocumentUpload={handleFileUpload}
-                  processedDocuments={processedDocuments}
-                  removeDocument={removeDocument}
-                  selectedModel={selectedModel}
-                  handleModelSelect={handleModelSelect}
-                  expandedLabel={expandedLabel}
-                  handleLabelClick={handleLabelClick}
-                  onEditMessage={editMessage}
-                  onRegenerateMessage={regenerateMessage}
-                  showScrollButton={showScrollButton}
-                  webSearchEnabled={webSearchEnabled}
-                  onWebSearchToggle={() => setWebSearchEnabled((prev) => !prev)}
-                  reasoningEffort={reasoningEffort}
-                  setReasoningEffort={setReasoningEffort}
-                  thinkingEnabled={thinkingEnabled}
-                  setThinkingEnabled={setThinkingEnabled}
-                  onOpenVerifier={() => setIsVerifierSidebarOpen(true)}
-                />
-              </div>
-            </div>
-          </div>
+            ) : null}
 
-          {/* Input Form - Show on mobile always, on desktop only when there are messages */}
-          {isClient &&
-            (windowWidth < CONSTANTS.MOBILE_BREAKPOINT ||
-              (currentChat?.messages && currentChat.messages.length > 0)) && (
+            {/* Rate Limit Banner */}
+            {shouldShowRateLimitBanner(rateLimit) && (
+              <RateLimitBanner rateLimit={rateLimit} isDarkMode={isDarkMode} />
+            )}
+
+            {/* Decryption Progress Banner */}
+            {decryptionProgress && decryptionProgress.isDecrypting && (
+              <div className="border-b border-border-subtle bg-surface-chat px-4 py-2 text-content-secondary">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <PiSpinner className="h-4 w-4 animate-spin text-content-secondary" />
+                    <span className="text-sm">
+                      Decrypting chats with new key...
+                    </span>
+                  </div>
+                  {decryptionProgress.total > 0 && (
+                    <span className="text-sm">
+                      {decryptionProgress.current} / {decryptionProgress.total}
+                    </span>
+                  )}
+                </div>
+              </div>
+            )}
+
+            {/* Messages Area */}
+            <QuoteSelectionPopover
+              containerRef={scrollContainerRef}
+              onQuote={(text) => {
+                setQuote(text)
+                inputRef.current?.focus()
+              }}
+              onAsk={(text) => {
+                setIsVerifierSidebarOpen(false)
+                setIsSettingsModalOpen(false)
+                if (
+                  windowWidth < CONSTANTS.SINGLE_SIDEBAR_BREAKPOINT &&
+                  isSidebarOpen
+                ) {
+                  setIsSidebarOpen(false)
+                }
+                setIsAskSidebarOpen(true)
+                // Hand the current chat transcript to the sidebar so the model
+                // can reason about the highlighted snippet in context. The
+                // transcript is sent as a hidden user message; only the quote
+                // and assistant reply are shown in the sidebar UI.
+                sidebarChat.askQuote(text, currentChat?.messages ?? [])
+              }}
+            />
+            <div className="relative flex min-h-0 flex-1">
+              {streamError && (
+                <StreamErrorBanner
+                  message={streamError}
+                  onDismiss={dismissStreamError}
+                  isDarkMode={isDarkMode}
+                />
+              )}
               <div
-                ref={inputAreaRef}
-                className="pointer-events-none absolute inset-x-0 bottom-0 z-10 px-4 pb-4"
-                style={{
-                  minHeight: '80px',
-                  maxHeight: '50dvh',
-                  paddingBottom: 'calc(env(safe-area-inset-bottom) + 1rem)',
-                }}
+                ref={scrollContainerRef}
+                onScroll={handleScroll}
+                data-scroll-container="main"
+                className="relative flex-1 overflow-y-auto bg-surface-chat-background"
+                style={
+                  inputAreaHeight
+                    ? ({
+                        paddingBottom: inputAreaHeight + 32,
+                        '--input-area-height': `${inputAreaHeight}px`,
+                        '--mask-fade-start': `calc(100% - ${inputAreaHeight + 80}px)`,
+                        '--mask-fade-end': `calc(100% - ${inputAreaHeight + 8}px)`,
+                        maskImage:
+                          'linear-gradient(to bottom, black 0, black var(--mask-fade-start), transparent var(--mask-fade-end)), linear-gradient(black, black)',
+                        maskSize:
+                          'calc(100% - var(--scrollbar-gutter, 14px)) 100%, var(--scrollbar-gutter, 14px) 100%',
+                        maskPosition: '0 0, 100% 0',
+                        maskRepeat: 'no-repeat, no-repeat',
+                        WebkitMaskImage:
+                          'linear-gradient(to bottom, black 0, black var(--mask-fade-start), transparent var(--mask-fade-end)), linear-gradient(black, black)',
+                        WebkitMaskSize:
+                          'calc(100% - var(--scrollbar-gutter, 14px)) 100%, var(--scrollbar-gutter, 14px) 100%',
+                        WebkitMaskPosition: '0 0, 100% 0',
+                        WebkitMaskRepeat: 'no-repeat, no-repeat',
+                      } as React.CSSProperties)
+                    : ({
+                        paddingBottom: inputAreaHeight + 32,
+                        '--input-area-height': `${inputAreaHeight}px`,
+                      } as React.CSSProperties)
+                }
               >
-                <form
-                  onSubmit={handleSubmit}
-                  className="pointer-events-auto relative mx-auto max-w-3xl px-1 md:px-8"
-                >
-                  <ChatInput
+                <div className="flex min-h-full min-w-0 flex-1 [container-type:inline-size]">
+                  <ChatMessages
+                    messages={currentChat?.messages || []}
+                    isDarkMode={isDarkMode}
+                    chatId={currentChat.id}
+                    isWaitingForResponse={isWaitingForResponse}
+                    isStreamingResponse={isStreaming}
+                    isPremium={isPremium}
+                    models={models}
+                    onSubmit={handleSubmit}
                     input={input}
                     setInput={setInput}
-                    handleSubmit={handleSubmit}
                     loadingState={loadingState}
+                    retryInfo={retryInfo}
                     cancelGeneration={cancelGeneration}
                     inputRef={inputRef}
                     handleInputFocus={handleInputFocus}
-                    inputMinHeight={inputMinHeight}
-                    isDarkMode={isDarkMode}
                     handleDocumentUpload={handleFileUpload}
                     processedDocuments={processedDocuments}
                     removeDocument={removeDocument}
-                    isPremium={isPremium}
-                    quote={quote}
-                    onClearQuote={() => setQuote(null)}
-                    hasMessages={
-                      currentChat?.messages && currentChat.messages.length > 0
-                    }
-                    audioModel={
-                      (
-                        models.find(
-                          (m) => m.modelName === CONSTANTS.DEFAULT_AUDIO_MODEL,
-                        ) || models.find((m) => m.type === 'audio')
-                      )?.modelName
-                    }
-                    modelSelectorButton={
-                      models.length > 0 &&
-                      selectedModel &&
-                      handleModelSelect ? (
-                        <div className="relative">
-                          <button
-                            type="button"
-                            data-model-selector
-                            onClick={(e) => {
-                              e.preventDefault()
-                              e.stopPropagation()
-                              handleLabelClick('model', () => {})
-                            }}
-                            className="flex items-center gap-1 text-content-secondary transition-colors hover:text-content-primary"
-                          >
-                            {(() => {
-                              const model = models.find(
-                                (m) => m.modelName === selectedModel,
-                              )
-                              if (!model) return null
-                              return (
-                                <>
-                                  <span className="text-xs font-medium">
-                                    {model.name}
-                                  </span>
-                                  <svg
-                                    className={`h-3 w-3 transition-transform ${expandedLabel === 'model' ? 'rotate-180' : ''}`}
-                                    fill="none"
-                                    stroke="currentColor"
-                                    viewBox="0 0 24 24"
-                                  >
-                                    <path
-                                      strokeLinecap="round"
-                                      strokeLinejoin="round"
-                                      strokeWidth={2}
-                                      d="M19 9l-7 7-7-7"
-                                    />
-                                  </svg>
-                                </>
-                              )
-                            })()}
-                          </button>
-
-                          {expandedLabel === 'model' && (
-                            <ModelSelector
-                              selectedModel={selectedModel}
-                              onSelect={handleModelSelect}
-                              isDarkMode={isDarkMode}
-                              models={models}
-                            />
-                          )}
-                        </div>
-                      ) : undefined
-                    }
-                    reasoningSelectorButton={(() => {
-                      const m = models.find(
-                        (mm) => mm.modelName === selectedModel,
-                      )
-                      if (!isReasoningModel(m)) return undefined
-                      return (
-                        <ReasoningEffortSelector
-                          supportsEffort={supportsReasoningEffort(m)}
-                          supportsToggle={supportsThinkingToggle(m)}
-                          reasoningEffort={reasoningEffort}
-                          onEffortChange={setReasoningEffort}
-                          thinkingEnabled={thinkingEnabled}
-                          onThinkingEnabledChange={setThinkingEnabled}
-                          isOpen={expandedLabel === 'reasoning'}
-                          onToggle={() =>
-                            handleLabelClick('reasoning', () => {})
-                          }
-                          onClose={() =>
-                            handleLabelClick('reasoning', () => {})
-                          }
-                        />
-                      )
-                    })()}
+                    selectedModel={selectedModel}
+                    handleModelSelect={handleModelSelect}
+                    expandedLabel={expandedLabel}
+                    handleLabelClick={handleLabelClick}
+                    onEditMessage={editMessage}
+                    onRegenerateMessage={regenerateMessage}
+                    showScrollButton={showScrollButton}
                     webSearchEnabled={webSearchEnabled}
                     onWebSearchToggle={() =>
                       setWebSearchEnabled((prev) => !prev)
                     }
+                    reasoningEffort={reasoningEffort}
+                    setReasoningEffort={setReasoningEffort}
+                    thinkingEnabled={thinkingEnabled}
+                    setThinkingEnabled={setThinkingEnabled}
+                    onOpenVerifier={() => setIsVerifierSidebarOpen(true)}
+                    isTemporaryMode={isTemporaryMode}
                   />
-                </form>
-
-                {/* Scroll to bottom button - absolutely positioned in parent */}
-                {showScrollButton && currentChat?.messages?.length > 0 && (
-                  <div className="pointer-events-auto absolute -top-[50px] left-1/2 z-10 -translate-x-1/2">
-                    <button
-                      onClick={() => scrollToLastMessage()}
-                      className="flex h-10 w-10 items-center justify-center rounded-full border border-border-subtle bg-surface-sidebar-button shadow-md transition-colors hover:bg-surface-sidebar-button-hover"
-                      aria-label="Scroll to bottom"
-                    >
-                      <ArrowDownIcon
-                        className="h-4 w-4 text-content-secondary"
-                        strokeWidth={2}
-                      />
-                    </button>
-                  </div>
-                )}
+                </div>
               </div>
-            )}
+            </div>
+
+            {/* Input Form - Show on mobile always, on desktop only when there are messages */}
+            {isClient &&
+              (windowWidth < CONSTANTS.MOBILE_BREAKPOINT ||
+                (currentChat?.messages && currentChat.messages.length > 0)) && (
+                <div
+                  ref={inputAreaRef}
+                  className="pointer-events-none absolute inset-x-0 bottom-0 z-10 px-4 pb-4"
+                  style={{
+                    minHeight: '80px',
+                    maxHeight: '50dvh',
+                    paddingBottom: 'calc(env(safe-area-inset-bottom) + 1rem)',
+                  }}
+                >
+                  <form
+                    onSubmit={handleSubmit}
+                    className="pointer-events-auto relative mx-auto max-w-3xl px-1 md:px-8"
+                  >
+                    <ChatInput
+                      input={input}
+                      setInput={setInput}
+                      handleSubmit={handleSubmit}
+                      loadingState={loadingState}
+                      cancelGeneration={cancelGeneration}
+                      inputRef={inputRef}
+                      handleInputFocus={handleInputFocus}
+                      inputMinHeight={inputMinHeight}
+                      isDarkMode={isDarkMode}
+                      handleDocumentUpload={handleFileUpload}
+                      processedDocuments={processedDocuments}
+                      removeDocument={removeDocument}
+                      isPremium={isPremium}
+                      quote={quote}
+                      onClearQuote={() => setQuote(null)}
+                      isTemporaryMode={isTemporaryMode}
+                      hasMessages={
+                        currentChat?.messages && currentChat.messages.length > 0
+                      }
+                      audioModel={
+                        (
+                          models.find(
+                            (m) =>
+                              m.modelName === CONSTANTS.DEFAULT_AUDIO_MODEL,
+                          ) || models.find((m) => m.type === 'audio')
+                        )?.modelName
+                      }
+                      modelSelectorButton={
+                        models.length > 0 &&
+                        selectedModel &&
+                        handleModelSelect ? (
+                          <div className="relative">
+                            <button
+                              type="button"
+                              data-model-selector
+                              onClick={(e) => {
+                                e.preventDefault()
+                                e.stopPropagation()
+                                handleLabelClick('model', () => {})
+                              }}
+                              className="flex items-center gap-1 text-content-secondary transition-colors hover:text-content-primary"
+                            >
+                              {(() => {
+                                const model = models.find(
+                                  (m) => m.modelName === selectedModel,
+                                )
+                                if (!model) return null
+                                return (
+                                  <>
+                                    <span className="text-xs font-medium">
+                                      {model.name}
+                                    </span>
+                                    <svg
+                                      className={`h-3 w-3 transition-transform ${expandedLabel === 'model' ? 'rotate-180' : ''}`}
+                                      fill="none"
+                                      stroke="currentColor"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <path
+                                        strokeLinecap="round"
+                                        strokeLinejoin="round"
+                                        strokeWidth={2}
+                                        d="M19 9l-7 7-7-7"
+                                      />
+                                    </svg>
+                                  </>
+                                )
+                              })()}
+                            </button>
+
+                            {expandedLabel === 'model' && (
+                              <ModelSelector
+                                selectedModel={selectedModel}
+                                onSelect={handleModelSelect}
+                                isDarkMode={isDarkMode}
+                                models={models}
+                              />
+                            )}
+                          </div>
+                        ) : undefined
+                      }
+                      reasoningSelectorButton={(() => {
+                        const m = models.find(
+                          (mm) => mm.modelName === selectedModel,
+                        )
+                        if (!isReasoningModel(m)) return undefined
+                        return (
+                          <ReasoningEffortSelector
+                            supportsEffort={supportsReasoningEffort(m)}
+                            supportsToggle={supportsThinkingToggle(m)}
+                            reasoningEffort={reasoningEffort}
+                            onEffortChange={setReasoningEffort}
+                            thinkingEnabled={thinkingEnabled}
+                            onThinkingEnabledChange={setThinkingEnabled}
+                            isOpen={expandedLabel === 'reasoning'}
+                            onToggle={() =>
+                              handleLabelClick('reasoning', () => {})
+                            }
+                            onClose={() =>
+                              handleLabelClick('reasoning', () => {})
+                            }
+                          />
+                        )
+                      })()}
+                      webSearchEnabled={webSearchEnabled}
+                      onWebSearchToggle={() =>
+                        setWebSearchEnabled((prev) => !prev)
+                      }
+                    />
+                  </form>
+
+                  {/* Scroll to bottom button - absolutely positioned in parent */}
+                  {showScrollButton && currentChat?.messages?.length > 0 && (
+                    <div className="pointer-events-auto absolute -top-[50px] left-1/2 z-10 -translate-x-1/2">
+                      <button
+                        onClick={() => scrollToLastMessage()}
+                        className="flex h-10 w-10 items-center justify-center rounded-full border border-border-subtle bg-surface-sidebar-button shadow-md transition-colors hover:bg-surface-sidebar-button-hover"
+                        aria-label="Scroll to bottom"
+                      >
+                        <ArrowDownIcon
+                          className="h-4 w-4 text-content-secondary"
+                          strokeWidth={2}
+                        />
+                      </button>
+                    </div>
+                  )}
+                </div>
+              )}
+          </div>
         </div>
       </div>
 

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -2281,7 +2281,7 @@ export function ChatInterface({
       {/* Temporary chat indicator (top-left, fills inner corner) */}
       {(isTemporaryMode || currentChat?.isTemporary) && (
         <div
-          className="pointer-events-none fixed top-0 z-40 flex items-center gap-1.5 rounded-br-lg bg-[hsl(163,22%,15%)] px-3 py-2 text-xs font-medium text-brand-accent-light transition-all duration-300"
+          className="pointer-events-none fixed top-0 z-40 flex items-center gap-1.5 rounded-br-lg bg-[hsl(18,90%,92%)] py-7 pl-16 pr-3 text-xs font-medium text-orange-600 transition-all duration-300 dark:bg-[hsl(20,40%,15%)] dark:text-orange-500 md:py-2 md:pl-3"
           style={{
             left: (() => {
               const isMobile = windowWidth < CONSTANTS.MOBILE_BREAKPOINT
@@ -2350,7 +2350,7 @@ export function ChatInterface({
                 className={cn(
                   'flex items-center justify-center rounded-lg border p-2.5 transition-all duration-200',
                   isTemporaryMode
-                    ? 'border-brand-accent-light/40 bg-brand-accent-light/15 text-brand-accent-light hover:bg-brand-accent-light/25'
+                    ? 'border-orange-500/40 bg-orange-500/15 text-orange-500 hover:bg-orange-500/25'
                     : 'border-border-subtle bg-surface-chat-background text-content-secondary hover:bg-surface-chat hover:text-content-primary',
                 )}
               >
@@ -2661,8 +2661,22 @@ export function ChatInterface({
           top: 0,
         }}
       >
-        <div className="relative flex h-full flex-col bg-surface-chat-background transition-colors">
-          <div className="relative flex h-full flex-col">
+        <div
+          className={cn(
+            'relative flex h-full flex-col transition-colors',
+            isTemporaryMode
+              ? 'bg-orange-500/15 p-2'
+              : 'bg-surface-chat-background',
+          )}
+        >
+          <div
+            className={cn(
+              'relative flex h-full flex-col',
+              isTemporaryMode
+                ? 'overflow-hidden rounded-lg bg-surface-chat-background'
+                : '',
+            )}
+          >
             {/* Project Mode Banner */}
             {(isProjectMode && activeProject) || loadingProject ? (
               <ProjectModeBanner

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -2631,8 +2631,8 @@ export function ChatInterface({
                   ? ({
                       paddingBottom: inputAreaHeight + 32,
                       '--input-area-height': `${inputAreaHeight}px`,
-                      '--mask-fade-start': `calc(100% - ${inputAreaHeight + 32}px)`,
-                      '--mask-fade-end': `calc(100% - ${inputAreaHeight}px)`,
+                      '--mask-fade-start': `calc(100% - ${inputAreaHeight + 80}px)`,
+                      '--mask-fade-end': `calc(100% - ${inputAreaHeight + 8}px)`,
                       maskImage:
                         'linear-gradient(to bottom, black 0, black var(--mask-fade-start), transparent var(--mask-fade-end)), linear-gradient(black, black)',
                       maskSize:

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -30,6 +30,7 @@ import { BiSolidLock, BiSolidLockOpen } from 'react-icons/bi'
 import { GoSidebarCollapse } from 'react-icons/go'
 import { IoShareOutline } from 'react-icons/io5'
 import { PiFilePlusLight, PiNotePencilLight, PiSpinner } from 'react-icons/pi'
+import { SlGhost } from 'react-icons/sl'
 import type { TinfoilAI } from 'tinfoil'
 
 import {
@@ -104,7 +105,7 @@ import { ReasoningEffortSelector } from './reasoning-effort-selector'
 import { initializeRenderers } from './renderers/client'
 import type { ProcessedDocument } from './renderers/types'
 import type { SettingsTab } from './settings-modal'
-import type { Attachment } from './types'
+import type { Attachment, Chat } from './types'
 // Lazy-load modals that aren't shown on initial load
 const CloudSyncSetupModal = dynamic(
   () =>
@@ -466,6 +467,12 @@ export function ChatInterface({
   // text. Nothing is persisted unless the user clicks "Open as chat".
   const [isAskSidebarOpen, setIsAskSidebarOpen] = useState(false)
 
+  // Temporary chat mode: when active the current chat is replaced with an
+  // ephemeral in-memory chat that is never persisted (no IndexedDB, no session
+  // storage, no cloud sync). Disabling restores the previously active chat.
+  const [isTemporaryMode, setIsTemporaryMode] = useState(false)
+  const previousChatIdRef = useRef<string | null>(null)
+
   // State for web search toggle (persisted in localStorage)
   const [webSearchEnabled, setWebSearchEnabled] = useState(() => {
     if (typeof window === 'undefined') return true
@@ -694,6 +701,8 @@ export function ChatInterface({
     setIsInitialLoad,
     setVerificationComplete,
     setVerificationSuccess,
+    setChats,
+    setCurrentChat,
 
     // Actions
     handleQuery,
@@ -757,6 +766,12 @@ export function ChatInterface({
       initialUrlChatLoadedRef.current = true
     }
 
+    // Temporary chats are ephemeral and never appear in the URL.
+    if (currentChat.isTemporary) {
+      clearUrl()
+      return
+    }
+
     // In local-only mode, a blank "new chat" should live at `/` (not `/chat/local`)
     // so it never depends on host routing for that path.
     if (currentChat.isLocalOnly && currentChat.isBlankChat) {
@@ -813,6 +828,7 @@ export function ChatInterface({
     currentChat.id,
     currentChat.isBlankChat,
     currentChat.isLocalOnly,
+    currentChat.isTemporary,
     currentChat.projectId,
     isProjectMode,
     activeProject?.id,
@@ -1278,6 +1294,44 @@ export function ChatInterface({
     createNewChat(false, true)
     exitProjectMode()
   }, [createNewChat, exitProjectMode])
+
+  const handleToggleTemporaryMode = useCallback(() => {
+    setIsTemporaryMode((prev) => {
+      const next = !prev
+      if (next) {
+        previousChatIdRef.current = currentChat?.id ?? null
+        const tempChat: Chat = {
+          id: `temp-${Date.now()}`,
+          title: 'Temporary Chat',
+          titleState: 'placeholder',
+          messages: [],
+          createdAt: new Date(),
+          isBlankChat: true,
+          isTemporary: true,
+        }
+        setCurrentChat(tempChat)
+      } else {
+        const previousId = previousChatIdRef.current
+        const restored = previousId
+          ? chats.find((c) => c.id === previousId)
+          : undefined
+        if (restored) {
+          setCurrentChat(restored)
+        } else {
+          createNewChat(false, true)
+        }
+        previousChatIdRef.current = null
+      }
+      return next
+    })
+  }, [chats, createNewChat, currentChat?.id, setCurrentChat])
+
+  useEffect(() => {
+    if (isTemporaryMode && currentChat && !currentChat.isTemporary) {
+      setIsTemporaryMode(false)
+      previousChatIdRef.current = null
+    }
+  }, [isTemporaryMode, currentChat])
 
   // Handler for exiting project mode while dragging - does NOT create a new chat
   // so the drag operation can continue and drop into cloud/local tabs
@@ -2224,6 +2278,28 @@ export function ChatInterface({
           </div>
         )}
 
+      {/* Temporary chat indicator (top-left, fills inner corner) */}
+      {(isTemporaryMode || currentChat?.isTemporary) && (
+        <div
+          className="pointer-events-none fixed top-0 z-40 flex items-center gap-1.5 rounded-br-lg bg-brand-accent-light/15 px-3 py-2 text-xs font-medium text-brand-accent-light transition-all duration-300"
+          style={{
+            left: (() => {
+              const isMobile = windowWidth < CONSTANTS.MOBILE_BREAKPOINT
+              if (isMobile) {
+                return isSidebarOpen ? '-9999px' : '0px'
+              }
+              if (isSidebarOpen) {
+                return `${CONSTANTS.CHAT_SIDEBAR_WIDTH_PX}px`
+              }
+              return `${CONSTANTS.CHAT_SIDEBAR_COLLAPSED_WIDTH_PX}px`
+            })(),
+          }}
+        >
+          <SlGhost className="h-3.5 w-3.5 shrink-0" />
+          <span>Temporary chat</span>
+        </div>
+      )}
+
       {/* Right side toggle buttons */}
       {!(
         windowWidth < CONSTANTS.MOBILE_BREAKPOINT &&
@@ -2259,18 +2335,47 @@ export function ChatInterface({
               </button>
             )}
 
-          {/* Share button - only show when there are messages */}
-          {currentChat?.messages && currentChat.messages.length > 0 && (
-            <button
-              type="button"
-              onClick={handleOpenShareModal}
-              className="flex items-center justify-center gap-1.5 rounded-lg border border-border-subtle bg-surface-chat-background p-2.5 text-content-secondary transition-all duration-200 hover:bg-surface-chat hover:text-content-primary md:px-3 md:py-2"
-              aria-label="Share"
-            >
-              <IoShareOutline className="h-4 w-4" />
-              <span className="hidden text-sm md:inline">Share</span>
-            </button>
+          {/* Temporary chat toggle - hidden once a chat has started */}
+          {!(currentChat?.messages && currentChat.messages.length > 0) && (
+            <div className="group relative">
+              <button
+                type="button"
+                onClick={handleToggleTemporaryMode}
+                aria-label={
+                  isTemporaryMode
+                    ? 'Exit temporary chat'
+                    : 'Start temporary chat'
+                }
+                aria-pressed={isTemporaryMode}
+                className={cn(
+                  'flex items-center justify-center rounded-lg border p-2.5 transition-all duration-200',
+                  isTemporaryMode
+                    ? 'border-brand-accent-light/40 bg-brand-accent-light/15 text-brand-accent-light hover:bg-brand-accent-light/25'
+                    : 'border-border-subtle bg-surface-chat-background text-content-secondary hover:bg-surface-chat hover:text-content-primary',
+                )}
+              >
+                <SlGhost className="h-4 w-4" />
+              </button>
+              <span className="pointer-events-none absolute -bottom-8 left-1/2 -translate-x-1/2 whitespace-nowrap rounded border border-border-subtle bg-surface-chat-background px-2 py-1 text-xs text-content-primary opacity-0 shadow-sm transition-opacity group-hover:opacity-100">
+                {isTemporaryMode ? 'Exit temporary chat' : 'Temporary chat'}
+              </span>
+            </div>
           )}
+
+          {/* Share button - only show when there are messages and chat is not temporary */}
+          {!currentChat?.isTemporary &&
+            currentChat?.messages &&
+            currentChat.messages.length > 0 && (
+              <button
+                type="button"
+                onClick={handleOpenShareModal}
+                className="flex items-center justify-center gap-1.5 rounded-lg border border-border-subtle bg-surface-chat-background p-2.5 text-content-secondary transition-all duration-200 hover:bg-surface-chat hover:text-content-primary md:px-3 md:py-2"
+                aria-label="Share"
+              >
+                <IoShareOutline className="h-4 w-4" />
+                <span className="hidden text-sm md:inline">Share</span>
+              </button>
+            )}
 
           {/* Verifier toggle button */}
           <div className="group relative">
@@ -2614,6 +2719,12 @@ export function ChatInterface({
             }}
           />
           <div className="relative flex min-h-0 flex-1">
+            {isTemporaryMode && (
+              <div
+                aria-hidden="true"
+                className="pointer-events-none absolute inset-0 z-30 rounded-2xl border-2 border-brand-accent-light/60 ring-1 ring-inset ring-brand-accent-light/20"
+              />
+            )}
             {streamError && (
               <StreamErrorBanner
                 message={streamError}

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -2281,7 +2281,7 @@ export function ChatInterface({
       {/* Temporary chat indicator (top-left, fills inner corner) */}
       {(isTemporaryMode || currentChat?.isTemporary) && (
         <div
-          className="pointer-events-none fixed top-0 z-40 flex items-center gap-1.5 rounded-br-lg bg-brand-accent-light/15 px-3 py-2 text-xs font-medium text-brand-accent-light transition-all duration-300"
+          className="pointer-events-none fixed top-0 z-40 flex items-center gap-1.5 rounded-br-lg bg-[hsl(163,22%,15%)] px-3 py-2 text-xs font-medium text-brand-accent-light transition-all duration-300"
           style={{
             left: (() => {
               const isMobile = windowWidth < CONSTANTS.MOBILE_BREAKPOINT
@@ -2661,22 +2661,8 @@ export function ChatInterface({
           top: 0,
         }}
       >
-        <div
-          className={cn(
-            'relative flex h-full flex-col transition-colors',
-            isTemporaryMode
-              ? 'bg-brand-accent-light/15 p-2'
-              : 'bg-surface-chat-background',
-          )}
-        >
-          <div
-            className={cn(
-              'relative flex h-full flex-col',
-              isTemporaryMode
-                ? 'overflow-hidden rounded-lg border border-brand-accent-light/40 bg-surface-chat-background shadow-[0_0_0_1px_rgba(0,0,0,0.04)_inset]'
-                : 'rounded-none border-0',
-            )}
-          >
+        <div className="relative flex h-full flex-col bg-surface-chat-background transition-colors">
+          <div className="relative flex h-full flex-col">
             {/* Project Mode Banner */}
             {(isProjectMode && activeProject) || loadingProject ? (
               <ProjectModeBanner

--- a/src/components/chat/chat-messages.tsx
+++ b/src/components/chat/chat-messages.tsx
@@ -49,6 +49,7 @@ type ChatMessagesProps = {
   thinkingEnabled?: boolean
   setThinkingEnabled?: (enabled: boolean) => void
   onOpenVerifier?: () => void
+  isTemporaryMode?: boolean
 }
 
 // Optimized wrapper component that receives expanded state from parent
@@ -220,6 +221,7 @@ export function ChatMessages({
   thinkingEnabled,
   setThinkingEnabled,
   onOpenVerifier,
+  isTemporaryMode,
 }: ChatMessagesProps) {
   const [mounted, setMounted] = useState(false)
   const maxMessages = useMaxMessages()
@@ -325,6 +327,7 @@ export function ChatMessages({
             thinkingEnabled={thinkingEnabled}
             setThinkingEnabled={setThinkingEnabled}
             onOpenVerifier={onOpenVerifier}
+            isTemporaryMode={isTemporaryMode}
           />
         </div>
       </div>

--- a/src/components/chat/chat-messages.tsx
+++ b/src/components/chat/chat-messages.tsx
@@ -145,7 +145,7 @@ const LoadingMessage = memo(function LoadingMessage({
   return (
     <div className="no-scroll-anchoring group mx-auto mb-6 flex w-full max-w-3xl flex-col items-start px-4">
       <div className="flex items-center gap-3">
-        <LoadingDots isThinking={false} />
+        <LoadingDots />
         {isRetrying && (
           <span className="text-sm text-content-secondary">
             {getRetryMessage()}

--- a/src/components/chat/hooks/chat-operations.ts
+++ b/src/components/chat/hooks/chat-operations.ts
@@ -57,6 +57,9 @@ export async function saveChat(
   skipCloudSync = false,
 ): Promise<Chat> {
   try {
+    if (chat.isTemporary) {
+      return chat
+    }
     if (isSignedIn) {
       return await chatStorage.saveChat(chat, skipCloudSync)
     } else {

--- a/src/components/chat/hooks/chat-persistence.ts
+++ b/src/components/chat/hooks/chat-persistence.ts
@@ -67,6 +67,10 @@ export function createUpdateChatWithHistoryCheck({
       }))
     }
 
+    if (updatedChat.isTemporary) {
+      return
+    }
+
     if (storeHistory) {
       const shouldSkipCloudSync =
         skipCloudSync || updatedChat.isLocalOnly || isStreamingRef.current

--- a/src/components/chat/hooks/use-chat-messaging.ts
+++ b/src/components/chat/hooks/use-chat-messaging.ts
@@ -176,7 +176,7 @@ export function useChatMessaging({
         const updatedChat = newChats.find(
           (c) => c.id === currentChatIdRef.current,
         )
-        if (updatedChat) {
+        if (updatedChat && !updatedChat.isTemporary) {
           if (storeHistory) {
             chatStorage
               .saveChatAndSync(updatedChat)
@@ -300,7 +300,24 @@ export function useChatMessaging({
       }
 
       // Handle blank chat conversion: create chat immediately with server-valid ID
-      if (isBlankChat && storeHistory) {
+      if (isBlankChat && currentChat.isTemporary) {
+        updatedMessages = userMessage ? [userMessage] : []
+        updatedChat = {
+          ...currentChat,
+          title: 'Temporary Chat',
+          titleState: 'placeholder',
+          messages: updatedMessages,
+          isBlankChat: false,
+          createdAt: new Date(),
+        }
+
+        currentChatIdRef.current = updatedChat.id
+        setCurrentChat(updatedChat)
+
+        if (scrollToBottom) {
+          setTimeout(() => scrollToBottom(), 50)
+        }
+      } else if (isBlankChat && storeHistory) {
         logInfo('[handleQuery] Converting blank chat to real chat', {
           component: 'useChatMessaging',
           action: 'handleQuery.blankChatConversion',
@@ -414,7 +431,9 @@ export function useChatMessaging({
           setTimeout(() => scrollToBottom(), 50)
         }
 
-        sessionChatStorage.saveChat(updatedChat)
+        if (!updatedChat.isTemporary) {
+          sessionChatStorage.saveChat(updatedChat)
+        }
 
         // Clear pendingSave flag immediately for session storage (it's synchronous)
         setTimeout(() => {
@@ -453,7 +472,9 @@ export function useChatMessaging({
         }
 
         // Save the updated chat
-        if (storeHistory) {
+        if (updatedChat.isTemporary) {
+          // Temporary chats are never persisted
+        } else if (storeHistory) {
           await chatStorage.saveChatAndSync(updatedChat)
         } else {
           sessionChatStorage.saveChat(updatedChat)

--- a/src/components/chat/hooks/use-chat-messaging.ts
+++ b/src/components/chat/hooks/use-chat-messaging.ts
@@ -313,6 +313,9 @@ export function useChatMessaging({
 
         currentChatIdRef.current = updatedChat.id
         setCurrentChat(updatedChat)
+        setChats((prevChats) =>
+          prevChats.map((c) => (c.id === updatedChat.id ? updatedChat : c)),
+        )
 
         if (scrollToBottom) {
           setTimeout(() => scrollToBottom(), 50)

--- a/src/components/chat/hooks/use-chat-state.ts
+++ b/src/components/chat/hooks/use-chat-state.ts
@@ -40,6 +40,8 @@ interface UseChatStateReturn {
   setIsInitialLoad: (isLoading: boolean) => void
   setVerificationComplete: (complete: boolean) => void
   setVerificationSuccess: (success: boolean) => void
+  setChats: React.Dispatch<React.SetStateAction<Chat[]>>
+  setCurrentChat: React.Dispatch<React.SetStateAction<Chat>>
 
   // Actions
   handleSubmit: (e: React.FormEvent) => void
@@ -297,6 +299,8 @@ export function useChatState({
     setIsInitialLoad,
     setVerificationComplete,
     setVerificationSuccess,
+    setChats,
+    setCurrentChat,
 
     // Actions
     handleSubmit,

--- a/src/components/chat/hooks/use-chat-storage.ts
+++ b/src/components/chat/hooks/use-chat-storage.ts
@@ -279,7 +279,7 @@ export function useChatStorage({
         )
 
         const chatToUpdate = updatedChats.find((c) => c.id === chatId)
-        if (chatToUpdate && storeHistory) {
+        if (chatToUpdate && !chatToUpdate.isTemporary && storeHistory) {
           persistenceManager.save(chatToUpdate).catch((error) => {
             logError('Failed to save chat title update', error, {
               component: 'useChatStorage',

--- a/src/components/chat/renderers/components/StreamingTracerDot.tsx
+++ b/src/components/chat/renderers/components/StreamingTracerDot.tsx
@@ -1,0 +1,79 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+
+interface StreamingTracerDotProps {
+  className?: string
+  label?: string
+  tone?: 'primary' | 'secondary'
+}
+
+const DOT_SIZE_PX = 10
+const STYLE_ELEMENT_ID = 'tracer-dot-styles'
+
+function ensureStylesInjected() {
+  if (typeof document === 'undefined') return
+  if (document.getElementById(STYLE_ELEMENT_ID)) return
+  const style = document.createElement('style')
+  style.id = STYLE_ELEMENT_ID
+  style.textContent = `
+    .tracer-dot {
+      width: ${DOT_SIZE_PX}px;
+      height: ${DOT_SIZE_PX}px;
+      border-radius: 9999px;
+      background: currentColor;
+      animation: tracer-dot-pulse 1.6s ease-in-out infinite;
+    }
+
+    @keyframes tracer-dot-pulse {
+      0%, 100% {
+        transform: scale(0.7);
+      }
+      50% {
+        transform: scale(1);
+      }
+    }
+  `
+  document.head.appendChild(style)
+}
+
+function createDotElement(): HTMLDivElement {
+  ensureStylesInjected()
+  const dot = document.createElement('div')
+  dot.className = 'tracer-dot'
+  return dot
+}
+
+export function StreamingTracerDot({
+  className = '',
+  label = 'Streaming response',
+  tone = 'primary',
+}: StreamingTracerDotProps) {
+  const toneClass =
+    tone === 'secondary' ? 'text-content-muted' : 'text-content-primary'
+  const hostRef = useRef<HTMLSpanElement | null>(null)
+
+  useEffect(() => {
+    const host = hostRef.current
+    if (!host) return
+
+    const dot = createDotElement()
+    host.appendChild(dot)
+
+    return () => {
+      if (dot.parentNode === host) {
+        host.removeChild(dot)
+      }
+    }
+  }, [])
+
+  return (
+    <span
+      ref={hostRef}
+      className={`inline-grid shrink-0 place-items-center align-middle ${toneClass} ${className}`}
+      role="status"
+      aria-label={label}
+      style={{ width: DOT_SIZE_PX, height: DOT_SIZE_PX }}
+    />
+  )
+}

--- a/src/components/chat/renderers/components/ThoughtProcess.tsx
+++ b/src/components/chat/renderers/components/ThoughtProcess.tsx
@@ -275,21 +275,24 @@ export const ThoughtProcess = memo(function ThoughtProcess({
           {isThinking ? (
             <div className="min-w-0">
               {thoughtSummary ? (
-                <span
-                  className="block animate-shimmer truncate bg-clip-text text-base font-medium text-transparent"
-                  style={{
-                    backgroundImage: isDarkMode
-                      ? 'linear-gradient(90deg, #9ca3af 0%, #e5e7eb 25%, #f9fafb 50%, #e5e7eb 75%, #9ca3af 100%)'
-                      : 'linear-gradient(90deg, #4b5563 0%, #6b7280 25%, #9ca3af 50%, #6b7280 75%, #4b5563 100%)',
-                    backgroundSize: '200% 100%',
-                  }}
-                >
-                  {thoughtSummary}
-                </span>
+                <div className="flex min-w-0 items-center gap-1.5">
+                  <span
+                    className="block animate-shimmer truncate bg-clip-text text-base font-medium text-transparent"
+                    style={{
+                      backgroundImage: isDarkMode
+                        ? 'linear-gradient(90deg, #9ca3af 0%, #e5e7eb 25%, #f9fafb 50%, #e5e7eb 75%, #9ca3af 100%)'
+                        : 'linear-gradient(90deg, #4b5563 0%, #6b7280 25%, #9ca3af 50%, #6b7280 75%, #4b5563 100%)',
+                      backgroundSize: '200% 100%',
+                    }}
+                  >
+                    {thoughtSummary}
+                  </span>
+                  <LoadingDots size="small" />
+                </div>
               ) : (
                 <div className="flex items-center gap-1.5 text-content-primary/50">
                   <span className="text-base font-medium">Thinking</span>
-                  <LoadingDots isThinking={true} size="small" />
+                  <LoadingDots size="small" />
                 </div>
               )}
             </div>

--- a/src/components/chat/renderers/default/DefaultMessageRenderer.tsx
+++ b/src/components/chat/renderers/default/DefaultMessageRenderer.tsx
@@ -17,6 +17,7 @@ import { MessageActions } from '../components/MessageActions'
 import { SourcesButton } from '../components/SourcesButton'
 import { StreamingChunkedText } from '../components/StreamingChunkedText'
 import { StreamingContentWrapper } from '../components/StreamingContentWrapper'
+import { StreamingTracerDot } from '../components/StreamingTracerDot'
 import { ThoughtProcess } from '../components/ThoughtProcess'
 import { URLFetchProcess } from '../components/URLFetchProcess'
 import { WebSearchProcess } from '../components/WebSearchProcess'
@@ -319,6 +320,26 @@ const DefaultMessageComponent = ({
               return null
           }
         })}
+
+      {!isUser &&
+        isStreaming &&
+        isLastMessage &&
+        (() => {
+          const lastBlock =
+            message.timeline && message.timeline.length > 0
+              ? message.timeline[message.timeline.length - 1]
+              : undefined
+          if (lastBlock?.type === 'thinking' && lastBlock.isThinking) {
+            return null
+          }
+          return (
+            <div className="w-full px-4 pb-2 pt-2">
+              <StreamingTracerDot
+                tone={lastBlock?.type === 'content' ? 'primary' : 'secondary'}
+              />
+            </div>
+          )
+        })()}
 
       {/* User message content (or assistant without timeline, e.g. rate limit errors) */}
       {message.content &&

--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -312,6 +312,7 @@ export function SettingsModal({
 
   // Advanced settings collapsed state
   const [advancedSettingsOpen, setAdvancedSettingsOpen] = useState(false)
+  const [dangerZoneOpen, setDangerZoneOpen] = useState(false)
 
   // Placeholder animation state
   const [placeholderIndex, setPlaceholderIndex] = useState(0)
@@ -2348,224 +2349,245 @@ ${encryptionKey.replace('key_', '')}
 
                   {/* Danger Zone */}
                   <div className="space-y-3">
-                    <h3 className="font-aeonik text-sm font-medium text-content-secondary">
-                      Danger Zone
-                    </h3>
-
-                    {/* Delete all saved chats */}
-                    <div
-                      className={cn(
-                        'rounded-lg border p-4',
-                        isDarkMode
-                          ? 'border-red-500/30 bg-red-950/10'
-                          : 'border-red-200 bg-red-50/50',
-                      )}
+                    <button
+                      onClick={() => setDangerZoneOpen(!dangerZoneOpen)}
+                      className="flex w-full items-center justify-between"
                     >
-                      <div className="space-y-3">
-                        <div>
-                          <div className="font-aeonik text-sm font-medium text-content-primary">
-                            Delete all saved chats
-                          </div>
-                          <div className="font-aeonik-fono text-xs text-content-muted">
-                            {isSignedIn
-                              ? 'Permanently delete every chat from this device and your encrypted cloud backup. This cannot be undone.'
-                              : 'Permanently delete every chat from this browser. This cannot be undone.'}
-                          </div>
-                        </div>
-                        {showDeleteAllChatsConfirm ? (
-                          <div className="space-y-2">
-                            <label className="block">
-                              <span className="font-aeonik-fono text-xs text-content-muted">
-                                Type{' '}
-                                <code className="font-mono text-content-primary">
-                                  {DELETE_ALL_CHATS_CONFIRM_PHRASE}
-                                </code>{' '}
-                                to confirm.
-                              </span>
-                              <input
-                                type="text"
-                                autoComplete="off"
-                                autoCorrect="off"
-                                autoCapitalize="off"
-                                spellCheck={false}
-                                value={deleteAllChatsConfirmText}
-                                onChange={(e) =>
-                                  setDeleteAllChatsConfirmText(e.target.value)
-                                }
-                                disabled={isDeletingAllChats}
-                                placeholder={DELETE_ALL_CHATS_CONFIRM_PHRASE}
-                                className={cn(
-                                  'mt-1 w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-red-500 disabled:opacity-60',
-                                  isDarkMode
-                                    ? 'border-border-strong bg-surface-chat text-content-secondary placeholder:text-content-muted'
-                                    : 'border-border-subtle bg-white text-content-primary placeholder:text-content-muted',
-                                )}
-                              />
-                            </label>
-                            <div className="flex flex-col gap-2 sm:flex-row">
-                              <button
-                                onClick={handleDeleteAllChats}
-                                disabled={
-                                  isDeletingAllChats ||
-                                  deleteAllChatsConfirmText
-                                    .trim()
-                                    .toLowerCase() !==
-                                    DELETE_ALL_CHATS_CONFIRM_PHRASE
-                                }
-                                className={cn(
-                                  'flex-1 rounded-md px-3 py-2 text-sm font-medium transition-colors',
-                                  isDarkMode
-                                    ? 'bg-red-600 text-white hover:bg-red-500 disabled:bg-red-900 disabled:text-red-300'
-                                    : 'bg-red-600 text-white hover:bg-red-700 disabled:bg-red-300 disabled:text-white/70',
-                                )}
-                              >
-                                {isDeletingAllChats
-                                  ? 'Deleting…'
-                                  : 'Yes, delete all my chats'}
-                              </button>
-                              <button
-                                onClick={() => {
-                                  setShowDeleteAllChatsConfirm(false)
-                                  setDeleteAllChatsConfirmText('')
-                                }}
-                                disabled={isDeletingAllChats}
-                                className={cn(
-                                  'flex-1 rounded-md border px-3 py-2 text-sm font-medium transition-colors',
-                                  isDarkMode
-                                    ? 'border-border-strong bg-surface-chat text-content-secondary hover:bg-surface-chat/80'
-                                    : 'border-border-subtle bg-white text-content-primary hover:bg-surface-chat',
-                                )}
-                              >
-                                Cancel
-                              </button>
-                            </div>
-                          </div>
-                        ) : (
-                          <button
-                            onClick={() => setShowDeleteAllChatsConfirm(true)}
-                            className={cn(
-                              'w-full rounded-md border px-3 py-2 text-sm font-medium transition-colors',
-                              isDarkMode
-                                ? 'border-red-500/40 bg-red-950/30 text-red-400 hover:bg-red-950/50'
-                                : 'border-red-300 bg-white text-red-600 hover:bg-red-100',
-                            )}
-                          >
-                            Delete all saved chats
-                          </button>
-                        )}
-                      </div>
-                    </div>
-
-                    {/* Delete all projects (signed-in premium users only) */}
-                    {isSignedIn && isPremium && (
-                      <div
+                      <h3 className="font-aeonik text-sm font-medium text-content-secondary">
+                        Danger Zone
+                      </h3>
+                      <ChevronDownIcon
                         className={cn(
-                          'rounded-lg border p-4',
-                          isDarkMode
-                            ? 'border-red-500/30 bg-red-950/10'
-                            : 'border-red-200 bg-red-50/50',
+                          'h-4 w-4 text-content-muted transition-transform',
+                          dangerZoneOpen && 'rotate-180',
                         )}
-                      >
-                        <div className="space-y-3">
-                          <div>
-                            <div className="font-aeonik text-sm font-medium text-content-primary">
-                              Delete all projects
-                            </div>
-                            <div className="font-aeonik-fono text-xs text-content-muted">
-                              Permanently delete every project and its
-                              documents. Chats inside projects will be detached
-                              but kept. This cannot be undone.
-                            </div>
-                          </div>
-                          {showDeleteAllProjectsConfirm ? (
-                            <div className="space-y-2">
-                              <label className="block">
-                                <span className="font-aeonik-fono text-xs text-content-muted">
-                                  Type{' '}
-                                  <code className="font-mono text-content-primary">
-                                    {DELETE_ALL_PROJECTS_CONFIRM_PHRASE}
-                                  </code>{' '}
-                                  to confirm.
-                                </span>
-                                <input
-                                  type="text"
-                                  autoComplete="off"
-                                  autoCorrect="off"
-                                  autoCapitalize="off"
-                                  spellCheck={false}
-                                  value={deleteAllProjectsConfirmText}
-                                  onChange={(e) =>
-                                    setDeleteAllProjectsConfirmText(
-                                      e.target.value,
-                                    )
-                                  }
-                                  disabled={isDeletingAllProjects}
-                                  placeholder={
-                                    DELETE_ALL_PROJECTS_CONFIRM_PHRASE
-                                  }
-                                  className={cn(
-                                    'mt-1 w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-red-500 disabled:opacity-60',
-                                    isDarkMode
-                                      ? 'border-border-strong bg-surface-chat text-content-secondary placeholder:text-content-muted'
-                                      : 'border-border-subtle bg-white text-content-primary placeholder:text-content-muted',
-                                  )}
-                                />
-                              </label>
-                              <div className="flex flex-col gap-2 sm:flex-row">
-                                <button
-                                  onClick={handleDeleteAllProjects}
-                                  disabled={
-                                    isDeletingAllProjects ||
-                                    deleteAllProjectsConfirmText
-                                      .trim()
-                                      .toLowerCase() !==
-                                      DELETE_ALL_PROJECTS_CONFIRM_PHRASE
-                                  }
-                                  className={cn(
-                                    'flex-1 rounded-md px-3 py-2 text-sm font-medium transition-colors',
-                                    isDarkMode
-                                      ? 'bg-red-600 text-white hover:bg-red-500 disabled:bg-red-900 disabled:text-red-300'
-                                      : 'bg-red-600 text-white hover:bg-red-700 disabled:bg-red-300 disabled:text-white/70',
-                                  )}
-                                >
-                                  {isDeletingAllProjects
-                                    ? 'Deleting…'
-                                    : 'Yes, delete all my projects'}
-                                </button>
-                                <button
-                                  onClick={() => {
-                                    setShowDeleteAllProjectsConfirm(false)
-                                    setDeleteAllProjectsConfirmText('')
-                                  }}
-                                  disabled={isDeletingAllProjects}
-                                  className={cn(
-                                    'flex-1 rounded-md border px-3 py-2 text-sm font-medium transition-colors',
-                                    isDarkMode
-                                      ? 'border-border-strong bg-surface-chat text-content-secondary hover:bg-surface-chat/80'
-                                      : 'border-border-subtle bg-white text-content-primary hover:bg-surface-chat',
-                                  )}
-                                >
-                                  Cancel
-                                </button>
+                      />
+                    </button>
+
+                    {dangerZoneOpen && (
+                      <>
+                        {/* Delete all saved chats */}
+                        <div
+                          className={cn(
+                            'rounded-lg border p-4',
+                            isDarkMode
+                              ? 'border-red-500/30 bg-red-950/10'
+                              : 'border-red-200 bg-red-50/50',
+                          )}
+                        >
+                          <div className="space-y-3">
+                            <div>
+                              <div className="font-aeonik text-sm font-medium text-content-primary">
+                                Delete all saved chats
+                              </div>
+                              <div className="font-aeonik-fono text-xs text-content-muted">
+                                {isSignedIn
+                                  ? 'Permanently delete every chat from this device and your encrypted cloud backup. This cannot be undone.'
+                                  : 'Permanently delete every chat from this browser. This cannot be undone.'}
                               </div>
                             </div>
-                          ) : (
-                            <button
-                              onClick={() =>
-                                setShowDeleteAllProjectsConfirm(true)
-                              }
-                              className={cn(
-                                'w-full rounded-md border px-3 py-2 text-sm font-medium transition-colors',
-                                isDarkMode
-                                  ? 'border-red-500/40 bg-red-950/30 text-red-400 hover:bg-red-950/50'
-                                  : 'border-red-300 bg-white text-red-600 hover:bg-red-100',
-                              )}
-                            >
-                              Delete all projects
-                            </button>
-                          )}
+                            {showDeleteAllChatsConfirm ? (
+                              <div className="space-y-2">
+                                <label className="block">
+                                  <span className="font-aeonik-fono text-xs text-content-muted">
+                                    Type{' '}
+                                    <code className="font-mono text-content-primary">
+                                      {DELETE_ALL_CHATS_CONFIRM_PHRASE}
+                                    </code>{' '}
+                                    to confirm.
+                                  </span>
+                                  <input
+                                    type="text"
+                                    autoComplete="off"
+                                    autoCorrect="off"
+                                    autoCapitalize="off"
+                                    spellCheck={false}
+                                    value={deleteAllChatsConfirmText}
+                                    onChange={(e) =>
+                                      setDeleteAllChatsConfirmText(
+                                        e.target.value,
+                                      )
+                                    }
+                                    disabled={isDeletingAllChats}
+                                    placeholder={
+                                      DELETE_ALL_CHATS_CONFIRM_PHRASE
+                                    }
+                                    className={cn(
+                                      'mt-1 w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-red-500 disabled:opacity-60',
+                                      isDarkMode
+                                        ? 'border-border-strong bg-surface-chat text-content-secondary placeholder:text-content-muted'
+                                        : 'border-border-subtle bg-white text-content-primary placeholder:text-content-muted',
+                                    )}
+                                  />
+                                </label>
+                                <div className="flex flex-col gap-2 sm:flex-row">
+                                  <button
+                                    onClick={handleDeleteAllChats}
+                                    disabled={
+                                      isDeletingAllChats ||
+                                      deleteAllChatsConfirmText
+                                        .trim()
+                                        .toLowerCase() !==
+                                        DELETE_ALL_CHATS_CONFIRM_PHRASE
+                                    }
+                                    className={cn(
+                                      'flex-1 rounded-md px-3 py-2 text-sm font-medium transition-colors',
+                                      isDarkMode
+                                        ? 'bg-red-600 text-white hover:bg-red-500 disabled:bg-red-900 disabled:text-red-300'
+                                        : 'bg-red-600 text-white hover:bg-red-700 disabled:bg-red-300 disabled:text-white/70',
+                                    )}
+                                  >
+                                    {isDeletingAllChats
+                                      ? 'Deleting…'
+                                      : 'Yes, delete all my chats'}
+                                  </button>
+                                  <button
+                                    onClick={() => {
+                                      setShowDeleteAllChatsConfirm(false)
+                                      setDeleteAllChatsConfirmText('')
+                                    }}
+                                    disabled={isDeletingAllChats}
+                                    className={cn(
+                                      'flex-1 rounded-md border px-3 py-2 text-sm font-medium transition-colors',
+                                      isDarkMode
+                                        ? 'border-border-strong bg-surface-chat text-content-secondary hover:bg-surface-chat/80'
+                                        : 'border-border-subtle bg-white text-content-primary hover:bg-surface-chat',
+                                    )}
+                                  >
+                                    Cancel
+                                  </button>
+                                </div>
+                              </div>
+                            ) : (
+                              <button
+                                onClick={() =>
+                                  setShowDeleteAllChatsConfirm(true)
+                                }
+                                className={cn(
+                                  'w-full rounded-md border px-3 py-2 text-sm font-medium transition-colors',
+                                  isDarkMode
+                                    ? 'border-red-500/40 bg-red-950/30 text-red-400 hover:bg-red-950/50'
+                                    : 'border-red-300 bg-white text-red-600 hover:bg-red-100',
+                                )}
+                              >
+                                Delete all saved chats
+                              </button>
+                            )}
+                          </div>
                         </div>
-                      </div>
+
+                        {/* Delete all projects (signed-in premium users only) */}
+                        {isSignedIn && isPremium && (
+                          <div
+                            className={cn(
+                              'rounded-lg border p-4',
+                              isDarkMode
+                                ? 'border-red-500/30 bg-red-950/10'
+                                : 'border-red-200 bg-red-50/50',
+                            )}
+                          >
+                            <div className="space-y-3">
+                              <div>
+                                <div className="font-aeonik text-sm font-medium text-content-primary">
+                                  Delete all projects
+                                </div>
+                                <div className="font-aeonik-fono text-xs text-content-muted">
+                                  Permanently delete every project and its
+                                  documents. Chats inside projects will be
+                                  detached but kept. This cannot be undone.
+                                </div>
+                              </div>
+                              {showDeleteAllProjectsConfirm ? (
+                                <div className="space-y-2">
+                                  <label className="block">
+                                    <span className="font-aeonik-fono text-xs text-content-muted">
+                                      Type{' '}
+                                      <code className="font-mono text-content-primary">
+                                        {DELETE_ALL_PROJECTS_CONFIRM_PHRASE}
+                                      </code>{' '}
+                                      to confirm.
+                                    </span>
+                                    <input
+                                      type="text"
+                                      autoComplete="off"
+                                      autoCorrect="off"
+                                      autoCapitalize="off"
+                                      spellCheck={false}
+                                      value={deleteAllProjectsConfirmText}
+                                      onChange={(e) =>
+                                        setDeleteAllProjectsConfirmText(
+                                          e.target.value,
+                                        )
+                                      }
+                                      disabled={isDeletingAllProjects}
+                                      placeholder={
+                                        DELETE_ALL_PROJECTS_CONFIRM_PHRASE
+                                      }
+                                      className={cn(
+                                        'mt-1 w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-red-500 disabled:opacity-60',
+                                        isDarkMode
+                                          ? 'border-border-strong bg-surface-chat text-content-secondary placeholder:text-content-muted'
+                                          : 'border-border-subtle bg-white text-content-primary placeholder:text-content-muted',
+                                      )}
+                                    />
+                                  </label>
+                                  <div className="flex flex-col gap-2 sm:flex-row">
+                                    <button
+                                      onClick={handleDeleteAllProjects}
+                                      disabled={
+                                        isDeletingAllProjects ||
+                                        deleteAllProjectsConfirmText
+                                          .trim()
+                                          .toLowerCase() !==
+                                          DELETE_ALL_PROJECTS_CONFIRM_PHRASE
+                                      }
+                                      className={cn(
+                                        'flex-1 rounded-md px-3 py-2 text-sm font-medium transition-colors',
+                                        isDarkMode
+                                          ? 'bg-red-600 text-white hover:bg-red-500 disabled:bg-red-900 disabled:text-red-300'
+                                          : 'bg-red-600 text-white hover:bg-red-700 disabled:bg-red-300 disabled:text-white/70',
+                                      )}
+                                    >
+                                      {isDeletingAllProjects
+                                        ? 'Deleting…'
+                                        : 'Yes, delete all my projects'}
+                                    </button>
+                                    <button
+                                      onClick={() => {
+                                        setShowDeleteAllProjectsConfirm(false)
+                                        setDeleteAllProjectsConfirmText('')
+                                      }}
+                                      disabled={isDeletingAllProjects}
+                                      className={cn(
+                                        'flex-1 rounded-md border px-3 py-2 text-sm font-medium transition-colors',
+                                        isDarkMode
+                                          ? 'border-border-strong bg-surface-chat text-content-secondary hover:bg-surface-chat/80'
+                                          : 'border-border-subtle bg-white text-content-primary hover:bg-surface-chat',
+                                      )}
+                                    >
+                                      Cancel
+                                    </button>
+                                  </div>
+                                </div>
+                              ) : (
+                                <button
+                                  onClick={() =>
+                                    setShowDeleteAllProjectsConfirm(true)
+                                  }
+                                  className={cn(
+                                    'w-full rounded-md border px-3 py-2 text-sm font-medium transition-colors',
+                                    isDarkMode
+                                      ? 'border-red-500/40 bg-red-950/30 text-red-400 hover:bg-red-950/50'
+                                      : 'border-red-300 bg-white text-red-600 hover:bg-red-100',
+                                  )}
+                                >
+                                  Delete all projects
+                                </button>
+                              )}
+                            </div>
+                          </div>
+                        )}
+                      </>
                     )}
                   </div>
                 </>

--- a/src/components/chat/types.ts
+++ b/src/components/chat/types.ts
@@ -118,6 +118,8 @@ export type Chat = {
   isBlankChat?: boolean
   // Local-only flag - true for chats that should never sync to cloud
   isLocalOnly?: boolean
+  // Temporary flag - true for ephemeral chats that are never persisted anywhere
+  isTemporary?: boolean
   // Pending save flag - true while initial save is in progress
   pendingSave?: boolean
   // Project association - when set, chat belongs to a project

--- a/src/components/loading-dots.tsx
+++ b/src/components/loading-dots.tsx
@@ -1,30 +1,15 @@
 import { memo } from 'react'
-
-const DEFAULT_WIDTH_PX = 36
-const SMALL_WIDTH_PX = 22
+import { StreamingTracerDot } from './chat/renderers/components/StreamingTracerDot'
 
 export const LoadingDots = memo(function LoadingDots({
-  isThinking = false,
   size = 'default',
 }: {
-  isThinking?: boolean
   size?: 'default' | 'small'
 }) {
-  const dotColor = isThinking ? 'currentColor' : 'hsl(var(--content-secondary))'
-  const widthPx = size === 'small' ? SMALL_WIDTH_PX : DEFAULT_WIDTH_PX
-
   return (
-    <div
-      style={
-        {
-          width: `${widthPx}px`,
-          aspectRatio: '4',
-          '--_g': `no-repeat radial-gradient(circle closest-side,${dotColor} 90%,transparent)`,
-          background: 'var(--_g) 0% 50%, var(--_g) 50% 50%, var(--_g) 100% 50%',
-          backgroundSize: 'calc(100%/3) 100%',
-          animation: 'loading-dots 1s infinite linear',
-        } as React.CSSProperties
-      }
+    <StreamingTracerDot
+      tone="secondary"
+      className={size === 'small' ? 'scale-90' : ''}
     />
   )
 })

--- a/src/components/modals/cloud-sync-setup-modal.tsx
+++ b/src/components/modals/cloud-sync-setup-modal.tsx
@@ -162,6 +162,20 @@ export function CloudSyncSetupModal({
         action: 'handleGenerateKey',
       })
 
+      // When the user has a PRF-capable passkey, the passkey wraps the
+      // encryption key for them — they don't need to manually save a recovery
+      // copy. Skip the "Save this key securely" step and complete the flow
+      // immediately. They can reveal the backup key from Settings later if
+      // they want a paper copy.
+      if (prfSupported && !manualRecoveryNeeded) {
+        const success = await onSetupComplete(newKey, keySetupMode)
+        if (success) {
+          persistCloudSyncEnabled(true)
+          onClose()
+          return
+        }
+      }
+
       setCurrentStep('key-display')
     } catch (error) {
       logError('Failed to generate encryption key', error, {

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -11,27 +11,6 @@
   }
 }
 
-@keyframes loading-dots {
-  33% {
-    background-size:
-      calc(100% / 3) 0%,
-      calc(100% / 3) 100%,
-      calc(100% / 3) 100%;
-  }
-  50% {
-    background-size:
-      calc(100% / 3) 100%,
-      calc(100% / 3) 0%,
-      calc(100% / 3) 100%;
-  }
-  66% {
-    background-size:
-      calc(100% / 3) 100%,
-      calc(100% / 3) 100%,
-      calc(100% / 3) 0%;
-  }
-}
-
 @layer base {
   :root {
     color-scheme: light;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a Temporary Chat mode that never stores conversations or shows chat URLs, plus a new streaming tracer dot and small UI polish including an inset frame. Cloud sync setup now skips the manual key step when a passkey can wrap the key.

- New Features
  - Temporary Chat: ghost toggle to start/exit; clears the URL; restores your previous chat on exit; input gets a dashed border and a top-left “Temporary chat” badge; subtle inset frame; Share is hidden; welcome screen and messages honor the mode.
  - Streaming tracer dot replaces loading dots; shown under the last streaming assistant message and next to the thinking summary.
  - Settings “Danger Zone” is now collapsible.

- Bug Fixes
  - Smoothed the gradient fade above the composer.
  - Fixed temporary blank chat conversion so the chats list updates correctly and isn’t persisted.

<sup>Written for commit e35216e1f692fe62e35089b10016d1a6a97bbedd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

