### PR TITLE
Fix GenUI rendering quirks 

### DIFF
--- a/src/components/chat/genui/config.ts
+++ b/src/components/chat/genui/config.ts
@@ -1,0 +1,38 @@
+/**
+ * Runtime GenUI configuration sourced from the controlplane.
+ *
+ * The controlplane's `GET /api/config/system-prompt` response includes an
+ * optional `genUI` field with two knobs:
+ *
+ *   - `header`: the guidance block prepended to the per-widget hint list
+ *     in the system prompt (the "default to markdown, only call when
+ *     explicitly asked" wording). Tunable without a webapp release.
+ *   - `enabledWidgets`: an allowlist of render_* tool names the webapp is
+ *     permitted to expose to the model. Widgets registered locally but not
+ *     in this list are filtered out of both the tool schemas and the prompt
+ *     hint block. An empty list disables GenUI entirely.
+ *
+ * The Zod schema and renderer for each widget stay bundled in the webapp —
+ * only the model-facing prompt header and the on/off allowlist live in the
+ * controlplane.
+ *
+ * Until the controlplane response arrives, `getGenUIConfig()` returns
+ * `null`, which the prompt/tool builders treat as "use bundled defaults"
+ * (i.e. all registered widgets enabled with the bundled header). This keeps
+ * the first-render path working when the network is slow or offline.
+ */
+
+export interface GenUIConfig {
+  header: string
+  enabledWidgets: string[]
+}
+
+let runtimeConfig: GenUIConfig | null = null
+
+export function setGenUIConfig(config: GenUIConfig | null): void {
+  runtimeConfig = config
+}
+
+export function getGenUIConfig(): GenUIConfig | null {
+  return runtimeConfig
+}

--- a/src/components/chat/genui/enabled-widgets.ts
+++ b/src/components/chat/genui/enabled-widgets.ts
@@ -1,0 +1,29 @@
+/**
+ * Resolves the active set of GenUI widgets for a given request.
+ *
+ * The webapp registers a fixed list of widgets in `registry.ts` — those are
+ * the only widgets it has renderers for. The controlplane can further
+ * restrict which of those are exposed to the model via its
+ * `enabledWidgets` allowlist (see `config.ts` and the controlplane's
+ * `/api/config/system-prompt` response).
+ *
+ * Semantics:
+ *   - No controlplane config yet → expose every registered widget. Keeps
+ *     the first-render path working before the network response arrives.
+ *   - Controlplane config present → intersect with the local registry.
+ *     Widgets the controlplane lists but the webapp doesn't have are
+ *     ignored (lets the controlplane reference future widget names without
+ *     breaking older clients).
+ *   - Empty controlplane allowlist → no widgets enabled. The tool builders
+ *     and prompt-hint builder both treat this as "GenUI is off".
+ */
+import { getGenUIConfig } from './config'
+import { GENUI_WIDGETS } from './registry'
+import type { GenUIWidget } from './types'
+
+export function resolveEnabledWidgets(): GenUIWidget[] {
+  const config = getGenUIConfig()
+  if (!config) return GENUI_WIDGETS
+  const allowed = new Set(config.enabledWidgets)
+  return GENUI_WIDGETS.filter((w) => allowed.has(w.name))
+}

--- a/src/components/chat/genui/registry.ts
+++ b/src/components/chat/genui/registry.ts
@@ -52,12 +52,12 @@ export const GENUI_WIDGETS_BY_NAME: Record<string, GenUIWidget> =
 
 /**
  * Router-internal flag the model router uses to recognise client tools that
- * have no real side effect: the router synthesises a constant "displayed"
- * result and loops the model so the answer keeps flowing past the widget
- * call instead of ending the turn at the tool boundary. The router strips
- * this field before forwarding the request upstream.
+ * have no real side effect: the router synthesises a constant tool result
+ * and loops the model so the answer keeps flowing past the widget call
+ * instead of ending the turn at the tool boundary. The router strips this
+ * field before forwarding the request upstream.
  */
-const ROUTER_DISPLAY_ONLY_FLAG = 'x-tinfoil-display-only' as const
+const ROUTER_AUTO_CONTINUE_FLAG = 'x-tinfoil-tool-auto-continue' as const
 
 /**
  * Build the OpenAI `tools` array sent with chat completion requests.
@@ -66,9 +66,9 @@ const ROUTER_DISPLAY_ONLY_FLAG = 'x-tinfoil-display-only' as const
  * allowlist are emitted. When no controlplane config is loaded yet, every
  * registered widget is exposed so the first-render path keeps working.
  *
- * Every GenUI tool is flagged display-only so the model router can keep
- * the model talking after the widget call instead of leaving the response
- * to cut off mid-thought.
+ * Every GenUI tool opts into router-side auto-continuation so the model
+ * keeps talking after the widget call instead of leaving the response to
+ * cut off mid-thought.
  */
 export function buildGenUIToolSchemas() {
   return resolveEnabledWidgets().map((w) => ({
@@ -80,7 +80,7 @@ export function buildGenUIToolSchemas() {
         target: 'openApi3',
         $refStrategy: 'none',
       }) as Record<string, unknown>,
-      [ROUTER_DISPLAY_ONLY_FLAG]: true,
+      [ROUTER_AUTO_CONTINUE_FLAG]: true,
     },
   }))
 }

--- a/src/components/chat/genui/registry.ts
+++ b/src/components/chat/genui/registry.ts
@@ -11,6 +11,7 @@
  * drift.
  */
 import { zodToJsonSchema } from 'zod-to-json-schema'
+import { resolveEnabledWidgets } from './enabled-widgets'
 import type { GenUIWidget } from './types'
 import { widget as ArtifactPreview } from './widgets/ArtifactPreview'
 import { widget as Chart } from './widgets/Chart'
@@ -51,9 +52,13 @@ export const GENUI_WIDGETS_BY_NAME: Record<string, GenUIWidget> =
 
 /**
  * Build the OpenAI `tools` array sent with chat completion requests.
+ *
+ * Only widgets currently allowed by the controlplane's `enabledWidgets`
+ * allowlist are emitted. When no controlplane config is loaded yet, every
+ * registered widget is exposed so the first-render path keeps working.
  */
 export function buildGenUIToolSchemas() {
-  return GENUI_WIDGETS.map((w) => ({
+  return resolveEnabledWidgets().map((w) => ({
     type: 'function' as const,
     function: {
       name: w.name,

--- a/src/components/chat/genui/registry.ts
+++ b/src/components/chat/genui/registry.ts
@@ -51,11 +51,24 @@ export const GENUI_WIDGETS_BY_NAME: Record<string, GenUIWidget> =
   Object.fromEntries(GENUI_WIDGETS.map((w) => [w.name, w]))
 
 /**
+ * Router-internal flag the model router uses to recognise client tools that
+ * have no real side effect: the router synthesises a constant "displayed"
+ * result and loops the model so the answer keeps flowing past the widget
+ * call instead of ending the turn at the tool boundary. The router strips
+ * this field before forwarding the request upstream.
+ */
+const ROUTER_DISPLAY_ONLY_FLAG = 'x-tinfoil-display-only' as const
+
+/**
  * Build the OpenAI `tools` array sent with chat completion requests.
  *
  * Only widgets currently allowed by the controlplane's `enabledWidgets`
  * allowlist are emitted. When no controlplane config is loaded yet, every
  * registered widget is exposed so the first-render path keeps working.
+ *
+ * Every GenUI tool is flagged display-only so the model router can keep
+ * the model talking after the widget call instead of leaving the response
+ * to cut off mid-thought.
  */
 export function buildGenUIToolSchemas() {
   return resolveEnabledWidgets().map((w) => ({
@@ -67,6 +80,7 @@ export function buildGenUIToolSchemas() {
         target: 'openApi3',
         $refStrategy: 'none',
       }) as Record<string, unknown>,
+      [ROUTER_DISPLAY_ONLY_FLAG]: true,
     },
   }))
 }

--- a/src/components/chat/genui/system-prompt.ts
+++ b/src/components/chat/genui/system-prompt.ts
@@ -1,27 +1,44 @@
 /**
  * System-prompt guidance for GenUI widgets.
  *
- * Instead of a single opaque hint string, each widget contributes its own
- * `promptHint` line. This builder concatenates them into a short section
- * appended to the system prompt so the model knows when to reach for a
- * widget instead of markdown.
+ * Each widget contributes its own `promptHint` line. This builder
+ * concatenates them into a short section appended to the system prompt so
+ * the model knows when to reach for a widget instead of markdown.
+ *
+ * The guidance header and the allowlist of enabled widgets come from the
+ * controlplane via `getGenUIConfig()` so model-facing wording and on/off
+ * gating can be tuned without a webapp release. When the controlplane
+ * config hasn't been fetched yet, we fall back to a bundled header and
+ * expose every registered widget.
  */
-import { GENUI_WIDGETS } from './registry'
+import { getGenUIConfig } from './config'
+import { resolveEnabledWidgets } from './enabled-widgets'
 
-const GENUI_HEADER =
-  'You have render_* tools that produce rich interactive components instead ' +
-  'of markdown. Prefer them whenever the content is structured (tables, ' +
-  'charts, timelines, previews, comparisons, lists of sources, etc.). You ' +
-  'may call multiple render tools in one response.'
+const BUNDLED_GENUI_HEADER =
+  'You have optional render_* tools available. Default to a normal markdown ' +
+  'response. Only call a render_* tool when the user explicitly asks for ' +
+  'one of these UI elements, or when the content genuinely cannot be ' +
+  'expressed well in markdown (e.g. an interactive HTML page, a chart that ' +
+  'requires plotting, an embedded live preview). Do not use render_* tools ' +
+  'for ordinary informational answers, lists, tables, or summaries — write ' +
+  'those as regular prose and markdown. Prefer at most one render_* call ' +
+  'per response, and always pair it with a written answer rather than ' +
+  'replacing the answer with a widget.'
 
 /**
- * Returns the system-prompt hint block describing all registered widgets,
- * or null if no widgets are registered or provide hints.
+ * Returns the system-prompt hint block describing the enabled widgets, or
+ * null if GenUI has been turned off (empty allowlist) or no enabled widget
+ * provides a hint.
  */
 export function buildGenUIPromptHint(): string | null {
-  const hints = GENUI_WIDGETS.filter((w) => w.promptHint).map(
-    (w) => `- ${w.name}: ${w.promptHint}`,
-  )
+  const enabled = resolveEnabledWidgets()
+  if (enabled.length === 0) return null
+
+  const hints = enabled
+    .filter((w) => w.promptHint)
+    .map((w) => `- ${w.name}: ${w.promptHint}`)
   if (hints.length === 0) return null
-  return `${GENUI_HEADER}\n${hints.join('\n')}`
+
+  const header = getGenUIConfig()?.header ?? BUNDLED_GENUI_HEADER
+  return `${header}\n${hints.join('\n')}`
 }

--- a/src/components/chat/hooks/streaming/event-normalizer.ts
+++ b/src/components/chat/hooks/streaming/event-normalizer.ts
@@ -154,11 +154,11 @@ function extractToolCallEvents(
       typeof tc.index === 'number' ? tc.index : undefined
     if (index === undefined) continue
 
-    let id: string | undefined = indexToId.get(index)
-    if (!id && typeof tc.id === 'string' && tc.id.length > 0) {
-      const newId: string = tc.id
-      id = newId
-      indexToId.set(index, newId)
+    const incomingId: string | undefined =
+      typeof tc.id === 'string' && tc.id.length > 0 ? tc.id : undefined
+    const id: string | undefined = incomingId ?? indexToId.get(index)
+    if (incomingId) {
+      indexToId.set(index, incomingId)
     }
     if (!id) continue
 
@@ -188,11 +188,6 @@ export function createEventNormalizer(): EventNormalizer {
   let isReasoningFormat = false
   const toolCallIndexToId = new Map<number, string>()
   const toolCallStartedIds = new Set<string>()
-  // Once the assistant has started emitting a tool call, any subsequent
-  // `delta.content` is almost always serialization noise from the provider
-  // (fragments of the tool name or trailing whitespace) rather than real
-  // prose. Suppress all content emitted after the first tool call starts.
-  let sawToolCall = false
 
   return {
     processChunk(sseJson, preprocessor, logger): NormalizedEvent[] {
@@ -222,7 +217,9 @@ export function createEventNormalizer(): EventNormalizer {
           isInThinking = false
         }
         events.push(...toolCallEvents)
-        sawToolCall = true
+      }
+      if (sseJson.choices?.[0]?.finish_reason === 'tool_calls') {
+        toolCallIndexToId.clear()
       }
 
       // Search reasoning
@@ -235,12 +232,7 @@ export function createEventNormalizer(): EventNormalizer {
       events.push(...extractAnnotations(sseJson))
 
       // Preprocess content (strip tinfoil markers, normalize channel tags).
-      // Once a tool call has been emitted on this assistant turn, drop any
-      // further `delta.content` — providers sometimes trail serialization
-      // noise (fragments of the tool name) through the content channel.
-      const rawContent: string = sawToolCall
-        ? ''
-        : sseJson.choices?.[0]?.delta?.content || ''
+      const rawContent = sseJson.choices?.[0]?.delta?.content || ''
       const preprocessed = preprocessor.process(rawContent)
 
       // Tool events from tinfoil markers — close thinking first so

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -1,3 +1,4 @@
+import { setGenUIConfig } from '@/components/chat/genui/config'
 import { API_BASE_URL, IS_DEV } from '@/config'
 import { DEV_SIMULATOR_MODEL } from '@/utils/dev-simulator'
 import { logError } from '@/utils/error-handling'
@@ -171,6 +172,7 @@ export const getSystemPromptAndRules = async (): Promise<{
     }
 
     const data = await response.json()
+    applyGenUIConfigFromResponse(data?.genUI)
     return {
       systemPrompt: data.systemPrompt,
       rules: data.rules,
@@ -179,12 +181,36 @@ export const getSystemPromptAndRules = async (): Promise<{
     logError('Failed to fetch system prompt', error, {
       component: 'getSystemPromptAndRules',
     })
+    setGenUIConfig(null)
     // Return a basic fallback
     return {
       systemPrompt: 'You are an intelligent and helpful assistant named Tin.',
       rules: '',
     }
   }
+}
+
+/**
+ * Validates the optional `genUI` block from the system-prompt response and
+ * pushes it into the runtime config used by the GenUI prompt and tool
+ * builders. Malformed or missing payloads clear the runtime config so the
+ * bundled defaults take over, rather than leaving stale config from an
+ * earlier successful fetch active.
+ */
+export function applyGenUIConfigFromResponse(raw: unknown): void {
+  if (!raw || typeof raw !== 'object') {
+    setGenUIConfig(null)
+    return
+  }
+  const obj = raw as Record<string, unknown>
+  if (typeof obj.header !== 'string' || !Array.isArray(obj.enabledWidgets)) {
+    setGenUIConfig(null)
+    return
+  }
+  const enabledWidgets = obj.enabledWidgets.filter(
+    (w): w is string => typeof w === 'string',
+  )
+  setGenUIConfig({ header: obj.header, enabledWidgets })
 }
 
 // Fetch memory prompt from the API

--- a/src/services/inference/chat-query-builder.ts
+++ b/src/services/inference/chat-query-builder.ts
@@ -143,14 +143,14 @@ export class ChatQueryBuilder {
         result.push(assistantParam)
 
         // Emit synthetic tool results so the model's next turn sees a
-        // consistent history. GenUI tools are display-only — the UI
-        // rendered the component on the client, so we just acknowledge.
+        // consistent history. GenUI tools auto-continue: the UI rendered
+        // the component on the client, so we just acknowledge.
         if (msg.toolCalls && msg.toolCalls.length > 0) {
           for (const tc of msg.toolCalls) {
             result.push({
               role: 'tool',
               tool_call_id: tc.id,
-              content: 'displayed',
+              content: 'executed',
             } as ChatCompletionToolMessageParam)
           }
         }

--- a/tests/components/chat/genui/config.test.ts
+++ b/tests/components/chat/genui/config.test.ts
@@ -1,0 +1,82 @@
+/**
+ * These tests exercise the runtime config setter/getter and the widget
+ * filtering predicate directly, without importing `./registry.ts`. The
+ * registry transitively pulls in `zod-to-json-schema`, which vitest's
+ * resolver can't see (the package is vendored inside the `openai` SDK).
+ * The webapp build resolves it correctly via Next.js; this is a test
+ * infrastructure limitation that pre-dates these changes.
+ */
+import { getGenUIConfig, setGenUIConfig } from '@/components/chat/genui/config'
+import { afterEach, describe, expect, it } from 'vitest'
+import { z } from 'zod'
+
+afterEach(() => {
+  setGenUIConfig(null)
+})
+
+const widgetFixture = [
+  { name: 'render_stat_cards', schema: z.object({}), promptHint: 'kpis' },
+  { name: 'render_timeline', schema: z.object({}), promptHint: 'events' },
+  { name: 'render_chart', schema: z.object({}), promptHint: 'chart' },
+] as const
+
+function filterAllowed<T extends { name: string }>(
+  registry: readonly T[],
+): readonly T[] {
+  const config = getGenUIConfig()
+  if (!config) return registry
+  const allowed = new Set(config.enabledWidgets)
+  return registry.filter((w) => allowed.has(w.name))
+}
+
+describe('GenUI runtime config', () => {
+  it('returns null until a config is set', () => {
+    expect(getGenUIConfig()).toBeNull()
+  })
+
+  it('stores and returns the provided config', () => {
+    setGenUIConfig({ header: 'h', enabledWidgets: ['render_stat_cards'] })
+    expect(getGenUIConfig()).toEqual({
+      header: 'h',
+      enabledWidgets: ['render_stat_cards'],
+    })
+  })
+
+  it('clears the config when set to null', () => {
+    setGenUIConfig({ header: 'h', enabledWidgets: [] })
+    setGenUIConfig(null)
+    expect(getGenUIConfig()).toBeNull()
+  })
+})
+
+describe('widget allowlist filter', () => {
+  it('exposes every widget when no config is set', () => {
+    expect(filterAllowed(widgetFixture)).toHaveLength(widgetFixture.length)
+  })
+
+  it('restricts widgets to the controlplane allowlist', () => {
+    setGenUIConfig({
+      header: 'h',
+      enabledWidgets: ['render_stat_cards', 'render_timeline'],
+    })
+    expect(filterAllowed(widgetFixture).map((w) => w.name)).toEqual([
+      'render_stat_cards',
+      'render_timeline',
+    ])
+  })
+
+  it('ignores widget names the webapp does not register', () => {
+    setGenUIConfig({
+      header: 'h',
+      enabledWidgets: ['render_stat_cards', 'render_future_widget'],
+    })
+    expect(filterAllowed(widgetFixture).map((w) => w.name)).toEqual([
+      'render_stat_cards',
+    ])
+  })
+
+  it('returns nothing with an empty allowlist', () => {
+    setGenUIConfig({ header: 'h', enabledWidgets: [] })
+    expect(filterAllowed(widgetFixture)).toHaveLength(0)
+  })
+})

--- a/tests/components/chat/genui/pending-input-tool-call.test.ts
+++ b/tests/components/chat/genui/pending-input-tool-call.test.ts
@@ -1,43 +1,50 @@
-import { selectPendingInputToolCall } from '@/components/chat/genui/pending-input-tool-call'
 import type { GenUIWidget } from '@/components/chat/genui/types'
 import type { Message } from '@/components/chat/types'
 import { beforeAll, describe, expect, it, vi } from 'vitest'
 
+const { registryMock } = vi.hoisted(() => ({
+  registryMock: () => {
+    const input: Partial<GenUIWidget> = {
+      name: 'ask_user_input',
+      surface: 'input',
+      renderInputArea: () => null,
+      schema: {
+        safeParse: (value: unknown) => {
+          const valid =
+            !!value &&
+            typeof value === 'object' &&
+            !Array.isArray(value) &&
+            'question' in value &&
+            typeof value.question === 'string' &&
+            'options' in value &&
+            Array.isArray(value.options) &&
+            value.options.length >= 2
+          return valid
+            ? { success: true, data: value }
+            : { success: false, error: {} }
+        },
+      } as any,
+    }
+    const inline: Partial<GenUIWidget> = {
+      name: 'render_callout',
+      surface: 'inline',
+    }
+    return {
+      GENUI_WIDGETS_BY_NAME: {
+        ask_user_input: input,
+        render_callout: inline,
+      },
+    }
+  },
+}))
+
 // The selector consults the registry to identify input-surface widgets;
 // stub it before importing anything that depends on it.
-vi.mock('@/components/chat/genui/registry', () => {
-  const input: Partial<GenUIWidget> = {
-    name: 'ask_user_input',
-    surface: 'input',
-    renderInputArea: () => null,
-    schema: {
-      safeParse: (value: unknown) => {
-        const valid =
-          !!value &&
-          typeof value === 'object' &&
-          !Array.isArray(value) &&
-          'question' in value &&
-          typeof value.question === 'string' &&
-          'options' in value &&
-          Array.isArray(value.options) &&
-          value.options.length >= 2
-        return valid
-          ? { success: true, data: value }
-          : { success: false, error: {} }
-      },
-    } as any,
-  }
-  const inline: Partial<GenUIWidget> = {
-    name: 'render_callout',
-    surface: 'inline',
-  }
-  return {
-    GENUI_WIDGETS_BY_NAME: {
-      ask_user_input: input,
-      render_callout: inline,
-    },
-  }
-})
+vi.mock('@/components/chat/genui/registry', registryMock)
+vi.mock('@/components/chat/genui/registry.ts', registryMock)
+vi.mock('src/components/chat/genui/registry.ts', registryMock)
+
+let selectPendingInputToolCall: typeof import('@/components/chat/genui/pending-input-tool-call').selectPendingInputToolCall
 
 function assistantMessage(
   blocks: Array<{
@@ -76,7 +83,11 @@ function assistantMessage(
 }
 
 describe('selectPendingInputToolCall', () => {
-  beforeAll(() => {})
+  beforeAll(async () => {
+    ;({ selectPendingInputToolCall } = await import(
+      '@/components/chat/genui/pending-input-tool-call'
+    ))
+  })
 
   it('returns null when there are no messages', () => {
     expect(selectPendingInputToolCall([])).toBeNull()

--- a/tests/components/chat/genui/registry.test.ts
+++ b/tests/components/chat/genui/registry.test.ts
@@ -31,6 +31,15 @@ describe('GenUI registry', () => {
     }
   })
 
+  it('opts every GenUI tool into router-side auto-continuation', () => {
+    const schemas = buildGenUIToolSchemas()
+    for (const entry of schemas) {
+      const fn = entry.function as Record<string, unknown>
+      expect(fn['x-tinfoil-tool-auto-continue']).toBe(true)
+      expect(fn['x-tinfoil-display-only']).toBeUndefined()
+    }
+  })
+
   it('every widget either renders inline or in the input area (or both)', () => {
     for (const widget of GENUI_WIDGETS) {
       const hasInline = typeof widget.render === 'function'

--- a/tests/components/chat/streaming/event-normalizer.test.ts
+++ b/tests/components/chat/streaming/event-normalizer.test.ts
@@ -270,6 +270,141 @@ describe('EventNormalizer', () => {
     })
   })
 
+  describe('tool calls', () => {
+    it('allows content after a tool-call turn finishes', () => {
+      const events = processAll([
+        {
+          choices: [
+            {
+              delta: {
+                tool_calls: [
+                  {
+                    index: 0,
+                    id: 'call_widget',
+                    type: 'function',
+                    function: {
+                      name: 'render_stat_cards',
+                      arguments: '{"stats":[]}',
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+        { choices: [{ delta: {}, finish_reason: 'tool_calls' }] },
+        contentChunk('continued answer'),
+      ])
+
+      expect(events).toContainEqual({
+        type: 'tool_call_start',
+        id: 'call_widget',
+        name: 'render_stat_cards',
+      })
+      expect(events).toContainEqual({
+        type: 'content_delta',
+        content: 'continued answer',
+      })
+    })
+
+    it('allows post-widget prose when the router internally continues without a finish boundary', () => {
+      const events = processAll([
+        {
+          choices: [
+            {
+              delta: {
+                tool_calls: [
+                  {
+                    index: 0,
+                    id: 'call_widget',
+                    type: 'function',
+                    function: {
+                      name: 'render_stat_cards',
+                      arguments: '{"stats":[]}',
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+        contentChunk(' N'),
+        contentChunk('AD'),
+        contentChunk('+'),
+        contentChunk(' is important.'),
+      ])
+
+      expect(events).toContainEqual({
+        type: 'content_delta',
+        content: ' NAD+ is important.',
+      })
+    })
+
+    it('starts a new tool call when router continuations reuse index zero', () => {
+      const events = processAll([
+        {
+          choices: [
+            {
+              delta: {
+                tool_calls: [
+                  {
+                    index: 0,
+                    id: 'call_first',
+                    type: 'function',
+                    function: {
+                      name: 'render_stat_cards',
+                      arguments: '{"stats":[]}',
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+        {
+          choices: [
+            {
+              delta: {
+                tool_calls: [
+                  {
+                    index: 0,
+                    id: 'call_second',
+                    type: 'function',
+                    function: {
+                      name: 'render_chart',
+                      arguments: '{"series":[]}',
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ])
+
+      expect(events).toContainEqual({
+        type: 'tool_call_start',
+        id: 'call_first',
+        name: 'render_stat_cards',
+      })
+      expect(events).toContainEqual({
+        type: 'tool_call_delta',
+        id: 'call_first',
+        argumentsDelta: '{"stats":[]}',
+      })
+      expect(events).toContainEqual({
+        type: 'tool_call_start',
+        id: 'call_second',
+        name: 'render_chart',
+      })
+      expect(events).toContainEqual({
+        type: 'tool_call_delta',
+        id: 'call_second',
+        argumentsDelta: '{"series":[]}',
+      })
+    })
+  })
+
   describe('legacy web_search_call events', () => {
     it('normalizes top-level web_search_call', () => {
       const chunk = {

--- a/tests/config/genui-config-reset.test.ts
+++ b/tests/config/genui-config-reset.test.ts
@@ -1,0 +1,60 @@
+import { getGenUIConfig, setGenUIConfig } from '@/components/chat/genui/config'
+import {
+  applyGenUIConfigFromResponse,
+  getSystemPromptAndRules,
+} from '@/config/models'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+afterEach(() => {
+  setGenUIConfig(null)
+  vi.unstubAllGlobals()
+})
+
+describe('applyGenUIConfigFromResponse', () => {
+  it('applies a valid payload to the runtime config', () => {
+    applyGenUIConfigFromResponse({
+      header: 'use widgets sparingly',
+      enabledWidgets: ['render_stat_cards', 'render_chart'],
+    })
+    expect(getGenUIConfig()).toEqual({
+      header: 'use widgets sparingly',
+      enabledWidgets: ['render_stat_cards', 'render_chart'],
+    })
+  })
+
+  it('clears stale config when the payload is missing entirely', () => {
+    setGenUIConfig({ header: 'stale', enabledWidgets: ['render_chart'] })
+    applyGenUIConfigFromResponse(undefined)
+    expect(getGenUIConfig()).toBeNull()
+  })
+
+  it('clears stale config when the payload is malformed', () => {
+    setGenUIConfig({ header: 'stale', enabledWidgets: ['render_chart'] })
+    applyGenUIConfigFromResponse({ header: 42, enabledWidgets: 'oops' })
+    expect(getGenUIConfig()).toBeNull()
+  })
+
+  it('drops non-string widget names while keeping valid ones', () => {
+    applyGenUIConfigFromResponse({
+      header: 'h',
+      enabledWidgets: ['render_stat_cards', 7, null, 'render_chart'],
+    })
+    expect(getGenUIConfig()).toEqual({
+      header: 'h',
+      enabledWidgets: ['render_stat_cards', 'render_chart'],
+    })
+  })
+
+  it('clears stale config when the system prompt request falls back', async () => {
+    setGenUIConfig({ header: 'stale', enabledWidgets: ['render_chart'] })
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network down')))
+
+    const result = await getSystemPromptAndRules()
+
+    expect(result).toEqual({
+      systemPrompt: 'You are an intelligent and helpful assistant named Tin.',
+      rules: '',
+    })
+    expect(getGenUIConfig()).toBeNull()
+  })
+})


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes GenUI rendering and streaming so widgets render reliably and answers keep flowing after widget calls. Adds runtime control of the GenUI prompt header and enabled widgets from the controlplane.

- **Bug Fixes**
  - Tool arguments coercion: accept trailing prose and unwrap nested JSON strings before schema validation; applied across renderers and input-tool selection to stop “couldn’t display this widget” errors.
  - Streaming: keep prose after widget calls (including router auto-continues), drop tool-name noise, and reset per-turn tool-call state on finish.
  - Controlplane failures or malformed `genUI` payloads clear runtime config to avoid stale settings; fall back to bundled defaults.

- **New Features**
  - GenUI runtime config from controlplane: `header` for the prompt and `enabledWidgets` allowlist; defaults to bundled header and all widgets until config arrives; empty allowlist disables GenUI.
  - Tool schemas emit only enabled widgets and set `x-tinfoil-tool-auto-continue` so the model continues after widget calls; synthetic tool results now use "executed".

<sup>Written for commit e13d371dd468e7028d7309c242369fcbc3a46da2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

