### PR TITLE
Code Exec file uploads

### DIFF
--- a/src/components/chat/attachment-helpers.ts
+++ b/src/components/chat/attachment-helpers.ts
@@ -1,4 +1,5 @@
-import type { Attachment, Message } from './types'
+import { CONSTANTS } from './constants'
+import type { Attachment, DocumentPage, Message } from './types'
 
 /**
  * Extract image attachments from a message, handling both new and legacy formats.
@@ -84,6 +85,54 @@ function extractImageDescription(
   const rest = multimodalText.slice(idx + marker.length)
   const nextImg = rest.indexOf('\n\nImage: ')
   return (nextImg === -1 ? rest : rest.slice(0, nextImg)).trim() || undefined
+}
+
+// Rough chars-per-token ratio used by the rest of the chat surface
+// (see estimateTokenCount in chat-interface.tsx). Inlined here so this
+// helper stays a pure leaf module.
+const CHARS_PER_TOKEN = 4
+
+export interface TruncateForCodeExecResult {
+  content: string
+  pages?: DocumentPage[]
+  truncated: boolean
+}
+
+/**
+ * Cap a docling result so a single attachment can't dominate the
+ * model's context window. Only invoked when the eager bucket upload
+ * succeeded — the truncation footer points the model at the full file
+ * in `/user-uploads/<fileName>`.
+ *
+ * Text-only docs: slice `content` to a token cap and append a footer.
+ * Multimodal docs (pages present): cap the pages array to a page count;
+ * the per-attachment `/user-uploads` hint emitted by chat-query-builder
+ * carries the "rest of the file lives in the sandbox" signal there, so
+ * no per-page footer is needed.
+ */
+export function truncateForCodeExec(opts: {
+  content: string
+  pages?: DocumentPage[]
+  fileName: string
+}): TruncateForCodeExecResult {
+  const { content, pages, fileName } = opts
+  const charCap = CONSTANTS.CODE_EXEC_TEXT_TOKEN_CAP_PER_FILE * CHARS_PER_TOKEN
+  const contentOver = content.length > charCap
+  const pagesOver =
+    !!pages && pages.length > CONSTANTS.CODE_EXEC_MAX_PAGES_PER_FILE
+
+  if (!contentOver && !pagesOver) {
+    return { content, pages, truncated: false }
+  }
+
+  const footer = `\n\n[...truncated. Full file at /user-uploads/${fileName} — read it with bash/python in the code execution environment.]`
+  return {
+    content: contentOver ? content.slice(0, charCap) + footer : content,
+    pages: pagesOver
+      ? pages!.slice(0, CONSTANTS.CODE_EXEC_MAX_PAGES_PER_FILE)
+      : pages,
+    truncated: true,
+  }
 }
 
 /**

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -300,8 +300,9 @@ export function ChatInterface({
 }: ChatInterfaceProps) {
   const { toast } = useToast()
   const { isSignedIn, isLoaded: isAuthLoaded } = useAuth()
-  // TODO: unflip this
-  const canUseCodeExecution = false
+  // Code execution requires a chat encryption key derived from the
+  // signed-in user's passkey, so it's only available to signed-in users.
+  const canUseCodeExecution = isSignedIn
   const { user } = useUser()
   const { openSignIn } = useClerk()
   const [failedImages, setFailedImages] = useState<Record<string, boolean>>({})
@@ -968,9 +969,8 @@ export function ChatInterface({
   useEffect(() => {
     const initTinfoil = async () => {
       try {
-        const { getVerificationDocument } = await import(
-          '@/services/inference/tinfoil-client'
-        )
+        const { getVerificationDocument } =
+          await import('@/services/inference/tinfoil-client')
         const doc = await getVerificationDocument()
         if (doc) {
           setVerificationDocument(doc)

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -54,6 +54,7 @@ import { ENCRYPTION_KEY_CHANGED_EVENT } from '@/services/encryption/encryption-s
 
 import { cloudSync } from '@/services/cloud/cloud-sync'
 import { encryptionService } from '@/services/encryption/encryption-service'
+import { uploadAttachmentToBucket } from '@/services/exec-snapshot/upload-attachment-to-bucket'
 import { chatStorage } from '@/services/storage/chat-storage'
 import { indexedDBStorage } from '@/services/storage/indexed-db'
 import {
@@ -247,6 +248,8 @@ function buildAttachment(opts: {
   textContent?: string
   description?: string
   pages?: DocumentPage[]
+  fileAccessToken?: string
+  sha256?: string
 }): Attachment | undefined {
   if (opts.imageData) {
     return {
@@ -257,6 +260,8 @@ function buildAttachment(opts: {
       base64: opts.imageData.base64,
       thumbnailBase64: opts.imageData.thumbnailBase64,
       description: opts.description ?? opts.fileName,
+      fileAccessToken: opts.fileAccessToken,
+      sha256: opts.sha256,
     }
   }
   // Synthesize textContent from pages when the document was uploaded in
@@ -275,6 +280,8 @@ function buildAttachment(opts: {
       fileName: opts.fileName,
       textContent: textContent || undefined,
       pages: opts.pages,
+      fileAccessToken: opts.fileAccessToken,
+      sha256: opts.sha256,
     }
   }
   return undefined
@@ -1689,9 +1696,39 @@ export function ChatInterface({
         },
       ])
 
+      // Kick off the bucket upload in parallel with docling/image processing.
+      // Gated on the same condition that lets the user enable the toggle —
+      // signed-in users with a derived encryption key. Failures are
+      // non-fatal: the attachment still works for non-code-exec purposes.
+      const bucketUploadPromise: Promise<{
+        fileAccessToken: string
+        sha256: string
+      } | null> =
+        canEnableCodeExecution && codeExecutionEncryptionKey
+          ? (async () => {
+              try {
+                const bearer = await getSessionToken()
+                if (!bearer) return null
+                return await uploadAttachmentToBucket(
+                  file,
+                  codeExecutionEncryptionKey,
+                  bearer,
+                )
+              } catch (err) {
+                logError('Bucket upload for /user-uploads failed', err, {
+                  component: 'ChatInterface',
+                  action: 'uploadAttachmentToBucket',
+                  metadata: { fileName: file.name },
+                })
+                return null
+              }
+            })()
+          : Promise.resolve(null)
+
       await handleDocumentUpload(
         file,
-        (content, documentId, imageData, hasDescription, pages) => {
+        async (content, documentId, imageData, hasDescription, pages) => {
+          const bucketResult = await bucketUploadPromise
           const newDocTokens = estimateTokenCount(content)
           const contextLimit = parseContextWindowTokens(
             selectedModelDetails?.contextWindow,
@@ -1725,6 +1762,8 @@ export function ChatInterface({
             textContent: content ?? undefined,
             description: hasDescription && content ? content : undefined,
             pages,
+            fileAccessToken: bucketResult?.fileAccessToken,
+            sha256: bucketResult?.sha256,
           })
 
           setProcessedDocuments((prev) => {
@@ -1782,6 +1821,8 @@ export function ChatInterface({
       )
     },
     [
+      canEnableCodeExecution,
+      codeExecutionEncryptionKey,
       handleDocumentUpload,
       processedDocuments,
       selectedModelDetails?.contextWindow,

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -1710,14 +1710,27 @@ export function ChatInterface({
         sha256: string
       } | null> = (() => {
         if (!canEnableCodeExecution || !codeExecutionEncryptionKey) {
+          const reasons: string[] = []
+          if (!isSignedIn) reasons.push('not signed in')
+          if (!codeExecutionEncryptionKey)
+            reasons.push('chat encryption key not derived')
+          const why = reasons.join('; ') || 'feature gate off'
           logInfo('Bucket upload skipped (gate off)', {
             component: 'ChatInterface',
             action: 'uploadAttachmentToBucket',
             metadata: {
               fileName: file.name,
-              canEnableCodeExecution,
+              isSignedIn,
+              canUseCodeExecution,
               hasEncryptionKey: !!codeExecutionEncryptionKey,
+              why,
             },
+          })
+          toast({
+            title: `Bucket upload skipped: ${file.name}`,
+            description: why,
+            variant: 'destructive',
+            position: 'top-left',
           })
           return Promise.resolve(null)
         }

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -33,6 +33,7 @@ import { IoShareOutline } from 'react-icons/io5'
 import { PiFilePlusLight, PiNotePencilLight, PiSpinner } from 'react-icons/pi'
 import { SlGhost } from 'react-icons/sl'
 
+import { truncateForCodeExec } from '@/components/chat/attachment-helpers'
 import {
   RateLimitBanner,
   shouldShowRateLimitBanner,
@@ -1729,29 +1730,46 @@ export function ChatInterface({
         file,
         async (content, documentId, imageData, hasDescription, pages) => {
           const bucketResult = await bucketUploadPromise
-          const newDocTokens = estimateTokenCount(content)
-          const contextLimit = parseContextWindowTokens(
-            selectedModelDetails?.contextWindow,
-          )
 
-          const existingTokens = processedDocuments.reduce(
-            (total, doc) => total + estimateTokenCount(doc.content),
-            0,
-          )
-
-          if (existingTokens + newDocTokens > contextLimit) {
-            setProcessedDocuments((prev) =>
-              prev.filter((doc) => doc.id !== tempDocId),
+          // Documents that landed in the buckets enclave can be capped
+          // per-file: the model reads the rest from /user-uploads via
+          // code execution. Without that fallback, fall through to the
+          // existing whole-context budget check.
+          let finalContent = content
+          let finalPages = pages
+          if (bucketResult && !imageData) {
+            const truncated = truncateForCodeExec({
+              content: content ?? '',
+              pages,
+              fileName: file.name,
+            })
+            finalContent = truncated.content
+            finalPages = truncated.pages
+          } else {
+            const newDocTokens = estimateTokenCount(content)
+            const contextLimit = parseContextWindowTokens(
+              selectedModelDetails?.contextWindow,
             )
 
-            toast({
-              title: 'Context window saturated',
-              description:
-                "The selected model's context window is full. Remove a document or choose a model with a larger context window before uploading more files.",
-              variant: 'destructive',
-              position: 'top-left',
-            })
-            return
+            const existingTokens = processedDocuments.reduce(
+              (total, doc) => total + estimateTokenCount(doc.content),
+              0,
+            )
+
+            if (existingTokens + newDocTokens > contextLimit) {
+              setProcessedDocuments((prev) =>
+                prev.filter((doc) => doc.id !== tempDocId),
+              )
+
+              toast({
+                title: 'Context window saturated',
+                description:
+                  "The selected model's context window is full. Remove a document or choose a model with a larger context window before uploading more files.",
+                variant: 'destructive',
+                position: 'top-left',
+              })
+              return
+            }
           }
 
           // Build an Attachment object from the upload result
@@ -1759,9 +1777,10 @@ export function ChatInterface({
             id: documentId,
             fileName: file.name,
             imageData: imageData ?? undefined,
-            textContent: content ?? undefined,
-            description: hasDescription && content ? content : undefined,
-            pages,
+            textContent: finalContent ?? undefined,
+            description:
+              hasDescription && finalContent ? finalContent : undefined,
+            pages: finalPages,
             fileAccessToken: bucketResult?.fileAccessToken,
             sha256: bucketResult?.sha256,
           })
@@ -1773,11 +1792,11 @@ export function ChatInterface({
                     id: documentId,
                     name: file.name,
                     time: new Date(),
-                    content,
+                    content: finalContent,
                     imageData,
                     attachment,
                     isImageDescription: !!imageData,
-                    hasDescription: hasDescription ?? !!content,
+                    hasDescription: hasDescription ?? !!finalContent,
                     isGeneratingDescription: false,
                   }
                 : doc,

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -62,7 +62,7 @@ import {
   isCloudSyncEnabled,
   setCloudSyncEnabled,
 } from '@/utils/cloud-sync-settings'
-import { logError } from '@/utils/error-handling'
+import { logError, logInfo } from '@/utils/error-handling'
 import { isSupportedFile } from '@/utils/file-types'
 import {
   getProjectUploadPreference,
@@ -1701,30 +1701,93 @@ export function ChatInterface({
       // Gated on the same condition that lets the user enable the toggle —
       // signed-in users with a derived encryption key. Failures are
       // non-fatal: the attachment still works for non-code-exec purposes.
+      //
+      // Observability: toasts + logInfo on every outcome (skipped,
+      // started, succeeded, failed) so we can see end-to-end behavior on
+      // preview without needing browser network-tab access.
       const bucketUploadPromise: Promise<{
         fileAccessToken: string
         sha256: string
-      } | null> =
-        canEnableCodeExecution && codeExecutionEncryptionKey
-          ? (async () => {
-              try {
-                const bearer = await getSessionToken()
-                if (!bearer) return null
-                return await uploadAttachmentToBucket(
-                  file,
-                  codeExecutionEncryptionKey,
-                  bearer,
-                )
-              } catch (err) {
-                logError('Bucket upload for /user-uploads failed', err, {
-                  component: 'ChatInterface',
-                  action: 'uploadAttachmentToBucket',
-                  metadata: { fileName: file.name },
-                })
-                return null
-              }
-            })()
-          : Promise.resolve(null)
+      } | null> = (() => {
+        if (!canEnableCodeExecution || !codeExecutionEncryptionKey) {
+          logInfo('Bucket upload skipped (gate off)', {
+            component: 'ChatInterface',
+            action: 'uploadAttachmentToBucket',
+            metadata: {
+              fileName: file.name,
+              canEnableCodeExecution,
+              hasEncryptionKey: !!codeExecutionEncryptionKey,
+            },
+          })
+          return Promise.resolve(null)
+        }
+
+        logInfo('Bucket upload starting', {
+          component: 'ChatInterface',
+          action: 'uploadAttachmentToBucket',
+          metadata: { fileName: file.name, fileSize: file.size },
+        })
+
+        return (async () => {
+          try {
+            const bearer = await getSessionToken()
+            if (!bearer) {
+              const msg = 'no auth bearer'
+              logError('Bucket upload aborted: no bearer', undefined, {
+                component: 'ChatInterface',
+                action: 'uploadAttachmentToBucket',
+                metadata: { fileName: file.name },
+              })
+              toast({
+                title: `Bucket upload failed: ${file.name}`,
+                description: msg,
+                variant: 'destructive',
+                position: 'top-left',
+              })
+              return null
+            }
+            const result = await uploadAttachmentToBucket(
+              file,
+              codeExecutionEncryptionKey,
+              bearer,
+            )
+            // The exact hint string chat-query-builder will inject into
+            // the user message for this attachment (text-only doc form;
+            // multimodal variants append a slight rephrasing).
+            const promptHint = `Available in code execution environment at: /user-uploads/${file.name}`
+            logInfo('Bucket upload succeeded', {
+              component: 'ChatInterface',
+              action: 'uploadAttachmentToBucket',
+              metadata: {
+                fileName: file.name,
+                fileAccessToken: result.fileAccessToken,
+                sha256: result.sha256,
+                promptHint,
+              },
+            })
+            toast({
+              title: `Bucket upload OK: ${file.name}`,
+              description: `accessToken: ${result.fileAccessToken}\nsha256: ${result.sha256}\nmodel will see: "${promptHint}"`,
+              position: 'top-left',
+            })
+            return result
+          } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err)
+            logError('Bucket upload for /user-uploads failed', err, {
+              component: 'ChatInterface',
+              action: 'uploadAttachmentToBucket',
+              metadata: { fileName: file.name, error: msg },
+            })
+            toast({
+              title: `Bucket upload failed: ${file.name}`,
+              description: msg,
+              variant: 'destructive',
+              position: 'top-left',
+            })
+            return null
+          }
+        })()
+      })()
 
       await handleDocumentUpload(
         file,

--- a/src/components/chat/constants.ts
+++ b/src/components/chat/constants.ts
@@ -10,6 +10,12 @@ export const CONSTANTS = {
   MAX_MESSAGE_LENGTH: 4000,
   MAX_DOCUMENT_SIZE_MB: 10, // Display value for error messages
   MAX_DOCUMENT_SIZE_BYTES: 11 * 1024 * 1024, // Actual limit: 11MB to tolerate ~10.5MB files
+  // Per-file caps applied when the code-exec bucket upload has succeeded
+  // and the model can fall back to reading the rest from /user-uploads.
+  // Text cap is on md_content tokens; page cap governs multimodal docs
+  // where each rendered page-image is the dominant token cost.
+  CODE_EXEC_TEXT_TOKEN_CAP_PER_FILE: 10000,
+  CODE_EXEC_MAX_PAGES_PER_FILE: 10,
   // Maximum number of messages to include in the context window (user can override in settings)
   MAX_PROMPT_MESSAGES: 75,
   MAX_PROMPT_MESSAGES_LIMIT: 200,

--- a/src/components/chat/hooks/use-chat-messaging.ts
+++ b/src/components/chat/hooks/use-chat-messaging.ts
@@ -552,6 +552,29 @@ export function useChatMessaging({
             )) ?? undefined)
           : undefined
 
+        // Walk every message's attachments and collect the ones that
+        // were successfully pre-uploaded to buckets at attach time.
+        // The orchestrator's protocol is a full reconciliation, so
+        // sending the chat's complete set every turn is correct;
+        // unchanged files are skipped server-side via sha match.
+        const codeExecutionUploads = codeExecutionEnabled
+          ? updatedMessages
+              .flatMap((m) => m.attachments ?? [])
+              .filter(
+                (
+                  a,
+                ): a is typeof a & {
+                  fileAccessToken: string
+                  sha256: string
+                } => !!a.fileAccessToken && !!a.sha256,
+              )
+              .map((a) => ({
+                fileAccessToken: a.fileAccessToken,
+                filename: a.fileName,
+                sha256: a.sha256,
+              }))
+          : undefined
+
         const response = await sendChatStream({
           model,
           systemPrompt: baseSystemPrompt,
@@ -572,6 +595,7 @@ export function useChatMessaging({
           codeExecutionAccessToken: updatedChat.codeExecutionAccessToken,
           codeExecutionEncryptionKey: codeExecutionEncryptionKey ?? undefined,
           codeExecutionContainerAuthToken,
+          codeExecutionUploads,
         })
 
         const assistantMessage = await processStreamingResponse(response, {

--- a/src/components/chat/types.ts
+++ b/src/components/chat/types.ts
@@ -121,6 +121,11 @@ export type Attachment = {
   pages?: DocumentPage[]
   // v1 format: per-attachment encryption key material (base64-encoded)
   encryptionKey?: string
+  // Bucket coordinates of the raw file bytes uploaded for code-exec
+  // /user-uploads sync. Present iff the eager bucket upload succeeded
+  // at attach time (requires signed-in + code-exec key derived).
+  fileAccessToken?: string
+  sha256?: string
 }
 
 export type Message = {

--- a/src/services/buckets/buckets-client.ts
+++ b/src/services/buckets/buckets-client.ts
@@ -1,19 +1,24 @@
 /**
- * Tinfoil Buckets client — attested PUT for /user-uploads bucket entries.
+ * Tinfoil Buckets client — attested PUT against the tinfoil-bucket S3 enclave.
  *
- * One bucket key per file (`fileAccessToken`); per-chat
- * `codeExecutionEncryptionKey` wraps every file in a chat. The buckets
- * enclave does the encryption: we send plaintext bytes + the wrapping
- * key over attested TLS, the enclave generates a DEK, encrypts in-memory,
- * and persists ciphertext to R2. The key is never persisted.
+ * Wire format (per smoke spec):
+ *   PUT  {ENCLAVE}/{BUCKET}/{key}
+ *   Authorization: Bearer <user api key>          // proxy validates + strips
+ *   X-Tinfoil-Encryption-Key: <std-padded b64>    // per-request AES-256 key
+ *   <raw bytes>
+ *
+ * The bucket name in the URL path is a stand-in: the sidecar always writes
+ * to its server-configured bucket, so any non-empty string works. The
+ * proxy stamps `X-Tinfoil-Tenant-Id` from the validated bearer; objects
+ * land under a per-user prefix server-side.
  */
-import { uint8ArrayToBase64 } from '@/utils/binary-codec'
 import { logError } from '@/utils/error-handling'
 import { SecureClient } from 'tinfoil'
 
 const BUCKETS_ENCLAVE =
-  process.env.NEXT_PUBLIC_BUCKETS_BASE_URL || 'https://buckets.tinfoil.sh'
-const BUCKETS_CONFIG_REPO = 'tinfoilsh/tinfoil-buckets'
+  process.env.NEXT_PUBLIC_BUCKETS_BASE_URL || 'https://bucket.tinfoil.sh'
+const BUCKETS_CONFIG_REPO = 'tinfoilsh/tinfoil-bucket'
+const BUCKETS_URL_BUCKET = 'tinfoil-bucket'
 
 let cachedClient: SecureClient | null = null
 
@@ -28,14 +33,14 @@ function getClient(): SecureClient {
 }
 
 /**
- * Store an encrypted item in buckets. The enclave wraps `value` with a
- * fresh DEK and stores the wrapped DEK in a key slot keyed by
- * `encryptionKeyB64Std`.
+ * Store raw bytes in the buckets enclave under `fileAccessToken`. The enclave
+ * encrypts in-memory with the supplied AES-256 key and persists ciphertext;
+ * the key never leaves the browser → enclave path.
  *
- * @param fileAccessToken  Bucket key (caller-chosen, treated as a password).
- * @param value            Plaintext bytes; base64-encoded on the wire.
- * @param encryptionKeyB64Std  AES-256 wrapping key, standard base64 with padding.
- * @param bearer           User's API key (Tinfoil session token), used for auth + tenant scoping.
+ * @param fileAccessToken      S3 object key (caller-chosen, opaque).
+ * @param value                Plaintext bytes; sent as the PUT body.
+ * @param encryptionKeyB64Std  AES-256 key, standard base64 with padding.
+ * @param bearer               User's Tinfoil API key.
  */
 export async function putBucketItem(
   fileAccessToken: string,
@@ -44,22 +49,17 @@ export async function putBucketItem(
   bearer: string,
 ): Promise<void> {
   const client = getClient()
-  const body = JSON.stringify({
-    value: uint8ArrayToBase64(value),
-    encryption_keys: [encryptionKeyB64Std],
-  })
+  const url = `${BUCKETS_ENCLAVE}/${BUCKETS_URL_BUCKET}/${fileAccessToken}`
 
-  const response = await client.fetch(
-    `${BUCKETS_ENCLAVE}/items/${fileAccessToken}`,
-    {
-      method: 'PUT',
-      headers: {
-        Authorization: `Bearer ${bearer}`,
-        'Content-Type': 'application/json',
-      },
-      body,
+  const response = await client.fetch(url, {
+    method: 'PUT',
+    headers: {
+      Authorization: `Bearer ${bearer}`,
+      'X-Tinfoil-Encryption-Key': encryptionKeyB64Std,
+      'Content-Type': 'application/octet-stream',
     },
-  )
+    body: value as BodyInit,
+  })
 
   if (!response.ok) {
     const errorText = await response.text().catch(() => '')

--- a/src/services/buckets/buckets-client.ts
+++ b/src/services/buckets/buckets-client.ts
@@ -1,0 +1,73 @@
+/**
+ * Tinfoil Buckets client — attested PUT for /user-uploads bucket entries.
+ *
+ * One bucket key per file (`fileAccessToken`); per-chat
+ * `codeExecutionEncryptionKey` wraps every file in a chat. The buckets
+ * enclave does the encryption: we send plaintext bytes + the wrapping
+ * key over attested TLS, the enclave generates a DEK, encrypts in-memory,
+ * and persists ciphertext to R2. The key is never persisted.
+ */
+import { uint8ArrayToBase64 } from '@/utils/binary-codec'
+import { logError } from '@/utils/error-handling'
+import { SecureClient } from 'tinfoil'
+
+const BUCKETS_ENCLAVE =
+  process.env.NEXT_PUBLIC_BUCKETS_BASE_URL || 'https://buckets.tinfoil.sh'
+const BUCKETS_CONFIG_REPO = 'tinfoilsh/tinfoil-buckets'
+
+let cachedClient: SecureClient | null = null
+
+function getClient(): SecureClient {
+  if (!cachedClient) {
+    cachedClient = new SecureClient({
+      enclaveURL: BUCKETS_ENCLAVE,
+      configRepo: BUCKETS_CONFIG_REPO,
+    })
+  }
+  return cachedClient
+}
+
+/**
+ * Store an encrypted item in buckets. The enclave wraps `value` with a
+ * fresh DEK and stores the wrapped DEK in a key slot keyed by
+ * `encryptionKeyB64Std`.
+ *
+ * @param fileAccessToken  Bucket key (caller-chosen, treated as a password).
+ * @param value            Plaintext bytes; base64-encoded on the wire.
+ * @param encryptionKeyB64Std  AES-256 wrapping key, standard base64 with padding.
+ * @param bearer           User's API key (Tinfoil session token), used for auth + tenant scoping.
+ */
+export async function putBucketItem(
+  fileAccessToken: string,
+  value: Uint8Array,
+  encryptionKeyB64Std: string,
+  bearer: string,
+): Promise<void> {
+  const client = getClient()
+  const body = JSON.stringify({
+    value: uint8ArrayToBase64(value),
+    encryption_keys: [encryptionKeyB64Std],
+  })
+
+  const response = await client.fetch(
+    `${BUCKETS_ENCLAVE}/items/${fileAccessToken}`,
+    {
+      method: 'PUT',
+      headers: {
+        Authorization: `Bearer ${bearer}`,
+        'Content-Type': 'application/json',
+      },
+      body,
+    },
+  )
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => '')
+    logError(`buckets PUT failed: ${response.status}`, undefined, {
+      component: 'buckets-client',
+      action: 'putBucketItem',
+      metadata: { status: response.status, error: errorText },
+    })
+    throw new Error(`buckets PUT failed: ${response.status}`)
+  }
+}

--- a/src/services/exec-snapshot/upload-attachment-to-bucket.ts
+++ b/src/services/exec-snapshot/upload-attachment-to-bucket.ts
@@ -1,0 +1,65 @@
+/**
+ * Upload an attached file's raw bytes to buckets so it can be synced to
+ * `/user-uploads` on the next code-execution call. One bucket entry per
+ * file (`fileAccessToken`); per-chat `codeExecutionEncryptionKey`
+ * wraps every file in the chat.
+ *
+ * Caller is responsible for gating: only invoke when
+ * `canEnableCodeExecution && codeExecutionEncryptionKey` are both set.
+ * On failure the caller should swallow + log; the attachment still works
+ * for non-code-exec purposes (docling text, image rendering).
+ */
+import { putBucketItem } from '@/services/buckets/buckets-client'
+import { base64UrlToUint8Array, uint8ArrayToBase64 } from '@/utils/binary-codec'
+
+function hexEncode(bytes: Uint8Array): string {
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('')
+}
+
+function generateFileAccessToken(): string {
+  const bytes = new Uint8Array(32)
+  crypto.getRandomValues(bytes)
+  return hexEncode(bytes)
+}
+
+async function sha256Hex(bytes: Uint8Array): Promise<string> {
+  const digest = await crypto.subtle.digest(
+    'SHA-256',
+    bytes as unknown as ArrayBuffer,
+  )
+  return hexEncode(new Uint8Array(digest))
+}
+
+export interface BucketUploadResult {
+  fileAccessToken: string
+  sha256: string
+}
+
+/**
+ * Upload `file`'s raw bytes to a fresh bucket key and return the
+ * coordinates needed to reference it in `code_execution_options.uploads`.
+ *
+ * @param file File from the picker.
+ * @param codeExecutionEncryptionKeyB64Url  Per-chat key (base64url, no
+ *   padding) — same value the inference request will carry as
+ *   `code_execution_options.encryptionKey`.
+ * @param bearer  User's API key for buckets auth.
+ */
+export async function uploadAttachmentToBucket(
+  file: File,
+  codeExecutionEncryptionKeyB64Url: string,
+  bearer: string,
+): Promise<BucketUploadResult> {
+  const bytes = new Uint8Array(await file.arrayBuffer())
+  const sha256 = await sha256Hex(bytes)
+  const fileAccessToken = generateFileAccessToken()
+
+  // Buckets accepts standard-padded base64 for encryption_keys.
+  const keyStdB64 = uint8ArrayToBase64(
+    base64UrlToUint8Array(codeExecutionEncryptionKeyB64Url),
+  )
+
+  await putBucketItem(fileAccessToken, bytes, keyStdB64, bearer)
+
+  return { fileAccessToken, sha256 }
+}

--- a/src/services/inference/chat-query-builder.ts
+++ b/src/services/inference/chat-query-builder.ts
@@ -3,7 +3,7 @@ import {
   getMessageImages,
 } from '@/components/chat/attachment-helpers'
 import { buildGenUIPromptHint } from '@/components/chat/genui/system-prompt'
-import type { Message } from '@/components/chat/types'
+import type { Attachment, Message } from '@/components/chat/types'
 import type { BaseModel } from '@/config/models'
 import type {
   ChatCompletionAssistantMessageParam,
@@ -12,6 +12,20 @@ import type {
   ChatCompletionToolMessageParam,
   ChatCompletionUserMessageParam,
 } from 'openai/resources/chat/completions'
+
+// Notes telling the model that an attachment is also reachable as a real
+// file inside the code-execution sandbox. Only emitted when the eager
+// bucket upload succeeded — `fileAccessToken` is the witness.
+function uploadPathLine(att: Attachment): string | null {
+  return att.fileAccessToken
+    ? `Available in code execution environment at: /user-uploads/${att.fileName}`
+    : null
+}
+function uploadHintInline(att: Attachment): string {
+  return att.fileAccessToken
+    ? ` — also available at /user-uploads/${att.fileName} in the code execution environment`
+    : ''
+}
 
 /**
  * Helper for building chat completion queries with model-specific system prompt injection
@@ -214,10 +228,13 @@ export class ChatQueryBuilder {
     if (textOnlyDocs.length > 0) {
       const docContent = textOnlyDocs
         .filter((a) => a.textContent)
-        .map(
-          (a) =>
-            `Document title: ${a.fileName}\nDocument contents:\n${a.textContent}`,
-        )
+        .map((a) => {
+          const path = uploadPathLine(a)
+          const header = path
+            ? `Document title: ${a.fileName}\n${path}`
+            : `Document title: ${a.fileName}`
+          return `${header}\nDocument contents:\n${a.textContent}`
+        })
         .join('\n\n')
       if (docContent) {
         textContent = `---\nDocument content:\n${docContent}\n---\n\n${textContent}`
@@ -235,9 +252,10 @@ export class ChatQueryBuilder {
       }> = []
 
       for (const doc of pagedDocs) {
+        const hint = uploadHintInline(doc)
         content.push({
           type: 'text',
-          text: `[Attached file: ${doc.fileName}]`,
+          text: `[Attached file: ${doc.fileName}${hint}]`,
         })
         for (const p of doc.pages!) {
           const label = p.is_scanned
@@ -260,6 +278,13 @@ export class ChatQueryBuilder {
 
       for (const img of imageAttachments) {
         if (img.base64 && img.mimeType) {
+          const hint = uploadHintInline(img)
+          if (hint) {
+            content.push({
+              type: 'text',
+              text: `[Image: ${img.fileName}${hint}]`,
+            })
+          }
           content.push({
             type: 'image_url',
             image_url: {
@@ -276,7 +301,10 @@ export class ChatQueryBuilder {
     if (imageAttachments.length > 0 && !multimodal) {
       const descriptions = imageAttachments
         .filter((a) => a.description)
-        .map((a) => `Image: ${a.fileName}\nDescription:\n${a.description}`)
+        .map((a) => {
+          const hint = uploadHintInline(a)
+          return `Image: ${a.fileName}${hint}\nDescription:\n${a.description}`
+        })
         .join('\n\n')
       if (descriptions) {
         textContent = `${textContent}\n\n[Treat these descriptions as if they are the raw images.]\n${descriptions}`

--- a/src/services/inference/inference-client.ts
+++ b/src/services/inference/inference-client.ts
@@ -128,6 +128,19 @@ export interface SendChatStreamParams {
   codeExecutionEncryptionKey?: string
   /** Per-chat hex token authenticating the code-exec container. */
   codeExecutionContainerAuthToken?: string
+  /**
+   * Manifest of files the orchestrator should reconcile into
+   * `/user-uploads` before this turn runs. Each entry references a
+   * bucket item the webapp pre-uploaded at attach time. The MCP only
+   * fetches files whose sha doesn't match what's already in the
+   * sandbox, so resending the full set every turn is cheap.
+   * Only forwarded when codeExecutionEnabled is true.
+   */
+  codeExecutionUploads?: Array<{
+    fileAccessToken: string
+    filename: string
+    sha256: string
+  }>
 }
 
 export async function sendChatStream(
@@ -150,6 +163,7 @@ export async function sendChatStream(
     codeExecutionAccessToken,
     codeExecutionEncryptionKey,
     codeExecutionContainerAuthToken,
+    codeExecutionUploads,
   } = params
 
   const genUITools = genUIEnabled ? buildGenUIToolSchemas() : []
@@ -355,10 +369,15 @@ export async function sendChatStream(
             'FETCH_ERROR',
           )
         }
+        // Always include `uploads` (possibly empty) so the orchestrator
+        // reconciles /user-uploads to the chat's current set of attached
+        // files. Omitting the field would leave the sandbox holding
+        // stale files from a prior turn.
         requestBody.code_execution_options = {
           accessToken: codeExecutionAccessToken,
           encryptionKey: codeExecutionEncryptionKey,
           containerAuthToken: codeExecutionContainerAuthToken,
+          uploads: codeExecutionUploads ?? [],
         }
       }
       if (piiCheckEnabled) {

--- a/tests/components/chat/attachment-helpers.test.ts
+++ b/tests/components/chat/attachment-helpers.test.ts
@@ -1,0 +1,83 @@
+import { truncateForCodeExec } from '@/components/chat/attachment-helpers'
+import { CONSTANTS } from '@/components/chat/constants'
+import type { DocumentPage } from '@/components/chat/types'
+import { describe, expect, it } from 'vitest'
+
+const CHARS_PER_TOKEN = 4
+const TEXT_CHAR_CAP =
+  CONSTANTS.CODE_EXEC_TEXT_TOKEN_CAP_PER_FILE * CHARS_PER_TOKEN
+const MAX_PAGES = CONSTANTS.CODE_EXEC_MAX_PAGES_PER_FILE
+
+const makePages = (n: number): DocumentPage[] =>
+  Array.from({ length: n }, (_, i) => ({
+    page: i + 1,
+    text: `p${i + 1}`,
+    image: '',
+    is_scanned: false,
+  }))
+
+describe('truncateForCodeExec', () => {
+  it('returns the input unchanged when content fits and no pages are over the cap', () => {
+    const content = 'a'.repeat(TEXT_CHAR_CAP)
+    const result = truncateForCodeExec({ content, fileName: 'small.md' })
+
+    expect(result.truncated).toBe(false)
+    expect(result.content).toBe(content)
+    expect(result.content).not.toContain('truncated')
+  })
+
+  it('caps content at the char limit and appends a footer pointing to /user-uploads', () => {
+    const content = 'a'.repeat(TEXT_CHAR_CAP + 1000)
+    const result = truncateForCodeExec({
+      content,
+      fileName: 'big.csv',
+    })
+
+    expect(result.truncated).toBe(true)
+    expect(result.content.startsWith('a'.repeat(TEXT_CHAR_CAP))).toBe(true)
+    expect(result.content).toContain('/user-uploads/big.csv')
+    expect(result.content).toContain('truncated')
+  })
+
+  it('caps pages at the max-pages limit', () => {
+    const pages = makePages(MAX_PAGES + 5)
+    const result = truncateForCodeExec({
+      content: 'short',
+      pages,
+      fileName: 'long.pdf',
+    })
+
+    expect(result.truncated).toBe(true)
+    expect(result.pages).toHaveLength(MAX_PAGES)
+    expect(result.pages?.[0].page).toBe(1)
+    expect(result.pages?.[MAX_PAGES - 1].page).toBe(MAX_PAGES)
+    // Short text content is left alone — no footer.
+    expect(result.content).toBe('short')
+  })
+
+  it('truncates content and pages together when both exceed the caps', () => {
+    const content = 'a'.repeat(TEXT_CHAR_CAP + 10)
+    const pages = makePages(MAX_PAGES + 3)
+    const result = truncateForCodeExec({
+      content,
+      pages,
+      fileName: 'huge.pdf',
+    })
+
+    expect(result.truncated).toBe(true)
+    expect(result.content).toContain('/user-uploads/huge.pdf')
+    expect(result.pages).toHaveLength(MAX_PAGES)
+  })
+
+  it('leaves pages alone when the array is at or below the cap', () => {
+    const pages = makePages(MAX_PAGES)
+    const result = truncateForCodeExec({
+      content: 'short',
+      pages,
+      fileName: 'edge.pdf',
+    })
+
+    expect(result.truncated).toBe(false)
+    expect(result.pages).toBe(pages)
+  })
+})

--- a/tests/services/exec-snapshot/upload-attachment-to-bucket.test.ts
+++ b/tests/services/exec-snapshot/upload-attachment-to-bucket.test.ts
@@ -1,0 +1,43 @@
+import { uploadAttachmentToBucket } from '@/services/exec-snapshot/upload-attachment-to-bucket'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/services/buckets/buckets-client', () => ({
+  putBucketItem: vi.fn().mockResolvedValue(undefined),
+}))
+
+const KNOWN_KEY_RAW = new Uint8Array(32).fill(7)
+// base64url (no padding) of 32 bytes of 0x07.
+const KNOWN_KEY_URL = 'BwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwc'
+// standard base64 with padding of the same 32 bytes.
+const KNOWN_KEY_STD = 'BwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwc='
+// sha256("hello") in hex.
+const HELLO_SHA256 =
+  '2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824'
+
+describe('uploadAttachmentToBucket', () => {
+  it('hashes the bytes, mints a 64-hex token, and converts the key to standard base64', async () => {
+    const file = new File([new TextEncoder().encode('hello')], 'hello.txt')
+    const { putBucketItem } = await import('@/services/buckets/buckets-client')
+    ;(putBucketItem as ReturnType<typeof vi.fn>).mockClear()
+
+    const { fileAccessToken, sha256 } = await uploadAttachmentToBucket(
+      file,
+      KNOWN_KEY_URL,
+      'bearer-tok',
+    )
+
+    expect(sha256).toBe(HELLO_SHA256)
+    expect(fileAccessToken).toMatch(/^[0-9a-f]{64}$/)
+    expect(putBucketItem).toHaveBeenCalledTimes(1)
+    const [tokenArg, bytesArg, keyArg, bearerArg] = (
+      putBucketItem as ReturnType<typeof vi.fn>
+    ).mock.calls[0]
+    expect(tokenArg).toBe(fileAccessToken)
+    expect(Array.from(bytesArg as Uint8Array)).toEqual(
+      Array.from(new TextEncoder().encode('hello')),
+    )
+    expect(keyArg).toBe(KNOWN_KEY_STD)
+    expect(bearerArg).toBe('bearer-tok')
+    void KNOWN_KEY_RAW // referenced for documentation
+  })
+})

--- a/tests/services/inference/chat-query-builder.test.ts
+++ b/tests/services/inference/chat-query-builder.test.ts
@@ -1,0 +1,176 @@
+import type { Attachment, Message } from '@/components/chat/types'
+import type { BaseModel } from '@/config/models'
+import { ChatQueryBuilder } from '@/services/inference/chat-query-builder'
+import { describe, expect, it } from 'vitest'
+
+const baseTextModel: BaseModel = {
+  modelName: 'llama3-3-70b',
+  image: '',
+  name: 'Llama',
+  nameShort: 'Llama',
+  description: '',
+  type: 'chat',
+  multimodal: false,
+}
+
+const baseMultimodalModel: BaseModel = {
+  ...baseTextModel,
+  modelName: 'qwen2-5-72b',
+  multimodal: true,
+}
+
+function userMessage(content: string, attachments: Attachment[]): Message {
+  return {
+    role: 'user',
+    content,
+    attachments,
+    timestamp: new Date(0),
+  }
+}
+
+function build(model: BaseModel, msg: Message) {
+  return ChatQueryBuilder.buildMessages({
+    model,
+    systemPrompt: '',
+    messages: [msg],
+    maxMessages: 10,
+  })
+}
+
+describe('chat-query-builder /user-uploads inline notes', () => {
+  describe('text-only document', () => {
+    const baseDoc: Attachment = {
+      id: 'a1',
+      type: 'document',
+      fileName: 'report.pdf',
+      textContent: 'doc body',
+    }
+
+    it('omits the path line when the file was not uploaded to buckets', () => {
+      const msgs = build(baseTextModel, userMessage('hi', [baseDoc]))
+      const userMsg = msgs[msgs.length - 1].content as string
+      expect(userMsg).toContain('Document title: report.pdf')
+      expect(userMsg).not.toContain('/user-uploads')
+    })
+
+    it('inserts the path line between title and contents when fileAccessToken is set', () => {
+      const msgs = build(
+        baseTextModel,
+        userMessage('hi', [
+          { ...baseDoc, fileAccessToken: 'fat-1', sha256: 'abc' },
+        ]),
+      )
+      const userMsg = msgs[msgs.length - 1].content as string
+      expect(userMsg).toContain(
+        'Document title: report.pdf\nAvailable in code execution environment at: /user-uploads/report.pdf\nDocument contents:\ndoc body',
+      )
+    })
+  })
+
+  describe('multimodal paged document', () => {
+    const pagedDoc: Attachment = {
+      id: 'a2',
+      type: 'document',
+      fileName: 'scan.pdf',
+      pages: [{ page: 1, text: 'p1', image: '', is_scanned: false }],
+    }
+
+    it('omits the hint when fileAccessToken is missing', () => {
+      const msgs = build(baseMultimodalModel, userMessage('hi', [pagedDoc]))
+      const blocks = msgs[msgs.length - 1].content as Array<{
+        type: string
+        text?: string
+      }>
+      const header = blocks.find((b) => b.text?.startsWith('[Attached file:'))
+      expect(header?.text).toBe('[Attached file: scan.pdf]')
+    })
+
+    it('appends the hint inline when fileAccessToken is set', () => {
+      const msgs = build(
+        baseMultimodalModel,
+        userMessage('hi', [
+          { ...pagedDoc, fileAccessToken: 'fat-2', sha256: 'def' },
+        ]),
+      )
+      const blocks = msgs[msgs.length - 1].content as Array<{
+        type: string
+        text?: string
+      }>
+      const header = blocks.find((b) => b.text?.startsWith('[Attached file:'))
+      expect(header?.text).toBe(
+        '[Attached file: scan.pdf — also available at /user-uploads/scan.pdf in the code execution environment]',
+      )
+    })
+  })
+
+  describe('multimodal image', () => {
+    const img: Attachment = {
+      id: 'a3',
+      type: 'image',
+      fileName: 'pic.png',
+      mimeType: 'image/png',
+      base64: 'AAA',
+    }
+
+    it('omits the labelling text block when fileAccessToken is missing', () => {
+      const msgs = build(baseMultimodalModel, userMessage('hi', [img]))
+      const blocks = msgs[msgs.length - 1].content as Array<{
+        type: string
+        text?: string
+      }>
+      const labelBlock = blocks.find((b) => b.text?.startsWith('[Image:'))
+      expect(labelBlock).toBeUndefined()
+    })
+
+    it('emits a label block before the image when fileAccessToken is set', () => {
+      const msgs = build(
+        baseMultimodalModel,
+        userMessage('hi', [
+          { ...img, fileAccessToken: 'fat-3', sha256: 'ghi' },
+        ]),
+      )
+      const blocks = msgs[msgs.length - 1].content as Array<{
+        type: string
+        text?: string
+        image_url?: { url: string }
+      }>
+      const labelIdx = blocks.findIndex((b) => b.text?.startsWith('[Image:'))
+      const imageIdx = blocks.findIndex((b) => b.image_url)
+      expect(labelIdx).toBeGreaterThanOrEqual(0)
+      expect(imageIdx).toBeGreaterThan(labelIdx)
+      expect(blocks[labelIdx].text).toBe(
+        '[Image: pic.png — also available at /user-uploads/pic.png in the code execution environment]',
+      )
+    })
+  })
+
+  describe('non-multimodal image with description', () => {
+    const img: Attachment = {
+      id: 'a4',
+      type: 'image',
+      fileName: 'pic.png',
+      mimeType: 'image/png',
+      base64: 'AAA',
+      description: 'a picture',
+    }
+
+    it('omits the hint when fileAccessToken is missing', () => {
+      const msgs = build(baseTextModel, userMessage('hi', [img]))
+      const userMsg = msgs[msgs.length - 1].content as string
+      expect(userMsg).toContain('Image: pic.png\nDescription:\na picture')
+    })
+
+    it('appends the hint inline when fileAccessToken is set', () => {
+      const msgs = build(
+        baseTextModel,
+        userMessage('hi', [
+          { ...img, fileAccessToken: 'fat-4', sha256: 'jkl' },
+        ]),
+      )
+      const userMsg = msgs[msgs.length - 1].content as string
+      expect(userMsg).toContain(
+        'Image: pic.png — also available at /user-uploads/pic.png in the code execution environment\nDescription:\na picture',
+      )
+    })
+  })
+})


### PR DESCRIPTION
Turn code execution on & allow for file uploads!

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable code execution for signed‑in users and sync attached files to `/user-uploads` on every turn. Files pre‑upload to secure `tinfoil` buckets; prompts add sandbox path hints; per‑file caps apply after uploads; status shows via toasts and logs without blocking.

- **New Features**
  - Enable code execution for signed‑in users; bucket pre‑uploads run in parallel when a `codeExecutionEncryptionKey` is present. Skips/failures are non‑blocking with toasts + logs.
  - Store `fileAccessToken` and `sha256` on attachments and always send `code_execution_options.uploads` (full set, possibly empty) each turn so `/user-uploads` stays in sync.
  - Apply caps only after successful uploads: `CODE_EXEC_TEXT_TOKEN_CAP_PER_FILE` (text) and `CODE_EXEC_MAX_PAGES_PER_FILE` (pages). Truncated text adds a footer pointing to `/user-uploads/<file>`.
  - Prompt hints: inject `/user-uploads/<file>` for text docs, inline labels for paged docs and images, and for image descriptions in text‑only flows. Tests cover truncation, upload hashing/key conversion, and hinting.

- **Dependencies**
  - Add buckets client using `tinfoil` `SecureClient` for attested PUTs to the buckets enclave.

<sup>Written for commit 6b1fcba4b0bca83217392b5922fe00e60cb124b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/377?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

