### PR TITLE
Queue messages sent while the assistant is replying

### DIFF
--- a/src/components/chat/chat-input.tsx
+++ b/src/components/chat/chat-input.tsx
@@ -93,6 +93,7 @@ export function ChatInput({
   const prevInputValueRef = useRef(input)
   const shouldRemountOnClearRef = useRef(false)
   const hasInitiallyFocusedRef = useRef(false)
+  const refocusAfterResetRef = useRef(false)
 
   const useIsomorphicLayoutEffect =
     typeof window !== 'undefined' ? useLayoutEffect : useEffect
@@ -123,13 +124,24 @@ export function ChatInput({
   useEffect(() => {
     const prev = prevInputValueRef.current
     if (prev !== '' && input === '' && shouldRemountOnClearRef.current) {
+      refocusAfterResetRef.current =
+        typeof document !== 'undefined' &&
+        inputRef.current !== null &&
+        document.activeElement === inputRef.current
       setTextareaResetNonce((n) => n + 1)
     }
     prevInputValueRef.current = input
     if (input === '') {
       shouldRemountOnClearRef.current = false
     }
-  }, [input])
+  }, [input, inputRef])
+
+  useEffect(() => {
+    if (refocusAfterResetRef.current && inputRef.current) {
+      inputRef.current.focus()
+      refocusAfterResetRef.current = false
+    }
+  }, [textareaResetNonce, inputRef])
 
   // --- Speech-to-text state ---
   const [isRecording, setIsRecording] = useState(false)
@@ -757,11 +769,7 @@ export function ChatInput({
                   )
                 const hasInput = input.trim().length > 0
                 const hasQuote = Boolean(quote)
-                if (
-                  loadingState === 'idle' &&
-                  !isTranscribing &&
-                  (hasInput || hasDocuments || hasQuote)
-                ) {
+                if (!isTranscribing && (hasInput || hasDocuments || hasQuote)) {
                   shouldRemountOnClearRef.current = true
                   handleSubmit(e)
                 }
@@ -1006,50 +1014,59 @@ export function ChatInput({
                   )}
                 </button>
               )}
-              <button
-                id="send-button"
-                type="button"
-                onClick={(e) => {
-                  if (
-                    loadingState === 'loading' ||
-                    loadingState === 'retrying'
-                  ) {
-                    e.preventDefault()
-                    cancelGeneration()
-                  } else {
-                    shouldRemountOnClearRef.current = true
-                    handleSubmit(e)
-                    // On iOS Safari, forcing blur here can lead to a "dead" touch region
-                    // after the keyboard dismisses. Keep focus on mobile; desktop can blur.
-                    const isMobile =
-                      typeof navigator !== 'undefined' &&
-                      /iPhone|iPad|iPod|Android/i.test(navigator.userAgent)
-                    if (!isMobile) {
-                      inputRef.current?.blur()
+              {(() => {
+                const isBusy =
+                  loadingState === 'loading' || loadingState === 'retrying'
+                const hasCompletedDocuments = Boolean(
+                  processedDocuments &&
+                  processedDocuments.some(
+                    (doc) => !doc.isUploading && !doc.isGeneratingDescription,
+                  ),
+                )
+                const hasSubmittableContent =
+                  Boolean(input.trim()) ||
+                  Boolean(quote) ||
+                  hasCompletedDocuments
+                const showStopAction = isBusy && !hasSubmittableContent
+
+                return (
+                  <button
+                    id="send-button"
+                    type="button"
+                    onClick={(e) => {
+                      if (showStopAction) {
+                        e.preventDefault()
+                        cancelGeneration()
+                      } else {
+                        shouldRemountOnClearRef.current = true
+                        handleSubmit(e)
+                        // On iOS Safari, forcing blur here can lead to a "dead" touch region
+                        // after the keyboard dismisses. Keep focus on mobile; desktop can blur.
+                        const isMobile =
+                          typeof navigator !== 'undefined' &&
+                          /iPhone|iPad|iPod|Android/i.test(navigator.userAgent)
+                        if (!isMobile) {
+                          inputRef.current?.blur()
+                        }
+                      }
+                    }}
+                    className="group ml-2 flex h-10 w-10 items-center justify-center rounded-full bg-button-send-background text-button-send-foreground transition-colors hover:bg-button-send-background/80 disabled:opacity-50 md:h-8 md:w-8"
+                    style={{ WebkitTapHighlightColor: 'transparent' }}
+                    disabled={
+                      showStopAction
+                        ? false
+                        : isTranscribing || !hasSubmittableContent
                     }
-                  }
-                }}
-                className="group ml-2 flex h-10 w-10 items-center justify-center rounded-full bg-button-send-background text-button-send-foreground transition-colors hover:bg-button-send-background/80 disabled:opacity-50 md:h-8 md:w-8"
-                style={{ WebkitTapHighlightColor: 'transparent' }}
-                disabled={
-                  loadingState !== 'loading' &&
-                  loadingState !== 'retrying' &&
-                  (isTranscribing ||
-                    (!input.trim() &&
-                      !quote &&
-                      (!processedDocuments ||
-                        !processedDocuments.some(
-                          (doc) =>
-                            !doc.isUploading && !doc.isGeneratingDescription,
-                        ))))
-                }
-              >
-                {loadingState === 'loading' || loadingState === 'retrying' ? (
-                  <div className="h-3.5 w-3.5 bg-button-send-foreground/80 transition-colors md:h-3 md:w-3" />
-                ) : (
-                  <FiArrowUp className="h-6 w-6 text-button-send-foreground transition-colors md:h-5 md:w-5" />
-                )}
-              </button>
+                    aria-label={showStopAction ? 'Stop generation' : 'Send'}
+                  >
+                    {showStopAction ? (
+                      <div className="h-3.5 w-3.5 bg-button-send-foreground/80 transition-colors md:h-3 md:w-3" />
+                    ) : (
+                      <FiArrowUp className="h-6 w-6 text-button-send-foreground transition-colors md:h-5 md:w-5" />
+                    )}
+                  </button>
+                )
+              })()}
             </div>
           </div>
         </div>

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -100,6 +100,7 @@ import {
 import { useChatState } from './hooks/use-chat-state'
 import { useCustomSystemPrompt } from './hooks/use-custom-system-prompt'
 import { useMaxMessages } from './hooks/use-max-messages'
+import { useMessageQueue } from './hooks/use-message-queue'
 import {
   isReasoningModel,
   supportsReasoningEffort,
@@ -108,6 +109,7 @@ import {
   useThinkingEnabled,
 } from './hooks/use-reasoning-effort'
 import { useSidebarChat } from './hooks/use-sidebar-chat'
+import { MessageQueue } from './message-queue'
 import { ModelSelector } from './model-selector'
 import { QuoteSelectionPopover } from './quote-selection-popover'
 import { ReasoningEffortSelector } from './reasoning-effort-selector'
@@ -770,6 +772,44 @@ export function ChatInterface({
   })
 
   const isTemporaryMode = currentChat?.isTemporary === true
+
+  const isRateLimited = useCallback(
+    () => Boolean(rateLimit && rateLimit.remaining <= 0),
+    [rateLimit],
+  )
+
+  const handleQueueDispatch = useCallback(() => {
+    if (rateLimit) snapshotAndDecrementRemaining()
+  }, [rateLimit])
+
+  const handleQueueRateLimited = useCallback(() => {
+    if (!isSignedIn) {
+      void openSignIn()
+      return
+    }
+    setIsSidebarOpen(true)
+    window.dispatchEvent(
+      new CustomEvent('highlightSidebarBox', {
+        detail: { isPremium },
+      }),
+    )
+  }, [isSignedIn, openSignIn, setIsSidebarOpen, isPremium])
+
+  // Queue of user messages submitted while the assistant is busy. The hook
+  // observes `loadingState` and dispatches one queued message per idle
+  // window, so the user's in-progress input is never wiped.
+  const {
+    queuedMessages,
+    submit: submitMessage,
+    removeQueuedMessage,
+  } = useMessageQueue({
+    chatId: currentChat?.id ?? null,
+    loadingState,
+    handleQuery,
+    isRateLimited,
+    onBeforeDispatch: handleQueueDispatch,
+    onRateLimited: handleQueueRateLimited,
+  })
 
   // Ask sidebar - ephemeral streaming only. Nothing is persisted until the
   // user clicks "Open as chat", which creates a new real chat seeded with the
@@ -1950,17 +1990,12 @@ export function ChatInterface({
         )
       })
 
-    handleQuery(
-      messageText,
-      attachments.length > 0 ? attachments : undefined,
-      undefined,
-      undefined,
-      quote ?? undefined,
-    )
-
-    if (rateLimit) {
-      snapshotAndDecrementRemaining()
-    }
+    setInput('')
+    submitMessage({
+      text: messageText,
+      attachments,
+      quote: quote ?? undefined,
+    })
 
     // Clear the quote after submission
     if (quote) {
@@ -2961,6 +2996,10 @@ export function ChatInterface({
                       onSubmit={handleSubmit}
                       className="pointer-events-auto relative z-10 mx-auto max-w-3xl px-1 md:px-8"
                     >
+                      <MessageQueue
+                        queue={queuedMessages}
+                        onRemove={removeQueuedMessage}
+                      />
                       <ChatInput
                         input={input}
                         setInput={setInput}

--- a/src/components/chat/hooks/use-message-queue.ts
+++ b/src/components/chat/hooks/use-message-queue.ts
@@ -1,0 +1,281 @@
+import { MESSAGE_QUEUE_PREFIX } from '@/constants/storage-keys'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import type { Attachment, LoadingState, Message, QueuedMessage } from '../types'
+
+type HandleQuery = (
+  query: string,
+  attachments?: Attachment[],
+  systemPromptOverride?: string,
+  baseMessages?: Message[],
+  quote?: string,
+) => void | Promise<unknown>
+
+export type QueueSubmitInput = {
+  text: string
+  attachments?: Attachment[]
+  quote?: string
+}
+
+type UseMessageQueueArgs = {
+  chatId: string | null | undefined
+  loadingState: LoadingState
+  handleQuery: HandleQuery
+  isRateLimited: () => boolean
+  onBeforeDispatch?: () => void
+  onRateLimited?: () => void
+}
+
+type UseMessageQueueReturn = {
+  queuedMessages: QueuedMessage[]
+  submit: (input: QueueSubmitInput) => void
+  removeQueuedMessage: (id: string) => void
+}
+
+const isBrowser = typeof window !== 'undefined'
+
+function storageKeyFor(chatId: string | null | undefined): string | null {
+  return chatId ? `${MESSAGE_QUEUE_PREFIX}${chatId}` : null
+}
+
+function generateQueuedId(): string {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    return crypto.randomUUID()
+  }
+  return `queued-${Date.now()}-${Math.random().toString(36).slice(2)}`
+}
+
+function loadFromStorage(key: string | null): QueuedMessage[] {
+  if (!key || !isBrowser) return []
+  try {
+    const raw = window.sessionStorage.getItem(key)
+    if (!raw) return []
+    const parsed = JSON.parse(raw) as QueuedMessage[]
+    return Array.isArray(parsed) ? parsed : []
+  } catch {
+    return []
+  }
+}
+
+function writeToStorage(key: string | null, queue: QueuedMessage[]): void {
+  if (!key || !isBrowser) return
+  try {
+    if (queue.length === 0) {
+      window.sessionStorage.removeItem(key)
+    } else {
+      window.sessionStorage.setItem(key, JSON.stringify(queue))
+    }
+  } catch {
+    /* sessionStorage may be unavailable or full; queue stays in memory */
+  }
+}
+
+function removeFromStorage(key: string | null): void {
+  if (!key || !isBrowser) return
+  try {
+    window.sessionStorage.removeItem(key)
+  } catch {
+    /* noop */
+  }
+}
+
+/**
+ * Holds user messages submitted while the assistant is busy and dispatches
+ * them one-at-a-time through a single async pump.
+ *
+ * Why a pump instead of an effect-per-tick:
+ *
+ *   `loadingState` is shared between the in-flight stream and the queue.
+ *   Cancelling a stream (Stop button) runs a chain of cleanup code in
+ *   `handleQuery`'s catch/finally and the streaming processor's finally
+ *   that asynchronously calls `setLoadingState('idle')` AFTER the queue
+ *   has already kicked off the next dispatch. An effect that drains on
+ *   every `loading → idle` transition mistakes that stale cleanup for
+ *   "my dispatch finished" and fires the next one in parallel.
+ *
+ *   The pump avoids that race entirely: it owns the dispatch lifecycle
+ *   end-to-end. It awaits `handleQuery`'s returned promise — which only
+ *   settles when the stream we kicked off truly completes — and only
+ *   then loops to the next message. Stale `loadingState` writes from a
+ *   previously-cancelled stream can't trigger anything because nothing
+ *   observes them.
+ */
+export function useMessageQueue({
+  chatId,
+  loadingState,
+  handleQuery,
+  isRateLimited,
+  onBeforeDispatch,
+  onRateLimited,
+}: UseMessageQueueArgs): UseMessageQueueReturn {
+  const initialKey = useMemo(() => storageKeyFor(chatId), [chatId])
+
+  const [queue, setQueue] = useState<QueuedMessage[]>(() =>
+    loadFromStorage(initialKey),
+  )
+  const queueRef = useRef<QueuedMessage[]>(queue)
+  const currentKeyRef = useRef<string | null>(initialKey)
+
+  const writeQueue = useCallback(
+    (updater: (prev: QueuedMessage[]) => QueuedMessage[]) => {
+      const next = updater(queueRef.current)
+      queueRef.current = next
+      setQueue(next)
+      writeToStorage(currentKeyRef.current, next)
+    },
+    [],
+  )
+
+  // Handle chat-id changes: migrate pending items to the new key, or load
+  // the new chat's stored queue if we have nothing pending.
+  useEffect(() => {
+    const nextKey = storageKeyFor(chatId)
+    if (nextKey === currentKeyRef.current) return
+
+    const previousKey = currentKeyRef.current
+    currentKeyRef.current = nextKey
+
+    if (queueRef.current.length > 0) {
+      removeFromStorage(previousKey)
+      writeToStorage(nextKey, queueRef.current)
+      return
+    }
+
+    const loaded = loadFromStorage(nextKey)
+    queueRef.current = loaded
+    setQueue(loaded)
+  }, [chatId])
+
+  const handleQueryRef = useRef(handleQuery)
+  const isRateLimitedRef = useRef(isRateLimited)
+  const onBeforeDispatchRef = useRef(onBeforeDispatch)
+  const onRateLimitedRef = useRef(onRateLimited)
+  useEffect(() => {
+    handleQueryRef.current = handleQuery
+    isRateLimitedRef.current = isRateLimited
+    onBeforeDispatchRef.current = onBeforeDispatch
+    onRateLimitedRef.current = onRateLimited
+  })
+
+  // Live mirror of `loadingState`, used by the pump to gate the next
+  // dispatch on the chat actually being idle.
+  const loadingStateRef = useRef<LoadingState>(loadingState)
+  // Pending resolvers for `waitForIdle`. Resolved whenever the chat
+  // transitions to `'idle'`.
+  const idleWaitersRef = useRef<Array<() => void>>([])
+  useEffect(() => {
+    loadingStateRef.current = loadingState
+    if (loadingState === 'idle' && idleWaitersRef.current.length > 0) {
+      const waiters = idleWaitersRef.current
+      idleWaitersRef.current = []
+      for (const resolve of waiters) resolve()
+    }
+  }, [loadingState])
+
+  const waitForIdle = useCallback((): Promise<void> => {
+    if (loadingStateRef.current === 'idle') return Promise.resolve()
+    return new Promise<void>((resolve) => {
+      idleWaitersRef.current.push(resolve)
+    })
+  }, [])
+
+  // Rate-limit prompt latch: show at most once per exhaustion window.
+  const rateLimitPromptShownRef = useRef(false)
+  useEffect(() => {
+    if (!isRateLimited()) {
+      rateLimitPromptShownRef.current = false
+    }
+  })
+
+  // Single-flight pump. While running, it owns the dispatch lifecycle and
+  // drains the queue one message at a time. Awaiting `handleQuery`'s
+  // promise is the only serialization signal we trust — it resolves
+  // exactly once, when the stream we kicked off completes (success,
+  // error, or abort).
+  const pumpRunningRef = useRef(false)
+
+  const runPump = useCallback(async (): Promise<void> => {
+    if (pumpRunningRef.current) return
+    pumpRunningRef.current = true
+    try {
+      while (queueRef.current.length > 0) {
+        await waitForIdle()
+
+        if (isRateLimitedRef.current()) {
+          if (!rateLimitPromptShownRef.current) {
+            rateLimitPromptShownRef.current = true
+            onRateLimitedRef.current?.()
+          }
+          return
+        }
+        rateLimitPromptShownRef.current = false
+
+        const [next, ...rest] = queueRef.current
+        if (!next) break
+        writeQueue(() => rest)
+        onBeforeDispatchRef.current?.()
+
+        try {
+          const result = handleQueryRef.current(
+            next.text,
+            next.attachments,
+            undefined,
+            undefined,
+            next.quote,
+          )
+          if (
+            result &&
+            typeof (result as Promise<unknown>).then === 'function'
+          ) {
+            await (result as Promise<unknown>)
+          }
+        } catch {
+          /* errors are surfaced by the chat itself; keep draining */
+        }
+      }
+    } finally {
+      pumpRunningRef.current = false
+      // If something was enqueued while the pump was tearing down,
+      // restart it on the next tick.
+      if (queueRef.current.length > 0) {
+        queueMicrotask(() => {
+          void runPump()
+        })
+      }
+    }
+  }, [waitForIdle, writeQueue])
+
+  const submit = useCallback(
+    (input: QueueSubmitInput): void => {
+      const item: QueuedMessage = {
+        id: generateQueuedId(),
+        text: input.text,
+        attachments:
+          input.attachments && input.attachments.length > 0
+            ? input.attachments
+            : undefined,
+        quote: input.quote ?? undefined,
+      }
+      writeQueue((prev) => [...prev, item])
+      void runPump()
+    },
+    [writeQueue, runPump],
+  )
+
+  // Restart the pump if there's something queued (e.g. left over in
+  // sessionStorage from a previous session) and we're idle on mount or
+  // after a chat switch.
+  useEffect(() => {
+    if (queue.length > 0 && !pumpRunningRef.current) {
+      void runPump()
+    }
+  }, [queue, runPump])
+
+  const removeQueuedMessage = useCallback(
+    (id: string): void => {
+      writeQueue((prev) => prev.filter((item) => item.id !== id))
+    },
+    [writeQueue],
+  )
+
+  return { queuedMessages: queue, submit, removeQueuedMessage }
+}

--- a/src/components/chat/message-queue.tsx
+++ b/src/components/chat/message-queue.tsx
@@ -1,0 +1,57 @@
+import { cn } from '@/components/ui/utils'
+import { TrashIcon } from '@heroicons/react/24/outline'
+import { HiOutlineQueueList } from 'react-icons/hi2'
+import type { QueuedMessage } from './types'
+
+const QUEUED_PREVIEW_MAX_LENGTH = 240
+
+type MessageQueueProps = {
+  queue: QueuedMessage[]
+  onRemove: (id: string) => void
+}
+
+export function MessageQueue({ queue, onRemove }: MessageQueueProps) {
+  if (queue.length === 0) return null
+
+  return (
+    <div className="mb-2 flex flex-col items-center gap-1.5 px-6 md:px-8">
+      {queue.map((item) => {
+        const previewText = item.text.trim()
+        const truncated =
+          previewText.length > QUEUED_PREVIEW_MAX_LENGTH
+            ? `${previewText.slice(0, QUEUED_PREVIEW_MAX_LENGTH).trimEnd()}…`
+            : previewText
+        const attachmentCount = item.attachments?.length ?? 0
+        const hasQuote = Boolean(item.quote)
+        const fallbackLabel =
+          attachmentCount > 0
+            ? `${attachmentCount} attachment${attachmentCount === 1 ? '' : 's'}`
+            : hasQuote
+              ? 'Quoted reply'
+              : 'Queued message'
+
+        return (
+          <div
+            key={item.id}
+            className={cn(
+              'group flex w-full items-start gap-2 rounded-2xl border border-border-subtle bg-surface-chat px-3 py-2 shadow-sm',
+            )}
+          >
+            <HiOutlineQueueList className="mt-0.5 h-4 w-4 flex-shrink-0 text-content-secondary" />
+            <p className="line-clamp-2 flex-1 whitespace-pre-wrap break-words text-sm text-content-secondary">
+              {truncated || fallbackLabel}
+            </p>
+            <button
+              type="button"
+              onClick={() => onRemove(item.id)}
+              aria-label="Remove queued message"
+              className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full text-content-secondary transition-colors hover:bg-surface-chat-background hover:text-content-primary"
+            >
+              <TrashIcon className="h-3.5 w-3.5" />
+            </button>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/components/chat/types.ts
+++ b/src/components/chat/types.ts
@@ -157,6 +157,13 @@ export type Chat = {
 
 export type LoadingState = 'idle' | 'loading' | 'streaming' | 'retrying'
 
+export type QueuedMessage = {
+  id: string
+  text: string
+  attachments?: Attachment[]
+  quote?: string
+}
+
 export type AIModel = string
 
 export type ModelInfo = {

--- a/src/constants/storage-keys.ts
+++ b/src/constants/storage-keys.ts
@@ -119,3 +119,6 @@ export const UI_EXPAND_PROJECT_DOCUMENTS = 'tinfoil-ui-expand-project-documents'
 // --- sessionStorage: Sync --------------------------------------------------
 export const SYNC_SESSION_CHATS = 'tinfoil-sync-session-chats'
 export const SYNC_DELETED_CHATS = 'tinfoil-sync-deleted-chats'
+
+// --- sessionStorage: Message queue -----------------------------------------
+export const MESSAGE_QUEUE_PREFIX = 'tinfoil-message-queue:'


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Queues messages sent while the assistant is replying so users can keep typing. Adds a compact per‑chat queue above the input, persists in `sessionStorage`, and drains one‑by‑one with rate‑limit gating to avoid parallel sends and Stop races.

- **New Features**
  - Queue on Enter/Send when busy; keep attachments and quotes; clear input; restore focus after reset.
  - Add `MessageQueue` above `ChatInput` with short preview and a remove button; inset styling; queue persists per chat and migrates on chat switch.
  - Dispatch via `useMessageQueue` pump; wait for idle, pause on rate‑limit, prompt sign‑in/upgrade once, decrement remaining on dispatch, and resume when limits allow.

- **Bug Fixes**
  - Allow sending while replying: Send now queues if there’s content; show Stop only when there’s nothing to send; respect attachment readiness.
  - Drain exactly one message at a time by holding a single in‑flight dispatch, preventing parallel sends and post‑Stop stale‑idle triggers.

<sup>Written for commit 3fb787da0f628508d4401cf5aaac3e25c1a85953. Summary will update on new commits. <a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/376?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

