### PR TITLE
feat(genui): show live progress while widget tool calls stream

### DIFF
--- a/src/components/chat/genui/GenUIToolCallRenderer.tsx
+++ b/src/components/chat/genui/GenUIToolCallRenderer.tsx
@@ -11,11 +11,44 @@
  * via `GenUIInputAreaRenderer`.
  */
 import { logError } from '@/utils/error-handling'
-import { RefreshCw, Sparkles } from 'lucide-react'
-import React, { memo, useEffect } from 'react'
+import { ChevronRight, RefreshCw, Sparkles } from 'lucide-react'
+import React, { memo, useEffect, useState } from 'react'
 import { PiSpinner } from 'react-icons/pi'
+import { tryParsePartialJson } from './partial-json'
 import { getGenUIWidget, renderGenUIInline } from './render'
 import type { GenUIToolCall } from './types'
+
+/**
+ * Convert a `render_artifact_preview` tool name into a human-friendly
+ * label for the streaming tracer ("artifact preview"). We strip the
+ * `render_` prefix (every GenUI widget uses it) and replace underscores
+ * with spaces.
+ */
+function prettyWidgetName(toolName: string): string {
+  return toolName.replace(/^render_/, '').replace(/_/g, ' ')
+}
+
+/**
+ * Pull a short human-readable hint out of partially-streamed tool
+ * arguments. We try the small set of fields most widgets surface as
+ * their primary label so the tracer can show "Generating chart: Sales
+ * by region" rather than a generic spinner. Returns null when nothing
+ * useful has streamed yet.
+ */
+function extractPartialHint(parsed: unknown): string | null {
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return null
+  }
+  const obj = parsed as Record<string, unknown>
+  const candidates = ['title', 'question', 'description', 'label', 'name']
+  for (const key of candidates) {
+    const value = obj[key]
+    if (typeof value === 'string' && value.trim().length > 0) {
+      return value.trim()
+    }
+  }
+  return null
+}
 
 interface GenUIToolCallRendererProps {
   toolCalls: GenUIToolCall[]
@@ -65,20 +98,7 @@ export const GenUIToolCallRenderer = memo(function GenUIToolCallRenderer({
         // tool call starts until the turn completes, even if the JSON
         // arguments finish parsing early.
         if (isStreaming) {
-          return (
-            <div
-              key={tc.id}
-              className="my-4 flex items-center gap-2 rounded-lg border border-border-subtle bg-transparent px-4 py-3"
-            >
-              <PiSpinner
-                className="h-3.5 w-3.5 animate-spin text-content-primary"
-                aria-hidden
-              />
-              <span className="text-sm font-medium text-content-primary">
-                Generating component
-              </span>
-            </div>
-          )
+          return <StreamingToolCallTracer key={tc.id} toolCall={tc} />
         }
 
         const input = resolveInput(tc)
@@ -134,6 +154,67 @@ export const GenUIToolCallRenderer = memo(function GenUIToolCallRenderer({
     </React.Fragment>
   )
 })
+
+/**
+ * Live tracer shown while the model is streaming a GenUI tool call.
+ *
+ * Replaces a static spinner with a card that surfaces:
+ *   - The widget name being generated (e.g. "artifact preview").
+ *   - A short hint pulled from the partially-streamed JSON when one is
+ *     available (the tool's `title` / `description` etc.).
+ *   - A live byte counter so the user can tell the stream is still
+ *     making progress even when no human-readable hint has streamed.
+ *   - A collapsible raw JSON view for power users who want to see
+ *     exactly what the model is sending.
+ */
+function StreamingToolCallTracer({ toolCall }: { toolCall: GenUIToolCall }) {
+  const [showRaw, setShowRaw] = useState(false)
+  const partial = tryParsePartialJson(toolCall.arguments)
+  const hint = extractPartialHint(partial)
+  const charCount = toolCall.arguments.length
+  const label = prettyWidgetName(toolCall.name)
+
+  return (
+    <div className="my-4 rounded-lg border border-border-subtle bg-transparent px-4 py-3">
+      <div className="flex items-center gap-2">
+        <PiSpinner
+          className="h-3.5 w-3.5 animate-spin text-content-primary"
+          aria-hidden
+        />
+        <span className="text-sm font-medium text-content-primary">
+          Generating {label}
+          {hint ? `: ${hint}` : null}
+        </span>
+        {charCount > 0 && (
+          <span className="ml-auto text-xs tabular-nums text-content-muted">
+            {charCount.toLocaleString()} chars
+          </span>
+        )}
+      </div>
+      {charCount > 0 && (
+        <div className="mt-2">
+          <button
+            type="button"
+            onClick={() => setShowRaw((prev) => !prev)}
+            className="flex items-center gap-1 text-xs text-content-muted hover:text-content-primary"
+            aria-expanded={showRaw}
+          >
+            <ChevronRight
+              className={`h-3 w-3 transition-transform ${showRaw ? 'rotate-90' : ''}`}
+              aria-hidden
+            />
+            {showRaw ? 'Hide stream' : 'Show stream'}
+          </button>
+          {showRaw && (
+            <pre className="mt-2 max-h-48 overflow-auto rounded-md bg-surface-chat-background p-2 text-xs text-content-muted">
+              <code>{toolCall.arguments}</code>
+            </pre>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
 
 function ParseFailureCard({
   toolName,

--- a/src/components/chat/genui/partial-json.ts
+++ b/src/components/chat/genui/partial-json.ts
@@ -1,0 +1,116 @@
+/**
+ * Best-effort partial-JSON parser.
+ *
+ * `JSON.parse` can't handle the truncated JSON we receive while a tool
+ * call is still streaming. This helper closes whatever containers and
+ * strings are still open and tries to parse the result. The goal is
+ * "show the user something useful", not faithful reconstruction — we
+ * deliberately tolerate dropped trailing characters and return null
+ * when the input is too garbled to yield anything.
+ */
+
+const TOKEN_OPEN_OBJECT = '{'
+const TOKEN_OPEN_ARRAY = '['
+const TOKEN_CLOSE_OBJECT = '}'
+const TOKEN_CLOSE_ARRAY = ']'
+const TOKEN_QUOTE = '"'
+
+function fastParse(input: string): unknown | undefined {
+  try {
+    return JSON.parse(input)
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Try to make `raw` syntactically valid JSON by stripping trailing
+ * fragments and appending the closers needed to balance the open
+ * containers. We attempt a few progressively more aggressive fixups
+ * because trimming the wrong amount can leave an empty key/value
+ * pair behind (e.g. `{"a":1,"b` → after closing the open string we'd
+ * get `{"a":1,"b"}` which is invalid; trimming the dangling key gives
+ * us `{"a":1}` which parses).
+ */
+export function tryParsePartialJson(raw: string): unknown {
+  if (!raw) return null
+  const trimmed = raw.trimStart()
+  if (!trimmed) return null
+
+  const direct = fastParse(trimmed)
+  if (direct !== undefined) return direct
+
+  const stack: string[] = []
+  let inString = false
+  let escaped = false
+
+  for (let i = 0; i < trimmed.length; i++) {
+    const ch = trimmed[i]
+    if (inString) {
+      if (escaped) {
+        escaped = false
+      } else if (ch === '\\') {
+        escaped = true
+      } else if (ch === TOKEN_QUOTE) {
+        inString = false
+      }
+      continue
+    }
+    if (ch === TOKEN_QUOTE) {
+      inString = true
+      continue
+    }
+    if (ch === TOKEN_OPEN_OBJECT || ch === TOKEN_OPEN_ARRAY) {
+      stack.push(ch)
+    } else if (ch === TOKEN_CLOSE_OBJECT || ch === TOKEN_CLOSE_ARRAY) {
+      stack.pop()
+    }
+  }
+
+  let candidate = trimmed
+  if (escaped) {
+    candidate = candidate.slice(0, -1)
+  }
+  if (inString) {
+    candidate += TOKEN_QUOTE
+  }
+
+  const closers = stack
+    .slice()
+    .reverse()
+    .map((open) =>
+      open === TOKEN_OPEN_OBJECT ? TOKEN_CLOSE_OBJECT : TOKEN_CLOSE_ARRAY,
+    )
+    .join('')
+
+  // First attempt: close as-is.
+  const firstAttempt = fastParse(candidate + closers)
+  if (firstAttempt !== undefined) return firstAttempt
+
+  // Strip a trailing comma and try again.
+  const noTrailingComma = candidate.replace(/,\s*$/, '')
+  const secondAttempt = fastParse(noTrailingComma + closers)
+  if (secondAttempt !== undefined) return secondAttempt
+
+  // Strip a dangling key fragment like `,"key` or `,"key":` so the
+  // surrounding object still parses.
+  const noDanglingKey = noTrailingComma
+    .replace(/,\s*"[^"]*"\s*:?\s*$/u, '')
+    .replace(/,\s*"[^"]*$/u, '')
+    .replace(/\{\s*"[^"]*"\s*:?\s*$/u, '{')
+    .replace(/\{\s*"[^"]*$/u, '{')
+  const thirdAttempt = fastParse(noDanglingKey + closers)
+  if (thirdAttempt !== undefined) return thirdAttempt
+
+  // Strip a dangling property whose value never finished, e.g.
+  // `{"a":1,"b":` or `{"a":1,"b":"foo` (after the closer attempt left
+  // an unterminated value).
+  const noDanglingValue = noDanglingKey.replace(
+    /,\s*"[^"]*"\s*:\s*[^,{}\[\]]*$/u,
+    '',
+  )
+  const fourthAttempt = fastParse(noDanglingValue + closers)
+  if (fourthAttempt !== undefined) return fourthAttempt
+
+  return null
+}

--- a/tests/components/chat/genui/partial-json.test.ts
+++ b/tests/components/chat/genui/partial-json.test.ts
@@ -1,0 +1,48 @@
+import { tryParsePartialJson } from '@/components/chat/genui/partial-json'
+import { describe, expect, it } from 'vitest'
+
+describe('tryParsePartialJson', () => {
+  it('parses well-formed JSON without modification', () => {
+    expect(tryParsePartialJson('{"a":1}')).toEqual({ a: 1 })
+  })
+
+  it('returns null for empty input', () => {
+    expect(tryParsePartialJson('')).toBeNull()
+    expect(tryParsePartialJson('   ')).toBeNull()
+  })
+
+  it('recovers an unterminated string value', () => {
+    const result = tryParsePartialJson('{"title":"My Slid')
+    expect(result).toEqual({ title: 'My Slid' })
+  })
+
+  it('recovers a missing closing brace', () => {
+    const result = tryParsePartialJson('{"a":1,"b":2')
+    expect(result).toEqual({ a: 1, b: 2 })
+  })
+
+  it('drops a trailing dangling key', () => {
+    const result = tryParsePartialJson('{"title":"Demo","desc')
+    expect(result).toEqual({ title: 'Demo' })
+  })
+
+  it('recovers a partial nested object', () => {
+    const result = tryParsePartialJson(
+      '{"title":"Demo","source":{"type":"html","html":"<h1',
+    )
+    expect(result).toEqual({
+      title: 'Demo',
+      source: { type: 'html', html: '<h1' },
+    })
+  })
+
+  it('recovers from a stream that ends in an open array', () => {
+    const result = tryParsePartialJson('{"items":[1,2,3')
+    expect(result).toEqual({ items: [1, 2, 3] })
+  })
+
+  it('strips a trailing comma after the last element', () => {
+    const result = tryParsePartialJson('{"a":1,')
+    expect(result).toEqual({ a: 1 })
+  })
+})


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Show live progress for GenUI widget tool calls during streaming with a tracer UI that surfaces the widget name, a partial hint, and stream details.

- **New Features**
  - Replace the generic spinner with a live tracer while the tool call streams.
  - Show the widget label (e.g., “artifact preview”) plus a hint from partially streamed args (title/question/description/label/name).
  - Display a live character count and an optional collapsible raw JSON stream.
  - Add a best‑effort partial JSON parser with unit tests to extract hints from incomplete payloads.

<sup>Written for commit 9bd5dd4a822148ed8293f003eb59cd90340061ba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

