### PR TITLE
Serialize chat sync uploads through queue

### DIFF
--- a/src/services/cloud/cloud-sync.ts
+++ b/src/services/cloud/cloud-sync.ts
@@ -652,11 +652,11 @@ export class CloudSyncService {
         action: 'backupUnsyncedChats',
       })
 
-      // Route each chat through doBackupChat for consistent streaming checks,
-      // upload logic, and markAsSynced handling
+      // Route each chat through the coalescer so periodic syncs share the
+      // same per-chat serialization as save-triggered uploads.
       const uploadPromises = chatsToSync.map(async (chat) => {
         try {
-          await this.doBackupChat(chat.id)
+          await this.uploadCoalescer.enqueueAndWait(chat.id)
           result.uploaded++
         } catch (error) {
           result.errors.push(
@@ -1228,9 +1228,7 @@ export class CloudSyncService {
 
       for (const chat of projectChatsToSync) {
         try {
-          // Call doBackupChat directly (not via coalescer) so we can
-          // await completion and accurately track upload results
-          await this.doBackupChat(chat.id)
+          await this.uploadCoalescer.enqueueAndWait(chat.id)
           result.uploaded++
         } catch (error) {
           result.errors.push(

--- a/src/services/cloud/upload-coalescer.ts
+++ b/src/services/cloud/upload-coalescer.ts
@@ -36,6 +36,13 @@ interface ChatUploadState {
   inFlight: Promise<void> | null
   /** Number of consecutive failures */
   failureCount: number
+  /** Last terminal upload error for this worker, if any */
+  lastError: Error | null
+  /** Waiters that want to know whether this worker ultimately succeeded */
+  resultWaiters: Array<{
+    resolve: () => void
+    reject: (error: Error) => void
+  }>
 }
 
 /**
@@ -91,6 +98,8 @@ export class UploadCoalescer {
         dirty: false,
         inFlight: null,
         failureCount: 0,
+        lastError: null,
+        resultWaiters: [],
       }
       this.states.set(chatId, state)
     }
@@ -119,9 +128,13 @@ export class UploadCoalescer {
           await this.uploadWithRetry(chatId, state)
           // Success - reset failure count
           state.failureCount = 0
+          state.lastError = null
         } catch (error) {
+          const uploadError =
+            error instanceof Error ? error : new Error(String(error))
           // Upload failed after all retries
           state.failureCount++
+          state.lastError = uploadError
           logError('Upload failed after retries', error, {
             component: 'UploadCoalescer',
             action: 'worker',
@@ -140,6 +153,15 @@ export class UploadCoalescer {
       // Worker done - clear in-flight promise
       state.inFlight = null
 
+      const resultWaiters = state.resultWaiters.splice(0)
+      for (const waiter of resultWaiters) {
+        if (state.lastError) {
+          waiter.reject(state.lastError)
+        } else {
+          waiter.resolve()
+        }
+      }
+
       // Clean up state if no longer needed.
       // Only delete from the map if this worker's generation still matches.
       // After clear(), the map may hold a new state for the same chatId
@@ -150,6 +172,22 @@ export class UploadCoalescer {
     })()
 
     state.inFlight = workerPromise
+  }
+
+  /**
+   * Enqueue a chat and wait for the coalesced worker to finish.
+   * Rejects when the worker exhausts retries without a later successful upload.
+   */
+  async enqueueAndWait(chatId: string): Promise<void> {
+    this.enqueue(chatId)
+    const state = this.states.get(chatId)
+    if (!state?.inFlight) {
+      return
+    }
+
+    await new Promise<void>((resolve, reject) => {
+      state.resultWaiters.push({ resolve, reject })
+    })
   }
 
   /**

--- a/tests/services/cloud/upload-coalescer.test.ts
+++ b/tests/services/cloud/upload-coalescer.test.ts
@@ -174,6 +174,21 @@ describe('UploadCoalescer', () => {
       // 1 initial + 2 retries = 3 total attempts
       expect(uploadFn).toHaveBeenCalledTimes(3)
     })
+
+    it('rejects enqueueAndWait after retries are exhausted', async () => {
+      const uploadFn = vi.fn().mockRejectedValue(new Error('Permanent failure'))
+      const coalescer = new UploadCoalescer(uploadFn, {
+        baseDelayMs: 100,
+        maxRetries: 1,
+      })
+
+      const uploadPromise = coalescer.enqueueAndWait('chat-1')
+      const expectation =
+        expect(uploadPromise).rejects.toThrow('Permanent failure')
+      await vi.runAllTimersAsync()
+
+      await expectation
+    })
   })
 
   describe('State tracking', () => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Serialize chat uploads via the `UploadCoalescer` queue to prevent concurrent per-chat uploads and keep periodic/project syncs consistent with save-triggered uploads. Adds `enqueueAndWait` so callers can await the queued upload and get errors after retries.

- **Bug Fixes**
  - Route periodic and project chat backups through `UploadCoalescer.enqueueAndWait`.
  - Track outcomes with `lastError` and notify waiters via `resultWaiters` to propagate success/failure.
  - Add test to ensure `enqueueAndWait` rejects when retries are exhausted.

<sup>Written for commit a0fdd65dca7b730fba3a19a6953b0fa37978a315. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

