### PR TITLE
fix: stop sidebar tab sync from breaking temporary chats

### DIFF
--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -875,6 +875,37 @@ export function ChatInterface({
     clearUrl,
   ])
 
+  // Sync document.title with the active chat's title so the browser tab
+  // reflects what the user is reading. Blank/placeholder/temporary chats fall
+  // back to the base title because their "title" is a generic label.
+  const currentChatTitle = currentChat?.title
+  const currentChatTitleState = currentChat?.titleState
+  const currentChatIsBlank = currentChat?.isBlankChat
+  const currentChatIsTemp = currentChat?.isTemporary
+  useEffect(() => {
+    if (typeof document === 'undefined') return
+
+    const base = CONSTANTS.BASE_DOCUMENT_TITLE
+    const trimmed = currentChatTitle?.trim()
+    const hasMeaningfulTitle =
+      !currentChatIsBlank &&
+      !currentChatIsTemp &&
+      currentChatTitleState !== 'placeholder' &&
+      !!trimmed &&
+      trimmed !== 'New Chat'
+
+    document.title = hasMeaningfulTitle ? `${trimmed} · ${base}` : base
+
+    return () => {
+      document.title = base
+    }
+  }, [
+    currentChatTitle,
+    currentChatTitleState,
+    currentChatIsBlank,
+    currentChatIsTemp,
+  ])
+
   // Initialize tinfoil client once when page loads
   useEffect(() => {
     const initTinfoil = async () => {

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -489,7 +489,8 @@ export function ChatInterface({
   // Temporary chat mode: when active the current chat is replaced with an
   // ephemeral in-memory chat that is never persisted (no IndexedDB, no session
   // storage, no cloud sync). Disabling restores the previously active chat.
-  const [isTemporaryMode, setIsTemporaryMode] = useState(false)
+  // The mode is derived from currentChat.isTemporary further below, after
+  // useChatState provides currentChat.
   const previousChatIdRef = useRef<string | null>(null)
 
   // Artifact-sidebar state — opened when a `render_artifact_preview` inline
@@ -766,6 +767,8 @@ export function ChatInterface({
     webSearchEnabled,
     piiCheckEnabled,
   })
+
+  const isTemporaryMode = currentChat?.isTemporary === true
 
   // Ask sidebar - ephemeral streaming only. Nothing is persisted until the
   // user clicks "Open as chat", which creates a new real chat seeded with the
@@ -1374,42 +1377,44 @@ export function ChatInterface({
   }, [createNewChat, exitProjectMode])
 
   const handleToggleTemporaryMode = useCallback(() => {
-    setIsTemporaryMode((prev) => {
-      const next = !prev
-      if (next) {
-        previousChatIdRef.current = currentChat?.id ?? null
-        const tempChat: Chat = {
-          id: `temp-${Date.now()}`,
-          title: 'Temporary Chat',
-          titleState: 'placeholder',
-          messages: [],
-          createdAt: new Date(),
-          isBlankChat: true,
-          isTemporary: true,
-        }
-        setCurrentChat(tempChat)
+    if (currentChat?.isTemporary) {
+      const previousId = previousChatIdRef.current
+      previousChatIdRef.current = null
+      const restored = previousId
+        ? chats.find((c) => c.id === previousId)
+        : undefined
+      if (restored) {
+        setCurrentChat(restored)
       } else {
-        const previousId = previousChatIdRef.current
-        const restored = previousId
-          ? chats.find((c) => c.id === previousId)
-          : undefined
-        if (restored) {
-          setCurrentChat(restored)
-        } else {
-          createNewChat(false, true)
-        }
-        previousChatIdRef.current = null
+        createNewChat(false, true)
       }
-      return next
-    })
-  }, [chats, createNewChat, currentChat?.id, setCurrentChat])
+      return
+    }
+
+    previousChatIdRef.current = currentChat?.id ?? null
+    const tempChat: Chat = {
+      id: `temp-${Date.now()}`,
+      title: 'Temporary Chat',
+      titleState: 'placeholder',
+      messages: [],
+      createdAt: new Date(),
+      isBlankChat: true,
+      isTemporary: true,
+    }
+    setCurrentChat(tempChat)
+  }, [
+    chats,
+    createNewChat,
+    currentChat?.id,
+    currentChat?.isTemporary,
+    setCurrentChat,
+  ])
 
   useEffect(() => {
-    if (isTemporaryMode && currentChat && !currentChat.isTemporary) {
-      setIsTemporaryMode(false)
+    if (!isTemporaryMode && previousChatIdRef.current) {
       previousChatIdRef.current = null
     }
-  }, [isTemporaryMode, currentChat])
+  }, [isTemporaryMode])
 
   // Handler for exiting project mode while dragging - does NOT create a new chat
   // so the drag operation can continue and drop into cloud/local tabs

--- a/src/components/chat/chat-sidebar.tsx
+++ b/src/components/chat/chat-sidebar.tsx
@@ -390,8 +390,16 @@ export function ChatSidebar({
     const shouldBeLocal = activeTab === 'local'
 
     // Only switch to blank chat if we're already on a blank chat
-    // This ensures we don't interrupt the user when they've selected a real chat
-    if (currentChat?.isBlankChat && currentChat.isLocalOnly !== shouldBeLocal) {
+    // This ensures we don't interrupt the user when they've selected a real chat.
+    // Temporary chats are also blank but must not be replaced here — doing so
+    // would silently exit temporary-chat mode whenever the active tab and the
+    // temp chat's isLocalOnly disagree (which is always, since temp chats
+    // leave isLocalOnly undefined).
+    if (
+      currentChat?.isBlankChat &&
+      !currentChat.isTemporary &&
+      currentChat.isLocalOnly !== shouldBeLocal
+    ) {
       createNewChat(shouldBeLocal, false)
     }
   }, [
@@ -402,6 +410,7 @@ export function ChatSidebar({
     createNewChat,
     currentChat?.isBlankChat,
     currentChat?.isLocalOnly,
+    currentChat?.isTemporary,
   ])
 
   // Calculate if we should show the Load More button

--- a/src/components/chat/chat-sidebar.tsx
+++ b/src/components/chat/chat-sidebar.tsx
@@ -782,7 +782,7 @@ export function ChatSidebar({
             >
               <img
                 src={isDarkMode ? '/icon-dark.png' : '/icon-light.png'}
-                alt="Tinfoil"
+                alt=""
                 className="h-6 w-6 transition-opacity group-hover/logo:opacity-0"
               />
               <GoSidebarCollapse className="absolute inset-0 m-auto h-5 w-5 text-content-secondary opacity-0 transition-opacity group-hover/logo:opacity-100" />

--- a/src/components/chat/constants.ts
+++ b/src/components/chat/constants.ts
@@ -53,4 +53,6 @@ export const CONSTANTS = {
     'How can I help you today?',
     'Your secrets are safe here...',
   ],
+  // Base document title used when no chat title is meaningful
+  BASE_DOCUMENT_TITLE: 'Tinfoil Private Chat',
 } as const


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes temporary chat stability when switching sidebar tabs and adds browser tab titles based on the selected chat. Also removes the sidebar logo alt text to prevent a brief placeholder flash.

- **Bug Fixes**
  - Derive temporary mode from `currentChat.isTemporary` and make the toggle reliably restore the previous chat or create a new one.
  - Prevent sidebar tab sync from replacing temporary blank chats.
  - Show the active chat title in the browser tab; hide the sidebar logo alt placeholder to avoid flicker.

<sup>Written for commit 975c01657333f1448ad12bb89028657146df8202. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

