### PR TITLE
feat: use image mode for pdf analysis with vision models

### DIFF
--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -113,7 +113,7 @@ import { ReasoningEffortSelector } from './reasoning-effort-selector'
 import { initializeRenderers } from './renderers/client'
 import type { ProcessedDocument } from './renderers/types'
 import type { SettingsTab } from './settings-modal'
-import type { Attachment, Chat } from './types'
+import type { Attachment, Chat, DocumentPage } from './types'
 // Lazy-load modals that aren't shown on initial load
 const CloudSyncSetupModal = dynamic(
   () =>
@@ -242,6 +242,7 @@ function buildAttachment(opts: {
   imageData?: { base64: string; mimeType: string; thumbnailBase64?: string }
   textContent?: string
   description?: string
+  pages?: DocumentPage[]
 }): Attachment | undefined {
   if (opts.imageData) {
     return {
@@ -254,12 +255,13 @@ function buildAttachment(opts: {
       description: opts.description ?? opts.fileName,
     }
   }
-  if (opts.textContent) {
+  if (opts.textContent || opts.pages?.length) {
     return {
       id: opts.id,
       type: 'document',
       fileName: opts.fileName,
       textContent: opts.textContent,
+      pages: opts.pages,
     }
   }
   return undefined
@@ -1570,7 +1572,7 @@ export function ChatInterface({
 
       await handleDocumentUpload(
         file,
-        (content, documentId, imageData, hasDescription) => {
+        (content, documentId, imageData, hasDescription, pages) => {
           const newDocTokens = estimateTokenCount(content)
           const contextLimit = parseContextWindowTokens(
             selectedModelDetails?.contextWindow,
@@ -1603,6 +1605,7 @@ export function ChatInterface({
             imageData: imageData ?? undefined,
             textContent: content ?? undefined,
             description: hasDescription && content ? content : undefined,
+            pages,
           })
 
           setProcessedDocuments((prev) => {
@@ -2916,127 +2919,130 @@ export function ChatInterface({
                   {selectPendingInputToolCallFromChat(currentChat) ? (
                     <div className="pointer-events-auto relative mx-auto max-w-3xl rounded-xl border border-border-subtle bg-surface-card p-3 px-1 md:px-8">
                       <GenUIInputAreaRenderer
-                        pending={selectPendingInputToolCallFromChat(currentChat)!}
+                        pending={
+                          selectPendingInputToolCallFromChat(currentChat)!
+                        }
                         isDarkMode={isDarkMode}
                         onResolve={resolveInputToolCall}
                       />
                     </div>
                   ) : (
-                  <form
-                    onSubmit={handleSubmit}
-                    className="pointer-events-auto relative mx-auto max-w-3xl px-1 md:px-8"
-                  >
-                    <ChatInput
-                      input={input}
-                      setInput={setInput}
-                      handleSubmit={handleSubmit}
-                      loadingState={loadingState}
-                      cancelGeneration={cancelGeneration}
-                      inputRef={inputRef}
-                      handleInputFocus={handleInputFocus}
-                      inputMinHeight={inputMinHeight}
-                      isDarkMode={isDarkMode}
-                      handleDocumentUpload={handleFileUpload}
-                      processedDocuments={processedDocuments}
-                      removeDocument={removeDocument}
-                      isPremium={isPremium}
-                      quote={quote}
-                      onClearQuote={() => setQuote(null)}
-                      isTemporaryMode={isTemporaryMode}
-                      hasMessages={
-                        currentChat?.messages && currentChat.messages.length > 0
-                      }
-                      audioModel={
-                        (
-                          models.find(
-                            (m) =>
-                              m.modelName === CONSTANTS.DEFAULT_AUDIO_MODEL,
-                          ) || models.find((m) => m.type === 'audio')
-                        )?.modelName
-                      }
-                      modelSelectorButton={
-                        models.length > 0 &&
-                        selectedModel &&
-                        handleModelSelect ? (
-                          <div className="relative">
-                            <button
-                              type="button"
-                              data-model-selector
-                              onClick={(e) => {
-                                e.preventDefault()
-                                e.stopPropagation()
-                                handleLabelClick('model', () => {})
-                              }}
-                              className="flex items-center gap-1 text-content-secondary transition-colors hover:text-content-primary"
-                            >
-                              {(() => {
-                                const model = models.find(
-                                  (m) => m.modelName === selectedModel,
-                                )
-                                if (!model) return null
-                                return (
-                                  <>
-                                    <span className="text-xs font-medium">
-                                      {model.name}
-                                    </span>
-                                    <svg
-                                      className={`h-3 w-3 transition-transform ${expandedLabel === 'model' ? 'rotate-180' : ''}`}
-                                      fill="none"
-                                      stroke="currentColor"
-                                      viewBox="0 0 24 24"
-                                    >
-                                      <path
-                                        strokeLinecap="round"
-                                        strokeLinejoin="round"
-                                        strokeWidth={2}
-                                        d="M19 9l-7 7-7-7"
-                                      />
-                                    </svg>
-                                  </>
-                                )
-                              })()}
-                            </button>
+                    <form
+                      onSubmit={handleSubmit}
+                      className="pointer-events-auto relative mx-auto max-w-3xl px-1 md:px-8"
+                    >
+                      <ChatInput
+                        input={input}
+                        setInput={setInput}
+                        handleSubmit={handleSubmit}
+                        loadingState={loadingState}
+                        cancelGeneration={cancelGeneration}
+                        inputRef={inputRef}
+                        handleInputFocus={handleInputFocus}
+                        inputMinHeight={inputMinHeight}
+                        isDarkMode={isDarkMode}
+                        handleDocumentUpload={handleFileUpload}
+                        processedDocuments={processedDocuments}
+                        removeDocument={removeDocument}
+                        isPremium={isPremium}
+                        quote={quote}
+                        onClearQuote={() => setQuote(null)}
+                        isTemporaryMode={isTemporaryMode}
+                        hasMessages={
+                          currentChat?.messages &&
+                          currentChat.messages.length > 0
+                        }
+                        audioModel={
+                          (
+                            models.find(
+                              (m) =>
+                                m.modelName === CONSTANTS.DEFAULT_AUDIO_MODEL,
+                            ) || models.find((m) => m.type === 'audio')
+                          )?.modelName
+                        }
+                        modelSelectorButton={
+                          models.length > 0 &&
+                          selectedModel &&
+                          handleModelSelect ? (
+                            <div className="relative">
+                              <button
+                                type="button"
+                                data-model-selector
+                                onClick={(e) => {
+                                  e.preventDefault()
+                                  e.stopPropagation()
+                                  handleLabelClick('model', () => {})
+                                }}
+                                className="flex items-center gap-1 text-content-secondary transition-colors hover:text-content-primary"
+                              >
+                                {(() => {
+                                  const model = models.find(
+                                    (m) => m.modelName === selectedModel,
+                                  )
+                                  if (!model) return null
+                                  return (
+                                    <>
+                                      <span className="text-xs font-medium">
+                                        {model.name}
+                                      </span>
+                                      <svg
+                                        className={`h-3 w-3 transition-transform ${expandedLabel === 'model' ? 'rotate-180' : ''}`}
+                                        fill="none"
+                                        stroke="currentColor"
+                                        viewBox="0 0 24 24"
+                                      >
+                                        <path
+                                          strokeLinecap="round"
+                                          strokeLinejoin="round"
+                                          strokeWidth={2}
+                                          d="M19 9l-7 7-7-7"
+                                        />
+                                      </svg>
+                                    </>
+                                  )
+                                })()}
+                              </button>
 
-                            {expandedLabel === 'model' && (
-                              <ModelSelector
-                                selectedModel={selectedModel}
-                                onSelect={handleModelSelect}
-                                isDarkMode={isDarkMode}
-                                models={models}
-                              />
-                            )}
-                          </div>
-                        ) : undefined
-                      }
-                      reasoningSelectorButton={(() => {
-                        const m = models.find(
-                          (mm) => mm.modelName === selectedModel,
-                        )
-                        if (!isReasoningModel(m)) return undefined
-                        return (
-                          <ReasoningEffortSelector
-                            supportsEffort={supportsReasoningEffort(m)}
-                            supportsToggle={supportsThinkingToggle(m)}
-                            reasoningEffort={reasoningEffort}
-                            onEffortChange={setReasoningEffort}
-                            thinkingEnabled={thinkingEnabled}
-                            onThinkingEnabledChange={setThinkingEnabled}
-                            isOpen={expandedLabel === 'reasoning'}
-                            onToggle={() =>
-                              handleLabelClick('reasoning', () => {})
-                            }
-                            onClose={() =>
-                              handleLabelClick('reasoning', () => {})
-                            }
-                          />
-                        )
-                      })()}
-                      webSearchEnabled={webSearchEnabled}
-                      onWebSearchToggle={() =>
-                        setWebSearchEnabled((prev) => !prev)
-                      }
-                    />
-                  </form>
+                              {expandedLabel === 'model' && (
+                                <ModelSelector
+                                  selectedModel={selectedModel}
+                                  onSelect={handleModelSelect}
+                                  isDarkMode={isDarkMode}
+                                  models={models}
+                                />
+                              )}
+                            </div>
+                          ) : undefined
+                        }
+                        reasoningSelectorButton={(() => {
+                          const m = models.find(
+                            (mm) => mm.modelName === selectedModel,
+                          )
+                          if (!isReasoningModel(m)) return undefined
+                          return (
+                            <ReasoningEffortSelector
+                              supportsEffort={supportsReasoningEffort(m)}
+                              supportsToggle={supportsThinkingToggle(m)}
+                              reasoningEffort={reasoningEffort}
+                              onEffortChange={setReasoningEffort}
+                              thinkingEnabled={thinkingEnabled}
+                              onThinkingEnabledChange={setThinkingEnabled}
+                              isOpen={expandedLabel === 'reasoning'}
+                              onToggle={() =>
+                                handleLabelClick('reasoning', () => {})
+                              }
+                              onClose={() =>
+                                handleLabelClick('reasoning', () => {})
+                              }
+                            />
+                          )
+                        })()}
+                        webSearchEnabled={webSearchEnabled}
+                        onWebSearchToggle={() =>
+                          setWebSearchEnabled((prev) => !prev)
+                        }
+                      />
+                    </form>
                   )}
 
                   {/* Scroll to bottom button - absolutely positioned in parent */}

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -255,12 +255,21 @@ function buildAttachment(opts: {
       description: opts.description ?? opts.fileName,
     }
   }
-  if (opts.textContent || opts.pages?.length) {
+  // Synthesize textContent from pages when the document was uploaded in
+  // images mode and md_content is missing, so consumers that filter on
+  // textContent (share, preview) still see the document.
+  const textContent =
+    opts.textContent ||
+    opts.pages
+      ?.map((p) => p.text)
+      .filter(Boolean)
+      .join('\n\n---\n\n')
+  if (textContent || opts.pages?.length) {
     return {
       id: opts.id,
       type: 'document',
       fileName: opts.fileName,
-      textContent: opts.textContent,
+      textContent: textContent || undefined,
       pages: opts.pages,
     }
   }

--- a/src/components/chat/document-uploader.tsx
+++ b/src/components/chat/document-uploader.tsx
@@ -296,8 +296,10 @@ export const useDocumentUploader = (
       formData.append('files', file)
 
       const { endpoint } = await getDocUploadModel()
-      // For vision-capable models, fetch per-page images alongside text
-      // so chat-query-builder can interleave them for the model.
+      // Decided at upload time based on the current model: vision-capable
+      // models get per-page images, text-only models skip the bandwidth.
+      // If the user later switches to a vision model they'll need to
+      // re-upload to get image rendering for an existing attachment.
       const fetchEndpoint = isCurrentModelMultimodal
         ? `${endpoint}?mode=images`
         : endpoint

--- a/src/components/chat/document-uploader.tsx
+++ b/src/components/chat/document-uploader.tsx
@@ -17,7 +17,7 @@ import {
 import { useState } from 'react'
 import { SecureClient } from 'tinfoil'
 import { CONSTANTS } from './constants'
-import type { DocumentProcessingResult } from './types'
+import type { DocumentPage, DocumentProcessingResult } from './types'
 
 /**
  * Re-export getFileIconType for backward compatibility
@@ -145,6 +145,7 @@ export const useDocumentUploader = (
         thumbnailBase64?: string
       },
       hasDescription?: boolean,
+      pages?: DocumentPage[],
     ) => void,
     onError: (error: Error, documentId: string) => void,
     onGeneratingDescription?: (
@@ -295,6 +296,11 @@ export const useDocumentUploader = (
       formData.append('files', file)
 
       const { endpoint } = await getDocUploadModel()
+      // For vision-capable models, fetch per-page images alongside text
+      // so chat-query-builder can interleave them for the model.
+      const fetchEndpoint = isCurrentModelMultimodal
+        ? `${endpoint}?mode=images`
+        : endpoint
 
       const apiKey = await getSessionToken()
       const client = new SecureClient()
@@ -305,7 +311,7 @@ export const useDocumentUploader = (
       )
 
       const response = await client
-        .fetch(endpoint, {
+        .fetch(fetchEndpoint, {
           method: 'POST',
           headers: {
             Authorization: `Bearer ${apiKey}`,
@@ -343,8 +349,15 @@ export const useDocumentUploader = (
       const processingResult =
         (await response.json()) as DocumentProcessingResult
 
-      if (processingResult.document && processingResult.document.md_content) {
-        onSuccess(processingResult.document.md_content, documentId)
+      const doc = processingResult.document
+      if (doc?.md_content || doc?.pages?.length) {
+        onSuccess(
+          doc.md_content ?? '',
+          documentId,
+          undefined,
+          undefined,
+          doc.pages,
+        )
       } else {
         onSuccess('', documentId)
       }

--- a/src/components/chat/types.ts
+++ b/src/components/chat/types.ts
@@ -80,6 +80,13 @@ export type TimelineBlock =
   | TimelineContentBlock
   | TimelineToolCallBlock
 
+export type DocumentPage = {
+  page: number
+  text: string
+  image: string
+  is_scanned: boolean
+}
+
 export type Attachment = {
   id: string
   type: 'image' | 'document'
@@ -90,6 +97,7 @@ export type Attachment = {
   textContent?: string
   description?: string
   fileSize?: number
+  pages?: DocumentPage[]
   // v1 format: per-attachment encryption key material (base64-encoded)
   encryptionKey?: string
 }
@@ -179,6 +187,7 @@ export interface DocumentMetadata {
 export interface DocumentProcessingResult {
   document?: {
     md_content: string
+    pages?: DocumentPage[]
     filename?: string
   } & DocumentMetadata
   status?: DocumentProcessingStatus

--- a/src/services/inference/chat-query-builder.ts
+++ b/src/services/inference/chat-query-builder.ts
@@ -206,8 +206,13 @@ export class ChatQueryBuilder {
 
     // Derive document content from attachments (or legacy fields via helpers)
     const docAttachments = getMessageDocuments(msg)
-    if (docAttachments.length > 0) {
-      const docContent = docAttachments
+    const pagedDocs = multimodal
+      ? docAttachments.filter((a) => a.pages && a.pages.length > 0)
+      : []
+    const textOnlyDocs = docAttachments.filter((a) => !pagedDocs.includes(a))
+
+    if (textOnlyDocs.length > 0) {
+      const docContent = textOnlyDocs
         .filter((a) => a.textContent)
         .map(
           (a) =>
@@ -222,12 +227,36 @@ export class ChatQueryBuilder {
     // Derive image data from attachments (or legacy fields via helpers)
     const imageAttachments = getMessageImages(msg)
 
-    if (imageAttachments.length > 0 && multimodal) {
+    if (multimodal && (imageAttachments.length > 0 || pagedDocs.length > 0)) {
       const content: Array<{
         type: string
         text?: string
         image_url?: { url: string }
-      }> = [{ type: 'text', text: textContent }]
+      }> = []
+
+      for (const doc of pagedDocs) {
+        content.push({
+          type: 'text',
+          text: `[Attached file: ${doc.fileName}]`,
+        })
+        for (const p of doc.pages!) {
+          const label = p.is_scanned
+            ? `Page ${p.page} (scanned):`
+            : `Page ${p.page}:`
+          content.push({
+            type: 'text',
+            text: p.text ? `${label}\n${p.text}` : label,
+          })
+          if (p.image) {
+            content.push({
+              type: 'image_url',
+              image_url: { url: `data:image/png;base64,${p.image}` },
+            })
+          }
+        }
+      }
+
+      content.push({ type: 'text', text: textContent })
 
       for (const img of imageAttachments) {
         if (img.base64 && img.mimeType) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enable image-based PDF analysis for vision-capable models. When a multimodal model is selected, PDFs are sent as per-page text + images; text-only flow remains for non-vision models.

- **New Features**
  - Added `DocumentPage` and `pages` support on `Attachment` and `DocumentProcessingResult`, and wired through the attachment builder.
  - Uploader uses `?mode=images` when the current model is multimodal; switching models later won’t add images—re-upload is needed.
  - Query builder: for multimodal, interleaves page labels/text with `image_url` entries; keeps text-only handling for other attachments.

- **Bug Fixes**
  - Attachment creation now works for image-mode PDFs without `md_content`, synthesizing text from `pages` so share/preview still show content.

<sup>Written for commit 7fbdd36bfd04e1a360dd745833caddac2a617985. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

