### PR TITLE
Improve chat share preview

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -137,11 +137,6 @@ export default function App({ Component, pageProps }: AppProps) {
           content="Private AI chat application supporting open source models through Tinfoil"
         />
         <meta key="og:type" property="og:type" content="website" />
-        <meta
-          key="og:image"
-          property="og:image"
-          content="/android-chrome-512x512.png"
-        />
         <meta key="twitter:card" name="twitter:card" content="summary" />
         <meta
           key="twitter:title"
@@ -152,11 +147,6 @@ export default function App({ Component, pageProps }: AppProps) {
           key="twitter:description"
           name="twitter:description"
           content="Private AI chat application supporting open source models through Tinfoil"
-        />
-        <meta
-          key="twitter:image"
-          name="twitter:image"
-          content="/android-chrome-512x512.png"
         />
       </Head>
       <style jsx global>{`

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -116,10 +116,47 @@ export default function App({ Component, pageProps }: AppProps) {
   return (
     <>
       <Head>
-        <title>Tinfoil Private Chat</title>
+        <title key="page-title">Tinfoil Private Chat</title>
         <meta
           name="viewport"
           content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover"
+        />
+        <meta
+          key="description"
+          name="description"
+          content="Verifiably Private AI chat application supporting open source models through Tinfoil"
+        />
+        <meta
+          key="og:title"
+          property="og:title"
+          content="Tinfoil Private Chat"
+        />
+        <meta
+          key="og:description"
+          property="og:description"
+          content="Private AI chat application supporting open source models through Tinfoil"
+        />
+        <meta key="og:type" property="og:type" content="website" />
+        <meta
+          key="og:image"
+          property="og:image"
+          content="/android-chrome-512x512.png"
+        />
+        <meta key="twitter:card" name="twitter:card" content="summary" />
+        <meta
+          key="twitter:title"
+          name="twitter:title"
+          content="Tinfoil Private Chat"
+        />
+        <meta
+          key="twitter:description"
+          name="twitter:description"
+          content="Private AI chat application supporting open source models through Tinfoil"
+        />
+        <meta
+          key="twitter:image"
+          name="twitter:image"
+          content="/android-chrome-512x512.png"
         />
       </Head>
       <style jsx global>{`

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -75,30 +75,11 @@ export default function Document() {
         />
 
         <meta
-          name="description"
-          content="Verifiably Private AI chat application supporting open source models through Tinfoil"
-        />
-        <meta
           name="keywords"
           content="AI chat, private AI, privacy, confidential computing, open source, secure AI, private chat"
         />
         <meta name="author" content="Tinfoil" />
-
-        <meta property="og:title" content="Tinfoil Private Chat" />
-        <meta
-          property="og:description"
-          content="Private AI chat application supporting open source models through Tinfoil"
-        />
-        <meta property="og:type" content="website" />
         <meta property="og:locale" content="en_US" />
-
-        <meta name="twitter:card" content="summary" />
-        <meta name="twitter:title" content="Tinfoil Private Chat" />
-        <meta
-          name="twitter:description"
-          content="Private AI chat application supporting open source models through Tinfoil"
-        />
-
         <meta name="robots" content="index, follow" />
 
         <link

--- a/src/pages/share/[[...slug]].tsx
+++ b/src/pages/share/[[...slug]].tsx
@@ -10,9 +10,14 @@ import {
   type ShareableChatData,
 } from '@/utils/compression'
 import { decryptShare, importKeyFromBase64url } from '@/utils/share-encryption'
+import Head from 'next/head'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
+
+const SHARE_PREVIEW_TITLE = 'Shared Chat \u2022 Tinfoil'
+const SHARE_PREVIEW_DESCRIPTION =
+  'Open this link to view a privately shared AI conversation on Tinfoil.'
 
 type LoadingState = 'loading' | 'error' | 'success'
 
@@ -140,44 +145,107 @@ export default function SharePage() {
     })
   }
 
+  const sharePreviewHead = (
+    <Head>
+      <title key="page-title">{SHARE_PREVIEW_TITLE}</title>
+      <meta
+        key="description"
+        name="description"
+        content={SHARE_PREVIEW_DESCRIPTION}
+      />
+      <meta key="og:title" property="og:title" content={SHARE_PREVIEW_TITLE} />
+      <meta
+        key="og:description"
+        property="og:description"
+        content={SHARE_PREVIEW_DESCRIPTION}
+      />
+      <meta key="og:type" property="og:type" content="article" />
+      <meta
+        key="twitter:title"
+        name="twitter:title"
+        content={SHARE_PREVIEW_TITLE}
+      />
+      <meta
+        key="twitter:description"
+        name="twitter:description"
+        content={SHARE_PREVIEW_DESCRIPTION}
+      />
+    </Head>
+  )
+
   if (loadingState === 'loading') {
     return (
-      <div
-        className={`flex min-h-screen items-center justify-center font-aeonik ${isDarkMode ? 'bg-surface-chat-background' : 'bg-white'}`}
-      >
-        <div className="text-content-secondary">Loading shared chat...</div>
-      </div>
+      <>
+        {sharePreviewHead}
+        <div
+          className={`flex min-h-screen items-center justify-center font-aeonik ${isDarkMode ? 'bg-surface-chat-background' : 'bg-white'}`}
+        >
+          <div className="text-content-secondary">Loading shared chat...</div>
+        </div>
+      </>
     )
   }
 
   if (loadingState === 'error' || !chatData || !model) {
     return (
-      <div
-        className={`flex min-h-screen items-center justify-center font-aeonik ${isDarkMode ? 'bg-surface-chat-background' : 'bg-white'}`}
-      >
-        <div className="text-center">
-          <h1 className="text-2xl font-bold text-content-primary">
-            Invalid Share Link
-          </h1>
-          <p className="mt-2 text-content-secondary">
-            {errorMessage ||
-              'This share link is invalid or has been corrupted.'}
-          </p>
-          <Link
-            href="/"
-            className="mt-4 inline-block rounded-lg bg-button-send-background px-4 py-2 text-button-send-foreground transition-opacity hover:opacity-90"
-          >
-            Start a new chat
-          </Link>
+      <>
+        {sharePreviewHead}
+        <div
+          className={`flex min-h-screen items-center justify-center font-aeonik ${isDarkMode ? 'bg-surface-chat-background' : 'bg-white'}`}
+        >
+          <div className="text-center">
+            <h1 className="text-2xl font-bold text-content-primary">
+              Invalid Share Link
+            </h1>
+            <p className="mt-2 text-content-secondary">
+              {errorMessage ||
+                'This share link is invalid or has been corrupted.'}
+            </p>
+            <Link
+              href="/"
+              className="mt-4 inline-block rounded-lg bg-button-send-background px-4 py-2 text-button-send-foreground transition-opacity hover:opacity-90"
+            >
+              Start a new chat
+            </Link>
+          </div>
         </div>
-      </div>
+      </>
     )
   }
+
+  const successHead = (
+    <Head>
+      <title key="page-title">{`${chatData.title} \u2022 Tinfoil`}</title>
+      <meta
+        key="description"
+        name="description"
+        content={SHARE_PREVIEW_DESCRIPTION}
+      />
+      <meta key="og:title" property="og:title" content={SHARE_PREVIEW_TITLE} />
+      <meta
+        key="og:description"
+        property="og:description"
+        content={SHARE_PREVIEW_DESCRIPTION}
+      />
+      <meta key="og:type" property="og:type" content="article" />
+      <meta
+        key="twitter:title"
+        name="twitter:title"
+        content={SHARE_PREVIEW_TITLE}
+      />
+      <meta
+        key="twitter:description"
+        name="twitter:description"
+        content={SHARE_PREVIEW_DESCRIPTION}
+      />
+    </Head>
+  )
 
   return (
     <div
       className={`flex min-h-screen flex-col font-aeonik ${isDarkMode ? 'bg-surface-chat-background' : 'bg-white'}`}
     >
+      {successHead}
       <header className="border-b border-border-subtle px-6 py-4">
         <div className="mx-auto max-w-3xl">
           <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes broken/low-quality social previews for shared chats by adding page-specific Open Graph/Twitter metadata and dynamic titles. Moves default SEO tags to `_app` and removes duplicates from `_document` to ensure consistent previews.

- **Bug Fixes**
  - Share page: adds dynamic `Head` for loading/error/success states; uses chat title on success; sets `og:type=article`; consistent description.
  - `_app`: sets default title, description, and OG/Twitter meta; adds `key` props to prevent duplicate tags.
  - `_document`: removes description and OG/Twitter tags to avoid duplication; keeps base meta.
  - Drops `og:image` from share previews.

<sup>Written for commit 9f0f1fccee30804e8dc1342109a34361e66372cd. Summary will update on new commits. <a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/383?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

