### PR TITLE
Fix edge cases in chat and profile sync logic

### DIFF
--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -1382,10 +1382,11 @@ export function SettingsModal({
         chatsById.set(chat.id, chat)
       }
 
-      const localChats = isSignedIn
-        ? await chatStorage.getAllChats()
-        : sessionChatStorage.getAllChats()
-      localChats.forEach(addChat)
+      const indexedDbChats = await chatStorage.getAllChats()
+      indexedDbChats.forEach(addChat)
+      if (!isSignedIn) {
+        sessionChatStorage.getAllChats().forEach(addChat)
+      }
 
       // If cloud sync is enabled, fetch all chats with pagination
       if (isCloudSyncEnabled() && isSignedIn) {

--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -1376,7 +1376,16 @@ export function SettingsModal({
     setExportType('chats')
 
     try {
-      const allChats: Chat[] = []
+      const chatsById = new Map<string, Chat>()
+      const addChat = (chat: Chat) => {
+        if (!chat.id || chatsById.has(chat.id)) return
+        chatsById.set(chat.id, chat)
+      }
+
+      const localChats = isSignedIn
+        ? await chatStorage.getAllChats()
+        : sessionChatStorage.getAllChats()
+      localChats.forEach(addChat)
 
       // If cloud sync is enabled, fetch all chats with pagination
       if (isCloudSyncEnabled() && isSignedIn) {
@@ -1392,7 +1401,7 @@ export function SettingsModal({
 
           // Convert StoredChat to Chat
           for (const storedChat of result.chats) {
-            allChats.push({
+            addChat({
               id: storedChat.id,
               title: storedChat.title,
               messages: storedChat.messages,
@@ -1407,14 +1416,10 @@ export function SettingsModal({
           hasMore = result.hasMore
           continuationToken = result.nextToken
         }
-      } else {
-        // For non-authenticated users, get all local chats
-        const localChats = await chatStorage.getAllChats()
-        allChats.push(...localChats)
       }
 
       // Filter out blank chats and chats that failed decryption
-      const exportableChats = allChats.filter(
+      const exportableChats = Array.from(chatsById.values()).filter(
         (chat) =>
           !chat.isBlankChat && chat.messages && chat.messages.length > 0,
       )

--- a/src/constants/storage-keys.ts
+++ b/src/constants/storage-keys.ts
@@ -100,6 +100,7 @@ export const SYNC_ALL_CHATS_STATUS = 'tinfoil-sync-all-chats-status'
 export const SYNC_PROJECT_CHAT_STATUS_PREFIX =
   'tinfoil-sync-project-chat-status-'
 export const SYNC_PROFILE_STATUS = 'tinfoil-sync-profile-status'
+export const SYNC_PROFILE_DIRTY = 'tinfoil-sync-profile-dirty'
 
 // --- localStorage: Development ---------------------------------------------
 export const DEV_ENABLE_DEBUG_LOGS = 'tinfoil-dev-enable-debug-logs'

--- a/src/hooks/use-profile-sync.ts
+++ b/src/hooks/use-profile-sync.ts
@@ -1,5 +1,8 @@
 import { CLOUD_SYNC } from '@/config'
-import { SYNC_PROFILE_STATUS } from '@/constants/storage-keys'
+import {
+  SYNC_PROFILE_DIRTY,
+  SYNC_PROFILE_STATUS,
+} from '@/constants/storage-keys'
 import { getCurrentCloudKeyAuthorizationMode } from '@/services/cloud/cloud-key-authorization'
 import type { ProfileSyncStatus } from '@/services/cloud/cloud-storage'
 import {
@@ -22,11 +25,32 @@ export function useProfileSync() {
   const syncDebounceTimer = useRef<NodeJS.Timeout | null>(null)
   const lastSyncedVersion = useRef<number>(0)
   const hasPendingChanges = useRef(false)
+  const isApplyingRemoteProfile = useRef(false)
   const lastSyncedProfile = useRef<ProfileData | null>(null)
   const profileSyncCache = useRef(
     new SyncStatusCache<ProfileSyncStatus>(PROFILE_SYNC_STATUS_KEY),
   )
   const [cloudSyncEnabled, setCloudSyncEnabled] = useState(isCloudSyncEnabled())
+
+  const hasLocalProfileChanges = useCallback(() => {
+    if (hasPendingChanges.current) return true
+    if (typeof window === 'undefined') return false
+    return localStorage.getItem(SYNC_PROFILE_DIRTY) === 'true'
+  }, [])
+
+  const markLocalProfileChanged = useCallback(() => {
+    hasPendingChanges.current = true
+    if (typeof window !== 'undefined') {
+      localStorage.setItem(SYNC_PROFILE_DIRTY, 'true')
+    }
+  }, [])
+
+  const clearLocalProfileChanged = useCallback(() => {
+    hasPendingChanges.current = false
+    if (typeof window !== 'undefined') {
+      localStorage.removeItem(SYNC_PROFILE_DIRTY)
+    }
+  }, [])
 
   // Listen for cloud sync setting changes
   useEffect(() => {
@@ -53,7 +77,7 @@ export function useProfileSync() {
     if (!isSignedIn || !isCloudSyncEnabled()) return
 
     // Skip sync if we have pending local changes
-    if (hasPendingChanges.current) {
+    if (hasLocalProfileChanges()) {
       logInfo('Skipping cloud sync - local changes pending', {
         component: 'ProfileSync',
         action: 'syncFromCloud',
@@ -68,7 +92,7 @@ export function useProfileSync() {
         const cloudVersion = cloudProfile.version || 0
 
         // Re-check pending changes after fetch to avoid race with local edits
-        if (hasPendingChanges.current) {
+        if (hasLocalProfileChanges()) {
           return
         }
 
@@ -80,7 +104,13 @@ export function useProfileSync() {
         // Check if the cloud profile is actually different from what we have
         if (hasProfileChanged(cloudProfile, lastSyncedProfile.current)) {
           // Apply cloud settings to localStorage
-          applySettingsToLocal(cloudProfile)
+          isApplyingRemoteProfile.current = true
+          try {
+            applySettingsToLocal(cloudProfile)
+          } finally {
+            isApplyingRemoteProfile.current = false
+          }
+          clearLocalProfileChanged()
           lastSyncedVersion.current = cloudVersion
           lastSyncedProfile.current = cloudProfile
 
@@ -102,14 +132,14 @@ export function useProfileSync() {
         action: 'syncFromCloud',
       })
     }
-  }, [isSignedIn])
+  }, [clearLocalProfileChanged, hasLocalProfileChanges, isSignedIn])
 
   // Smart sync: check sync status first and only fetch profile if changed
   const smartSyncFromCloud = useCallback(async () => {
     if (!isSignedIn || !isCloudSyncEnabled()) return
 
     // Skip sync if we have pending local changes
-    if (hasPendingChanges.current) {
+    if (hasLocalProfileChanges()) {
       return
     }
 
@@ -161,7 +191,7 @@ export function useProfileSync() {
         const cloudVersion = cloudProfile.version || 0
 
         // Re-check pending changes after fetch
-        if (hasPendingChanges.current) {
+        if (hasLocalProfileChanges()) {
           return
         }
 
@@ -172,7 +202,13 @@ export function useProfileSync() {
 
         // Apply if changed
         if (hasProfileChanged(cloudProfile, lastSyncedProfile.current)) {
-          applySettingsToLocal(cloudProfile)
+          isApplyingRemoteProfile.current = true
+          try {
+            applySettingsToLocal(cloudProfile)
+          } finally {
+            isApplyingRemoteProfile.current = false
+          }
+          clearLocalProfileChanged()
           lastSyncedVersion.current = cloudVersion
           lastSyncedProfile.current = cloudProfile
         }
@@ -186,7 +222,7 @@ export function useProfileSync() {
         action: 'smartSyncFromCloud',
       })
     }
-  }, [isSignedIn])
+  }, [clearLocalProfileChanged, hasLocalProfileChanges, isSignedIn])
 
   // Sync profile from local to cloud (debounced)
   const syncToCloud = useCallback(async () => {
@@ -211,7 +247,6 @@ export function useProfileSync() {
           profileSync.hasFailedRemoteDecryption() &&
           authorizationMode !== 'explicit_start_fresh'
         ) {
-          hasPendingChanges.current = false
           return
         }
 
@@ -223,7 +258,7 @@ export function useProfileSync() {
             component: 'ProfileSync',
             action: 'syncToCloud',
           })
-          hasPendingChanges.current = false
+          clearLocalProfileChanged()
           return
         }
 
@@ -244,7 +279,7 @@ export function useProfileSync() {
             lastSyncedVersion.current = result.version
           }
           lastSyncedProfile.current = localSettings
-          hasPendingChanges.current = false
+          clearLocalProfileChanged()
 
           logInfo('Profile synced to cloud', {
             component: 'ProfileSync',
@@ -259,16 +294,9 @@ export function useProfileSync() {
           component: 'ProfileSync',
           action: 'syncToCloud',
         })
-        // Keep pending changes flag on error
-      } finally {
-        if (hasPendingChanges.current) {
-          setTimeout(() => {
-            hasPendingChanges.current = false
-          }, 10000)
-        }
       }
     }, 2000) // 2 second debounce
-  }, [isSignedIn])
+  }, [clearLocalProfileChanged, isSignedIn])
 
   // Initial sync when authenticated and periodic sync (only if cloud sync is enabled)
   useEffect(() => {
@@ -288,34 +316,52 @@ export function useProfileSync() {
         component: 'useProfileSync',
         action: 'initialize',
       })
-      // Initial sync on page load - this will also set lastSyncedVersion
-      syncFromCloud().then(() => {
-        // After initial sync, get the current cloud version and profile
-        const cachedProfile = profileSync.getCachedProfile()
-        if (cachedProfile) {
-          if (cachedProfile.version) {
-            lastSyncedVersion.current = cachedProfile.version
+      if (hasLocalProfileChanges()) {
+        syncToCloud()
+      } else {
+        // Initial sync on page load - this will also set lastSyncedVersion
+        syncFromCloud().then(() => {
+          // After initial sync, get the current cloud version and profile
+          const cachedProfile = profileSync.getCachedProfile()
+          if (cachedProfile) {
+            if (cachedProfile.version) {
+              lastSyncedVersion.current = cachedProfile.version
+            }
+            lastSyncedProfile.current = cachedProfile
           }
-          lastSyncedProfile.current = cachedProfile
-        }
-      })
+        })
+      }
     }
 
     // Use smart sync at regular intervals to reduce bandwidth
     const interval = setInterval(() => {
-      smartSyncFromCloud()
+      if (hasLocalProfileChanges()) {
+        syncToCloud()
+      } else {
+        smartSyncFromCloud()
+      }
     }, CLOUD_SYNC.PROFILE_SYNC_INTERVAL)
 
     return () => clearInterval(interval)
-  }, [isSignedIn, cloudSyncEnabled, syncFromCloud, smartSyncFromCloud])
+  }, [
+    hasLocalProfileChanges,
+    isSignedIn,
+    cloudSyncEnabled,
+    syncFromCloud,
+    smartSyncFromCloud,
+    syncToCloud,
+  ])
 
   // Listen for settings changes and sync to cloud
   useEffect(() => {
     if (!isSignedIn) return
 
     const handleSettingsChange = () => {
+      if (isApplyingRemoteProfile.current) {
+        return
+      }
       // Immediately mark as pending to prevent cloud overwrites during debounce
-      hasPendingChanges.current = true
+      markLocalProfileChanged()
       syncToCloud()
     }
 
@@ -342,13 +388,19 @@ export function useProfileSync() {
         clearTimeout(syncDebounceTimer.current)
       }
     }
-  }, [isSignedIn, syncToCloud])
+  }, [isSignedIn, markLocalProfileChanged, syncToCloud])
 
   // Retry decryption when encryption key changes
   const retryDecryption = useCallback(async () => {
     const decryptedProfile = await profileSync.retryDecryptionWithNewKey()
     if (decryptedProfile) {
-      applySettingsToLocal(decryptedProfile)
+      isApplyingRemoteProfile.current = true
+      try {
+        applySettingsToLocal(decryptedProfile)
+      } finally {
+        isApplyingRemoteProfile.current = false
+      }
+      clearLocalProfileChanged()
       // Update the synced version and profile after successful decryption
       if (decryptedProfile.version) {
         lastSyncedVersion.current = decryptedProfile.version
@@ -362,7 +414,7 @@ export function useProfileSync() {
         },
       })
     }
-  }, [])
+  }, [clearLocalProfileChanged])
 
   return {
     syncFromCloud,

--- a/src/hooks/use-profile-sync.ts
+++ b/src/hooks/use-profile-sync.ts
@@ -302,11 +302,11 @@ export function useProfileSync() {
   useEffect(() => {
     if (!isSignedIn || !cloudSyncEnabled) {
       hasInitialized.current = false
-      hasPendingChanges.current = false
       lastSyncedVersion.current = 0
       lastSyncedProfile.current = null
       profileSyncCache.current.clear()
       profileSync.clearCache()
+      clearLocalProfileChanged()
       return
     }
 
@@ -344,6 +344,7 @@ export function useProfileSync() {
 
     return () => clearInterval(interval)
   }, [
+    clearLocalProfileChanged,
     hasLocalProfileChanges,
     isSignedIn,
     cloudSyncEnabled,

--- a/src/services/cloud/chat-ingestion.ts
+++ b/src/services/cloud/chat-ingestion.ts
@@ -180,13 +180,10 @@ export async function syncRemoteDeletions(
 ): Promise<void> {
   try {
     const { deletedIds } = await cloudStorage.getDeletedChatsSince(since)
-    const localChatMap = new Map(
-      (await indexedDBStorage.getAllChats()).map((chat) => [chat.id, chat]),
-    )
     const successfulIds: string[] = []
     for (const id of deletedIds) {
       try {
-        const localChat = localChatMap.get(id)
+        const localChat = await indexedDBStorage.getChat(id)
         if (localChat?.isLocalOnly) {
           continue
         }

--- a/src/services/cloud/chat-ingestion.ts
+++ b/src/services/cloud/chat-ingestion.ts
@@ -180,9 +180,17 @@ export async function syncRemoteDeletions(
 ): Promise<void> {
   try {
     const { deletedIds } = await cloudStorage.getDeletedChatsSince(since)
+    const localChatMap = new Map(
+      (await indexedDBStorage.getAllChats()).map((chat) => [chat.id, chat]),
+    )
     const successfulIds: string[] = []
     for (const id of deletedIds) {
       try {
+        const localChat = localChatMap.get(id)
+        if (localChat?.isLocalOnly) {
+          continue
+        }
+
         await indexedDBStorage.deleteChat(id)
         // Mirror the deletion into the in-memory tracker so any concurrent
         // listing/ingest pass that already observed the chat won't bring

--- a/src/services/cloud/cloud-storage.ts
+++ b/src/services/cloud/cloud-storage.ts
@@ -15,6 +15,7 @@ import { processRemoteChat, type RemoteChatData } from './chat-codec'
 const API_BASE_URL =
   process.env.NEXT_PUBLIC_API_BASE_URL || 'https://api.tinfoil.sh'
 const AUTH_INIT_WAIT_MS = 3000
+const RESTORE_DELETED_CHAT_HEADER = 'X-Restore-Deleted-Chat'
 
 export interface ChatListResponse {
   conversations: Array<{
@@ -55,6 +56,10 @@ export interface BulkUploadResponse {
   results: BulkConversationResult[]
   succeeded: number
   failed: number
+}
+
+export interface UploadChatOptions {
+  restoreDeleted?: boolean
 }
 
 export type RawChatContent =
@@ -115,7 +120,10 @@ export class CloudStorageService {
     return authTokenManager.isAuthenticated()
   }
 
-  async uploadChat(chat: StoredChat): Promise<string | null> {
+  async uploadChat(
+    chat: StoredChat,
+    options: UploadChatOptions = {},
+  ): Promise<string | null> {
     const messages: Message[] = (chat.messages as Message[]) || []
 
     await this.encryptAndUploadAttachments(messages, chat.id)
@@ -132,6 +140,9 @@ export class CloudStorageService {
     }
     if (chat.projectId) {
       headers['X-Project-Id'] = chat.projectId
+    }
+    if (options.restoreDeleted) {
+      headers[RESTORE_DELETED_CHAT_HEADER] = 'true'
     }
 
     const response = await fetch(

--- a/src/services/cloud/cloud-sync.ts
+++ b/src/services/cloud/cloud-sync.ts
@@ -11,7 +11,11 @@ import { indexedDBStorage, type StoredChat } from '../storage/indexed-db'
 import { processRemoteChat } from './chat-codec'
 import { ingestRemoteChats, syncRemoteDeletions } from './chat-ingestion'
 import { canWriteToCloud } from './cloud-key-authorization'
-import { cloudStorage, type ChatSyncStatus } from './cloud-storage'
+import {
+  cloudStorage,
+  type ChatSyncStatus,
+  type UploadChatOptions,
+} from './cloud-storage'
 import {
   reencryptAndUploadChats as doReencryptAndUpload,
   retryDecryptionWithNewKey as doRetryDecryption,
@@ -485,7 +489,10 @@ export class CloudSyncService {
     await this.uploadCoalescer.waitForAllUploads()
   }
 
-  async backupChatNow(chatId: string): Promise<void> {
+  async backupChatNow(
+    chatId: string,
+    options: UploadChatOptions = {},
+  ): Promise<void> {
     if (!(await cloudStorage.isAuthenticated())) {
       throw new Error('Authentication required for cloud sync')
     }
@@ -507,7 +514,7 @@ export class CloudSyncService {
       throw new Error('Chat is not eligible for cloud sync')
     }
 
-    await cloudStorage.uploadChat(chat)
+    await cloudStorage.uploadChat(chat, options)
 
     const newVersion = (chat.syncVersion ?? 0) + 1
     await indexedDBStorage.markAsSynced(chatId, newVersion)

--- a/src/services/cloud/cloud-sync.ts
+++ b/src/services/cloud/cloud-sync.ts
@@ -514,6 +514,10 @@ export class CloudSyncService {
       throw new Error('Chat is not eligible for cloud sync')
     }
 
+    if (streamingTracker.isStreaming(chatId)) {
+      throw new Error('Cannot sync chat while it is streaming')
+    }
+
     await cloudStorage.uploadChat(chat, options)
 
     const newVersion = (chat.syncVersion ?? 0) + 1

--- a/src/services/cloud/cloud-sync.ts
+++ b/src/services/cloud/cloud-sync.ts
@@ -485,6 +485,34 @@ export class CloudSyncService {
     await this.uploadCoalescer.waitForAllUploads()
   }
 
+  async backupChatNow(chatId: string): Promise<void> {
+    if (!(await cloudStorage.isAuthenticated())) {
+      throw new Error('Authentication required for cloud sync')
+    }
+
+    if (!(await canWriteToCloud())) {
+      throw new Error('Cloud sync key is not authorized')
+    }
+
+    if (streamingTracker.isStreaming(chatId)) {
+      throw new Error('Cannot sync chat while it is streaming')
+    }
+
+    const chat = await indexedDBStorage.getChat(chatId)
+    if (!chat) {
+      throw new Error('Chat not found')
+    }
+
+    if (!isUploadableChat(chat, isStreaming)) {
+      throw new Error('Chat is not eligible for cloud sync')
+    }
+
+    await cloudStorage.uploadChat(chat)
+
+    const newVersion = (chat.syncVersion ?? 0) + 1
+    await indexedDBStorage.markAsSynced(chatId, newVersion)
+  }
+
   private async doBackupChat(chatId: string): Promise<void> {
     try {
       if (!(await canWriteToCloud())) {

--- a/src/services/cloud/profile-settings-serializer.ts
+++ b/src/services/cloud/profile-settings-serializer.ts
@@ -180,21 +180,27 @@ export function applySettingsToLocal(settings: ProfileData): void {
     settings.additionalContext !== undefined ||
     settings.isUsingPersonalization !== undefined
 
-  // Personalization
-  if (shouldApplyPersonalization) {
-    localStorage.setItem(USER_PREFS_NICKNAME, settings.nickname ?? '')
-    localStorage.setItem(USER_PREFS_PROFESSION, settings.profession ?? '')
-    localStorage.setItem(
-      USER_PREFS_TRAITS,
-      JSON.stringify(settings.traits ?? []),
-    )
+  // Personalization: only apply fields that the cloud payload explicitly
+  // provided so a partial update never erases unrelated local values.
+  if (settings.nickname !== undefined) {
+    localStorage.setItem(USER_PREFS_NICKNAME, settings.nickname)
+  }
+  if (settings.profession !== undefined) {
+    localStorage.setItem(USER_PREFS_PROFESSION, settings.profession)
+  }
+  if (settings.traits !== undefined) {
+    localStorage.setItem(USER_PREFS_TRAITS, JSON.stringify(settings.traits))
+  }
+  if (settings.additionalContext !== undefined) {
     localStorage.setItem(
       USER_PREFS_ADDITIONAL_CONTEXT,
-      settings.additionalContext ?? '',
+      settings.additionalContext,
     )
+  }
+  if (settings.isUsingPersonalization !== undefined) {
     localStorage.setItem(
       USER_PREFS_PERSONALIZATION_ENABLED,
-      (settings.isUsingPersonalization ?? false).toString(),
+      settings.isUsingPersonalization.toString(),
     )
   }
 

--- a/src/services/cloud/profile-settings-serializer.ts
+++ b/src/services/cloud/profile-settings-serializer.ts
@@ -73,10 +73,10 @@ export function loadLocalSettings(): ProfileData {
 
   // Personalization
   const nickname = localStorage.getItem(USER_PREFS_NICKNAME)
-  if (nickname) settings.nickname = nickname
+  if (nickname !== null) settings.nickname = nickname
 
   const profession = localStorage.getItem(USER_PREFS_PROFESSION)
-  if (profession) settings.profession = profession
+  if (profession !== null) settings.profession = profession
 
   const traits = localStorage.getItem(USER_PREFS_TRAITS)
   if (traits) {
@@ -88,7 +88,7 @@ export function loadLocalSettings(): ProfileData {
   }
 
   const additionalContext = localStorage.getItem(USER_PREFS_ADDITIONAL_CONTEXT)
-  if (additionalContext) settings.additionalContext = additionalContext
+  if (additionalContext !== null) settings.additionalContext = additionalContext
 
   const isUsingPersonalization = localStorage.getItem(
     USER_PREFS_PERSONALIZATION_ENABLED,
@@ -108,7 +108,7 @@ export function loadLocalSettings(): ProfileData {
   const customSystemPrompt = localStorage.getItem(
     USER_PREFS_CUSTOM_SYSTEM_PROMPT,
   )
-  if (customSystemPrompt) {
+  if (customSystemPrompt !== null) {
     settings.customSystemPrompt = customSystemPrompt
   }
 
@@ -173,30 +173,28 @@ export function applySettingsToLocal(settings: ProfileData): void {
     )
   }
 
+  const shouldApplyPersonalization =
+    settings.nickname !== undefined ||
+    settings.profession !== undefined ||
+    settings.traits !== undefined ||
+    settings.additionalContext !== undefined ||
+    settings.isUsingPersonalization !== undefined
+
   // Personalization
-  if (settings.nickname !== undefined) {
-    localStorage.setItem(USER_PREFS_NICKNAME, settings.nickname)
-  }
-
-  if (settings.profession !== undefined) {
-    localStorage.setItem(USER_PREFS_PROFESSION, settings.profession)
-  }
-
-  if (settings.traits !== undefined) {
-    localStorage.setItem(USER_PREFS_TRAITS, JSON.stringify(settings.traits))
-  }
-
-  if (settings.additionalContext !== undefined) {
+  if (shouldApplyPersonalization) {
+    localStorage.setItem(USER_PREFS_NICKNAME, settings.nickname ?? '')
+    localStorage.setItem(USER_PREFS_PROFESSION, settings.profession ?? '')
+    localStorage.setItem(
+      USER_PREFS_TRAITS,
+      JSON.stringify(settings.traits ?? []),
+    )
     localStorage.setItem(
       USER_PREFS_ADDITIONAL_CONTEXT,
-      settings.additionalContext,
+      settings.additionalContext ?? '',
     )
-  }
-
-  if (settings.isUsingPersonalization !== undefined) {
     localStorage.setItem(
       USER_PREFS_PERSONALIZATION_ENABLED,
-      settings.isUsingPersonalization.toString(),
+      (settings.isUsingPersonalization ?? false).toString(),
     )
   }
 
@@ -236,26 +234,20 @@ export function applySettingsToLocal(settings: ProfileData): void {
   }
 
   // Trigger personalization change event
-  if (
-    settings.nickname !== undefined ||
-    settings.profession !== undefined ||
-    settings.traits !== undefined ||
-    settings.additionalContext !== undefined ||
-    settings.isUsingPersonalization !== undefined
-  ) {
+  if (shouldApplyPersonalization) {
     window.dispatchEvent(
       new CustomEvent('personalizationChanged', {
         detail: {
           nickname:
-            settings.nickname ||
-            localStorage.getItem(USER_PREFS_NICKNAME) ||
+            settings.nickname ??
+            localStorage.getItem(USER_PREFS_NICKNAME) ??
             '',
           profession:
-            settings.profession ||
-            localStorage.getItem(USER_PREFS_PROFESSION) ||
+            settings.profession ??
+            localStorage.getItem(USER_PREFS_PROFESSION) ??
             '',
           traits:
-            settings.traits ||
+            settings.traits ??
             (() => {
               try {
                 return JSON.parse(
@@ -266,12 +258,12 @@ export function applySettingsToLocal(settings: ProfileData): void {
               }
             })(),
           additionalContext:
-            settings.additionalContext ||
-            localStorage.getItem(USER_PREFS_ADDITIONAL_CONTEXT) ||
+            settings.additionalContext ??
+            localStorage.getItem(USER_PREFS_ADDITIONAL_CONTEXT) ??
             '',
           language:
-            settings.language ||
-            localStorage.getItem(USER_PREFS_LANGUAGE) ||
+            settings.language ??
+            localStorage.getItem(USER_PREFS_LANGUAGE) ??
             'English',
           isEnabled:
             settings.isUsingPersonalization ??

--- a/src/services/storage/chat-storage.ts
+++ b/src/services/storage/chat-storage.ts
@@ -273,24 +273,40 @@ export class ChatStorageService {
   async convertChatToCloud(chatId: string): Promise<void> {
     await this.initialize()
 
+    const existingChat = await indexedDBStorage.getChat(chatId)
+    if (!existingChat) {
+      throw new Error('Chat not found')
+    }
+
     await indexedDBStorage.resetChatTimestamps(chatId)
     await indexedDBStorage.updateChatLocalOnly(chatId, false)
 
-    chatEvents.emit({ reason: 'save', ids: [chatId] })
+    try {
+      await cloudSync.backupChatNow(chatId)
+    } catch (error) {
+      await indexedDBStorage.saveChat(existingChat)
+      throw error
+    }
 
-    await cloudSync.backupChat(chatId)
+    chatEvents.emit({ reason: 'save', ids: [chatId] })
   }
 
   async convertChatToLocal(chatId: string): Promise<void> {
     await this.initialize()
 
+    const existingChat = await indexedDBStorage.getChat(chatId)
+    if (!existingChat) {
+      throw new Error('Chat not found')
+    }
+
     await indexedDBStorage.resetChatTimestamps(chatId)
     await indexedDBStorage.updateChatLocalOnly(chatId, true)
     await indexedDBStorage.updateChatProject(chatId, null)
 
-    chatEvents.emit({ reason: 'save', ids: [chatId] })
-
-    cloudSync.deleteFromCloud(chatId).catch((error) => {
+    try {
+      await cloudSync.deleteFromCloud(chatId)
+    } catch (error) {
+      await indexedDBStorage.saveChat(existingChat)
       logError(
         'Failed to delete chat from cloud during local conversion',
         error,
@@ -300,7 +316,10 @@ export class ChatStorageService {
           metadata: { chatId },
         },
       )
-    })
+      throw error
+    }
+
+    chatEvents.emit({ reason: 'save', ids: [chatId] })
   }
 
   async removeChatFromProject(chatId: string): Promise<void> {

--- a/src/services/storage/chat-storage.ts
+++ b/src/services/storage/chat-storage.ts
@@ -282,7 +282,7 @@ export class ChatStorageService {
     await indexedDBStorage.updateChatLocalOnly(chatId, false)
 
     try {
-      await cloudSync.backupChatNow(chatId)
+      await cloudSync.backupChatNow(chatId, { restoreDeleted: true })
     } catch (error) {
       await indexedDBStorage.saveChat(existingChat)
       throw error

--- a/tests/services/cloud/chat-ingestion.test.ts
+++ b/tests/services/cloud/chat-ingestion.test.ts
@@ -1,0 +1,66 @@
+import { syncRemoteDeletions } from '@/services/cloud/chat-ingestion'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockGetDeletedChatsSince = vi.fn()
+const mockGetAllChats = vi.fn()
+const mockDeleteChat = vi.fn()
+const mockMarkAsDeleted = vi.fn()
+const mockEmit = vi.fn()
+
+vi.mock('@/utils/error-handling', () => ({
+  logError: vi.fn(),
+}))
+
+vi.mock('@/services/cloud/cloud-storage', () => ({
+  cloudStorage: {
+    getDeletedChatsSince: (...args: any[]) => mockGetDeletedChatsSince(...args),
+  },
+}))
+
+vi.mock('@/services/storage/indexed-db', () => ({
+  indexedDBStorage: {
+    getAllChats: (...args: any[]) => mockGetAllChats(...args),
+    deleteChat: (...args: any[]) => mockDeleteChat(...args),
+  },
+}))
+
+vi.mock('@/services/storage/deleted-chats-tracker', () => ({
+  deletedChatsTracker: {
+    markAsDeleted: (...args: any[]) => mockMarkAsDeleted(...args),
+  },
+}))
+
+vi.mock('@/services/storage/chat-events', () => ({
+  chatEvents: {
+    emit: (...args: any[]) => mockEmit(...args),
+  },
+}))
+
+vi.mock('@/services/cloud/chat-codec', () => ({
+  processRemoteChat: vi.fn(),
+}))
+
+describe('syncRemoteDeletions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockDeleteChat.mockResolvedValue(undefined)
+  })
+
+  it('preserves local-only chats when their cloud copy was deleted', async () => {
+    mockGetDeletedChatsSince.mockResolvedValue({
+      deletedIds: ['local-chat', 'cloud-chat'],
+    })
+    mockGetAllChats.mockResolvedValue([{ id: 'local-chat', isLocalOnly: true }])
+
+    await syncRemoteDeletions('2026-01-01T00:00:00.000Z', 'test')
+
+    expect(mockDeleteChat).toHaveBeenCalledTimes(1)
+    expect(mockDeleteChat).toHaveBeenCalledWith('cloud-chat')
+    expect(mockMarkAsDeleted).toHaveBeenCalledTimes(1)
+    expect(mockMarkAsDeleted).toHaveBeenCalledWith('cloud-chat')
+    expect(mockEmit).toHaveBeenCalledWith({
+      reason: 'sync',
+      ids: ['cloud-chat'],
+    })
+  })
+})

--- a/tests/services/cloud/chat-ingestion.test.ts
+++ b/tests/services/cloud/chat-ingestion.test.ts
@@ -2,7 +2,7 @@ import { syncRemoteDeletions } from '@/services/cloud/chat-ingestion'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mockGetDeletedChatsSince = vi.fn()
-const mockGetAllChats = vi.fn()
+const mockGetChat = vi.fn()
 const mockDeleteChat = vi.fn()
 const mockMarkAsDeleted = vi.fn()
 const mockEmit = vi.fn()
@@ -19,7 +19,7 @@ vi.mock('@/services/cloud/cloud-storage', () => ({
 
 vi.mock('@/services/storage/indexed-db', () => ({
   indexedDBStorage: {
-    getAllChats: (...args: any[]) => mockGetAllChats(...args),
+    getChat: (...args: any[]) => mockGetChat(...args),
     deleteChat: (...args: any[]) => mockDeleteChat(...args),
   },
 }))
@@ -50,7 +50,9 @@ describe('syncRemoteDeletions', () => {
     mockGetDeletedChatsSince.mockResolvedValue({
       deletedIds: ['local-chat', 'cloud-chat'],
     })
-    mockGetAllChats.mockResolvedValue([{ id: 'local-chat', isLocalOnly: true }])
+    mockGetChat.mockImplementation(async (id: string) =>
+      id === 'local-chat' ? { id, isLocalOnly: true } : null,
+    )
 
     await syncRemoteDeletions('2026-01-01T00:00:00.000Z', 'test')
 

--- a/tests/services/cloud/cloud-storage.test.ts
+++ b/tests/services/cloud/cloud-storage.test.ts
@@ -6,6 +6,7 @@ const mockGetAuthHeaders = vi.fn()
 const mockIsAuthenticated = vi.fn()
 const mockIsInitialized = vi.fn()
 const mockWaitForInit = vi.fn()
+const mockEncryptV1 = vi.fn()
 
 vi.mock('@/services/auth', () => ({
   authTokenManager: {
@@ -13,6 +14,12 @@ vi.mock('@/services/auth', () => ({
     isAuthenticated: (...args: any[]) => mockIsAuthenticated(...args),
     isInitialized: (...args: any[]) => mockIsInitialized(...args),
     waitForInit: (...args: any[]) => mockWaitForInit(...args),
+  },
+}))
+
+vi.mock('@/services/encryption/encryption-service', () => ({
+  encryptionService: {
+    encryptV1: (...args: any[]) => mockEncryptV1(...args),
   },
 }))
 
@@ -24,6 +31,7 @@ describe('CloudStorageService auth readiness', () => {
     mockIsAuthenticated.mockResolvedValue(true)
     mockIsInitialized.mockReturnValue(true)
     mockWaitForInit.mockResolvedValue(true)
+    mockEncryptV1.mockResolvedValue(new Uint8Array([1, 2, 3]))
     vi.stubGlobal(
       'fetch',
       vi.fn().mockResolvedValue({
@@ -61,5 +69,25 @@ describe('CloudStorageService auth readiness', () => {
     expect(isAuthenticated).toBe(true)
     expect(mockWaitForInit).toHaveBeenCalledWith(3000)
     expect(mockIsAuthenticated).toHaveBeenCalledTimes(1)
+  })
+
+  it('marks restore uploads so the backend can clear stale tombstones', async () => {
+    const service = new CloudStorageService()
+    await service.uploadChat(
+      {
+        id: 'chat-1',
+        title: 'Local chat',
+        messages: [{ role: 'user', content: 'hi' }],
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+        lastAccessedAt: 0,
+      } as any,
+      { restoreDeleted: true },
+    )
+
+    const fetchCall = vi.mocked(fetch).mock.calls[0]
+    expect(fetchCall?.[1]?.headers).toMatchObject({
+      'X-Restore-Deleted-Chat': 'true',
+    })
   })
 })

--- a/tests/services/cloud/profile-settings-serializer.test.ts
+++ b/tests/services/cloud/profile-settings-serializer.test.ts
@@ -1,0 +1,55 @@
+import {
+  USER_PREFS_ADDITIONAL_CONTEXT,
+  USER_PREFS_CUSTOM_SYSTEM_PROMPT,
+  USER_PREFS_NICKNAME,
+  USER_PREFS_PERSONALIZATION_ENABLED,
+  USER_PREFS_PROFESSION,
+  USER_PREFS_TRAITS,
+} from '@/constants/storage-keys'
+import {
+  applySettingsToLocal,
+  loadLocalSettings,
+} from '@/services/cloud/profile-settings-serializer'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+describe('profile-settings-serializer', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('preserves empty local personalization values for syncing clears', () => {
+    localStorage.setItem(USER_PREFS_NICKNAME, '')
+    localStorage.setItem(USER_PREFS_PROFESSION, '')
+    localStorage.setItem(USER_PREFS_TRAITS, JSON.stringify([]))
+    localStorage.setItem(USER_PREFS_ADDITIONAL_CONTEXT, '')
+    localStorage.setItem(USER_PREFS_CUSTOM_SYSTEM_PROMPT, '')
+    localStorage.setItem(USER_PREFS_PERSONALIZATION_ENABLED, 'false')
+
+    expect(loadLocalSettings()).toMatchObject({
+      nickname: '',
+      profession: '',
+      traits: [],
+      additionalContext: '',
+      customSystemPrompt: '',
+      isUsingPersonalization: false,
+    })
+  })
+
+  it('clears local personalization fields when the remote profile omits them', () => {
+    localStorage.setItem(USER_PREFS_NICKNAME, 'old')
+    localStorage.setItem(USER_PREFS_PROFESSION, 'old job')
+    localStorage.setItem(USER_PREFS_TRAITS, JSON.stringify(['concise']))
+    localStorage.setItem(USER_PREFS_ADDITIONAL_CONTEXT, 'old context')
+    localStorage.setItem(USER_PREFS_PERSONALIZATION_ENABLED, 'true')
+
+    applySettingsToLocal({ isUsingPersonalization: false })
+
+    expect(localStorage.getItem(USER_PREFS_NICKNAME)).toBe('')
+    expect(localStorage.getItem(USER_PREFS_PROFESSION)).toBe('')
+    expect(localStorage.getItem(USER_PREFS_TRAITS)).toBe('[]')
+    expect(localStorage.getItem(USER_PREFS_ADDITIONAL_CONTEXT)).toBe('')
+    expect(localStorage.getItem(USER_PREFS_PERSONALIZATION_ENABLED)).toBe(
+      'false',
+    )
+  })
+})

--- a/tests/services/cloud/profile-settings-serializer.test.ts
+++ b/tests/services/cloud/profile-settings-serializer.test.ts
@@ -35,19 +35,32 @@ describe('profile-settings-serializer', () => {
     })
   })
 
-  it('clears local personalization fields when the remote profile omits them', () => {
-    localStorage.setItem(USER_PREFS_NICKNAME, 'old')
-    localStorage.setItem(USER_PREFS_PROFESSION, 'old job')
+  it('keeps unspecified personalization fields intact on partial remote updates', () => {
+    localStorage.setItem(USER_PREFS_NICKNAME, 'Alice')
+    localStorage.setItem(USER_PREFS_PROFESSION, 'Dev')
     localStorage.setItem(USER_PREFS_TRAITS, JSON.stringify(['concise']))
-    localStorage.setItem(USER_PREFS_ADDITIONAL_CONTEXT, 'old context')
+    localStorage.setItem(USER_PREFS_ADDITIONAL_CONTEXT, 'context')
     localStorage.setItem(USER_PREFS_PERSONALIZATION_ENABLED, 'true')
 
-    applySettingsToLocal({ isUsingPersonalization: false })
+    applySettingsToLocal({ nickname: 'Bob' })
+
+    expect(localStorage.getItem(USER_PREFS_NICKNAME)).toBe('Bob')
+    expect(localStorage.getItem(USER_PREFS_PROFESSION)).toBe('Dev')
+    expect(localStorage.getItem(USER_PREFS_TRAITS)).toBe(
+      JSON.stringify(['concise']),
+    )
+    expect(localStorage.getItem(USER_PREFS_ADDITIONAL_CONTEXT)).toBe('context')
+    expect(localStorage.getItem(USER_PREFS_PERSONALIZATION_ENABLED)).toBe(
+      'true',
+    )
+  })
+
+  it('clears explicitly emptied personalization fields', () => {
+    localStorage.setItem(USER_PREFS_NICKNAME, 'Alice')
+
+    applySettingsToLocal({ nickname: '', isUsingPersonalization: false })
 
     expect(localStorage.getItem(USER_PREFS_NICKNAME)).toBe('')
-    expect(localStorage.getItem(USER_PREFS_PROFESSION)).toBe('')
-    expect(localStorage.getItem(USER_PREFS_TRAITS)).toBe('[]')
-    expect(localStorage.getItem(USER_PREFS_ADDITIONAL_CONTEXT)).toBe('')
     expect(localStorage.getItem(USER_PREFS_PERSONALIZATION_ENABLED)).toBe(
       'false',
     )


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes chat sync between local and cloud, protects local-only chats and profile edits, and makes restore-to-cloud reliable.

- **Bug Fixes**
  - Preserve local-only chats during remote deletion sync; skip deleting if `isLocalOnly`, without scanning all chats.
  - Export now merges local, session, and cloud chats with de-dupe by id; filters blanks/failed decrypts.
  - Profile sync: track local edits with `SYNC_PROFILE_DIRTY`, skip cloud pulls while dirty, avoid loops while applying remote, and clear the flag after successful sync/decrypt and on sign-out.
  - Personalization: remote partial updates only change fields provided; explicit empty values clear settings; loading preserves empty strings/arrays.
  - Converting chats rolls back local changes on cloud failure and waits for cloud delete before finalizing local conversion.
  - Safer uploads: block syncing a chat that is streaming or begins streaming mid-sync.

- **New Features**
  - `CloudSyncService.backupChatNow(chatId, { restoreDeleted })` for immediate, guarded uploads.
  - Cloud uploads can set `X-Restore-Deleted-Chat` so the backend clears stale tombstones when restoring a chat.
  - Added tests covering deletion sync behavior, restore header usage, and personalization serialization.

<sup>Written for commit 2e7a6565d57f5d5e8fa27ca554fca78ed4135f6d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

