### PR TITLE
fix: make stale passkey recovery actionable

### DIFF
--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -392,6 +392,7 @@ export function ChatInterface({
     manualRecoveryNeeded,
     passkeySetupAvailable,
     passkeySetupFailed,
+    passkeyRecoveryFailure,
     passkeyFirstTimePromptAvailable,
     setupPasskey,
     setupFirstTimePasskey,
@@ -3092,6 +3093,7 @@ export function ChatInterface({
           }
           passkeyRecoveryNeeded={passkeyRecoveryNeeded}
           manualRecoveryNeeded={manualRecoveryNeeded}
+          passkeyRecoveryFailure={passkeyRecoveryFailure}
           onSkipRecovery={() => {
             skipPasskeyRecovery()
             setShowCloudSyncSetupModal(false)

--- a/src/components/modals/cloud-sync-setup-modal.tsx
+++ b/src/components/modals/cloud-sync-setup-modal.tsx
@@ -40,6 +40,7 @@ interface CloudSyncSetupModalBaseProps {
   initialCloudSyncEnabled?: boolean
   prfSupported?: boolean
   manualRecoveryNeeded?: boolean
+  passkeyRecoveryFailure?: 'auth_failed' | 'stale_backup' | null
   /**
    * When true, the modal skips the passkey-based flow entirely and opens
    * directly on the manual "generate or restore key" step. Used when the
@@ -85,6 +86,7 @@ export function CloudSyncSetupModal({
   passkeyRecoveryNeeded = false,
   prfSupported = false,
   manualRecoveryNeeded = false,
+  passkeyRecoveryFailure = null,
   forceManualFlow = false,
   onSkipRecovery,
   onRecoverWithPasskey,
@@ -792,8 +794,9 @@ ${generatedKey.replace('key_', '')}
         <div className="flex items-start gap-2 rounded-lg border border-amber-500/30 bg-amber-500/10 p-3">
           <ExclamationTriangleIcon className="mt-0.5 h-4 w-4 flex-shrink-0 text-amber-500" />
           <p className="text-xs text-amber-700 dark:text-amber-400">
-            Passkey authentication failed. You can try again or enter your
-            encryption key manually.
+            {passkeyRecoveryFailure === 'stale_backup'
+              ? "This passkey is valid, but its backup key doesn't match your existing cloud data. Enter your backup key manually, or start fresh if you no longer need the old data."
+              : 'Passkey authentication failed. You can try again or enter your encryption key manually.'}
           </p>
         </div>
       )}

--- a/src/hooks/use-passkey-backup.ts
+++ b/src/hooks/use-passkey-backup.ts
@@ -22,6 +22,7 @@ import {
   authenticatePrfPasskey,
   createPrfPasskey,
   decryptKeyBundle,
+  deletePasskeyCredential,
   deriveKeyEncryptionKey,
   getCachedPrfResult,
   getPasskeyCredentialState,
@@ -68,7 +69,26 @@ export interface PasskeyBackupState {
    * prompt automatically on page load.
    */
   passkeyFirstTimePromptAvailable: boolean
+  /** Specific passkey recovery failure to show users a useful next step. */
+  passkeyRecoveryFailure: PasskeyRecoveryFailure | null
 }
+
+export type PasskeyRecoveryFailure = 'auth_failed' | 'stale_backup'
+
+type StoredPasskeyBackup = {
+  credentialId: string
+  syncVersion: number
+  bundleVersion: number
+}
+
+type GeneratedPasskeyKey = {
+  key: string
+  credentialId: string
+}
+
+type ApplyRecoveredKeyBundleResult =
+  | { mode: CloudKeyAuthorizationMode }
+  | { mode: null; reason: PasskeyRecoveryFailure }
 
 export interface UsePasskeyBackupOptions {
   /** Current encryption key from useCloudSync (null if not yet set) */
@@ -215,6 +235,7 @@ export function usePasskeyBackup({
     passkeySetupFailed: false,
     passkeyRetryAvailable: true,
     passkeyFirstTimePromptAvailable: false,
+    passkeyRecoveryFailure: null,
   })
 
   const isMountedRef = useRef(true)
@@ -267,6 +288,7 @@ export function usePasskeyBackup({
           passkeySetupFailed: false,
           passkeyRetryAvailable: true,
           passkeyFirstTimePromptAvailable: false,
+          passkeyRecoveryFailure: null,
         })
       }
       previousUserIdRef.current = currentUserId
@@ -308,13 +330,13 @@ export function usePasskeyBackup({
       incrementBundleVersion?: boolean
       enforceRemoteBundleVersion?: boolean
     },
-  ): Promise<boolean> => {
+  ): Promise<StoredPasskeyBackup | null> => {
     const passkeyResult = await createPrfPasskey(
       userInfo.userId,
       userInfo.userName,
       userInfo.displayName,
     )
-    if (!passkeyResult) return false
+    if (!passkeyResult) return null
 
     const kek = await deriveKeyEncryptionKey(passkeyResult.prfOutput)
     const result = await storeEncryptedKeys(
@@ -327,11 +349,15 @@ export function usePasskeyBackup({
         enforceRemoteBundleVersion: options?.enforceRemoteBundleVersion,
       },
     )
-    if (!result) return false
+    if (!result) return null
     localStorage.setItem(SECRET_PASSKEY_BACKED_UP, 'true')
     setLocalSyncVersion(passkeyResult.credentialId, result.syncVersion)
     setLocalBundleVersion(result.bundleVersion)
-    return true
+    return {
+      credentialId: passkeyResult.credentialId,
+      syncVersion: result.syncVersion,
+      bundleVersion: result.bundleVersion,
+    }
   }
 
   /**
@@ -346,7 +372,7 @@ export function usePasskeyBackup({
         incrementBundleVersion?: boolean
         enforceRemoteBundleVersion?: boolean
       },
-    ): Promise<string | null> => {
+    ): Promise<GeneratedPasskeyKey | null> => {
       const userInfo = getPasskeyUserInfo()
       if (!userInfo) return null
 
@@ -368,7 +394,7 @@ export function usePasskeyBackup({
       if (!created) return null
 
       await encryptionService.setKey(newKey)
-      return newKey
+      return { key: newKey, credentialId: created.credentialId }
     },
     [],
   )
@@ -435,6 +461,7 @@ export function usePasskeyBackup({
         passkeyActive: true,
         passkeyRecoveryNeeded: false,
         manualRecoveryNeeded: false,
+        passkeyRecoveryFailure: null,
       }))
     }
   }
@@ -453,6 +480,7 @@ export function usePasskeyBackup({
         passkeyActive: true,
         passkeyRecoveryNeeded: false,
         manualRecoveryNeeded: false,
+        passkeyRecoveryFailure: null,
       }))
     }
   }
@@ -534,7 +562,7 @@ export function usePasskeyBackup({
         primary: string | null
         alternatives: string[]
       },
-    ): Promise<CloudKeyAuthorizationMode | null> => {
+    ): Promise<ApplyRecoveredKeyBundleResult> => {
       await encryptionService.setAllKeys(bundle.primary, bundle.alternatives)
 
       const authorizationMode = getRecoveredAuthorizationMode(
@@ -544,10 +572,10 @@ export function usePasskeyBackup({
       if (authorizationMode === 'explicit_start_fresh') {
         try {
           await authorizeCurrentPrimaryKeyOrThrow('explicit_start_fresh')
-          return 'explicit_start_fresh'
+          return { mode: 'explicit_start_fresh' }
         } catch {
           await rollbackToPreviousKeys(previousKeys)
-          return null
+          return { mode: null, reason: 'stale_backup' }
         }
       }
 
@@ -556,20 +584,20 @@ export function usePasskeyBackup({
         validation = await validateCurrentPrimaryKey()
       } catch {
         await rollbackToPreviousKeys(previousKeys)
-        return null
+        return { mode: null, reason: 'auth_failed' }
       }
 
       if (!validation.canWrite) {
         await rollbackToPreviousKeys(previousKeys)
-        return null
+        return { mode: null, reason: 'stale_backup' }
       }
 
       try {
         await authorizeCurrentPrimaryKeyOrThrow('validated')
-        return 'validated'
+        return { mode: 'validated' }
       } catch {
         await rollbackToPreviousKeys(previousKeys)
-        return null
+        return { mode: null, reason: 'auth_failed' }
       }
     },
     [getRecoveredAuthorizationMode, rollbackToPreviousKeys],
@@ -580,6 +608,16 @@ export function usePasskeyBackup({
    * Called after key changes to keep the backup in sync.
    */
   const updatePasskeyBackup = useCallback(async (): Promise<void> => {
+    const markBackupUpdateNeeded = (): void => {
+      if (!isMountedRef.current) return
+      setState((prev) => ({
+        ...prev,
+        passkeySetupFailed: true,
+        passkeySetupAvailable: true,
+        passkeyRetryAvailable: true,
+      }))
+    }
+
     try {
       const authorizationMode = await getCurrentCloudKeyAuthorizationMode()
       if (!authorizationMode) return
@@ -595,7 +633,10 @@ export function usePasskeyBackup({
         cached && entries.some((e) => e.id === cached.credentialId)
           ? cached
           : await authenticatePrfPasskey(entries.map((e) => e.id))
-      if (!result) return
+      if (!result) {
+        markBackupUpdateNeeded()
+        return
+      }
 
       const kek = await deriveKeyEncryptionKey(result.prfOutput)
       const keys = encryptionService.getAllKeys()
@@ -636,9 +677,20 @@ export function usePasskeyBackup({
         },
       )
 
-      if (stored) {
-        setLocalSyncVersion(result.credentialId, stored.syncVersion)
-        setLocalBundleVersion(stored.bundleVersion)
+      if (!stored) {
+        markBackupUpdateNeeded()
+        return
+      }
+
+      setLocalSyncVersion(result.credentialId, stored.syncVersion)
+      setLocalBundleVersion(stored.bundleVersion)
+      if (isMountedRef.current) {
+        setState((prev) => ({
+          ...prev,
+          passkeySetupFailed: false,
+          passkeySetupAvailable: false,
+          passkeyActive: true,
+        }))
       }
 
       logInfo('Updated passkey backup after key change', {
@@ -658,12 +710,14 @@ export function usePasskeyBackup({
             },
           },
         )
+        markBackupUpdateNeeded()
         return
       }
       logError('Failed to update passkey backup after key change', error, {
         component: 'usePasskeyBackup',
         action: 'updatePasskeyBackup',
       })
+      markBackupUpdateNeeded()
     }
   }, [doesCurrentStateMatchBundle])
 
@@ -701,8 +755,10 @@ export function usePasskeyBackup({
       }
 
       const previousKeys = encryptionService.getAllKeys()
-      const appliedMode = await applyRecoveredKeyBundle(bundle, previousKeys)
-      if (!appliedMode) return
+      const applied = await applyRecoveredKeyBundle(bundle, previousKeys)
+      if (!applied.mode) {
+        return
+      }
 
       setLocalSyncVersion(cached.credentialId, entry.sync_version)
       if (entry.bundle_version !== undefined) {
@@ -735,16 +791,39 @@ export function usePasskeyBackup({
     // "warning dismissed" flag, so a dismissal from an earlier failure
     // flow doesn't silently suppress the warning on a new attempt.
     setupWarningDismissedFlag.clear()
+    if (isMountedRef.current) {
+      setState((prev) => ({ ...prev, passkeyRecoveryFailure: null }))
+    }
     try {
       const previousKeys = encryptionService.getAllKeys()
       const recovery = await performPasskeyRecovery()
-      if (!recovery) return null
+      if (!recovery) {
+        if (isMountedRef.current) {
+          setState((prev) => ({
+            ...prev,
+            passkeyRecoveryFailure: 'auth_failed',
+          }))
+        }
+        return null
+      }
 
-      const appliedMode = await applyRecoveredKeyBundle(
+      const applied = await applyRecoveredKeyBundle(
         recovery.keyBundle,
         previousKeys,
       )
-      if (!appliedMode) return null
+      if (!applied.mode) {
+        if (isMountedRef.current) {
+          setState((prev) => ({
+            ...prev,
+            passkeyRecoveryFailure: applied.reason,
+            manualRecoveryNeeded:
+              applied.reason === 'stale_backup'
+                ? true
+                : prev.manualRecoveryNeeded,
+          }))
+        }
+        return null
+      }
 
       applyRecoveredKeys(recovery)
       passkeyRecoveryDismissedFlag.clear()
@@ -1041,7 +1120,7 @@ export function usePasskeyBackup({
         component: 'usePasskeyBackup',
         action: 'setupNewKeySplit',
       })
-      return newKey
+      return newKey.key
     } catch (error) {
       if (error instanceof PrfNotSupportedError) throw error
       if (error instanceof PasskeyTimeoutError) throw error
@@ -1101,31 +1180,47 @@ export function usePasskeyBackup({
     }
 
     try {
-      const previousKeys = encryptionService.getAllKeys()
-      const newKey = await generateKeyWithPasskeyBackup('validated')
+      const remoteState = await inspectRemoteEncryptedState()
+      if (remoteState !== 'empty') {
+        if (isMountedRef.current) {
+          setState((prev) => ({
+            ...prev,
+            manualRecoveryNeeded: remoteState === 'exists',
+            passkeyFirstTimePromptAvailable: false,
+            passkeySetupFailed: true,
+            passkeyRetryAvailable: false,
+          }))
+        }
+        return false
+      }
 
-      if (newKey) {
-        const appliedMode = await applyRecoveredKeyBundle(
+      const previousKeys = encryptionService.getAllKeys()
+      const generated = await generateKeyWithPasskeyBackup('validated')
+
+      if (generated) {
+        const applied = await applyRecoveredKeyBundle(
           {
-            primary: newKey,
+            primary: generated.key,
             alternatives: [],
             authorizationMode: 'validated',
           },
           previousKeys,
         )
-        if (!appliedMode) {
+        if (!applied.mode) {
+          await deletePasskeyCredential(generated.credentialId)
           if (isMountedRef.current) {
             setState((prev) => ({
               ...prev,
               manualRecoveryNeeded: true,
               passkeyFirstTimePromptAvailable: false,
+              passkeyRecoveryFailure: applied.reason,
             }))
           }
           return false
         }
 
         applyNewPasskeyKey()
-        onEncryptionKeyRecoveredRef.current?.(newKey)
+        onEncryptionKeyRecoveredRef.current?.(generated.key)
         if (isMountedRef.current) {
           setState((prev) => ({
             ...prev,

--- a/src/services/passkey/index.ts
+++ b/src/services/passkey/index.ts
@@ -1,6 +1,7 @@
 export {
   PasskeyCredentialConflictError,
   decryptKeyBundle,
+  deletePasskeyCredential,
   encryptKeyBundle,
   getPasskeyCredentialState,
   hasPasskeyCredentials,

--- a/src/services/passkey/passkey-key-storage.ts
+++ b/src/services/passkey/passkey-key-storage.ts
@@ -225,6 +225,23 @@ export async function savePasskeyCredentials(
   }
 }
 
+export async function deletePasskeyCredential(
+  credentialId: string,
+): Promise<boolean> {
+  try {
+    const entries = await loadPasskeyCredentials()
+    const updated = entries.filter((entry) => entry.id !== credentialId)
+    if (updated.length === entries.length) return true
+    return await savePasskeyCredentials(updated)
+  } catch (error) {
+    logError('Failed to delete passkey credential', error, {
+      component: 'PasskeyKeyStorage',
+      action: 'deletePasskeyCredential',
+    })
+    return false
+  }
+}
+
 /**
  * Check if any passkey credentials exist for the authenticated user.
  */


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make passkey recovery failures actionable. Users now see a clear stale-backup message with a direct path to manual key entry, and we prevent orphaned credentials and stuck states.

- **Bug Fixes**
  - Differentiate recovery failures: `stale_backup` vs `auth_failed`, and surface the right next step.
  - Show a targeted stale-backup warning in the Cloud Sync modal; enable manual recovery when needed.
  - Block first-time passkey setup if remote data exists; route to manual recovery instead.
  - Delete the newly created passkey credential if applying the generated key fails to avoid orphaned entries.

- **Refactors**
  - Return structured results from backup creation and key-bundle application, including failure reasons.
  - Add and export `deletePasskeyCredential` for local storage cleanup.
  - Keep passkey backup flags in sync after key changes; reset failure state on new attempts.
  - Wire `passkeyRecoveryFailure` through `ChatInterface` to `CloudSyncSetupModal` for precise messaging.

<sup>Written for commit b096602fd883adc098e6ebaea9a49fb7501dd53f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

