### PR TITLE
fix: preserve full conversation timeline when sharing chats

### DIFF
--- a/src/components/chat/share-modal.tsx
+++ b/src/components/chat/share-modal.tsx
@@ -244,6 +244,11 @@ export function ShareModal({
                 description: a.description,
               }))
             : undefined,
+          timeline: m.timeline,
+          annotations: m.annotations,
+          webSearch: m.webSearch,
+          webSearchBeforeThinking: m.webSearchBeforeThinking,
+          urlFetches: m.urlFetches,
         })),
         createdAt: chatCreatedAt ? chatCreatedAt.getTime() : Date.now(),
       }

--- a/src/components/chat/shared-chat-view.tsx
+++ b/src/components/chat/shared-chat-view.tsx
@@ -78,6 +78,11 @@ export function SharedChatView({
             base64: a.thumbnailBase64,
           }),
         ),
+        timeline: m.timeline,
+        annotations: m.annotations,
+        webSearch: m.webSearch,
+        webSearchBeforeThinking: m.webSearchBeforeThinking,
+        urlFetches: m.urlFetches,
       })),
     [chatData],
   )

--- a/src/utils/compression.ts
+++ b/src/utils/compression.ts
@@ -1,3 +1,9 @@
+import type {
+  Annotation,
+  TimelineBlock,
+  URLFetchState,
+  WebSearchState,
+} from '@/components/chat/types'
 import { logError, logWarning } from '@/utils/error-handling'
 import pako from 'pako'
 
@@ -28,6 +34,15 @@ export type ShareableChatData = {
     thinkingDuration?: number
     isError?: boolean
     attachments?: ShareableAttachment[]
+    // Timeline is the source of truth for assistant messages; preserving it
+    // keeps web searches, URL fetches, tool widgets, and code execution
+    // results visible in shared views. Optional for back-compat with shares
+    // created before the timeline was included.
+    timeline?: TimelineBlock[]
+    annotations?: Annotation[]
+    webSearch?: WebSearchState
+    webSearchBeforeThinking?: boolean
+    urlFetches?: URLFetchState[]
   }>
   createdAt: number
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Preserves the full conversation timeline when sharing chats so the shared view shows searches, URL fetches, tool outputs, and annotations exactly like the original conversation.

- **Bug Fixes**
  - Include `timeline`, `annotations`, `webSearch`, `webSearchBeforeThinking`, and `urlFetches` in the share payload and render them in the shared view.
  - Extend `ShareableChatData` with these optional fields for backward compatibility.

<sup>Written for commit affe37592c52198ce5d75e0ff1ba58e1d8a088f1. Summary will update on new commits. <a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/382?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

