### PR TITLE
fix: deliver attestation details to the verification sidebar reliably

### DIFF
--- a/src/components/verification-sidebar.tsx
+++ b/src/components/verification-sidebar.tsx
@@ -75,15 +75,6 @@ export function VerifierSidebar({
         const doc = await getVerificationDocument()
         if (doc) {
           setVerificationDocument(doc)
-          if (isReady && iframeRef.current) {
-            iframeRef.current.contentWindow?.postMessage(
-              {
-                type: 'TINFOIL_VERIFICATION_DOCUMENT',
-                document: doc,
-              },
-              '*',
-            )
-          }
           if (onVerificationUpdate) {
             onVerificationUpdate(doc)
           }
@@ -131,7 +122,7 @@ export function VerifierSidebar({
     }
 
     isRetryingRef.current = false
-  }, [isReady, onVerificationUpdate, onVerificationComplete])
+  }, [onVerificationUpdate, onVerificationComplete])
 
   // Handle messages from iframe
   useEffect(() => {
@@ -139,27 +130,28 @@ export function VerifierSidebar({
       // Security: You may want to check event.origin here in production
       if (event.data.type === 'TINFOIL_VERIFICATION_CENTER_READY') {
         setIsReady(true)
-        // Send verification document if we have it
-        if (verificationDocument && iframeRef.current) {
-          iframeRef.current.contentWindow?.postMessage(
-            {
-              type: 'TINFOIL_VERIFICATION_DOCUMENT',
-              document: verificationDocument,
-            },
-            '*',
-          )
-        }
       } else if (event.data.type === 'TINFOIL_VERIFICATION_CENTER_CLOSED') {
         setIsOpen(false)
       } else if (event.data.type === 'TINFOIL_REQUEST_VERIFICATION_DOCUMENT') {
-        // Refresh the verification document
         fetchVerificationDocument()
       }
     }
 
     window.addEventListener('message', handleMessage)
     return () => window.removeEventListener('message', handleMessage)
-  }, [verificationDocument, setIsOpen, fetchVerificationDocument])
+  }, [setIsOpen, fetchVerificationDocument])
+
+  useEffect(() => {
+    if (isReady && verificationDocument && iframeRef.current) {
+      iframeRef.current.contentWindow?.postMessage(
+        {
+          type: 'TINFOIL_VERIFICATION_DOCUMENT',
+          document: verificationDocument,
+        },
+        '*',
+      )
+    }
+  }, [isReady, verificationDocument])
 
   // Fetch verification document when sidebar opens
   useEffect(() => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Ensure the verification sidebar reliably receives attestation details by sending the document only after the iframe is ready. This removes race conditions and duplicate messages.

- **Bug Fixes**
  - Post `TINFOIL_VERIFICATION_DOCUMENT` from a dedicated effect when `isReady` and `verificationDocument` are both set.
  - Remove document sends from fetch flow and `TINFOIL_VERIFICATION_CENTER_READY` handler.
  - Tidy effect deps: drop `isReady` from fetch effect and `verificationDocument` from message listener to avoid unnecessary reruns.

<sup>Written for commit 761515f1f2e0a3074164b6bae40e989744b4c98c. Summary will update on new commits. <a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/379?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

