### PR TITLE
Cleanup slop comments throughout codebase 

### DIFF
--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -423,7 +423,6 @@ export function ChatInterface({
   })
   updatePasskeyBackupRef.current = updatePasskeyBackup
 
-  // Initialize profile sync
   const {
     retryDecryption: retryProfileDecryption,
     syncFromCloud: syncProfileFromCloud,
@@ -541,10 +540,8 @@ export function ChatInterface({
   // State for tracking verification document
   const [verificationDocument, setVerificationDocument] = useState<any>(null)
 
-  // Get the user's email
   const userEmail = user?.primaryEmailAddress?.emailAddress || ''
 
-  // Use subscription status from hook
   const isPremium = chat_subscription_active ?? false
 
   // Load projects for move to project functionality
@@ -566,7 +563,6 @@ export function ChatInterface({
   const modKey = isMac ? '⌘' : 'Ctrl+'
   const shiftKey = isMac ? '⇧' : 'Shift+'
 
-  // Use custom system prompt hook
   const { effectiveSystemPrompt, processedRules } = useCustomSystemPrompt(
     systemPrompt,
     rules,
@@ -601,7 +597,6 @@ export function ChatInterface({
   // Combine prop and router detection for local chat URL
   const isLocalChatUrl = isLocalChatUrlProp || isLocalChatUrlFromRouter
 
-  // Initialize renderers on mount
   useEffect(() => {
     initializeRenderers()
   }, [])
@@ -960,9 +955,8 @@ export function ChatInterface({
   useEffect(() => {
     const initTinfoil = async () => {
       try {
-        const { getVerificationDocument } = await import(
-          '@/services/inference/tinfoil-client'
-        )
+        const { getVerificationDocument } =
+          await import('@/services/inference/tinfoil-client')
         const doc = await getVerificationDocument()
         if (doc) {
           setVerificationDocument(doc)
@@ -1658,9 +1652,6 @@ export function ChatInterface({
     [reloadChats, toast],
   )
 
-  // Don't automatically create new chats - let the chat state handle initialization
-  // This effect has been removed to prevent unnecessary chat creation
-
   // Helper to process file and add to chat attachments
   const processFileForChat = useCallback(
     async (file: File) => {
@@ -2228,9 +2219,6 @@ export function ChatInterface({
       wasThinking: nowThinkingish || Boolean(prev?.wasThinking),
     }
   }, [currentChat?.messages])
-
-  // Removed all automatic scroll behaviors during streaming. Scrolling now only occurs
-  // via the explicit button or when a chat is loaded/switched.
 
   // Show loading while auth or config is still loading
   const needsAuthLoading = (initialChatId || initialProjectId) && !isAuthLoaded

--- a/src/components/chat/chat-messages.tsx
+++ b/src/components/chat/chat-messages.tsx
@@ -159,7 +159,6 @@ const LoadingMessage = memo(function LoadingMessage({
   )
 })
 
-// Helper to generate unique message keys
 const getMessageKey = (
   prefix: string,
   message: Message,
@@ -174,8 +173,6 @@ const getMessageKey = (
   return `${prefix}-${message.role}-${timestamp}`
 }
 
-// Removed duplicate WelcomeScreen component - using imported version from './WelcomeScreen'
-// Separator component
 const MessagesSeparator = memo(function MessagesSeparator({
   isDarkMode,
 }: {

--- a/src/components/chat/chat-sidebar.tsx
+++ b/src/components/chat/chat-sidebar.tsx
@@ -110,13 +110,11 @@ type ChatSidebarProps = {
   windowWidth: number
 }
 
-// Add this constant at the top of the file
 const MOBILE_BREAKPOINT = 1024 // Same as in chat-interface.tsx
 
-// Add this useEffect function to prevent zooming on mobile Safari
+// Prevent pinch-zoom on mobile Safari while the chat UI is mounted.
 function usePreventZoom() {
   useEffect(() => {
-    // Set viewport meta tag to prevent zooming
     const viewportMeta = document.createElement('meta')
     viewportMeta.name = 'viewport'
     viewportMeta.content =
@@ -124,7 +122,6 @@ function usePreventZoom() {
     document.head.appendChild(viewportMeta)
 
     return () => {
-      // Only remove if the meta tag exists and is a child of document.head
       if (viewportMeta.parentNode === document.head) {
         document.head.removeChild(viewportMeta)
       }

--- a/src/components/chat/document-uploader.tsx
+++ b/src/components/chat/document-uploader.tsx
@@ -160,13 +160,11 @@ export const useDocumentUploader = (
     const documentId = getDocumentId()
 
     try {
-      // Add this document to uploading state
       setUploadingDocuments((prev) => ({
         ...prev,
         [documentId]: true,
       }))
 
-      // Check file size
       if (file.size > CONSTANTS.MAX_DOCUMENT_SIZE_BYTES) {
         onError(
           new Error(

--- a/src/components/chat/hooks/use-chat-state.ts
+++ b/src/components/chat/hooks/use-chat-state.ts
@@ -283,7 +283,6 @@ export function useChatState({
         // Only create a new chat if there are no chats
         createNewChat()
       } else {
-        // Just ensure loading state is cleared
         setIsInitialLoad(false)
       }
     }

--- a/src/components/chat/renderers/default/DefaultInputRenderer.tsx
+++ b/src/components/chat/renderers/default/DefaultInputRenderer.tsx
@@ -6,13 +6,11 @@ export const DefaultInputRenderer: InputRenderer = {
   canRender: () => true,
 
   render: (props: InputRenderProps) => {
-    // Wrap the existing ChatInput component
-    // ChatInput expects handleSubmit to be (e: FormEvent) => void
-    // but our onSubmit is more complex, so we need to wrap it
+    // ChatInput expects an (e: FormEvent) => void handler, while
+    // InputRenderer.onSubmit takes the message content. Bridge the two and
+    // let the parent attach processed documents from its own state.
     const handleSubmit = (e: React.FormEvent) => {
       e.preventDefault()
-      // For now, just pass the input text
-      // The actual document handling will be done in the parent component
       props.onSubmit(props.input)
     }
 

--- a/src/components/code-block.tsx
+++ b/src/components/code-block.tsx
@@ -175,18 +175,14 @@ const PREVIEWABLE_LANGUAGES = [
 const isCodeWorthPreviewing = (code: string, language: string): boolean => {
   const trimmed = code.trim()
 
-  // Too short to be meaningful
   if (trimmed.length < 20) return false
 
-  // Single line is usually just an example snippet
   if (!trimmed.includes('\n') && trimmed.length < 80) return false
 
   switch (language) {
     case 'html': {
-      // Must have actual content, not just a single tag or link/style reference
       const tagCount = (trimmed.match(/<[a-z]/gi) || []).length
       if (tagCount <= 1) return false
-      // Skip if it's just a single link/script/style/meta tag (but allow full documents)
       if (/^<(link|script|style|meta)\b/i.test(trimmed) && tagCount <= 2)
         return false
       return true
@@ -196,13 +192,11 @@ const isCodeWorthPreviewing = (code: string, language: string): boolean => {
     case 'js':
     case 'typescript':
     case 'ts': {
-      // Skip if it's just comments
       const withoutComments = trimmed
         .replace(/\/\*[\s\S]*?\*\//g, '')
         .replace(/\/\/.*/g, '')
         .trim()
       if (withoutComments.length < 10) return false
-      // Skip simple declarations without logic
       const hasLogic =
         /\b(if|for|while|function|=>|console\.|return|\.map|\.filter|\.reduce|\.forEach|async|await|new |class )/i.test(
           trimmed,
@@ -212,36 +206,30 @@ const isCodeWorthPreviewing = (code: string, language: string): boolean => {
     }
 
     case 'css': {
-      // Must have actual rules, not just a selector or single property
       const ruleCount = (trimmed.match(/\{/g) || []).length
       if (ruleCount < 1) return false
-      // Must have actual properties
       const propertyCount = (trimmed.match(/:\s*[^;]+;/g) || []).length
       if (propertyCount < 2) return false
       return true
     }
 
     case 'svg': {
-      // Must be a complete SVG
       return /<svg[\s\S]*<\/svg>/i.test(trimmed)
     }
 
     case 'markdown':
     case 'md': {
-      // Must have some formatting or be substantial
       const hasFormatting = /[#*`\[\]|]/.test(trimmed)
       return hasFormatting || trimmed.length > 100
     }
 
     case 'mermaid': {
-      // Must have a diagram type
       return /^(graph|flowchart|sequenceDiagram|classDiagram|stateDiagram|erDiagram|journey|gantt|pie|mindmap)/m.test(
         trimmed,
       )
     }
 
     case 'json': {
-      // Must be an object or array with content
       try {
         const parsed = JSON.parse(trimmed)
         if (typeof parsed !== 'object' || parsed === null) return false
@@ -392,27 +380,16 @@ const MarkdownPreview = ({
 )
 
 const stripModuleSyntax = (code: string): string => {
-  return (
-    code
-      // Remove import statements entirely
-      .replace(/^import\s+.*?['"];?\s*$/gm, '')
-      // Remove `export { ... }` statements entirely
-      .replace(/^export\s+\{[^}]*\}\s*(from\s+['"][^'"]*['"])?\s*;?\s*$/gm, '')
-      // Remove `export * from` statements entirely
-      .replace(/^export\s+\*\s+from\s+['"][^'"]*['"];?\s*$/gm, '')
-      // Remove `export default` (leave the declaration)
-      .replace(/^export\s+default\s+/gm, '')
-      // Remove `export` keyword from declarations (export const, export function, etc.)
-      .replace(/^export\s+/gm, '')
-      // Remove type annotations after colons (e.g., `: string`, `: number[]`, `: void`)
-      .replace(/:\s*[A-Za-z_$][\w$]*(?:<[^>]+>)?(?:\[\])?(?=\s*[,)=;{\n])/g, '')
-      // Remove generic type parameters on functions (e.g., `<T>`, `<T, U>`)
-      .replace(/(<[A-Za-z_$][\w$]*(?:\s*,\s*[A-Za-z_$][\w$]*)*>)(?=\s*\()/g, '')
-      // Remove `as Type` assertions
-      .replace(/\s+as\s+[A-Za-z_$][\w$]*(?:<[^>]+>)?/g, '')
-      // Remove interface/type declarations
-      .replace(/^(interface|type)\s+[^{]+\{[^}]*\}\s*/gm, '')
-  )
+  return code
+    .replace(/^import\s+.*?['"];?\s*$/gm, '')
+    .replace(/^export\s+\{[^}]*\}\s*(from\s+['"][^'"]*['"])?\s*;?\s*$/gm, '')
+    .replace(/^export\s+\*\s+from\s+['"][^'"]*['"];?\s*$/gm, '')
+    .replace(/^export\s+default\s+/gm, '')
+    .replace(/^export\s+/gm, '')
+    .replace(/:\s*[A-Za-z_$][\w$]*(?:<[^>]+>)?(?:\[\])?(?=\s*[,)=;{\n])/g, '')
+    .replace(/(<[A-Za-z_$][\w$]*(?:\s*,\s*[A-Za-z_$][\w$]*)*>)(?=\s*\()/g, '')
+    .replace(/\s+as\s+[A-Za-z_$][\w$]*(?:<[^>]+>)?/g, '')
+    .replace(/^(interface|type)\s+[^{]+\{[^}]*\}\s*/gm, '')
 }
 
 const JavaScriptPreview = ({ code }: { code: string }) => {
@@ -533,7 +510,6 @@ try {
     indexURL: '${PYODIDE_CDN_BASE}'
   });
 
-  // Redirect stdout
   pyodide.runPython(\`
 import sys
 from io import StringIO
@@ -541,7 +517,6 @@ sys.stdout = StringIO()
 sys.stderr = StringIO()
 \`);
 
-  // Run user code
   const userCode = ${jsonEscapedCode};
   try {
     const result = pyodide.runPython(userCode);
@@ -937,10 +912,8 @@ export const CodeBlock = memo(function CodeBlock({
   const isMarkdown = language === 'markdown' || language === 'md'
   const isExecutable = EXECUTABLE_LANGUAGES.includes(language)
 
-  // Check if this language supports preview (static check, doesn't depend on code content)
   const languageSupportsPreview = PREVIEWABLE_LANGUAGES.includes(language)
 
-  // Check if the current code is worth previewing
   const codeIsWorthPreviewing =
     languageSupportsPreview && isCodeWorthPreviewing(code, language)
 
@@ -949,10 +922,8 @@ export const CodeBlock = memo(function CodeBlock({
   const canShowPreview =
     languageSupportsPreview && (isExecutable || !isStreaming)
 
-  // Track if user has manually changed the view mode
   const userHasToggledRef = useRef(false)
 
-  // Determine initial view mode based on current state
   const shouldStartInPreview =
     codeIsWorthPreviewing && !isExecutable && !isStreaming
 
@@ -960,7 +931,6 @@ export const CodeBlock = memo(function CodeBlock({
     shouldStartInPreview ? 'preview' : 'code',
   )
 
-  // Switch to preview mode when streaming ends (only if user hasn't manually toggled)
   const wasStreamingRef = useRef(isStreaming)
   useEffect(() => {
     const streamingJustEnded = wasStreamingRef.current && !isStreaming
@@ -981,7 +951,6 @@ export const CodeBlock = memo(function CodeBlock({
     setViewMode(mode)
   }
 
-  // Determine what to actually show: preview only if allowed and code is worth it
   const showPreview =
     canShowPreview && codeIsWorthPreviewing && viewMode === 'preview'
 

--- a/src/components/icons/lazy-icons.tsx
+++ b/src/components/icons/lazy-icons.tsx
@@ -1,7 +1,6 @@
 import { lazy, Suspense } from 'react'
 import type { IconBaseProps } from 'react-icons'
 
-// Lazy load individual icons
 const AiOutlineCloudSyncLazy = lazy(() =>
   import('react-icons/ai').then((m) => ({ default: m.AiOutlineCloudSync })),
 )
@@ -26,7 +25,6 @@ const PiSpinnerThinLazy = lazy(() =>
   import('react-icons/pi').then((m) => ({ default: m.PiSpinnerThin })),
 )
 
-// File icons from react-icons/fa
 const FaFileLazy = lazy(() =>
   import('react-icons/fa').then((m) => ({ default: m.FaFile })),
 )
@@ -61,7 +59,6 @@ const FaFileAltLazy = lazy(() =>
   import('react-icons/fa').then((m) => ({ default: m.FaFileAlt })),
 )
 
-// Icon wrapper component
 function IconWrapper({ Icon, ...props }: { Icon: any } & IconBaseProps) {
   return (
     <Suspense
@@ -76,7 +73,6 @@ function IconWrapper({ Icon, ...props }: { Icon: any } & IconBaseProps) {
   )
 }
 
-// Export wrapped icons
 export const AiOutlineCloudSync = (props: IconBaseProps) => (
   <IconWrapper Icon={AiOutlineCloudSyncLazy} {...props} />
 )

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -5,7 +5,6 @@ import * as React from 'react'
 
 import { cn } from './utils'
 
-// Define available toast positions
 export type ToastPosition =
   | 'top-left'
   | 'top-center'
@@ -14,11 +13,11 @@ export type ToastPosition =
   | 'bottom-center'
   | 'bottom-right'
 
-// Create a context to store and provide the position configuration
 const ToastPositionContext = React.createContext<ToastPosition>('bottom-right')
 
-interface ToastProviderProps
-  extends React.ComponentPropsWithoutRef<typeof ToastPrimitives.Provider> {
+interface ToastProviderProps extends React.ComponentPropsWithoutRef<
+  typeof ToastPrimitives.Provider
+> {
   position?: ToastPosition
   children: React.ReactNode
 }
@@ -35,7 +34,6 @@ const ToastProvider = ({
   )
 }
 
-// Hook to use the toast position
 const useToastPosition = () => React.useContext(ToastPositionContext)
 
 const ToastViewport = React.forwardRef<
@@ -44,7 +42,6 @@ const ToastViewport = React.forwardRef<
 >(({ className, ...props }, ref) => {
   const position = useToastPosition()
 
-  // Generate position-specific classes
   const positionClasses = {
     'top-left': 'top-0 left-0 flex-col-reverse',
     'top-center': 'top-0 left-1/2 -translate-x-1/2 flex-col-reverse',
@@ -68,7 +65,6 @@ const ToastViewport = React.forwardRef<
 })
 ToastViewport.displayName = ToastPrimitives.Viewport.displayName
 
-// Update toast variants to handle animations based on position
 const TOAST_VARIANTS = cva(
   'group pointer-events-auto relative flex w-full items-center justify-between space-x-4 overflow-hidden rounded-md border p-6 pr-8 shadow-lg transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80',
   {
@@ -92,7 +88,6 @@ const Toast = React.forwardRef<
 >(({ className, variant, ...props }, ref) => {
   const position = useToastPosition()
 
-  // Define animation classes based on position
   const animationClasses = {
     'top-left':
       'data-[state=closed]:slide-out-to-left-full data-[state=open]:slide-in-from-left-full',

--- a/src/components/verification-sidebar.tsx
+++ b/src/components/verification-sidebar.tsx
@@ -43,13 +43,11 @@ export function VerifierSidebar({
   const isRetryingRef = useRef(false)
 
   const fetchVerificationDocument = useCallback(async () => {
-    // Prevent concurrent retry attempts
     if (isRetryingRef.current) return
     isRetryingRef.current = true
     retryCountRef.current = 0
 
     const attemptFetch = async (): Promise<boolean> => {
-      // Check internet connection
       if (!isOnline()) {
         logInfo('No internet connection, waiting to retry verification', {
           component: 'VerifierSidebar',
@@ -82,10 +80,8 @@ export function VerifierSidebar({
       }
     }
 
-    // Try initial fetch
     let success = await attemptFetch()
 
-    // Retry with exponential backoff if initial attempt failed
     while (
       !success &&
       retryCountRef.current < CONSTANTS.VERIFICATION_MAX_RETRIES
@@ -112,7 +108,6 @@ export function VerifierSidebar({
     isRetryingRef.current = false
   }, [onVerificationUpdate, onVerificationComplete])
 
-  // Handle messages from iframe
   useEffect(() => {
     const handleMessage = (event: MessageEvent) => {
       if (event.origin !== VERIFICATION_CENTER_ORIGIN) return
@@ -148,14 +143,12 @@ export function VerifierSidebar({
     return () => timers.forEach(clearTimeout)
   }, [isReady, verificationDocument])
 
-  // Fetch verification document when sidebar opens
   useEffect(() => {
     if (isOpen && isClient) {
       fetchVerificationDocument()
     }
   }, [isOpen, isClient, fetchVerificationDocument])
 
-  // Control open/close state
   useEffect(() => {
     if (isReady && iframeRef.current) {
       const message = isOpen
@@ -172,14 +165,12 @@ export function VerifierSidebar({
 
   return (
     <>
-      {/* Right Sidebar wrapper */}
       <div
         className={`${
           isOpen ? 'translate-x-0' : 'translate-x-full'
         } fixed right-0 top-0 z-40 flex h-full w-[85vw] overflow-hidden border-l border-border-subtle bg-surface-sidebar font-aeonik transition-all duration-200 ease-in-out`}
         style={{ maxWidth: `${CONSTANTS.VERIFIER_SIDEBAR_WIDTH_PX}px` }}
       >
-        {/* Verification Center iframe */}
         {isClient && (
           <iframe
             ref={iframeRef}
@@ -191,7 +182,6 @@ export function VerifierSidebar({
           />
         )}
 
-        {/* Close button overlay */}
         <div className="absolute right-0 top-0 flex items-center justify-end p-4">
           <button
             onClick={() => setIsOpen(false)}
@@ -202,7 +192,6 @@ export function VerifierSidebar({
         </div>
       </div>
 
-      {/* Mobile overlay */}
       {isOpen && (
         <div
           className="fixed inset-0 z-30 bg-black/50 md:hidden"

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -110,7 +110,6 @@ export type BaseModel = {
   requestParams?: Record<string, unknown>
 }
 
-// Helper function to validate if a specific model name exists in the models list
 export const isModelNameAvailable = (
   modelName: string,
   models: BaseModel[],
@@ -118,7 +117,6 @@ export const isModelNameAvailable = (
   return models.some((m) => m.modelName === modelName)
 }
 
-// Helper function to check if running in local development
 const isLocalDevelopment = (): boolean => {
   return (
     typeof window !== 'undefined' &&

--- a/src/hooks/use-chat-router.ts
+++ b/src/hooks/use-chat-router.ts
@@ -16,7 +16,6 @@ export function useChatRouter(): UseChatRouterReturn {
   const router = useRouter()
   const [isRouterReady, setIsRouterReady] = useState(false)
 
-  // Parse initial values from URL when router is ready
   const initialChatId =
     router.isReady && typeof router.query.chatId === 'string'
       ? router.query.chatId
@@ -26,20 +25,17 @@ export function useChatRouter(): UseChatRouterReturn {
       ? router.query.projectId
       : null
 
-  // Detect if current URL is a local chat URL
   const isLocalChatUrl =
     router.isReady && router.pathname === '/chat/local/[chatId]'
 
-  // Mark router as ready
   useEffect(() => {
     if (router.isReady && !isRouterReady) {
       setIsRouterReady(true)
     }
   }, [router.isReady, isRouterReady])
 
-  // Update URL when chat changes
   // Use history.replaceState directly to avoid Next.js route changes
-  // This keeps us on the same page component while updating the URL
+  // This keeps us on the same page component while updating the URL.
   const updateUrlForChat = useCallback((chatId: string, projectId?: string) => {
     if (typeof window === 'undefined') return
 
@@ -47,7 +43,6 @@ export function useChatRouter(): UseChatRouterReturn {
       ? `/project/${projectId}/chat/${chatId}`
       : `/chat/${chatId}`
 
-    // Only update if path actually changed
     if (window.location.pathname !== newPath) {
       window.history.replaceState(
         { ...window.history.state, as: newPath, url: newPath },
@@ -57,7 +52,6 @@ export function useChatRouter(): UseChatRouterReturn {
     }
   }, [])
 
-  // Update URL for local-only chats
   const updateUrlForLocalChat = useCallback((chatId: string) => {
     if (typeof window === 'undefined') return
 
@@ -72,7 +66,6 @@ export function useChatRouter(): UseChatRouterReturn {
     }
   }, [])
 
-  // Update URL when in project mode with blank chat
   const updateUrlForProject = useCallback((projectId: string) => {
     if (typeof window === 'undefined') return
 
@@ -87,7 +80,6 @@ export function useChatRouter(): UseChatRouterReturn {
     }
   }, [])
 
-  // Clear URL when going to blank/new chat
   const clearUrl = useCallback(() => {
     if (typeof window === 'undefined') return
 

--- a/src/hooks/use-cloud-sync.ts
+++ b/src/hooks/use-cloud-sync.ts
@@ -57,7 +57,6 @@ export function useCloudSync(options?: UseCloudSyncOptions) {
   const onKeyChangedRef = useRef(options?.onKeyChanged)
   onKeyChangedRef.current = options?.onKeyChanged
 
-  // Cleanup on unmount
   useEffect(() => {
     return () => {
       isMountedRef.current = false
@@ -107,7 +106,6 @@ export function useCloudSync(options?: UseCloudSyncOptions) {
       initializingRef.current = true
 
       try {
-        // Initialize centralized auth token manager
         authTokenManager.initialize(getToken)
 
         const existingKey = localStorage.getItem(USER_ENCRYPTION_KEY)
@@ -177,7 +175,6 @@ export function useCloudSync(options?: UseCloudSyncOptions) {
 
   // Full sync chats (always fetches first page)
   const syncChats = useCallback(async () => {
-    // Check if cloud sync is enabled
     if (!isCloudSyncEnabled()) {
       logInfo('Cloud sync is disabled, skipping sync', {
         component: 'useCloudSync',
@@ -291,7 +288,6 @@ export function useCloudSync(options?: UseCloudSyncOptions) {
     }
   }, [])
 
-  // Backup a single chat
   const backupChat = useCallback(async (chatId: string) => {
     await cloudSync.backupChat(chatId)
   }, [])
@@ -352,7 +348,6 @@ export function useCloudSync(options?: UseCloudSyncOptions) {
     }
   }, [])
 
-  // Retry decryption for failed chats
   const retryDecryptionWithNewKey = useCallback(
     (opts?: { runInBackground?: boolean }) => {
       const { runInBackground = false } = opts || {}

--- a/src/hooks/use-profile-sync.ts
+++ b/src/hooks/use-profile-sync.ts
@@ -76,7 +76,6 @@ export function useProfileSync() {
   const syncFromCloud = useCallback(async () => {
     if (!isSignedIn || !isCloudSyncEnabled()) return
 
-    // Skip sync if we have pending local changes
     if (hasLocalProfileChanges()) {
       logInfo('Skipping cloud sync - local changes pending', {
         component: 'ProfileSync',
@@ -101,9 +100,7 @@ export function useProfileSync() {
           return
         }
 
-        // Check if the cloud profile is actually different from what we have
         if (hasProfileChanged(cloudProfile, lastSyncedProfile.current)) {
-          // Apply cloud settings to localStorage
           isApplyingRemoteProfile.current = true
           try {
             applySettingsToLocal(cloudProfile)
@@ -138,13 +135,11 @@ export function useProfileSync() {
   const smartSyncFromCloud = useCallback(async () => {
     if (!isSignedIn || !isCloudSyncEnabled()) return
 
-    // Skip sync if we have pending local changes
     if (hasLocalProfileChanges()) {
       return
     }
 
     try {
-      // Get remote sync status
       const remoteStatus = await profileSync.getSyncStatus()
 
       if (!remoteStatus) {
@@ -156,10 +151,8 @@ export function useProfileSync() {
         return
       }
 
-      // Get cached status
       const cached = profileSyncCache.current.load()
 
-      // Check if we need to sync
       const needsSync =
         !cached ||
         !cached.exists ||
@@ -200,7 +193,6 @@ export function useProfileSync() {
           return
         }
 
-        // Apply if changed
         if (hasProfileChanged(cloudProfile, lastSyncedProfile.current)) {
           isApplyingRemoteProfile.current = true
           try {
@@ -228,7 +220,6 @@ export function useProfileSync() {
   const syncToCloud = useCallback(async () => {
     if (!isSignedIn || !isCloudSyncEnabled()) return
 
-    // Clear any existing debounce timer
     if (syncDebounceTimer.current) {
       clearTimeout(syncDebounceTimer.current)
     }
@@ -252,7 +243,6 @@ export function useProfileSync() {
 
         const localSettings = loadLocalSettings()
 
-        // Check if local settings are different from last synced profile
         if (!hasProfileChanged(localSettings, lastSyncedProfile.current)) {
           logInfo('Skipping cloud sync - no changes detected', {
             component: 'ProfileSync',
@@ -366,7 +356,6 @@ export function useProfileSync() {
       syncToCloud()
     }
 
-    // Listen for all settings change events
     const events = [
       'themeChanged',
       'maxPromptMessagesChanged',
@@ -384,7 +373,6 @@ export function useProfileSync() {
         window.removeEventListener(event, handleSettingsChange)
       })
 
-      // Clear debounce timer on cleanup
       if (syncDebounceTimer.current) {
         clearTimeout(syncDebounceTimer.current)
       }

--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -1,4 +1,3 @@
-// This builds upon your existing hooks implementation
 import type {
   ToastActionElement,
   ToastPosition,
@@ -75,10 +74,8 @@ const addToRemoveQueue = (toastId: string) => {
   toastTimeouts.set(toastId, timeout)
 }
 
-// Initialize state with position
 let memoryState: State = { toasts: [], position: 'bottom-right' }
 
-// Update setToastPosition to update state
 export function setToastPosition(position: ToastPosition) {
   dispatch({
     type: 'UPDATE_POSITION',
@@ -86,7 +83,6 @@ export function setToastPosition(position: ToastPosition) {
   })
 }
 
-// Update reducer to handle position
 export const reducer = (state: State, action: Action): State => {
   switch (action.type) {
     case 'ADD_TOAST':
@@ -150,10 +146,8 @@ function dispatch(action: Action) {
   })
 }
 
-// Store the currently set position
 let currentPosition: ToastPosition = 'bottom-right'
 
-// Get the current position
 export function getToastPosition(): ToastPosition {
   return currentPosition
 }

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -57,18 +57,12 @@ export default function Document() {
   return (
     <Html lang="en" data-theme="light" className="overflow-x-hidden">
       <Head>
-        {/* Theme initialization script - must run before first paint */}
         <script dangerouslySetInnerHTML={{ __html: themeScript }} />
-        {/* App-height initialization script - must run before first paint so the
-            bottom-anchored mobile chat input is visible on every browser */}
         <script dangerouslySetInnerHTML={{ __html: appHeightScript }} />
-        {/* Preconnect to external domains */}
         <link rel="preconnect" href="https://clerk.accounts.dev" />
 
-        {/* PWA Manifest */}
         <link rel="manifest" href="/site.webmanifest" />
 
-        {/* Theme color - adapts to light/dark mode */}
         <meta
           name="theme-color"
           content="#ffffff"
@@ -80,7 +74,6 @@ export default function Document() {
           media="(prefers-color-scheme: dark)"
         />
 
-        {/* Meta tags */}
         <meta
           name="description"
           content="Verifiably Private AI chat application supporting open source models through Tinfoil"
@@ -91,7 +84,6 @@ export default function Document() {
         />
         <meta name="author" content="Tinfoil" />
 
-        {/* Open Graph */}
         <meta property="og:title" content="Tinfoil Private Chat" />
         <meta
           property="og:description"
@@ -100,7 +92,6 @@ export default function Document() {
         <meta property="og:type" content="website" />
         <meta property="og:locale" content="en_US" />
 
-        {/* Twitter Card */}
         <meta name="twitter:card" content="summary" />
         <meta name="twitter:title" content="Tinfoil Private Chat" />
         <meta
@@ -108,10 +99,8 @@ export default function Document() {
           content="Private AI chat application supporting open source models through Tinfoil"
         />
 
-        {/* Robots */}
         <meta name="robots" content="index, follow" />
 
-        {/* Favicons */}
         <link
           rel="icon"
           href="/icon-light.png"
@@ -125,7 +114,6 @@ export default function Document() {
           type="image/png"
         />
 
-        {/* Apple Touch Icons */}
         <link
           rel="apple-touch-icon"
           href="/apple-touch-icon-light.png"
@@ -144,11 +132,9 @@ export default function Document() {
           sizes="180x180"
         />
 
-        {/* Android Chrome Icons */}
         <link rel="icon" href="/android-chrome-192x192.png" sizes="192x192" />
         <link rel="icon" href="/android-chrome-512x512.png" sizes="512x512" />
 
-        {/* Plausible Analytics */}
         <Script
           defer
           data-domain="chat.tinfoil.sh"

--- a/src/services/cloud/cloud-storage.ts
+++ b/src/services/cloud/cloud-storage.ts
@@ -221,7 +221,6 @@ export class CloudStorageService {
       throw new Error('Maximum 100 chats per bulk upload request')
     }
 
-    // Step 1: Upload attachments and encrypt each chat to v1 binary
     const metadata: Array<{
       conversationId: string
       messageCount: number
@@ -247,7 +246,6 @@ export class CloudStorageService {
       binaryParts.push({ id: chat.id, data: binary })
     }
 
-    // Step 2: Build multipart form — metadata JSON + one binary part per conversation
     const formData = new FormData()
     formData.append(
       'metadata',

--- a/src/services/cloud/cloud-sync.ts
+++ b/src/services/cloud/cloud-sync.ts
@@ -64,7 +64,6 @@ export class CloudSyncService {
   private projectSyncCaches = new Map<string, SyncStatusCache<ChatSyncStatus>>()
 
   constructor() {
-    // Initialize upload coalescer with doBackupChat as the upload function
     this.uploadCoalescer = new UploadCoalescer(
       (chatId) => this.doBackupChat(chatId),
       {
@@ -77,12 +76,10 @@ export class CloudSyncService {
     if (typeof window !== 'undefined') {
       window.addEventListener('storage', (e) => {
         if (e.key === SYNC_CHAT_STATUS) {
-          // Another tab updated sync status, invalidate our cache
           this.chatSyncCache.invalidate()
         } else if (e.key === SYNC_ALL_CHATS_STATUS) {
           this.allChatsSyncCache.invalidate()
         } else if (e.key?.startsWith(SYNC_PROJECT_CHAT_STATUS_PREFIX)) {
-          // Another tab updated project sync status, invalidate that project's cache
           const projectId = e.key.slice(SYNC_PROJECT_CHAT_STATUS_PREFIX.length)
           const existingCache = this.projectSyncCaches.get(projectId)
           if (existingCache) {
@@ -110,7 +107,6 @@ export class CloudSyncService {
    * Throws if a sync is already in progress.
    */
   private async withSyncLock<T>(fn: () => Promise<T>): Promise<T> {
-    // Check if sync is already in progress (atomic check)
     if (this.syncLock) {
       logInfo('[CloudSync] Sync already in progress, skipping', {
         component: 'CloudSync',
@@ -119,7 +115,6 @@ export class CloudSyncService {
       throw new Error('Sync already in progress')
     }
 
-    // Acquire lock
     let resolve: () => void
     this.syncLock = new Promise<void>((r) => {
       resolve = r
@@ -129,7 +124,6 @@ export class CloudSyncService {
     try {
       return await fn()
     } finally {
-      // Release lock
       this.syncLock = null
       if (this.syncLockResolve) {
         this.syncLockResolve()
@@ -148,10 +142,8 @@ export class CloudSyncService {
     }
 
     try {
-      // First check if we have local unsynced changes
       const unsyncedChats = await indexedDBStorage.getUnsyncedChats()
       const chatsNeedingUpload = unsyncedChats.filter((chat) => {
-        // Filter by project if specified
         if (projectId) {
           if (chat.projectId !== projectId) return false
         } else {
@@ -169,17 +161,14 @@ export class CloudSyncService {
         }
       }
 
-      // Fetch remote sync status
       const remoteStatus = projectId
         ? await projectStorage.getProjectChatsSyncStatus(projectId)
         : await cloudStorage.getChatSyncStatus()
 
-      // Get cached status
       const cachedStatus = projectId
         ? this.getProjectSyncCache(projectId).load()
         : this.chatSyncCache.load()
 
-      // If no cached status, we need a full sync
       if (!cachedStatus) {
         return {
           needsSync: true,
@@ -201,7 +190,6 @@ export class CloudSyncService {
         },
       })
 
-      // Compare count
       if (remoteStatus.count !== cachedStatus.count) {
         return {
           needsSync: true,
@@ -211,7 +199,6 @@ export class CloudSyncService {
         }
       }
 
-      // Compare lastUpdated timestamps
       if (remoteStatus.lastUpdated !== cachedStatus.lastUpdated) {
         return {
           needsSync: true,
@@ -221,7 +208,6 @@ export class CloudSyncService {
         }
       }
 
-      // No changes detected
       return {
         needsSync: false,
         reason: 'no_changes',
@@ -248,7 +234,6 @@ export class CloudSyncService {
 
       const remoteAllStatus = await cloudStorage.getAllChatsSyncStatus()
 
-      // If nothing changed globally, skip
       if (
         cachedAllStatus &&
         remoteAllStatus.count === cachedAllStatus.count &&
@@ -286,14 +271,12 @@ export class CloudSyncService {
           const localProjectId = localChat?.projectId ?? undefined
 
           if (localChat && remoteProjectId !== localProjectId) {
-            // Project assignment changed — update local state
             await indexedDBStorage.updateChatProject(
               remoteChat.id,
               remoteChat.projectId ?? null,
             )
             changedIds.push(remoteChat.id)
           } else if (!localChat && remoteChat.content) {
-            // New chat we don't have locally — ingest it
             const ingestResult = await ingestRemoteChats([remoteChat], {
               fetchMissingContent: true,
               projectId: remoteChat.projectId ?? undefined,
@@ -329,7 +312,6 @@ export class CloudSyncService {
     }
   }
 
-  // Perform a delta sync - only fetch chats that changed since last sync
   async syncChangedChats(): Promise<SyncResult> {
     return this.withSyncLock(() => this.doSyncChangedChats())
   }
@@ -353,7 +335,6 @@ export class CloudSyncService {
         await syncRemoteDeletions(cachedStatus.lastUpdated, 'syncChangedChats')
       }
 
-      // Backup any unsynced local changes
       const backupResult = await this.backupUnsyncedChats()
       result.uploaded = backupResult.uploaded
       result.errors.push(...backupResult.errors)
@@ -423,7 +404,6 @@ export class CloudSyncService {
         continuationToken = updatedChats.nextContinuationToken
       }
 
-      // Update cached sync status
       try {
         const newStatus = await cloudStorage.getChatSyncStatus()
         this.chatSyncCache.save(newStatus)
@@ -457,7 +437,6 @@ export class CloudSyncService {
 
   // Backup a single chat to the cloud with coalescing and retry
   async backupChat(chatId: string): Promise<void> {
-    // Don't attempt backup if not authenticated
     if (!(await cloudStorage.isAuthenticated())) {
       return
     }
@@ -530,9 +509,7 @@ export class CloudSyncService {
         return
       }
 
-      // Check if chat is currently streaming
       if (streamingTracker.isStreaming(chatId)) {
-        // Check if we already have a callback registered for this chat
         if (this.streamingCallbacks.has(chatId)) {
           logInfo('Streaming callback already registered for chat', {
             component: 'CloudSync',
@@ -548,12 +525,9 @@ export class CloudSyncService {
           metadata: { chatId },
         })
 
-        // Mark that we have a callback registered
         this.streamingCallbacks.add(chatId)
 
-        // Register to sync once streaming ends
         streamingTracker.onStreamEnd(chatId, () => {
-          // Remove from tracking set
           this.streamingCallbacks.delete(chatId)
 
           logInfo('Streaming ended, triggering delayed sync', {
@@ -561,7 +535,6 @@ export class CloudSyncService {
             action: 'backupChat',
             metadata: { chatId },
           })
-          // Re-trigger the backup after streaming ends.
           // Errors are handled internally by the upload coalescer.
           this.backupChat(chatId)
         })
@@ -603,7 +576,6 @@ export class CloudSyncService {
 
       await cloudStorage.uploadChat(chat)
 
-      // Mark as synced with incremented version
       const newVersion = (chat.syncVersion ?? 0) + 1
       await indexedDBStorage.markAsSynced(chatId, newVersion)
     } catch (error) {
@@ -618,7 +590,6 @@ export class CloudSyncService {
     }
   }
 
-  // Backup all unsynced chats
   async backupUnsyncedChats(): Promise<SyncResult> {
     const result: SyncResult = {
       uploaded: 0,
@@ -633,7 +604,6 @@ export class CloudSyncService {
     try {
       const unsyncedChats = await indexedDBStorage.getUnsyncedChats()
 
-      // Debug logging
       logInfo(`Found unsynced chats: ${unsyncedChats.length}`, {
         component: 'CloudSync',
         action: 'backupUnsyncedChats',
@@ -756,12 +726,10 @@ export class CloudSyncService {
         await syncRemoteDeletions(cachedStatus.lastUpdated, 'syncAllChats')
       }
 
-      // Backup any unsynced local changes
       const backupResult = await this.backupUnsyncedChats()
       result.uploaded = backupResult.uploaded
       result.errors.push(...backupResult.errors)
 
-      // Then, get list of remote chats with content
       const remoteList = await this.listChatsWithRetry({
         includeContent: true,
         limit: PAGINATION.CHATS_PER_PAGE,
@@ -792,7 +760,6 @@ export class CloudSyncService {
       result.downloaded += ingestResult.downloaded
       result.errors.push(...ingestResult.errors)
 
-      // Update cached sync status after successful sync
       try {
         const newStatus = await cloudStorage.getChatSyncStatus()
         this.chatSyncCache.save(newStatus)
@@ -864,14 +831,11 @@ export class CloudSyncService {
     return projectId ? this.syncProjectChats(projectId) : this.syncAllChats()
   }
 
-  // Check if currently syncing
   get syncing(): boolean {
     return this.syncLock !== null
   }
 
-  // Delete a chat from cloud storage
   async deleteFromCloud(chatId: string): Promise<void> {
-    // Don't attempt deletion if not authenticated
     if (!(await cloudStorage.isAuthenticated())) {
       return
     }
@@ -900,7 +864,6 @@ export class CloudSyncService {
     }
   }
 
-  // Update a chat's project association on the server
   async updateChatProject(
     chatId: string,
     projectId: string | null,
@@ -948,7 +911,6 @@ export class CloudSyncService {
   }): Promise<PaginatedChatsResult> {
     const { limit, continuationToken, loadLocal = true } = options
 
-    // If no authentication, just return local chats
     if (!(await cloudStorage.isAuthenticated())) {
       if (loadLocal) {
         return this.paginateLocalChats(limit, continuationToken)
@@ -964,13 +926,10 @@ export class CloudSyncService {
         includeContent: true,
       })
 
-      // Process the chat data from each remote chat in parallel
       const downloadedChats: StoredChat[] = []
       const chatsToProcess = remoteList.conversations || []
 
-      // Process all chats in parallel for better performance
       const processPromises = chatsToProcess.map(async (remoteChat) => {
-        // Skip if this chat was recently deleted
         if (deletedChatsTracker.isDeleted(remoteChat.id)) {
           logInfo('Skipping load for recently deleted chat', {
             component: 'CloudSync',
@@ -995,10 +954,8 @@ export class CloudSyncService {
         }
       })
 
-      // Wait for all decryptions to complete
       const results = await Promise.all(processPromises)
 
-      // Filter out nulls and add to downloadedChats
       for (const chat of results) {
         if (chat) {
           downloadedChats.push(chat)
@@ -1025,7 +982,6 @@ export class CloudSyncService {
     }
   }
 
-  // Retry decryption for chats that failed to decrypt
   async retryDecryptionWithNewKey(
     options: {
       onProgress?: (current: number, total: number) => void
@@ -1051,7 +1007,6 @@ export class CloudSyncService {
   }): Promise<{ hasMore: boolean; nextToken?: string; saved: number }> {
     const { limit, continuationToken } = options
 
-    // Only operate when authenticated
     if (!(await cloudStorage.isAuthenticated())) {
       return { hasMore: false, saved: 0 }
     }
@@ -1170,7 +1125,6 @@ export class CloudSyncService {
         },
       })
 
-      // Update cached sync status after successful sync
       try {
         const newStatus =
           await projectStorage.getProjectChatsSyncStatus(projectId)
@@ -1219,7 +1173,6 @@ export class CloudSyncService {
     }
 
     try {
-      // First, backup any unsynced local project chats
       const unsyncedChats = await indexedDBStorage.getUnsyncedChats()
       const projectChatsToSync = unsyncedChats.filter(
         (chat) =>
@@ -1278,7 +1231,6 @@ export class CloudSyncService {
             action: 'syncProjectChatsChanged',
             metadata: { projectId, since: cachedStatus.lastUpdated },
           })
-          // Update the cached status
           try {
             const newStatus =
               await projectStorage.getProjectChatsSyncStatus(projectId)
@@ -1314,13 +1266,11 @@ export class CloudSyncService {
         result.downloaded += ingestResult.downloaded
         result.errors.push(...ingestResult.errors)
 
-        // Check if there are more pages
         hasMore =
           updatedChats.hasMore === true && !!updatedChats.nextContinuationToken
         cursorId = updatedChats.nextContinuationToken
       }
 
-      // Update cached sync status
       try {
         const newStatus =
           await projectStorage.getProjectChatsSyncStatus(projectId)

--- a/src/services/cloud/profile-sync.ts
+++ b/src/services/cloud/profile-sync.ts
@@ -64,7 +64,6 @@ export class ProfileSyncService {
     return data.data as string
   }
 
-  // Get profile from cloud
   async fetchProfile(): Promise<ProfileData | null> {
     try {
       const payload = await this.fetchEncryptedProfilePayload()
@@ -76,12 +75,10 @@ export class ProfileSyncService {
         return null
       }
 
-      // Try to decrypt the profile data
       try {
         const encrypted = JSON.parse(payload)
         const decrypted = await encryptionService.decrypt(encrypted)
 
-        // Cache the decrypted profile
         this.cachedProfile = decrypted
         this.failedDecryptionData = null
 
@@ -137,7 +134,6 @@ export class ProfileSyncService {
     }
   }
 
-  // Save profile to cloud
   async saveProfile(
     profile: ProfileData,
   ): Promise<{ success: boolean; version?: number }> {
@@ -160,14 +156,12 @@ export class ProfileSyncService {
         },
       })
 
-      // Add metadata
       const profileWithMetadata: ProfileData = {
         ...profile,
         updatedAt: new Date().toISOString(),
         version: (profile.version || 0) + 1,
       }
 
-      // Encrypt the profile data
       const encrypted = await encryptionService.encrypt(profileWithMetadata)
 
       logInfo('Encrypted profile data', {
@@ -198,7 +192,6 @@ export class ProfileSyncService {
         throw new Error(`Failed to save profile: ${response.statusText}`)
       }
 
-      // Update cache
       this.cachedProfile = profileWithMetadata
 
       logInfo('Profile saved successfully', {
@@ -233,7 +226,6 @@ export class ProfileSyncService {
     }
   }
 
-  // Retry decryption with new key
   async retryDecryptionWithNewKey(): Promise<ProfileData | null> {
     if (!this.failedDecryptionData) {
       return null
@@ -243,7 +235,6 @@ export class ProfileSyncService {
       const encrypted = JSON.parse(this.failedDecryptionData)
       const decrypted = await encryptionService.decrypt(encrypted)
 
-      // Cache the successfully decrypted profile
       this.cachedProfile = decrypted
       this.failedDecryptionData = null
 
@@ -272,7 +263,6 @@ export class ProfileSyncService {
     return this.failedDecryptionData !== null
   }
 
-  // Clear cache
   clearCache(): void {
     this.cachedProfile = null
     this.failedDecryptionData = null

--- a/src/services/cloud/upload-coalescer.ts
+++ b/src/services/cloud/upload-coalescer.ts
@@ -104,10 +104,8 @@ export class UploadCoalescer {
       this.states.set(chatId, state)
     }
 
-    // Mark as dirty (needs upload)
     state.dirty = true
 
-    // If no upload in progress, start the worker
     if (!state.inFlight) {
       this.startWorker(chatId, state)
     }
@@ -121,18 +119,15 @@ export class UploadCoalescer {
     const workerGeneration = this.generation
     const workerPromise = (async () => {
       while (state.dirty && workerGeneration === this.generation) {
-        // Clear dirty flag before upload
         state.dirty = false
 
         try {
           await this.uploadWithRetry(chatId, state)
-          // Success - reset failure count
           state.failureCount = 0
           state.lastError = null
         } catch (error) {
           const uploadError =
             error instanceof Error ? error : new Error(String(error))
-          // Upload failed after all retries
           state.failureCount++
           state.lastError = uploadError
           logError('Upload failed after retries', error, {
@@ -150,7 +145,6 @@ export class UploadCoalescer {
         }
       }
 
-      // Worker done - clear in-flight promise
       state.inFlight = null
 
       const resultWaiters = state.resultWaiters.splice(0)
@@ -206,12 +200,10 @@ export class UploadCoalescer {
       } catch (error) {
         lastError = error instanceof Error ? error : new Error(String(error))
 
-        // Don't retry on final attempt
         if (attempt === this.config.maxRetries) {
           break
         }
 
-        // Calculate backoff delay
         const delay = Math.min(
           this.config.baseDelayMs * Math.pow(2, attempt),
           this.config.maxDelayMs,
@@ -229,10 +221,8 @@ export class UploadCoalescer {
           },
         })
 
-        // Wait before retry
         await this.sleep(delay)
 
-        // Check if new changes came in during wait
         if (state.dirty) {
           // New changes - let the outer loop handle it with fresh data
           return
@@ -240,13 +230,9 @@ export class UploadCoalescer {
       }
     }
 
-    // All retries exhausted
     throw lastError ?? new Error('Upload failed')
   }
 
-  /**
-   * Sleep for a specified duration.
-   */
   private sleep(ms: number): Promise<void> {
     return new Promise((resolve) => setTimeout(resolve, ms))
   }

--- a/src/services/inference/inference-client.ts
+++ b/src/services/inference/inference-client.ts
@@ -223,7 +223,6 @@ export async function sendChatStream(
           throw err
         }
 
-        // Check if we should retry
         if (attempt < maxRetries && isRetryableError(err)) {
           const backoffDelay =
             CONSTANTS.MESSAGE_SEND_RETRY_DELAY_MS * Math.pow(2, attempt)
@@ -276,7 +275,6 @@ export async function sendChatStream(
   const maxRetries = CONSTANTS.MESSAGE_SEND_MAX_RETRIES
 
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
-    // Check if aborted before attempting
     if (signal.aborted) {
       throw new DOMException('Aborted', 'AbortError')
     }
@@ -299,7 +297,6 @@ export async function sendChatStream(
     }
 
     try {
-      // Build request body
       const requestBody: Record<string, unknown> = {
         model: model.modelName,
         messages,
@@ -439,7 +436,6 @@ export async function sendChatStream(
         throw err
       }
 
-      // Check if we should retry
       if (attempt < maxRetries && isRetryableError(err)) {
         const backoffDelay =
           CONSTANTS.MESSAGE_SEND_RETRY_DELAY_MS * Math.pow(2, attempt)
@@ -455,14 +451,12 @@ export async function sendChatStream(
           },
         })
 
-        // Notify caller that we're retrying
         onRetry?.(attempt + 1, maxRetries)
 
         await delay(backoffDelay)
         continue
       }
 
-      // Log final failure
       logError('Chat stream request failed after retries', err, {
         component: 'inference-client',
         action: 'sendChatStream',

--- a/src/services/inference/inference-client.ts
+++ b/src/services/inference/inference-client.ts
@@ -479,7 +479,8 @@ export async function sendChatStream(
     }
   }
 
-  // This should not be reached, but just in case
+  // Fallback: every branch above should already have thrown, but if the
+  // retry loop exits without doing so we still need to surface an error.
   const anyErr = lastError as any
   const msg = anyErr?.message || 'Unknown network error'
   throw new ChatError(

--- a/src/services/storage/chat-storage.ts
+++ b/src/services/storage/chat-storage.ts
@@ -113,7 +113,6 @@ export class ChatStorageService {
   }
 
   async saveChatAndSync(chat: Chat): Promise<Chat> {
-    // Just use the regular saveChat method with sync enabled
     return await this.saveChat(chat, false)
   }
 

--- a/src/services/storage/session-storage.ts
+++ b/src/services/storage/session-storage.ts
@@ -3,7 +3,6 @@ import { SYNC_SESSION_CHATS } from '@/constants/storage-keys'
 import { logError } from '@/utils/error-handling'
 
 export const sessionChatStorage = {
-  // Get all chats from session storage
   getAllChats(): Chat[] {
     try {
       const chatsJson = sessionStorage.getItem(SYNC_SESSION_CHATS)
@@ -32,7 +31,6 @@ export const sessionChatStorage = {
     }
   },
 
-  // Save a chat to session storage
   saveChat(chat: Chat): void {
     try {
       // Validate chat parameter
@@ -80,7 +78,6 @@ export const sessionChatStorage = {
     }
   },
 
-  // Delete a chat from session storage
   deleteChat(chatId: string): void {
     try {
       const chats = this.getAllChats()
@@ -95,7 +92,6 @@ export const sessionChatStorage = {
     }
   },
 
-  // Clear all chats from session storage
   clearAll(): void {
     try {
       sessionStorage.removeItem(SYNC_SESSION_CHATS)

--- a/src/utils/dev-simulator.ts
+++ b/src/utils/dev-simulator.ts
@@ -545,7 +545,6 @@ export async function* simulateStream(
   yield 'data: [DONE]\n\n'
 }
 
-// Helper to chunk text
 function chunkText(text: string, chunkSize: number): string[] {
   const chunks: string[] = []
   for (let i = 0; i < text.length; i += chunkSize) {
@@ -554,7 +553,6 @@ function chunkText(text: string, chunkSize: number): string[] {
   return chunks
 }
 
-// Helper to escape JSON strings
 function escapeJson(str: string): string {
   return str
     .replace(/\\/g, '\\\\')

--- a/src/utils/error-handling.ts
+++ b/src/utils/error-handling.ts
@@ -39,31 +39,9 @@ export function logError(
     return
   }
 
-  // In production, you would send to your logging service
-  // For now, we'll silently handle errors to avoid console spam
-  const errorInfo = {
-    level: 'error' as LogLevel,
-    message,
-    error:
-      error instanceof Error
-        ? {
-            name: error.name,
-            message: error.message,
-            stack: error.stack,
-          }
-        : error,
-    context,
-    timestamp: new Date().toISOString(),
-    url:
-      typeof window !== 'undefined'
-        ? window.location.href.split('#')[0]
-        : undefined,
-    userAgent:
-      typeof window !== 'undefined' ? window.navigator.userAgent : undefined,
-  }
-
-  // TODO: Send to actual logging service (e.g., Sentry, LogRocket, etc.)
-  // logToService(errorInfo)
+  // In production, errors are silently dropped. Tinfoil's privacy model
+  // forbids shipping user data (or anything that could deanonymize a user) to
+  // a third-party logging service, so no remote logging is wired up here.
 }
 
 /**
@@ -80,10 +58,7 @@ export function logWarning(message: string, context?: ErrorContext): void {
       `[${timestamp}] [${context?.component || 'Unknown'}] ${message}`,
       context?.metadata || '',
     )
-    return
   }
-
-  // TODO: Send to logging service
 }
 
 /**
@@ -106,10 +81,7 @@ export function logInfo(message: string, context?: ErrorContext): void {
       `[${timestamp}] [${context?.component || 'Unknown'}] ${message}`,
       context?.metadata || '',
     )
-    return
   }
-
-  // TODO: Send to logging service
 }
 
 /**

--- a/src/utils/error-handling.ts
+++ b/src/utils/error-handling.ts
@@ -1,7 +1,9 @@
 import { DEV_ENABLE_DEBUG_LOGS } from '@/constants/storage-keys'
 
 /**
- * Error handling utilities for production-ready logging
+ * Logging helpers that print to the dev console only. By design, nothing
+ * here ever leaves the user's browser — Tinfoil's privacy model forbids
+ * shipping logs, errors, or telemetry to any third party.
  */
 
 type LogLevel = 'error' | 'warn' | 'info' | 'debug'
@@ -62,13 +64,10 @@ export function logWarning(message: string, context?: ErrorContext): void {
 }
 
 /**
- * Log info - replace console.log calls with this
- *
- * To enable in production, run in browser console:
- * localStorage.setItem('tinfoil-dev-enable-debug-logs', 'true')
- *
- * To disable:
- * localStorage.removeItem('tinfoil-dev-enable-debug-logs')
+ * In a production build, info logs are off by default. Power users can opt
+ * in from their own DevTools console (the toggle is purely client-side):
+ *   localStorage.setItem('tinfoil-dev-enable-debug-logs', 'true')
+ *   localStorage.removeItem('tinfoil-dev-enable-debug-logs')
  */
 export function logInfo(message: string, context?: ErrorContext): void {
   const debugEnabled =

--- a/src/utils/file-types.ts
+++ b/src/utils/file-types.ts
@@ -137,43 +137,36 @@ export function isPlainTextFile(filename: string): boolean {
 export function getFileIconType(filename: string): string {
   const lowerFilename = filename.toLowerCase()
 
-  // Check document types
   for (const [type, extensions] of Object.entries(DOCUMENT_EXTENSIONS)) {
     if (extensions.some((ext) => lowerFilename.endsWith(ext))) {
       return type
     }
   }
 
-  // Check if it's an image
   if (hasImageExtension(filename)) {
     return 'image'
   }
 
-  // Check media types
   for (const [type, extensions] of Object.entries(MEDIA_EXTENSIONS)) {
     if (extensions.some((ext) => lowerFilename.endsWith(ext))) {
       return type
     }
   }
 
-  // Check financial types
   if (FINANCIAL_EXTENSIONS.some((ext) => lowerFilename.endsWith(ext))) {
     return 'csv'
   }
 
-  // Check archive types
   if (ARCHIVE_EXTENSIONS.some((ext) => lowerFilename.endsWith(ext))) {
     return 'zip'
   }
 
-  // Check code types
   for (const [type, extensions] of Object.entries(CODE_EXTENSIONS)) {
     if (extensions.some((ext) => lowerFilename.endsWith(ext))) {
       return type
     }
   }
 
-  // Default
   return 'file'
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed redundant “slop” comments across the codebase to reduce noise and make the code easier to read. No functional changes; logging docs were clarified to reinforce our local-only privacy stance.

- **Refactors**
  - Deleted decorative/restatement comments in chat, sync, UI, and utils modules.
  - Minor formatting and small cleanups (e.g., `stripModuleSyntax`, toast types) without changing behavior.
  - Simplified `logError` by removing unused error object construction; reaffirmed no remote logging.

<sup>Written for commit 71d871011cfe23bcd73ed656ca520fb50b2b4a4d. Summary will update on new commits. <a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/381?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

