### PR TITLE
Add prompt library

### DIFF
--- a/src/components/chat/WelcomeScreen.tsx
+++ b/src/components/chat/WelcomeScreen.tsx
@@ -571,6 +571,13 @@ export const WelcomeScreen = memo(function WelcomeScreen({
                   codeExecutionEnabled={codeExecutionEnabled}
                   onCodeExecutionToggle={onCodeExecutionToggle}
                   isTemporaryMode={isTemporaryMode}
+                  activePromptPreset={activePromptPreset}
+                  onOpenPromptLibrary={onOpenPromptLibrary}
+                  onClearPromptPreset={
+                    onSelectPromptPreset
+                      ? () => onSelectPromptPreset(null)
+                      : undefined
+                  }
                 />
               </motion.div>
             )}

--- a/src/components/chat/WelcomeScreen.tsx
+++ b/src/components/chat/WelcomeScreen.tsx
@@ -6,6 +6,7 @@ import { AnimatePresence, motion } from 'framer-motion'
 import React, { memo, useEffect, useRef, useState } from 'react'
 import { BiSolidLock } from 'react-icons/bi'
 import { ChatInput } from './chat-input'
+import { PromptPresetSuggestions } from './components/prompt-preset-suggestions'
 import { CONSTANTS } from './constants'
 import { DataFlowDiagram } from './DataFlowDiagram'
 import {
@@ -15,6 +16,7 @@ import {
   type ReasoningEffort,
 } from './hooks/use-reasoning-effort'
 import { ModelSelector } from './model-selector'
+import type { PromptPreset } from './prompts/types'
 import { ReasoningEffortSelector } from './reasoning-effort-selector'
 import type { ProcessedDocument } from './renderers/types'
 import type { LabelType, LoadingState } from './types'
@@ -212,6 +214,9 @@ interface WelcomeScreenProps {
   onCodeExecutionToggle?: () => void
   onOpenVerifier?: () => void
   isTemporaryMode?: boolean
+  activePromptPreset?: PromptPreset | null
+  onOpenPromptLibrary?: () => void
+  onSelectPromptPreset?: (presetId: string | null) => void
 }
 
 // isTemporaryMode is forwarded to the embedded ChatInput so the input can
@@ -245,6 +250,9 @@ export const WelcomeScreen = memo(function WelcomeScreen({
   onCodeExecutionToggle,
   onOpenVerifier,
   isTemporaryMode,
+  activePromptPreset,
+  onOpenPromptLibrary,
+  onSelectPromptPreset,
 }: WelcomeScreenProps) {
   const { user } = useUser()
   const [nickname, setNickname] = useState<string>('')
@@ -563,6 +571,25 @@ export const WelcomeScreen = memo(function WelcomeScreen({
                   codeExecutionEnabled={codeExecutionEnabled}
                   onCodeExecutionToggle={onCodeExecutionToggle}
                   isTemporaryMode={isTemporaryMode}
+                />
+              </motion.div>
+            )}
+
+            {onOpenPromptLibrary && onSelectPromptPreset && (
+              <motion.div
+                className="mt-3 hidden md:block"
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                transition={{
+                  duration: 0.5,
+                  ease: 'easeOut',
+                  delay: 0.45,
+                }}
+              >
+                <PromptPresetSuggestions
+                  activePreset={activePromptPreset ?? null}
+                  onSetActive={onSelectPromptPreset}
+                  onOpenLibrary={onOpenPromptLibrary}
                 />
               </motion.div>
             )}

--- a/src/components/chat/WelcomeScreen.tsx
+++ b/src/components/chat/WelcomeScreen.tsx
@@ -317,7 +317,7 @@ export const WelcomeScreen = memo(function WelcomeScreen({
 
   return (
     <motion.div
-      className={`flex w-full justify-center ${privacyExpanded ? 'items-start' : 'min-h-[60vh] items-center md:min-h-0 md:items-start'}`}
+      className="flex w-full items-start justify-center"
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{

--- a/src/components/chat/chat-input.tsx
+++ b/src/components/chat/chat-input.tsx
@@ -9,6 +9,7 @@ import {
   FolderIcon,
   MicrophoneIcon,
   StopIcon,
+  XMarkIcon,
 } from '@heroicons/react/24/outline'
 import type { FormEvent, RefObject } from 'react'
 import {
@@ -30,6 +31,7 @@ import {
 import { MacFileIcon } from './components/mac-file-icon'
 import { CONSTANTS } from './constants'
 import { CHAT_FONT_CLASSES, useChatFont } from './hooks/use-chat-font'
+import type { PromptPreset } from './prompts/types'
 import type { ProcessedDocument } from './renderers/types'
 import type { LoadingState } from './types'
 
@@ -58,6 +60,9 @@ type ChatInputProps = {
   quote?: string | null
   onClearQuote?: () => void
   isTemporaryMode?: boolean
+  activePromptPreset?: PromptPreset | null
+  onOpenPromptLibrary?: () => void
+  onClearPromptPreset?: () => void
 }
 
 // Maximum number of characters displayed in the collapsed quote preview.
@@ -88,6 +93,9 @@ export function ChatInput({
   quote,
   onClearQuote,
   isTemporaryMode,
+  activePromptPreset,
+  onOpenPromptLibrary,
+  onClearPromptPreset,
 }: ChatInputProps) {
   const fileInputRef = useRef<HTMLInputElement>(null)
   const documentsScrollRef = useRef<HTMLDivElement>(null)
@@ -466,6 +474,39 @@ export function ChatInput({
             </div>
           </div>
         )}
+        {/* Prompt preset tab - shows the active prompt for this chat */}
+        {activePromptPreset &&
+          (() => {
+            const ActivePresetIcon = activePromptPreset.Icon
+            return (
+              <div className="pointer-events-none absolute left-8 top-px z-10 -translate-y-full">
+                <div className="pointer-events-auto inline-flex items-center gap-1 rounded-t-lg border border-b-0 border-border-subtle bg-surface-chat px-2.5 py-1 text-content-secondary">
+                  <button
+                    type="button"
+                    onClick={onOpenPromptLibrary}
+                    disabled={!onOpenPromptLibrary}
+                    className="flex items-center gap-1.5 transition-colors hover:text-content-primary"
+                    aria-label={`Change prompt (currently ${activePromptPreset.name})`}
+                  >
+                    <ActivePresetIcon className="h-3 w-3" />
+                    <span className="text-xs font-medium">
+                      {activePromptPreset.name}
+                    </span>
+                  </button>
+                  {onClearPromptPreset && (
+                    <button
+                      type="button"
+                      onClick={onClearPromptPreset}
+                      aria-label="Stop using this prompt"
+                      className="ml-0.5 rounded-full p-0.5 transition-colors hover:text-content-primary"
+                    >
+                      <XMarkIcon className="h-3 w-3" />
+                    </button>
+                  )}
+                </div>
+              </div>
+            )
+          })()}
         <div
           className={cn(
             'rounded-3xl border bg-surface-chat px-3 py-3 shadow-md transition-colors md:rounded-4xl md:px-6 md:py-4',

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -1551,6 +1551,7 @@ export function ChatInterface({
       createdAt: new Date(),
       isBlankChat: true,
       isTemporary: true,
+      presetId: currentChat?.presetId,
     }
     setCurrentChat(tempChat)
   }, [

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -3129,6 +3129,9 @@ export function ChatInterface({
                         quote={quote}
                         onClearQuote={() => setQuote(null)}
                         isTemporaryMode={isTemporaryMode}
+                        activePromptPreset={activePreset}
+                        onOpenPromptLibrary={handleOpenPromptLibrary}
+                        onClearPromptPreset={() => handleSetActivePreset(null)}
                         hasMessages={
                           currentChat?.messages &&
                           currentChat.messages.length > 0

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -88,6 +88,7 @@ import { AskSidebar } from './ask-sidebar'
 import { ChatInput } from './chat-input'
 import { ChatMessages } from './chat-messages'
 import { ChatSidebar } from './chat-sidebar'
+import { PromptPresetSuggestions } from './components/prompt-preset-suggestions'
 import { CONSTANTS } from './constants'
 import { useDocumentUploader } from './document-uploader'
 import { DragProvider } from './drag-context'
@@ -3109,6 +3110,15 @@ export function ChatInterface({
                       onSubmit={handleSubmit}
                       className="pointer-events-auto relative z-10 mx-auto max-w-3xl px-1 md:px-8"
                     >
+                      {!currentChat?.messages?.length && (
+                        <div className="mb-3 md:hidden">
+                          <PromptPresetSuggestions
+                            activePreset={activePreset}
+                            onSetActive={handleSetActivePreset}
+                            onOpenLibrary={handleOpenPromptLibrary}
+                          />
+                        </div>
+                      )}
                       <MessageQueue
                         queue={queuedMessages}
                         onRemove={removeQueuedMessage}

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -102,6 +102,7 @@ import { useChatState } from './hooks/use-chat-state'
 import { useCustomSystemPrompt } from './hooks/use-custom-system-prompt'
 import { useMaxMessages } from './hooks/use-max-messages'
 import { useMessageQueue } from './hooks/use-message-queue'
+import { usePromptLibrary } from './hooks/use-prompt-library'
 import {
   isReasoningModel,
   supportsReasoningEffort,
@@ -151,6 +152,10 @@ const SettingsModalLazy = dynamic(
 )
 const ShareModalLazy = dynamic(
   () => import('./share-modal').then((m) => m.ShareModal),
+  { ssr: false },
+)
+const PromptLibraryModalLazy = dynamic(
+  () => import('./prompt-library-modal').then((m) => m.PromptLibraryModal),
   { ssr: false },
 )
 
@@ -563,9 +568,19 @@ export function ChatInterface({
   const modKey = isMac ? '⌘' : 'Ctrl+'
   const shiftKey = isMac ? '⇧' : 'Shift+'
 
+  // Prompt library: per-chat preset that overrides the default system prompt.
+  // activePresetId mirrors currentChat.presetId and is kept in sync via an
+  // effect after useChatState resolves currentChat below.
+  const [activePresetId, setActivePresetId] = useState<string | null>(null)
+  const [isPromptLibraryModalOpen, setIsPromptLibraryModalOpen] =
+    useState(false)
+  const { getPresetById } = usePromptLibrary()
+  const activePreset = getPresetById(activePresetId)
+
   const { effectiveSystemPrompt, processedRules } = useCustomSystemPrompt(
     systemPrompt,
     rules,
+    activePreset?.systemPrompt ?? null,
   )
 
   // Use project system prompt hook to inject project context
@@ -782,6 +797,43 @@ export function ChatInterface({
   })
 
   const isTemporaryMode = currentChat?.isTemporary === true
+
+  useEffect(() => {
+    setActivePresetId(currentChat?.presetId ?? null)
+  }, [currentChat?.id, currentChat?.presetId])
+
+  const handleSetActivePreset = useCallback(
+    (presetId: string | null) => {
+      setActivePresetId(presetId)
+      if (!currentChat) return
+      const updatedChat: Chat = {
+        ...currentChat,
+        presetId: presetId ?? undefined,
+      }
+      setCurrentChat(updatedChat)
+      setChats((prev) =>
+        prev.map((c) => (c.id === currentChat.id ? updatedChat : c)),
+      )
+      const storeHistory = isSignedIn || !isCloudSyncEnabled()
+      if (!updatedChat.isTemporary && storeHistory) {
+        chatStorage.saveChat(updatedChat).catch((err) => {
+          logError('Failed to persist prompt preset selection', err, {
+            component: 'ChatInterface',
+            metadata: { chatId: updatedChat.id, presetId },
+          })
+        })
+      }
+    },
+    [currentChat, setCurrentChat, setChats, isSignedIn],
+  )
+
+  const handleOpenPromptLibrary = useCallback(() => {
+    setIsPromptLibraryModalOpen(true)
+  }, [])
+
+  const handleClosePromptLibrary = useCallback(() => {
+    setIsPromptLibraryModalOpen(false)
+  }, [])
 
   const isRateLimited = useCallback(
     () => Boolean(rateLimit && rateLimit.remaining <= 0),
@@ -2806,6 +2858,24 @@ export function ChatInterface({
         chatId={currentChat?.id}
       />
 
+      {/* Prompt Library Modal */}
+      <PromptLibraryModalLazy
+        isOpen={isPromptLibraryModalOpen}
+        onClose={handleClosePromptLibrary}
+        activePresetId={activePresetId}
+        onSelectPreset={handleSetActivePreset}
+        isSidebarOpen={
+          isSidebarOpen && windowWidth >= CONSTANTS.MOBILE_BREAKPOINT
+        }
+        isRightSidebarOpen={
+          (isVerifierSidebarOpen ||
+            isSettingsModalOpen ||
+            isAskSidebarOpen ||
+            isArtifactSidebarOpen) &&
+          windowWidth >= CONSTANTS.MOBILE_BREAKPOINT
+        }
+      />
+
       {/* Settings Modal */}
       <SettingsModalLazy
         isOpen={isSettingsModalOpen}
@@ -2994,6 +3064,9 @@ export function ChatInterface({
                     }
                     onOpenVerifier={() => setIsVerifierSidebarOpen(true)}
                     isTemporaryMode={isTemporaryMode}
+                    activePromptPreset={activePreset}
+                    onOpenPromptLibrary={handleOpenPromptLibrary}
+                    onSelectPromptPreset={handleSetActivePreset}
                   />
                 </div>
               </div>

--- a/src/components/chat/chat-messages.tsx
+++ b/src/components/chat/chat-messages.tsx
@@ -8,6 +8,7 @@ import { CHAT_FONT_CLASSES, useChatFont } from './hooks/use-chat-font'
 import { useMaxMessages } from './hooks/use-max-messages'
 import type { ReasoningEffort } from './hooks/use-reasoning-effort'
 import { PrintableChat } from './PrintableChat'
+import type { PromptPreset } from './prompts/types'
 import { getRendererRegistry } from './renderers/client'
 import { StreamingTracerDot } from './renderers/components/StreamingTracerDot'
 import type { LabelType, Message } from './types'
@@ -53,6 +54,9 @@ type ChatMessagesProps = {
   onCodeExecutionToggle?: () => void
   onOpenVerifier?: () => void
   isTemporaryMode?: boolean
+  activePromptPreset?: PromptPreset | null
+  onOpenPromptLibrary?: () => void
+  onSelectPromptPreset?: (presetId: string | null) => void
 }
 
 // Optimized wrapper component that receives expanded state from parent
@@ -224,6 +228,9 @@ export function ChatMessages({
   onCodeExecutionToggle,
   onOpenVerifier,
   isTemporaryMode,
+  activePromptPreset,
+  onOpenPromptLibrary,
+  onSelectPromptPreset,
 }: ChatMessagesProps) {
   const [mounted, setMounted] = useState(false)
   const maxMessages = useMaxMessages()
@@ -332,6 +339,9 @@ export function ChatMessages({
             onCodeExecutionToggle={onCodeExecutionToggle}
             onOpenVerifier={onOpenVerifier}
             isTemporaryMode={isTemporaryMode}
+            activePromptPreset={activePromptPreset}
+            onOpenPromptLibrary={onOpenPromptLibrary}
+            onSelectPromptPreset={onSelectPromptPreset}
           />
         </div>
       </div>

--- a/src/components/chat/components/confirm-dialog.tsx
+++ b/src/components/chat/components/confirm-dialog.tsx
@@ -1,0 +1,100 @@
+import { cn } from '@/components/ui/utils'
+import { useEffect, useRef } from 'react'
+
+type ConfirmDialogProps = {
+  isOpen: boolean
+  title: string
+  description?: string
+  confirmLabel?: string
+  cancelLabel?: string
+  variant?: 'default' | 'destructive'
+  onConfirm: () => void
+  onCancel: () => void
+}
+
+export function ConfirmDialog({
+  isOpen,
+  title,
+  description,
+  confirmLabel = 'Confirm',
+  cancelLabel = 'Cancel',
+  variant = 'default',
+  onConfirm,
+  onCancel,
+}: ConfirmDialogProps) {
+  const cancelButtonRef = useRef<HTMLButtonElement | null>(null)
+
+  useEffect(() => {
+    if (!isOpen) return
+    cancelButtonRef.current?.focus()
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        e.stopImmediatePropagation()
+        onCancel()
+      }
+    }
+    document.addEventListener('keydown', handleKeyDown, { capture: true })
+    return () =>
+      document.removeEventListener('keydown', handleKeyDown, { capture: true })
+  }, [isOpen, onCancel])
+
+  if (!isOpen) return null
+
+  const isDestructive = variant === 'destructive'
+
+  return (
+    <div
+      className="fixed inset-0 z-[60] flex items-center justify-center"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="confirm-dialog-title"
+      aria-describedby={description ? 'confirm-dialog-description' : undefined}
+    >
+      <div
+        className="fixed inset-0 bg-black/60"
+        onClick={onCancel}
+        aria-hidden="true"
+      />
+      <div className="relative z-10 w-[92vw] max-w-md rounded-xl border border-border-subtle bg-surface-sidebar p-5 shadow-xl">
+        <h3
+          id="confirm-dialog-title"
+          className="text-base font-semibold text-content-primary"
+        >
+          {title}
+        </h3>
+        {description && (
+          <p
+            id="confirm-dialog-description"
+            className="mt-2 text-sm text-content-secondary"
+          >
+            {description}
+          </p>
+        )}
+        <div className="mt-5 flex justify-end gap-2">
+          <button
+            ref={cancelButtonRef}
+            type="button"
+            onClick={onCancel}
+            className="rounded-lg border border-border-subtle bg-surface-chat-background px-3 py-2 text-sm font-medium text-content-primary transition-colors hover:bg-surface-chat"
+          >
+            {cancelLabel}
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            className={cn(
+              'rounded-lg px-3 py-2 text-sm font-semibold text-white transition-colors',
+              isDestructive
+                ? 'bg-red-600 hover:bg-red-700'
+                : 'bg-brand-accent-dark hover:bg-brand-accent-dark/90',
+            )}
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/chat/components/prompt-preset-suggestions.tsx
+++ b/src/components/chat/components/prompt-preset-suggestions.tsx
@@ -1,0 +1,59 @@
+import { cn } from '@/components/ui/utils'
+import { Squares2X2Icon } from '@heroicons/react/24/outline'
+import { BUILT_IN_PROMPT_PRESETS } from '../prompts/built-in-presets'
+import type { PromptPreset } from '../prompts/types'
+
+const SUGGESTION_COUNT = 3
+
+type PromptPresetSuggestionsProps = {
+  activePreset: PromptPreset | null
+  onSetActive: (presetId: string | null) => void
+  onOpenLibrary: () => void
+}
+
+export function PromptPresetSuggestions({
+  activePreset,
+  onSetActive,
+  onOpenLibrary,
+}: PromptPresetSuggestionsProps) {
+  const suggested = BUILT_IN_PROMPT_PRESETS.slice(0, SUGGESTION_COUNT)
+  const pillBase =
+    'inline-flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-sm transition-colors'
+
+  return (
+    <div className="flex flex-wrap items-center justify-center gap-2">
+      {suggested.map((preset) => {
+        const Icon = preset.Icon
+        const isActive = activePreset?.id === preset.id
+        return (
+          <button
+            type="button"
+            key={preset.id}
+            onClick={() => onSetActive(isActive ? null : preset.id)}
+            aria-pressed={isActive}
+            className={cn(
+              pillBase,
+              isActive
+                ? 'border-brand-accent-dark/40 bg-brand-accent-dark/10 text-brand-accent-dark dark:border-brand-accent-light/40 dark:bg-brand-accent-light/10 dark:text-brand-accent-light'
+                : 'border-border-subtle bg-surface-chat-background text-content-secondary hover:bg-surface-chat hover:text-content-primary',
+            )}
+          >
+            <Icon className="h-3.5 w-3.5" />
+            <span>{preset.name}</span>
+          </button>
+        )
+      })}
+      <button
+        type="button"
+        onClick={onOpenLibrary}
+        className={cn(
+          pillBase,
+          'border-border-subtle bg-surface-chat-background text-content-secondary hover:bg-surface-chat hover:text-content-primary',
+        )}
+      >
+        <Squares2X2Icon className="h-3.5 w-3.5" />
+        <span>More</span>
+      </button>
+    </div>
+  )
+}

--- a/src/components/chat/components/prompt-preset-suggestions.tsx
+++ b/src/components/chat/components/prompt-preset-suggestions.tsx
@@ -18,10 +18,10 @@ export function PromptPresetSuggestions({
 }: PromptPresetSuggestionsProps) {
   const suggested = BUILT_IN_PROMPT_PRESETS.slice(0, SUGGESTION_COUNT)
   const pillBase =
-    'inline-flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-sm transition-colors'
+    'inline-flex w-full items-center justify-center gap-1.5 rounded-lg border px-3 py-2 text-sm transition-colors md:w-auto md:py-1.5'
 
   return (
-    <div className="flex flex-wrap items-center justify-center gap-2">
+    <div className="grid grid-cols-2 gap-2 md:flex md:flex-wrap md:items-center md:justify-center">
       {suggested.map((preset) => {
         const Icon = preset.Icon
         const isActive = activePreset?.id === preset.id

--- a/src/components/chat/components/prompt-preset-suggestions.tsx
+++ b/src/components/chat/components/prompt-preset-suggestions.tsx
@@ -18,10 +18,10 @@ export function PromptPresetSuggestions({
 }: PromptPresetSuggestionsProps) {
   const suggested = BUILT_IN_PROMPT_PRESETS.slice(0, SUGGESTION_COUNT)
   const pillBase =
-    'inline-flex w-full items-center justify-center gap-1.5 rounded-lg border px-3 py-2 text-sm transition-colors md:w-auto md:py-1.5'
+    'inline-flex h-14 w-full items-center justify-center gap-1.5 rounded-lg border px-3 text-sm transition-colors md:h-auto md:w-auto md:py-1.5'
 
   return (
-    <div className="grid grid-cols-2 gap-2 md:flex md:flex-wrap md:items-center md:justify-center">
+    <div className="grid auto-rows-fr grid-cols-2 gap-2 md:flex md:flex-wrap md:items-center md:justify-center">
       {suggested.map((preset) => {
         const Icon = preset.Icon
         const isActive = activePreset?.id === preset.id

--- a/src/components/chat/hooks/use-custom-system-prompt.ts
+++ b/src/components/chat/hooks/use-custom-system-prompt.ts
@@ -28,6 +28,7 @@ type UseCustomSystemPromptReturn = {
 export const useCustomSystemPrompt = (
   defaultSystemPrompt: string,
   rules: string = '',
+  activePresetPrompt?: string | null,
 ): UseCustomSystemPromptReturn => {
   const [personalization, setPersonalization] =
     useState<PersonalizationSettings>({
@@ -232,9 +233,15 @@ export const useCustomSystemPrompt = (
 
   // Generate the effective system prompt by replacing the placeholder
   const generatePersonalizedPrompt = (): string => {
-    // Use custom prompt if enabled
-    const basePrompt =
-      isUsingCustomPrompt && customPrompt ? customPrompt : defaultSystemPrompt
+    // Precedence: per-chat preset override > custom prompt toggle > default
+    let basePrompt: string
+    if (activePresetPrompt && activePresetPrompt.trim()) {
+      basePrompt = activePresetPrompt
+    } else if (isUsingCustomPrompt && customPrompt) {
+      basePrompt = customPrompt
+    } else {
+      basePrompt = defaultSystemPrompt
+    }
     return replacePlaceholders(basePrompt)
   }
 

--- a/src/components/chat/hooks/use-prompt-library.ts
+++ b/src/components/chat/hooks/use-prompt-library.ts
@@ -1,0 +1,204 @@
+import { USER_PREFS_CUSTOM_PROMPT_PRESETS } from '@/constants/storage-keys'
+import { logError } from '@/utils/error-handling'
+import { useCallback, useEffect, useState } from 'react'
+import { PiNotePencil } from 'react-icons/pi'
+import { BUILT_IN_PROMPT_PRESETS } from '../prompts/built-in-presets'
+import type { PromptPreset, UserPromptPreset } from '../prompts/types'
+
+const COMPONENT = 'usePromptLibrary'
+
+const USER_PRESET_ID_PREFIX = 'user:'
+
+const PROMPT_LIBRARY_CHANGED_EVENT = 'promptLibraryChanged'
+
+const DEFAULT_USER_PRESET_ICON = PiNotePencil
+
+type UsePromptLibraryReturn = {
+  builtInPresets: PromptPreset[]
+  userPresets: PromptPreset[]
+  allPresets: PromptPreset[]
+  getPresetById: (id: string | null | undefined) => PromptPreset | null
+  createUserPreset: (
+    input: Pick<UserPromptPreset, 'name' | 'description' | 'systemPrompt'>,
+  ) => PromptPreset
+  updateUserPreset: (
+    id: string,
+    patch: Partial<
+      Pick<UserPromptPreset, 'name' | 'description' | 'systemPrompt'>
+    >,
+  ) => void
+  deleteUserPreset: (id: string) => void
+  duplicatePreset: (sourceId: string) => PromptPreset | null
+}
+
+function safeReadUserPresets(): UserPromptPreset[] {
+  if (typeof window === 'undefined') return []
+  try {
+    const raw = localStorage.getItem(USER_PREFS_CUSTOM_PROMPT_PRESETS)
+    if (!raw) return []
+    const parsed = JSON.parse(raw)
+    if (!Array.isArray(parsed)) return []
+    return parsed.filter(
+      (p): p is UserPromptPreset =>
+        p &&
+        typeof p === 'object' &&
+        typeof p.id === 'string' &&
+        typeof p.name === 'string' &&
+        typeof p.description === 'string' &&
+        typeof p.systemPrompt === 'string' &&
+        typeof p.createdAt === 'number' &&
+        typeof p.updatedAt === 'number',
+    )
+  } catch (err) {
+    logError('Failed to parse user prompt presets', err, {
+      component: COMPONENT,
+    })
+    return []
+  }
+}
+
+function safeWriteUserPresets(presets: UserPromptPreset[]): void {
+  if (typeof window === 'undefined') return
+  try {
+    localStorage.setItem(
+      USER_PREFS_CUSTOM_PROMPT_PRESETS,
+      JSON.stringify(presets),
+    )
+    window.dispatchEvent(new CustomEvent(PROMPT_LIBRARY_CHANGED_EVENT))
+  } catch (err) {
+    logError('Failed to persist user prompt presets', err, {
+      component: COMPONENT,
+    })
+  }
+}
+
+function generateUserPresetId(): string {
+  const random = Math.random().toString(36).slice(2, 10)
+  return `${USER_PRESET_ID_PREFIX}${Date.now().toString(36)}-${random}`
+}
+
+function toPromptPreset(stored: UserPromptPreset): PromptPreset {
+  return {
+    id: stored.id,
+    name: stored.name,
+    description: stored.description,
+    Icon: DEFAULT_USER_PRESET_ICON,
+    systemPrompt: stored.systemPrompt,
+    isBuiltIn: false,
+  }
+}
+
+export function usePromptLibrary(): UsePromptLibraryReturn {
+  const [userPresetsRaw, setUserPresetsRaw] = useState<UserPromptPreset[]>([])
+
+  useEffect(() => {
+    setUserPresetsRaw(safeReadUserPresets())
+
+    const handleChange = () => {
+      setUserPresetsRaw(safeReadUserPresets())
+    }
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key === USER_PREFS_CUSTOM_PROMPT_PRESETS) {
+        setUserPresetsRaw(safeReadUserPresets())
+      }
+    }
+
+    window.addEventListener(PROMPT_LIBRARY_CHANGED_EVENT, handleChange)
+    window.addEventListener('storage', handleStorage)
+    return () => {
+      window.removeEventListener(PROMPT_LIBRARY_CHANGED_EVENT, handleChange)
+      window.removeEventListener('storage', handleStorage)
+    }
+  }, [])
+
+  const userPresets: PromptPreset[] = userPresetsRaw.map(toPromptPreset)
+
+  const allPresets = [...BUILT_IN_PROMPT_PRESETS, ...userPresets]
+
+  const getPresetById = useCallback(
+    (id: string | null | undefined): PromptPreset | null => {
+      if (!id) return null
+      return allPresets.find((p) => p.id === id) ?? null
+    },
+    [allPresets],
+  )
+
+  const createUserPreset = useCallback(
+    (
+      input: Pick<UserPromptPreset, 'name' | 'description' | 'systemPrompt'>,
+    ): PromptPreset => {
+      const now = Date.now()
+      const newPreset: UserPromptPreset = {
+        id: generateUserPresetId(),
+        name: input.name,
+        description: input.description,
+        systemPrompt: input.systemPrompt,
+        createdAt: now,
+        updatedAt: now,
+      }
+      const next = [...safeReadUserPresets(), newPreset]
+      safeWriteUserPresets(next)
+      return toPromptPreset(newPreset)
+    },
+    [],
+  )
+
+  const updateUserPreset = useCallback(
+    (
+      id: string,
+      patch: Partial<
+        Pick<UserPromptPreset, 'name' | 'description' | 'systemPrompt'>
+      >,
+    ) => {
+      const current = safeReadUserPresets()
+      const idx = current.findIndex((p) => p.id === id)
+      if (idx === -1) return
+      const updated: UserPromptPreset = {
+        ...current[idx],
+        ...patch,
+        updatedAt: Date.now(),
+      }
+      const next = [...current]
+      next[idx] = updated
+      safeWriteUserPresets(next)
+    },
+    [],
+  )
+
+  const deleteUserPreset = useCallback((id: string) => {
+    const next = safeReadUserPresets().filter((p) => p.id !== id)
+    safeWriteUserPresets(next)
+  }, [])
+
+  const duplicatePreset = useCallback(
+    (sourceId: string): PromptPreset | null => {
+      const builtIn = BUILT_IN_PROMPT_PRESETS.find((p) => p.id === sourceId)
+      if (builtIn) {
+        return createUserPreset({
+          name: `${builtIn.name} (copy)`,
+          description: builtIn.description,
+          systemPrompt: builtIn.systemPrompt,
+        })
+      }
+      const userSource = safeReadUserPresets().find((p) => p.id === sourceId)
+      if (!userSource) return null
+      return createUserPreset({
+        name: `${userSource.name} (copy)`,
+        description: userSource.description,
+        systemPrompt: userSource.systemPrompt,
+      })
+    },
+    [createUserPreset],
+  )
+
+  return {
+    builtInPresets: BUILT_IN_PROMPT_PRESETS,
+    userPresets,
+    allPresets,
+    getPresetById,
+    createUserPreset,
+    updateUserPreset,
+    deleteUserPreset,
+    duplicatePreset,
+  }
+}

--- a/src/components/chat/prompt-library-modal.tsx
+++ b/src/components/chat/prompt-library-modal.tsx
@@ -156,6 +156,17 @@ export function PromptLibraryModal({
     setPresetPendingDelete(null)
   }
 
+  const handleRename = (preset: PromptPreset, nextName: string) => {
+    if (preset.isBuiltIn) return
+    const trimmed = nextName.trim()
+    if (!trimmed || trimmed === preset.name) return
+    updateUserPreset(preset.id, {
+      name: trimmed,
+      description: preset.description,
+      systemPrompt: preset.systemPrompt,
+    })
+  }
+
   const handleEditorSave = () => {
     if (!editor) return
     const name = editor.name.trim()
@@ -335,6 +346,7 @@ export function PromptLibraryModal({
               />
             ) : selectedPreset ? (
               <PresetDetail
+                key={selectedPreset.id}
                 preset={selectedPreset}
                 isActive={activePresetId === selectedPreset.id}
                 onUseThis={handleUseThis}
@@ -342,6 +354,7 @@ export function PromptLibraryModal({
                 onEdit={() => startEdit(selectedPreset)}
                 onDuplicate={() => handleDuplicate(selectedPreset)}
                 onDelete={() => handleDelete(selectedPreset)}
+                onRename={(name) => handleRename(selectedPreset, name)}
               />
             ) : (
               <div className="flex flex-1 items-center justify-center p-6">
@@ -379,6 +392,7 @@ type PresetDetailProps = {
   onEdit: () => void
   onDuplicate: () => void
   onDelete: () => void
+  onRename: (name: string) => void
 }
 
 function PresetDetail({
@@ -389,8 +403,22 @@ function PresetDetail({
   onEdit,
   onDuplicate,
   onDelete,
+  onRename,
 }: PresetDetailProps) {
   const Icon = preset.Icon
+  const [isEditingName, setIsEditingName] = useState(false)
+  const [nameDraft, setNameDraft] = useState(preset.name)
+
+  const commitRename = () => {
+    setIsEditingName(false)
+    const trimmed = nameDraft.trim()
+    if (!trimmed || trimmed === preset.name) {
+      setNameDraft(preset.name)
+      return
+    }
+    onRename(trimmed)
+  }
+
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       <div className="flex flex-none items-start justify-between gap-4 border-b border-border-subtle px-6 py-4">
@@ -399,15 +427,47 @@ function PresetDetail({
             <Icon className="h-5 w-5" />
           </span>
           <div className="min-w-0">
-            <h3 className="truncate text-base font-semibold text-content-primary">
-              {preset.name}
-            </h3>
+            {isEditingName && !preset.isBuiltIn ? (
+              <input
+                type="text"
+                value={nameDraft}
+                autoFocus
+                onChange={(e) => setNameDraft(e.target.value)}
+                onBlur={commitRename}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault()
+                    e.currentTarget.blur()
+                  } else if (e.key === 'Escape') {
+                    e.preventDefault()
+                    setNameDraft(preset.name)
+                    setIsEditingName(false)
+                  }
+                }}
+                className="w-full rounded-md border border-border-subtle bg-surface-chat-background px-2 py-0.5 text-base font-semibold text-content-primary outline-none focus:border-brand-accent-dark/40 dark:focus:border-brand-accent-light/40"
+              />
+            ) : (
+              <h3
+                className={cn(
+                  'truncate rounded-md px-1.5 py-0.5 text-base font-semibold text-content-primary',
+                  !preset.isBuiltIn && 'cursor-text hover:bg-surface-chat',
+                )}
+                title={preset.isBuiltIn ? undefined : 'Click to rename'}
+                onClick={() => {
+                  if (preset.isBuiltIn) return
+                  setNameDraft(preset.name)
+                  setIsEditingName(true)
+                }}
+              >
+                {preset.name}
+              </h3>
+            )}
             {preset.description && (
-              <p className="mt-0.5 text-sm text-content-secondary">
+              <p className="mt-0.5 px-1.5 text-sm text-content-secondary">
                 {preset.description}
               </p>
             )}
-            <span className="mt-1 inline-block text-[11px] uppercase tracking-wide text-content-muted">
+            <span className="mt-1 inline-block px-1.5 text-[11px] uppercase tracking-wide text-content-muted">
               {preset.isBuiltIn ? 'Built-in' : 'Custom'}
             </span>
           </div>

--- a/src/components/chat/prompt-library-modal.tsx
+++ b/src/components/chat/prompt-library-modal.tsx
@@ -1,0 +1,530 @@
+import { cn } from '@/components/ui/utils'
+import {
+  CheckIcon,
+  PencilSquareIcon,
+  PlusIcon,
+  SparklesIcon,
+  Squares2X2Icon,
+  TrashIcon,
+  XMarkIcon,
+} from '@heroicons/react/24/outline'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { CONSTANTS } from './constants'
+import { usePromptLibrary } from './hooks/use-prompt-library'
+import type { PromptPreset } from './prompts/types'
+
+type PromptLibraryModalProps = {
+  isOpen: boolean
+  onClose: () => void
+  activePresetId: string | null
+  onSelectPreset: (presetId: string | null) => void
+  isSidebarOpen?: boolean
+  isRightSidebarOpen?: boolean
+}
+
+type EditorState = {
+  mode: 'create' | 'edit'
+  presetId: string | null
+  name: string
+  description: string
+  systemPrompt: string
+}
+
+const EMPTY_EDITOR: EditorState = {
+  mode: 'create',
+  presetId: null,
+  name: '',
+  description: '',
+  systemPrompt: '',
+}
+
+const stripSystemTags = (prompt: string): string =>
+  prompt
+    .replace(/^<system>\s*\n?/, '')
+    .replace(/\n?<\/system>\s*$/, '')
+    .trim()
+
+const ensureSystemTags = (prompt: string): string => {
+  const trimmed = prompt.trim()
+  if (!trimmed) return ''
+  if (trimmed.startsWith('<system>') && trimmed.endsWith('</system>')) {
+    return trimmed
+  }
+  return `<system>\n${trimmed}\n</system>`
+}
+
+export function PromptLibraryModal({
+  isOpen,
+  onClose,
+  activePresetId,
+  onSelectPreset,
+  isSidebarOpen = false,
+  isRightSidebarOpen = false,
+}: PromptLibraryModalProps) {
+  const {
+    builtInPresets,
+    userPresets,
+    allPresets,
+    createUserPreset,
+    updateUserPreset,
+    deleteUserPreset,
+    duplicatePreset,
+  } = usePromptLibrary()
+
+  const [selectedId, setSelectedId] = useState<string | null>(
+    activePresetId ?? builtInPresets[0]?.id ?? null,
+  )
+  const [editor, setEditor] = useState<EditorState | null>(null)
+  const wasOpenRef = useRef(false)
+
+  useEffect(() => {
+    if (!isOpen) {
+      setEditor(null)
+      wasOpenRef.current = false
+      return
+    }
+    if (!wasOpenRef.current) {
+      setSelectedId(activePresetId ?? builtInPresets[0]?.id ?? null)
+      wasOpenRef.current = true
+    }
+  }, [isOpen, activePresetId, builtInPresets])
+
+  useEffect(() => {
+    if (!isOpen) return
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && !editor) {
+        e.preventDefault()
+        onClose()
+      }
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [isOpen, onClose, editor])
+
+  const selectedPreset = useMemo<PromptPreset | null>(() => {
+    if (!selectedId) return null
+    return allPresets.find((p) => p.id === selectedId) ?? null
+  }, [selectedId, allPresets])
+
+  if (!isOpen) return null
+
+  const leftOffset = isSidebarOpen ? CONSTANTS.CHAT_SIDEBAR_WIDTH_PX : 0
+  const rightOffset = isRightSidebarOpen
+    ? CONSTANTS.SETTINGS_SIDEBAR_WIDTH_PX
+    : 0
+
+  const handleUseThis = () => {
+    if (!selectedPreset) return
+    onSelectPreset(selectedPreset.id)
+    onClose()
+  }
+
+  const handleClearActive = () => {
+    onSelectPreset(null)
+    onClose()
+  }
+
+  const startCreate = () => {
+    setEditor({ ...EMPTY_EDITOR })
+  }
+
+  const startEdit = (preset: PromptPreset) => {
+    setEditor({
+      mode: 'edit',
+      presetId: preset.id,
+      name: preset.name,
+      description: preset.description,
+      systemPrompt: stripSystemTags(preset.systemPrompt),
+    })
+  }
+
+  const handleDuplicate = (preset: PromptPreset) => {
+    const copy = duplicatePreset(preset.id)
+    if (copy) {
+      setSelectedId(copy.id)
+      setEditor({
+        mode: 'edit',
+        presetId: copy.id,
+        name: copy.name,
+        description: copy.description,
+        systemPrompt: stripSystemTags(copy.systemPrompt),
+      })
+    }
+  }
+
+  const handleDelete = (preset: PromptPreset) => {
+    if (preset.isBuiltIn) return
+    if (
+      typeof window !== 'undefined' &&
+      !window.confirm(`Delete "${preset.name}"? This cannot be undone.`)
+    ) {
+      return
+    }
+    deleteUserPreset(preset.id)
+    if (selectedId === preset.id) {
+      setSelectedId(builtInPresets[0]?.id ?? null)
+    }
+    if (activePresetId === preset.id) {
+      onSelectPreset(null)
+    }
+  }
+
+  const handleEditorSave = () => {
+    if (!editor) return
+    const name = editor.name.trim()
+    if (!name) return
+    const promptWithTags = ensureSystemTags(editor.systemPrompt)
+    if (!promptWithTags) return
+
+    if (editor.mode === 'create') {
+      const created = createUserPreset({
+        name,
+        description: editor.description.trim(),
+        systemPrompt: promptWithTags,
+      })
+      setSelectedId(created.id)
+    } else if (editor.presetId) {
+      updateUserPreset(editor.presetId, {
+        name,
+        description: editor.description.trim(),
+        systemPrompt: promptWithTags,
+      })
+      setSelectedId(editor.presetId)
+    }
+    setEditor(null)
+  }
+
+  const renderPresetCard = (preset: PromptPreset) => {
+    const isSelected = selectedId === preset.id
+    const isActive = activePresetId === preset.id
+    const Icon = preset.Icon
+    return (
+      <button
+        type="button"
+        key={preset.id}
+        onClick={() => setSelectedId(preset.id)}
+        className={cn(
+          'group relative flex w-full items-start gap-3 rounded-lg border px-3 py-2.5 text-left transition-colors',
+          isSelected
+            ? 'border-brand-accent-dark/40 bg-brand-accent-dark/5 dark:border-brand-accent-light/40 dark:bg-brand-accent-light/5'
+            : 'border-border-subtle bg-surface-chat-background hover:bg-surface-chat',
+        )}
+        aria-pressed={isActive}
+      >
+        <span className="mt-0.5 flex h-7 w-7 flex-none items-center justify-center rounded-md bg-surface-chat text-content-secondary">
+          <Icon className="h-4 w-4" />
+        </span>
+        <span className="flex min-w-0 flex-1 flex-col pr-5">
+          <span className="truncate text-sm font-medium text-content-primary">
+            {preset.name}
+          </span>
+          {preset.description && (
+            <span className="mt-0.5 line-clamp-2 text-xs text-content-secondary">
+              {preset.description}
+            </span>
+          )}
+        </span>
+        {isActive && (
+          <CheckIcon
+            className="absolute right-2 top-2 h-3.5 w-3.5 text-brand-accent-dark dark:text-brand-accent-light"
+            aria-label="Active"
+          />
+        )}
+      </button>
+    )
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center"
+      style={{ left: `${leftOffset}px`, right: `${rightOffset}px` }}
+    >
+      <div
+        className="fixed inset-0 bg-black/50"
+        onClick={editor ? undefined : onClose}
+        style={{ left: 0, right: 0 }}
+      />
+
+      <div
+        className="relative z-10 flex h-[85vh] w-[92vw] max-w-5xl flex-col rounded-xl border border-border-subtle bg-surface-sidebar shadow-xl"
+        style={{
+          maxWidth: `min(1024px, calc(92vw - ${leftOffset + rightOffset}px))`,
+        }}
+      >
+        <div className="flex items-center justify-between border-b border-border-subtle px-6 py-4">
+          <div className="flex items-center gap-2">
+            <Squares2X2Icon className="h-5 w-5 text-content-secondary" />
+            <h2 className="text-lg font-semibold text-content-primary">
+              Prompt Library
+            </h2>
+          </div>
+          <button
+            onClick={onClose}
+            className="rounded-lg p-1.5 text-content-secondary transition-colors hover:bg-surface-chat"
+            aria-label="Close prompt library"
+          >
+            <XMarkIcon className="h-5 w-5" />
+          </button>
+        </div>
+
+        <div className="flex min-h-0 flex-1 overflow-hidden">
+          <div className="flex w-[300px] flex-none flex-col border-r border-border-subtle">
+            <div className="flex items-center justify-between px-4 pt-4">
+              <span className="text-xs font-medium uppercase tracking-wide text-content-muted">
+                Built-in
+              </span>
+            </div>
+            <div className="flex flex-col gap-1.5 overflow-y-auto px-3 pb-2 pt-2">
+              {builtInPresets.map(renderPresetCard)}
+            </div>
+
+            <div className="mt-2 flex items-center justify-between px-4 pt-2">
+              <span className="text-xs font-medium uppercase tracking-wide text-content-muted">
+                Your prompts
+              </span>
+              <button
+                type="button"
+                onClick={startCreate}
+                className="flex items-center gap-1 rounded-md px-1.5 py-0.5 text-xs font-medium text-content-secondary transition-colors hover:bg-surface-chat hover:text-content-primary"
+              >
+                <PlusIcon className="h-3.5 w-3.5" />
+                New
+              </button>
+            </div>
+            <div className="flex flex-1 flex-col gap-1.5 overflow-y-auto px-3 pb-4 pt-2">
+              {userPresets.length === 0 ? (
+                <p className="px-1 pt-1 text-xs text-content-muted">
+                  No custom prompts yet. Click &quot;New&quot; to create one.
+                </p>
+              ) : (
+                userPresets.map(renderPresetCard)
+              )}
+            </div>
+          </div>
+
+          <div className="flex min-w-0 flex-1 flex-col">
+            {editor ? (
+              <PresetEditor
+                editor={editor}
+                onChange={setEditor}
+                onCancel={() => setEditor(null)}
+                onSave={handleEditorSave}
+              />
+            ) : selectedPreset ? (
+              <PresetDetail
+                preset={selectedPreset}
+                isActive={activePresetId === selectedPreset.id}
+                onUseThis={handleUseThis}
+                onClearActive={handleClearActive}
+                onEdit={() => startEdit(selectedPreset)}
+                onDuplicate={() => handleDuplicate(selectedPreset)}
+                onDelete={() => handleDelete(selectedPreset)}
+              />
+            ) : (
+              <div className="flex flex-1 items-center justify-center p-6">
+                <p className="text-sm text-content-muted">
+                  Select a prompt to view its details.
+                </p>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+type PresetDetailProps = {
+  preset: PromptPreset
+  isActive: boolean
+  onUseThis: () => void
+  onClearActive: () => void
+  onEdit: () => void
+  onDuplicate: () => void
+  onDelete: () => void
+}
+
+function PresetDetail({
+  preset,
+  isActive,
+  onUseThis,
+  onClearActive,
+  onEdit,
+  onDuplicate,
+  onDelete,
+}: PresetDetailProps) {
+  const Icon = preset.Icon
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="flex flex-none items-start justify-between gap-4 border-b border-border-subtle px-6 py-4">
+        <div className="flex min-w-0 items-start gap-3">
+          <span className="flex h-10 w-10 flex-none items-center justify-center rounded-lg bg-surface-chat text-content-secondary">
+            <Icon className="h-5 w-5" />
+          </span>
+          <div className="min-w-0">
+            <h3 className="truncate text-base font-semibold text-content-primary">
+              {preset.name}
+            </h3>
+            {preset.description && (
+              <p className="mt-0.5 text-sm text-content-secondary">
+                {preset.description}
+              </p>
+            )}
+            <span className="mt-1 inline-block text-[11px] uppercase tracking-wide text-content-muted">
+              {preset.isBuiltIn ? 'Built-in' : 'Custom'}
+            </span>
+          </div>
+        </div>
+        <div className="flex flex-none items-center gap-2">
+          {isActive ? (
+            <button
+              type="button"
+              onClick={onClearActive}
+              className="rounded-lg border border-border-subtle bg-surface-chat-background px-3 py-2 text-sm font-medium text-content-primary transition-colors hover:bg-surface-chat"
+            >
+              Stop using
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={onUseThis}
+              className="flex items-center gap-1.5 rounded-lg bg-brand-accent-dark px-3 py-2 text-sm font-semibold text-white transition-colors hover:bg-brand-accent-dark/90"
+            >
+              <SparklesIcon className="h-4 w-4" />
+              Use for this chat
+            </button>
+          )}
+        </div>
+      </div>
+
+      <div className="flex flex-none items-center gap-2 border-b border-border-subtle px-6 py-2">
+        {!preset.isBuiltIn && (
+          <button
+            type="button"
+            onClick={onEdit}
+            className="flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium text-content-secondary transition-colors hover:bg-surface-chat hover:text-content-primary"
+          >
+            <PencilSquareIcon className="h-3.5 w-3.5" />
+            Edit
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={onDuplicate}
+          className="flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium text-content-secondary transition-colors hover:bg-surface-chat hover:text-content-primary"
+        >
+          <PlusIcon className="h-3.5 w-3.5" />
+          Duplicate
+        </button>
+        {!preset.isBuiltIn && (
+          <button
+            type="button"
+            onClick={onDelete}
+            className="flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium text-red-500 transition-colors hover:bg-red-500/10"
+          >
+            <TrashIcon className="h-3.5 w-3.5" />
+            Delete
+          </button>
+        )}
+      </div>
+
+      <div className="flex min-h-0 flex-1 flex-col px-6 py-4">
+        <span className="mb-2 text-xs font-medium uppercase tracking-wide text-content-muted">
+          System prompt
+        </span>
+        <pre className="flex-1 overflow-auto whitespace-pre-wrap rounded-lg border border-border-subtle bg-surface-chat-background p-4 font-mono text-[13px] text-content-primary">
+          {preset.systemPrompt}
+        </pre>
+      </div>
+    </div>
+  )
+}
+
+type PresetEditorProps = {
+  editor: EditorState
+  onChange: (editor: EditorState) => void
+  onCancel: () => void
+  onSave: () => void
+}
+
+function PresetEditor({
+  editor,
+  onChange,
+  onCancel,
+  onSave,
+}: PresetEditorProps) {
+  const canSave =
+    editor.name.trim().length > 0 && editor.systemPrompt.trim().length > 0
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="flex flex-none items-center justify-between gap-4 border-b border-border-subtle px-6 py-4">
+        <h3 className="text-base font-semibold text-content-primary">
+          {editor.mode === 'create' ? 'New prompt' : 'Edit prompt'}
+        </h3>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="rounded-lg border border-border-subtle bg-surface-chat-background px-3 py-2 text-sm font-medium text-content-primary transition-colors hover:bg-surface-chat"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={onSave}
+            disabled={!canSave}
+            className="rounded-lg bg-brand-accent-dark px-3 py-2 text-sm font-semibold text-white transition-colors hover:bg-brand-accent-dark/90 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            Save
+          </button>
+        </div>
+      </div>
+      <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto px-6 py-4">
+        <label className="flex flex-col gap-1">
+          <span className="text-xs font-medium uppercase tracking-wide text-content-muted">
+            Name
+          </span>
+          <input
+            type="text"
+            value={editor.name}
+            onChange={(e) => onChange({ ...editor, name: e.target.value })}
+            placeholder="e.g. SQL Buddy"
+            className="rounded-lg border border-border-subtle bg-surface-chat-background px-3 py-2 text-sm text-content-primary focus:border-brand-accent-dark focus:outline-none"
+          />
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-xs font-medium uppercase tracking-wide text-content-muted">
+            Short description
+          </span>
+          <input
+            type="text"
+            value={editor.description}
+            onChange={(e) =>
+              onChange({ ...editor, description: e.target.value })
+            }
+            placeholder="What does this prompt do?"
+            className="rounded-lg border border-border-subtle bg-surface-chat-background px-3 py-2 text-sm text-content-primary focus:border-brand-accent-dark focus:outline-none"
+          />
+        </label>
+        <label className="flex min-h-0 flex-1 flex-col gap-1">
+          <span className="text-xs font-medium uppercase tracking-wide text-content-muted">
+            System prompt
+          </span>
+          <textarea
+            value={editor.systemPrompt}
+            onChange={(e) =>
+              onChange({ ...editor, systemPrompt: e.target.value })
+            }
+            placeholder="You are a helpful assistant that..."
+            className="min-h-[240px] flex-1 resize-y rounded-lg border border-border-subtle bg-surface-chat-background p-3 font-mono text-[13px] text-content-primary focus:border-brand-accent-dark focus:outline-none"
+          />
+          <span className="text-[11px] text-content-muted">
+            Placeholders supported: {`{USER_PREFERENCES}`}, {`{LANGUAGE}`},{' '}
+            {`{CURRENT_DATETIME}`}, {`{TIMEZONE}`}.
+          </span>
+        </label>
+      </div>
+    </div>
+  )
+}

--- a/src/components/chat/prompt-library-modal.tsx
+++ b/src/components/chat/prompt-library-modal.tsx
@@ -11,6 +11,13 @@ import {
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { CONSTANTS } from './constants'
 import { usePromptLibrary } from './hooks/use-prompt-library'
+import {
+  EMPTY_PRESET_EDITOR_STATE,
+  PresetEditor,
+  ensureSystemTags,
+  stripSystemTags,
+  type PresetEditorState,
+} from './prompts/preset-editor'
 import type { PromptPreset } from './prompts/types'
 
 type PromptLibraryModalProps = {
@@ -20,37 +27,6 @@ type PromptLibraryModalProps = {
   onSelectPreset: (presetId: string | null) => void
   isSidebarOpen?: boolean
   isRightSidebarOpen?: boolean
-}
-
-type EditorState = {
-  mode: 'create' | 'edit'
-  presetId: string | null
-  name: string
-  description: string
-  systemPrompt: string
-}
-
-const EMPTY_EDITOR: EditorState = {
-  mode: 'create',
-  presetId: null,
-  name: '',
-  description: '',
-  systemPrompt: '',
-}
-
-const stripSystemTags = (prompt: string): string =>
-  prompt
-    .replace(/^<system>\s*\n?/, '')
-    .replace(/\n?<\/system>\s*$/, '')
-    .trim()
-
-const ensureSystemTags = (prompt: string): string => {
-  const trimmed = prompt.trim()
-  if (!trimmed) return ''
-  if (trimmed.startsWith('<system>') && trimmed.endsWith('</system>')) {
-    return trimmed
-  }
-  return `<system>\n${trimmed}\n</system>`
 }
 
 export function PromptLibraryModal({
@@ -74,7 +50,7 @@ export function PromptLibraryModal({
   const [selectedId, setSelectedId] = useState<string | null>(
     activePresetId ?? builtInPresets[0]?.id ?? null,
   )
-  const [editor, setEditor] = useState<EditorState | null>(null)
+  const [editor, setEditor] = useState<PresetEditorState | null>(null)
   const wasOpenRef = useRef(false)
 
   useEffect(() => {
@@ -125,7 +101,7 @@ export function PromptLibraryModal({
   }
 
   const startCreate = () => {
-    setEditor({ ...EMPTY_EDITOR })
+    setEditor({ ...EMPTY_PRESET_EDITOR_STATE })
   }
 
   const startEdit = (preset: PromptPreset) => {
@@ -435,95 +411,6 @@ function PresetDetail({
         <pre className="flex-1 overflow-auto whitespace-pre-wrap rounded-lg border border-border-subtle bg-surface-chat-background p-4 font-mono text-[13px] text-content-primary">
           {preset.systemPrompt}
         </pre>
-      </div>
-    </div>
-  )
-}
-
-type PresetEditorProps = {
-  editor: EditorState
-  onChange: (editor: EditorState) => void
-  onCancel: () => void
-  onSave: () => void
-}
-
-function PresetEditor({
-  editor,
-  onChange,
-  onCancel,
-  onSave,
-}: PresetEditorProps) {
-  const canSave =
-    editor.name.trim().length > 0 && editor.systemPrompt.trim().length > 0
-
-  return (
-    <div className="flex min-h-0 flex-1 flex-col">
-      <div className="flex flex-none items-center justify-between gap-4 border-b border-border-subtle px-6 py-4">
-        <h3 className="text-base font-semibold text-content-primary">
-          {editor.mode === 'create' ? 'New prompt' : 'Edit prompt'}
-        </h3>
-        <div className="flex items-center gap-2">
-          <button
-            type="button"
-            onClick={onCancel}
-            className="rounded-lg border border-border-subtle bg-surface-chat-background px-3 py-2 text-sm font-medium text-content-primary transition-colors hover:bg-surface-chat"
-          >
-            Cancel
-          </button>
-          <button
-            type="button"
-            onClick={onSave}
-            disabled={!canSave}
-            className="rounded-lg bg-brand-accent-dark px-3 py-2 text-sm font-semibold text-white transition-colors hover:bg-brand-accent-dark/90 disabled:cursor-not-allowed disabled:opacity-50"
-          >
-            Save
-          </button>
-        </div>
-      </div>
-      <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto px-6 py-4">
-        <label className="flex flex-col gap-1">
-          <span className="text-xs font-medium uppercase tracking-wide text-content-muted">
-            Name
-          </span>
-          <input
-            type="text"
-            value={editor.name}
-            onChange={(e) => onChange({ ...editor, name: e.target.value })}
-            placeholder="e.g. SQL Buddy"
-            className="rounded-lg border border-border-subtle bg-surface-chat-background px-3 py-2 text-sm text-content-primary focus:border-brand-accent-dark focus:outline-none"
-          />
-        </label>
-        <label className="flex flex-col gap-1">
-          <span className="text-xs font-medium uppercase tracking-wide text-content-muted">
-            Short description
-          </span>
-          <input
-            type="text"
-            value={editor.description}
-            onChange={(e) =>
-              onChange({ ...editor, description: e.target.value })
-            }
-            placeholder="What does this prompt do?"
-            className="rounded-lg border border-border-subtle bg-surface-chat-background px-3 py-2 text-sm text-content-primary focus:border-brand-accent-dark focus:outline-none"
-          />
-        </label>
-        <label className="flex min-h-0 flex-1 flex-col gap-1">
-          <span className="text-xs font-medium uppercase tracking-wide text-content-muted">
-            System prompt
-          </span>
-          <textarea
-            value={editor.systemPrompt}
-            onChange={(e) =>
-              onChange({ ...editor, systemPrompt: e.target.value })
-            }
-            placeholder="You are a helpful assistant that..."
-            className="min-h-[240px] flex-1 resize-y rounded-lg border border-border-subtle bg-surface-chat-background p-3 font-mono text-[13px] text-content-primary focus:border-brand-accent-dark focus:outline-none"
-          />
-          <span className="text-[11px] text-content-muted">
-            Placeholders supported: {`{USER_PREFERENCES}`}, {`{LANGUAGE}`},{' '}
-            {`{CURRENT_DATETIME}`}, {`{TIMEZONE}`}.
-          </span>
-        </label>
       </div>
     </div>
   )

--- a/src/components/chat/prompt-library-modal.tsx
+++ b/src/components/chat/prompt-library-modal.tsx
@@ -1,5 +1,6 @@
 import { cn } from '@/components/ui/utils'
 import {
+  ArrowLeftIcon,
   CheckIcon,
   PencilSquareIcon,
   PlusIcon,
@@ -51,16 +52,19 @@ export function PromptLibraryModal({
     activePresetId ?? builtInPresets[0]?.id ?? null,
   )
   const [editor, setEditor] = useState<PresetEditorState | null>(null)
+  const [mobileView, setMobileView] = useState<'list' | 'detail'>('list')
   const wasOpenRef = useRef(false)
 
   useEffect(() => {
     if (!isOpen) {
       setEditor(null)
+      setMobileView('list')
       wasOpenRef.current = false
       return
     }
     if (!wasOpenRef.current) {
       setSelectedId(activePresetId ?? builtInPresets[0]?.id ?? null)
+      setMobileView('list')
       wasOpenRef.current = true
     }
   }, [isOpen, activePresetId, builtInPresets])
@@ -102,6 +106,7 @@ export function PromptLibraryModal({
 
   const startCreate = () => {
     setEditor({ ...EMPTY_PRESET_EDITOR_STATE })
+    setMobileView('detail')
   }
 
   const startEdit = (preset: PromptPreset) => {
@@ -112,6 +117,7 @@ export function PromptLibraryModal({
       description: preset.description,
       systemPrompt: stripSystemTags(preset.systemPrompt),
     })
+    setMobileView('detail')
   }
 
   const handleDuplicate = (preset: PromptPreset) => {
@@ -125,6 +131,7 @@ export function PromptLibraryModal({
         description: copy.description,
         systemPrompt: stripSystemTags(copy.systemPrompt),
       })
+      setMobileView('detail')
     }
   }
 
@@ -178,7 +185,10 @@ export function PromptLibraryModal({
       <button
         type="button"
         key={preset.id}
-        onClick={() => setSelectedId(preset.id)}
+        onClick={() => {
+          setSelectedId(preset.id)
+          setMobileView('detail')
+        }}
         className={cn(
           'group relative flex w-full items-start gap-3 rounded-lg border px-3 py-2.5 text-left transition-colors',
           isSelected
@@ -227,10 +237,25 @@ export function PromptLibraryModal({
           maxWidth: `min(1024px, calc(92vw - ${leftOffset + rightOffset}px))`,
         }}
       >
-        <div className="flex items-center justify-between border-b border-border-subtle px-6 py-4">
-          <div className="flex items-center gap-2">
-            <Squares2X2Icon className="h-5 w-5 text-content-secondary" />
-            <h2 className="text-lg font-semibold text-content-primary">
+        <div className="flex items-center justify-between border-b border-border-subtle px-4 py-3 md:px-6 md:py-4">
+          <div className="flex min-w-0 items-center gap-2">
+            {mobileView === 'detail' && (
+              <button
+                type="button"
+                onClick={() => {
+                  if (editor) {
+                    setEditor(null)
+                  }
+                  setMobileView('list')
+                }}
+                className="-ml-1 flex h-8 w-8 items-center justify-center rounded-lg text-content-secondary transition-colors hover:bg-surface-chat md:hidden"
+                aria-label="Back to library"
+              >
+                <ArrowLeftIcon className="h-5 w-5" />
+              </button>
+            )}
+            <Squares2X2Icon className="hidden h-5 w-5 text-content-secondary md:block" />
+            <h2 className="truncate text-base font-semibold text-content-primary md:text-lg">
               Prompt Library
             </h2>
           </div>
@@ -244,13 +269,18 @@ export function PromptLibraryModal({
         </div>
 
         <div className="flex min-h-0 flex-1 overflow-hidden">
-          <div className="flex w-[300px] flex-none flex-col border-r border-border-subtle">
+          <div
+            className={cn(
+              'flex min-h-0 w-full flex-none flex-col md:w-[300px] md:border-r md:border-border-subtle',
+              mobileView === 'detail' ? 'hidden md:flex' : 'flex',
+            )}
+          >
             <div className="flex items-center justify-between px-4 pt-4">
               <span className="text-xs font-medium uppercase tracking-wide text-content-muted">
                 Built-in
               </span>
             </div>
-            <div className="flex flex-col gap-1.5 overflow-y-auto px-3 pb-2 pt-2">
+            <div className="flex flex-col gap-1.5 px-3 pb-2 pt-2">
               {builtInPresets.map(renderPresetCard)}
             </div>
 
@@ -267,7 +297,7 @@ export function PromptLibraryModal({
                 New
               </button>
             </div>
-            <div className="flex flex-1 flex-col gap-1.5 overflow-y-auto px-3 pb-4 pt-2">
+            <div className="flex min-h-0 flex-1 flex-col gap-1.5 overflow-y-auto px-3 pb-4 pt-2">
               {userPresets.length === 0 ? (
                 <p className="px-1 pt-1 text-xs text-content-muted">
                   No custom prompts yet. Click &quot;New&quot; to create one.
@@ -278,13 +308,24 @@ export function PromptLibraryModal({
             </div>
           </div>
 
-          <div className="flex min-w-0 flex-1 flex-col">
+          <div
+            className={cn(
+              'min-w-0 flex-1 flex-col',
+              mobileView === 'list' ? 'hidden md:flex' : 'flex',
+            )}
+          >
             {editor ? (
               <PresetEditor
                 editor={editor}
                 onChange={setEditor}
-                onCancel={() => setEditor(null)}
-                onSave={handleEditorSave}
+                onCancel={() => {
+                  setEditor(null)
+                  setMobileView('list')
+                }}
+                onSave={() => {
+                  handleEditorSave()
+                  setMobileView('detail')
+                }}
               />
             ) : selectedPreset ? (
               <PresetDetail

--- a/src/components/chat/prompt-library-modal.tsx
+++ b/src/components/chat/prompt-library-modal.tsx
@@ -275,36 +275,38 @@ export function PromptLibraryModal({
               mobileView === 'detail' ? 'hidden md:flex' : 'flex',
             )}
           >
-            <div className="flex items-center justify-between px-4 pt-4">
-              <span className="text-xs font-medium uppercase tracking-wide text-content-muted">
-                Built-in
-              </span>
-            </div>
-            <div className="flex flex-col gap-1.5 px-3 pb-2 pt-2">
-              {builtInPresets.map(renderPresetCard)}
-            </div>
+            <div className="flex min-h-0 flex-1 flex-col overflow-y-auto pb-8">
+              <div className="flex items-center justify-between px-4 pt-4">
+                <span className="text-xs font-medium uppercase tracking-wide text-content-muted">
+                  Built-in
+                </span>
+              </div>
+              <div className="flex flex-col gap-1.5 px-3 pb-2 pt-2">
+                {builtInPresets.map(renderPresetCard)}
+              </div>
 
-            <div className="mt-2 flex items-center justify-between px-4 pt-2">
-              <span className="text-xs font-medium uppercase tracking-wide text-content-muted">
-                Your prompts
-              </span>
-              <button
-                type="button"
-                onClick={startCreate}
-                className="flex items-center gap-1 rounded-md px-1.5 py-0.5 text-xs font-medium text-content-secondary transition-colors hover:bg-surface-chat hover:text-content-primary"
-              >
-                <PlusIcon className="h-3.5 w-3.5" />
-                New
-              </button>
-            </div>
-            <div className="flex min-h-0 flex-1 flex-col gap-1.5 overflow-y-auto px-3 pb-4 pt-2">
-              {userPresets.length === 0 ? (
-                <p className="px-1 pt-1 text-xs text-content-muted">
-                  No custom prompts yet. Click &quot;New&quot; to create one.
-                </p>
-              ) : (
-                userPresets.map(renderPresetCard)
-              )}
+              <div className="mt-2 flex items-center justify-between px-4 pt-2">
+                <span className="text-xs font-medium uppercase tracking-wide text-content-muted">
+                  Your prompts
+                </span>
+                <button
+                  type="button"
+                  onClick={startCreate}
+                  className="flex items-center gap-1 rounded-md px-1.5 py-0.5 text-xs font-medium text-content-secondary transition-colors hover:bg-surface-chat hover:text-content-primary"
+                >
+                  <PlusIcon className="h-3.5 w-3.5" />
+                  New
+                </button>
+              </div>
+              <div className="flex flex-col gap-1.5 px-3 pt-2">
+                {userPresets.length === 0 ? (
+                  <p className="px-1 pt-1 text-xs text-content-muted">
+                    No custom prompts yet. Click &quot;New&quot; to create one.
+                  </p>
+                ) : (
+                  userPresets.map(renderPresetCard)
+                )}
+              </div>
             </div>
           </div>
 

--- a/src/components/chat/prompt-library-modal.tsx
+++ b/src/components/chat/prompt-library-modal.tsx
@@ -10,6 +10,7 @@ import {
   XMarkIcon,
 } from '@heroicons/react/24/outline'
 import { useEffect, useMemo, useRef, useState } from 'react'
+import { ConfirmDialog } from './components/confirm-dialog'
 import { CONSTANTS } from './constants'
 import { usePromptLibrary } from './hooks/use-prompt-library'
 import {
@@ -53,6 +54,8 @@ export function PromptLibraryModal({
   )
   const [editor, setEditor] = useState<PresetEditorState | null>(null)
   const [mobileView, setMobileView] = useState<'list' | 'detail'>('list')
+  const [presetPendingDelete, setPresetPendingDelete] =
+    useState<PromptPreset | null>(null)
   const wasOpenRef = useRef(false)
 
   useEffect(() => {
@@ -137,12 +140,12 @@ export function PromptLibraryModal({
 
   const handleDelete = (preset: PromptPreset) => {
     if (preset.isBuiltIn) return
-    if (
-      typeof window !== 'undefined' &&
-      !window.confirm(`Delete "${preset.name}"? This cannot be undone.`)
-    ) {
-      return
-    }
+    setPresetPendingDelete(preset)
+  }
+
+  const handleConfirmDelete = () => {
+    const preset = presetPendingDelete
+    if (!preset) return
     deleteUserPreset(preset.id)
     if (selectedId === preset.id) {
       setSelectedId(builtInPresets[0]?.id ?? null)
@@ -150,6 +153,7 @@ export function PromptLibraryModal({
     if (activePresetId === preset.id) {
       onSelectPreset(null)
     }
+    setPresetPendingDelete(null)
   }
 
   const handleEditorSave = () => {
@@ -349,6 +353,20 @@ export function PromptLibraryModal({
           </div>
         </div>
       </div>
+
+      <ConfirmDialog
+        isOpen={presetPendingDelete !== null}
+        title="Delete prompt?"
+        description={
+          presetPendingDelete
+            ? `"${presetPendingDelete.name}" will be permanently removed. This cannot be undone.`
+            : undefined
+        }
+        confirmLabel="Delete"
+        variant="destructive"
+        onConfirm={handleConfirmDelete}
+        onCancel={() => setPresetPendingDelete(null)}
+      />
     </div>
   )
 }

--- a/src/components/chat/prompt-library-modal.tsx
+++ b/src/components/chat/prompt-library-modal.tsx
@@ -222,7 +222,7 @@ export function PromptLibraryModal({
       />
 
       <div
-        className="relative z-10 flex h-[85vh] w-[92vw] max-w-5xl flex-col rounded-xl border border-border-subtle bg-surface-sidebar shadow-xl"
+        className="relative z-10 flex h-[85dvh] w-[92vw] max-w-5xl flex-col rounded-xl border border-border-subtle bg-surface-sidebar shadow-xl"
         style={{
           maxWidth: `min(1024px, calc(92vw - ${leftOffset + rightOffset}px))`,
         }}

--- a/src/components/chat/prompts/built-in-presets.ts
+++ b/src/components/chat/prompts/built-in-presets.ts
@@ -19,11 +19,21 @@ export const BUILT_IN_PROMPT_PRESETS: PromptPreset[] = [
     Icon: PiStudent,
     isBuiltIn: true,
     systemPrompt: wrap(`
-You are a patient, encouraging tutor. Explain concepts step by step, starting from
-fundamentals and building up. Ask clarifying questions when the user's level is
-unclear, and check understanding before moving on. Use concrete examples and
-analogies. Prefer Socratic prompts over giving away the answer immediately, and
-celebrate progress without being saccharine.
+You are a patient tutor. Open by gauging the learner's current level with one
+short, specific question — do not lecture before you know what they already
+know. Then teach in small steps:
+
+- Build from the simplest correct mental model up to the full idea.
+- Give one concrete example and one analogy per concept. When they conflict,
+  trust the example.
+- Before introducing the next step, ask one question that checks whether the
+  current step landed.
+- When the learner is wrong, point to the exact misconception in their own
+  words and correct it. Don't restart the whole topic.
+
+Prefer Socratic prompts over handing over the answer. When the learner is
+stuck, narrow the gap with a hint rather than solving it for them. Avoid empty
+praise; acknowledge progress only when it reflects real understanding.
 
 {USER_PREFERENCES}
 
@@ -33,18 +43,31 @@ Respond in {LANGUAGE}. Current time: {CURRENT_DATETIME} ({TIMEZONE}).
   {
     id: 'builtin:code-reviewer',
     name: 'Code Reviewer',
-    description: 'Senior engineer who reviews code thoroughly',
+    description:
+      'Thorough reviewer who finds bugs, security issues, and design smells',
     Icon: PiCode,
     isBuiltIn: true,
     systemPrompt: wrap(`
-You are a senior software engineer performing a code review. For each snippet
-the user shares:
+You review code carefully. For each snippet the user shares, work through it
+in this order:
+
 1. Summarize what the code does in one or two sentences.
-2. Flag bugs, security issues, race conditions, and correctness problems first.
-3. Note design and readability concerns next, with concrete suggestions.
-4. Call out minor style nits last, clearly labelled as nits.
-Prefer specific, actionable feedback over general advice. Quote the exact lines
-you are referring to. If something looks fine, say so.
+2. Correctness and bugs first: incorrect logic, off-by-one errors, missing
+   null or undefined handling, unhandled error paths, races, edge cases, and
+   anything the code silently swallows.
+3. Security next: untrusted input handling, injection, secret exposure,
+   broken auth assumptions, time-of-check vs time-of-use, unsafe defaults.
+4. Design and readability: unclear names, leaky abstractions, hidden
+   coupling, and code that will rot. Pair every concern with a concrete
+   alternative.
+5. Style nits last, clearly labelled "nit:".
+
+Quote the exact lines you're referring to. For each issue, name the failure
+mode and the fix, not just the symptom. If something looks correct, say so
+explicitly so the user knows it was checked.
+
+After your first pass, re-read your own findings and drop anything that
+doesn't reproduce on a careful second look. Don't pad the review.
 
 {USER_PREFERENCES}
 
@@ -54,16 +77,28 @@ Respond in {LANGUAGE}. Current time: {CURRENT_DATETIME} ({TIMEZONE}).
   {
     id: 'builtin:writing-coach',
     name: 'Writing Coach',
-    description: 'Editor who sharpens prose without rewriting your voice',
+    description: 'Editor who sharpens prose without flattening your voice',
     Icon: PiPencilLine,
     isBuiltIn: true,
     systemPrompt: wrap(`
-You are a thoughtful writing coach. When the user shares writing, preserve their
-voice. Identify the strongest sentence and the weakest sentence, then suggest
-targeted edits for clarity, rhythm, and concision. Offer at most one rewrite of
-a tricky paragraph rather than redrafting the whole piece. Explain why each
-change improves the writing. When asked for new copy, ask about audience and
-tone before drafting.
+You sharpen writing without erasing the writer's voice. Work as an analyzer
+first, a rewriter only when asked.
+
+When the user shares prose:
+
+- Quote the strongest sentence and say in one line why it works.
+- Quote the weakest sentence and propose a tighter version that keeps the
+  writer's cadence, lexicon, and sentence-length pattern.
+- Offer at most one full rewrite of a tricky paragraph. Don't redraft the
+  whole piece unprompted.
+- For every edit, give a one-sentence reason tied to clarity, rhythm, pacing,
+  or concision — never just "smoother" or "better".
+- Call out tics worth keeping: a recurring image, a punchy fragment, an odd
+  adverb that's load-bearing.
+
+When asked for new copy, ask about audience, intent, and length cap before
+drafting. Match the user's register — if they write in fragments, reply in
+fragments; if they write in long periodic sentences, do the same.
 
 {USER_PREFERENCES}
 
@@ -73,16 +108,31 @@ Respond in {LANGUAGE}. Current time: {CURRENT_DATETIME} ({TIMEZONE}).
   {
     id: 'builtin:brainstorm',
     name: 'Brainstorming Partner',
-    description: 'Generative thinking partner for ideas and tradeoffs',
+    description:
+      'Divergence engine that resists settling on the obvious answer',
     Icon: PiLightbulb,
     isBuiltIn: true,
     systemPrompt: wrap(`
-You are an energetic brainstorming partner. When the user shares a problem,
-generate a wide range of candidate ideas first, including unconventional ones.
-Group ideas by theme, then highlight the two or three with the best
-risk-to-payoff ratio and explain the tradeoffs. Ask follow-up questions to
-narrow the scope when the prompt is ambiguous. Avoid prematurely converging on
-a single answer.
+You are a divergence engine. When the user shares a problem, your job is to
+widen the space of ideas before narrowing it.
+
+First pass: generate at least ten distinct candidate ideas. Push for range —
+mix safe, weird, contrarian, and adjacent-domain ideas. Do not evaluate,
+rank, or filter them yet. Do not ask "which do you want to explore?" until
+the user signals they're done diverging.
+
+Tools to break out of obvious answers:
+- Reframe the constraint: "if budget weren't an issue", "if it had to ship
+  tomorrow", "if it had to work for one person only".
+- Cross-pollinate: borrow a mechanism from a totally unrelated field.
+- Invert: what would make this problem worse, and what does that reveal?
+- Voices: how would a skeptic, a child, and a domain expert each propose
+  something different.
+
+Group ideas by theme only after the first wide pass. Once the user signals
+they want to converge, surface two or three with the best risk-to-payoff
+ratio and name the real tradeoff for each. Never collapse to a single
+recommendation unless the user explicitly asks.
 
 {USER_PREFERENCES}
 
@@ -92,15 +142,32 @@ Respond in {LANGUAGE}. Current time: {CURRENT_DATETIME} ({TIMEZONE}).
   {
     id: 'builtin:translator',
     name: 'Translator',
-    description: 'Faithful translator with cultural and tonal awareness',
+    description:
+      'Faithful translator that preserves tone, register, and formatting',
     Icon: PiTranslate,
     isBuiltIn: true,
     systemPrompt: wrap(`
-You are a careful translator. Detect the source language automatically. Render
-translations that preserve meaning, tone, and register. When idioms do not
-transfer cleanly, give a literal translation followed by a natural one and a
-brief note. Ask which target language the user wants if it is not specified in
-their preferences. Never invent content that was not in the source.
+You translate accurately and faithfully. Detect the source language. If the
+target language isn't specified in the user's preferences or message, ask
+which one — and which regional variant if it matters (e.g. European vs
+Brazilian Portuguese, Mainland vs Taiwan Mandarin, Latin American vs
+Castilian Spanish).
+
+For each translation:
+
+- Match the source's register, formality, and tone. Don't elevate or flatten.
+- Keep terminology consistent within a passage. Don't paraphrase or smooth
+  things out.
+- When an idiom or culturally loaded phrase has no clean equivalent, give
+  the natural translation first, then a literal gloss in parentheses, then a
+  one-line note on what's lost — but only when the difference actually
+  changes meaning.
+- Preserve punctuation, line breaks, capitalization, and inline formatting
+  (markdown, code, tags).
+
+Never add content that wasn't in the source. If something in the source is
+ambiguous, flag it once and translate the most plausible reading rather than
+expanding into every alternative.
 
 {USER_PREFERENCES}
 
@@ -185,10 +252,20 @@ Respond in {LANGUAGE}. Current time: {CURRENT_DATETIME} ({TIMEZONE}).
     Icon: PiLightning,
     isBuiltIn: true,
     systemPrompt: wrap(`
-You are a concise assistant. Answer in the fewest words that fully address the
-question. Skip filler phrases, restated questions, and unnecessary caveats. Use
-short paragraphs or bullet lists only when they aid scanning. If the user asks
-for more depth, expand on request rather than upfront.
+Answer in the fewest words that fully address the question. Treat brevity as
+a hard constraint, not a style preference.
+
+Do not:
+- Open with "Sure", "Great question", "Absolutely", or any affirmation.
+- Restate the user's question.
+- Hedge with "It depends" unless the dependency genuinely changes the
+  answer — and then state both branches in one line each.
+- Add caveats about edge cases the user didn't ask about.
+- Repeat yourself or summarize at the end.
+
+Default to one short paragraph or up to five bullets. Code blocks and tables
+are fine when they're the shortest correct answer. If the user wants more
+depth, they'll ask.
 
 {USER_PREFERENCES}
 

--- a/src/components/chat/prompts/built-in-presets.ts
+++ b/src/components/chat/prompts/built-in-presets.ts
@@ -1,0 +1,126 @@
+import {
+  PiCode,
+  PiLightbulb,
+  PiLightning,
+  PiPencilLine,
+  PiStudent,
+  PiTranslate,
+} from 'react-icons/pi'
+import type { PromptPreset } from './types'
+
+const wrap = (body: string) => `<system>\n${body.trim()}\n</system>`
+
+export const BUILT_IN_PROMPT_PRESETS: PromptPreset[] = [
+  {
+    id: 'builtin:tutor',
+    name: 'Tutor',
+    description: 'Patient teacher who explains step by step',
+    Icon: PiStudent,
+    isBuiltIn: true,
+    systemPrompt: wrap(`
+You are a patient, encouraging tutor. Explain concepts step by step, starting from
+fundamentals and building up. Ask clarifying questions when the user's level is
+unclear, and check understanding before moving on. Use concrete examples and
+analogies. Prefer Socratic prompts over giving away the answer immediately, and
+celebrate progress without being saccharine.
+
+{USER_PREFERENCES}
+
+Respond in {LANGUAGE}. Current time: {CURRENT_DATETIME} ({TIMEZONE}).
+`),
+  },
+  {
+    id: 'builtin:code-reviewer',
+    name: 'Code Reviewer',
+    description: 'Senior engineer who reviews code thoroughly',
+    Icon: PiCode,
+    isBuiltIn: true,
+    systemPrompt: wrap(`
+You are a senior software engineer performing a code review. For each snippet
+the user shares:
+1. Summarize what the code does in one or two sentences.
+2. Flag bugs, security issues, race conditions, and correctness problems first.
+3. Note design and readability concerns next, with concrete suggestions.
+4. Call out minor style nits last, clearly labelled as nits.
+Prefer specific, actionable feedback over general advice. Quote the exact lines
+you are referring to. If something looks fine, say so.
+
+{USER_PREFERENCES}
+
+Respond in {LANGUAGE}. Current time: {CURRENT_DATETIME} ({TIMEZONE}).
+`),
+  },
+  {
+    id: 'builtin:writing-coach',
+    name: 'Writing Coach',
+    description: 'Editor who sharpens prose without rewriting your voice',
+    Icon: PiPencilLine,
+    isBuiltIn: true,
+    systemPrompt: wrap(`
+You are a thoughtful writing coach. When the user shares writing, preserve their
+voice. Identify the strongest sentence and the weakest sentence, then suggest
+targeted edits for clarity, rhythm, and concision. Offer at most one rewrite of
+a tricky paragraph rather than redrafting the whole piece. Explain why each
+change improves the writing. When asked for new copy, ask about audience and
+tone before drafting.
+
+{USER_PREFERENCES}
+
+Respond in {LANGUAGE}. Current time: {CURRENT_DATETIME} ({TIMEZONE}).
+`),
+  },
+  {
+    id: 'builtin:brainstorm',
+    name: 'Brainstorming Partner',
+    description: 'Generative thinking partner for ideas and tradeoffs',
+    Icon: PiLightbulb,
+    isBuiltIn: true,
+    systemPrompt: wrap(`
+You are an energetic brainstorming partner. When the user shares a problem,
+generate a wide range of candidate ideas first, including unconventional ones.
+Group ideas by theme, then highlight the two or three with the best
+risk-to-payoff ratio and explain the tradeoffs. Ask follow-up questions to
+narrow the scope when the prompt is ambiguous. Avoid prematurely converging on
+a single answer.
+
+{USER_PREFERENCES}
+
+Respond in {LANGUAGE}. Current time: {CURRENT_DATETIME} ({TIMEZONE}).
+`),
+  },
+  {
+    id: 'builtin:translator',
+    name: 'Translator',
+    description: 'Faithful translator with cultural and tonal awareness',
+    Icon: PiTranslate,
+    isBuiltIn: true,
+    systemPrompt: wrap(`
+You are a careful translator. Detect the source language automatically. Render
+translations that preserve meaning, tone, and register. When idioms do not
+transfer cleanly, give a literal translation followed by a natural one and a
+brief note. Ask which target language the user wants if it is not specified in
+their preferences. Never invent content that was not in the source.
+
+{USER_PREFERENCES}
+
+Respond in {LANGUAGE}. Current time: {CURRENT_DATETIME} ({TIMEZONE}).
+`),
+  },
+  {
+    id: 'builtin:concise',
+    name: 'Concise Assistant',
+    description: 'No-fluff answers with the minimum needed context',
+    Icon: PiLightning,
+    isBuiltIn: true,
+    systemPrompt: wrap(`
+You are a concise assistant. Answer in the fewest words that fully address the
+question. Skip filler phrases, restated questions, and unnecessary caveats. Use
+short paragraphs or bullet lists only when they aid scanning. If the user asks
+for more depth, expand on request rather than upfront.
+
+{USER_PREFERENCES}
+
+Respond in {LANGUAGE}. Current time: {CURRENT_DATETIME} ({TIMEZONE}).
+`),
+  },
+]

--- a/src/components/chat/prompts/built-in-presets.ts
+++ b/src/components/chat/prompts/built-in-presets.ts
@@ -2,6 +2,7 @@ import {
   PiCode,
   PiLightbulb,
   PiLightning,
+  PiMaskHappy,
   PiPencilLine,
   PiStudent,
   PiTranslate,
@@ -100,6 +101,77 @@ translations that preserve meaning, tone, and register. When idioms do not
 transfer cleanly, give a literal translation followed by a natural one and a
 brief note. Ask which target language the user wants if it is not specified in
 their preferences. Never invent content that was not in the source.
+
+{USER_PREFERENCES}
+
+Respond in {LANGUAGE}. Current time: {CURRENT_DATETIME} ({TIMEZONE}).
+`),
+  },
+  {
+    id: 'builtin:roleplay',
+    name: 'Role-play',
+    description: 'Collaborative storyteller with in-character dialogue',
+    Icon: PiMaskHappy,
+    isBuiltIn: true,
+    systemPrompt: wrap(`
+<role>
+You are a collaborative role-play partner running an in-character scene with
+the user. You play one or more non-user characters and never play, speak for,
+think for, or describe feelings of the user's character.
+</role>
+
+<format>
+Weave two layers together in flowing prose. No headers, no bullet lists, no
+recaps.
+
+- Narration goes in *single asterisks*: actions, body language, gaze, posture,
+  environment, weather, sensory detail, and what your character notices or
+  feels.
+- Dialogue goes in plain "double quotes": what your character says aloud, in
+  their voice and register, with contractions, hesitations, and verbal tics
+  intact.
+
+A typical turn is one to four short paragraphs that interleave narration and
+dialogue. Mirror the user's pacing and length — a brief beat for a brief beat,
+a longer paragraph when they write one.
+</format>
+
+<example>
+*She drags a hand through her hair and slides the half-finished mug across the
+table.* "You really want to go through this again." *Not a question. Her eyes
+don't leave yours, and the kitchen tap drips somewhere behind her.*
+</example>
+
+<style>
+Show emotion through body language and concrete sensory detail rather than
+naming it. Prefer "her knuckles whitened around the mug" to "she was angry";
+"his shoulders dropped half an inch" to "he relaxed". Every turn must include
+at least one fresh sensory detail (sight, sound, smell, touch, taste) and at
+least one specific piece of body language. Vary sentence openings — do not
+start every paragraph with the character's name or with "She" or "He".
+</style>
+
+<rules>
+Stay strictly in character. Do not:
+- Speak, think, act, or assume feelings for the user's character. Only react
+  to what the user writes.
+- Break the fourth wall, add out-of-character commentary, system notes, or
+  meta hints.
+- End a turn with a recap, a closing summary, or a prompt like "What do you
+  do next?".
+- Advance time unilaterally past major beats — pause and let the user
+  respond.
+- Lean on stock role-play phrases such as "she smiled softly", "a mix of X
+  and Y", trailing "..., huh?", "barely above a whisper", or "ministrations".
+
+Maintain continuity with prior turns: physical positions, what each character
+is holding, time of day, weather, established relationships, and emotional
+state.
+
+If no scene has been established yet, ask only what is essential — setting,
+your character's name and situation, and any content limits — then begin.
+Once the scene is set, dive straight in.
+</rules>
 
 {USER_PREFERENCES}
 

--- a/src/components/chat/prompts/preset-editor.tsx
+++ b/src/components/chat/prompts/preset-editor.tsx
@@ -1,0 +1,119 @@
+export type PresetEditorState = {
+  mode: 'create' | 'edit'
+  presetId: string | null
+  name: string
+  description: string
+  systemPrompt: string
+}
+
+export const EMPTY_PRESET_EDITOR_STATE: PresetEditorState = {
+  mode: 'create',
+  presetId: null,
+  name: '',
+  description: '',
+  systemPrompt: '',
+}
+
+export const stripSystemTags = (prompt: string): string =>
+  prompt
+    .replace(/^<system>\s*\n?/, '')
+    .replace(/\n?<\/system>\s*$/, '')
+    .trim()
+
+export const ensureSystemTags = (prompt: string): string => {
+  const trimmed = prompt.trim()
+  if (!trimmed) return ''
+  if (trimmed.startsWith('<system>') && trimmed.endsWith('</system>')) {
+    return trimmed
+  }
+  return `<system>\n${trimmed}\n</system>`
+}
+
+type PresetEditorProps = {
+  editor: PresetEditorState
+  onChange: (editor: PresetEditorState) => void
+  onCancel: () => void
+  onSave: () => void
+}
+
+export function PresetEditor({
+  editor,
+  onChange,
+  onCancel,
+  onSave,
+}: PresetEditorProps) {
+  const canSave =
+    editor.name.trim().length > 0 && editor.systemPrompt.trim().length > 0
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="flex flex-none items-center justify-between gap-4 border-b border-border-subtle px-6 py-4">
+        <h3 className="text-base font-semibold text-content-primary">
+          {editor.mode === 'create' ? 'New prompt' : 'Edit prompt'}
+        </h3>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="rounded-lg border border-border-subtle bg-surface-chat-background px-3 py-2 text-sm font-medium text-content-primary transition-colors hover:bg-surface-chat"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={onSave}
+            disabled={!canSave}
+            className="rounded-lg bg-brand-accent-dark px-3 py-2 text-sm font-semibold text-white transition-colors hover:bg-brand-accent-dark/90 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            Save
+          </button>
+        </div>
+      </div>
+      <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto px-6 py-4">
+        <label className="flex flex-col gap-1">
+          <span className="text-xs font-medium uppercase tracking-wide text-content-muted">
+            Name
+          </span>
+          <input
+            type="text"
+            value={editor.name}
+            onChange={(e) => onChange({ ...editor, name: e.target.value })}
+            placeholder="e.g. SQL Buddy"
+            className="rounded-lg border border-border-subtle bg-surface-chat-background px-3 py-2 text-sm text-content-primary focus:border-brand-accent-dark focus:outline-none"
+          />
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-xs font-medium uppercase tracking-wide text-content-muted">
+            Short description
+          </span>
+          <input
+            type="text"
+            value={editor.description}
+            onChange={(e) =>
+              onChange({ ...editor, description: e.target.value })
+            }
+            placeholder="What does this prompt do?"
+            className="rounded-lg border border-border-subtle bg-surface-chat-background px-3 py-2 text-sm text-content-primary focus:border-brand-accent-dark focus:outline-none"
+          />
+        </label>
+        <label className="flex min-h-0 flex-1 flex-col gap-1">
+          <span className="text-xs font-medium uppercase tracking-wide text-content-muted">
+            System prompt
+          </span>
+          <textarea
+            value={editor.systemPrompt}
+            onChange={(e) =>
+              onChange({ ...editor, systemPrompt: e.target.value })
+            }
+            placeholder="You are a helpful assistant that..."
+            className="min-h-[240px] flex-1 resize-y rounded-lg border border-border-subtle bg-surface-chat-background p-3 font-mono text-[13px] text-content-primary focus:border-brand-accent-dark focus:outline-none"
+          />
+          <span className="text-[11px] text-content-muted">
+            Placeholders supported: {`{USER_PREFERENCES}`}, {`{LANGUAGE}`},{' '}
+            {`{CURRENT_DATETIME}`}, {`{TIMEZONE}`}.
+          </span>
+        </label>
+      </div>
+    </div>
+  )
+}

--- a/src/components/chat/prompts/types.ts
+++ b/src/components/chat/prompts/types.ts
@@ -1,0 +1,19 @@
+import type { IconType } from 'react-icons'
+
+export type PromptPreset = {
+  id: string
+  name: string
+  description: string
+  Icon: IconType
+  systemPrompt: string
+  isBuiltIn: boolean
+}
+
+export type UserPromptPreset = {
+  id: string
+  name: string
+  description: string
+  systemPrompt: string
+  createdAt: number
+  updatedAt: number
+}

--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -54,8 +54,12 @@ import {
   EyeIcon,
   EyeSlashIcon,
   MoonIcon,
+  PencilSquareIcon,
+  PlusIcon,
   SparklesIcon,
+  Squares2X2Icon,
   SunIcon,
+  TrashIcon,
   UserCircleIcon,
   UserIcon,
   XMarkIcon,
@@ -76,6 +80,13 @@ import { RiLightbulbFill, RiShieldKeyholeFill } from 'react-icons/ri'
 import QRCode from 'react-qr-code'
 import { CONSTANTS } from './constants'
 import { normalizeChatFont, type ChatFont } from './hooks/use-chat-font'
+import { usePromptLibrary } from './hooks/use-prompt-library'
+import {
+  EMPTY_PRESET_EDITOR_STATE,
+  PresetEditor,
+  type PresetEditorState,
+} from './prompts/preset-editor'
+import type { PromptPreset } from './prompts/types'
 import type { Chat } from './types'
 
 const CHARS = '0123456789ABCDEF!@#$%^&*()_+<>?/'
@@ -166,6 +177,7 @@ export type SettingsTab =
   | 'general'
   | 'chat'
   | 'personalization'
+  | 'prompts'
   | 'cloud-sync'
   | 'import'
   | 'export'
@@ -278,6 +290,19 @@ export function SettingsModal({
 
   // Chat font setting
   const [chatFont, setChatFont] = useState<ChatFont>('system')
+
+  // Prompt library management state
+  const {
+    builtInPresets,
+    userPresets,
+    createUserPreset,
+    updateUserPreset,
+    deleteUserPreset,
+    duplicatePreset,
+  } = usePromptLibrary()
+  const [promptEditor, setPromptEditor] = useState<PresetEditorState | null>(
+    null,
+  )
 
   // Active tab state
   const [activeTab, setActiveTab] = useState<SettingsTab>(
@@ -781,6 +806,67 @@ export function SettingsModal({
     }
   }
 
+  const startCreatePreset = () => {
+    setPromptEditor({ ...EMPTY_PRESET_EDITOR_STATE })
+  }
+
+  const startEditPreset = (preset: PromptPreset) => {
+    setPromptEditor({
+      mode: 'edit',
+      presetId: preset.id,
+      name: preset.name,
+      description: preset.description,
+      systemPrompt: stripSystemTags(preset.systemPrompt),
+    })
+  }
+
+  const handleDuplicatePreset = (preset: PromptPreset) => {
+    const copy = duplicatePreset(preset.id)
+    if (!copy) return
+    setPromptEditor({
+      mode: 'edit',
+      presetId: copy.id,
+      name: copy.name,
+      description: copy.description,
+      systemPrompt: stripSystemTags(copy.systemPrompt),
+    })
+  }
+
+  const handleDeletePreset = (preset: PromptPreset) => {
+    if (preset.isBuiltIn) return
+    if (
+      typeof window !== 'undefined' &&
+      !window.confirm(`Delete "${preset.name}"? This cannot be undone.`)
+    ) {
+      return
+    }
+    deleteUserPreset(preset.id)
+  }
+
+  const handleSavePromptEditor = () => {
+    if (!promptEditor) return
+    const name = promptEditor.name.trim()
+    if (!name) return
+    const trimmed = promptEditor.systemPrompt.trim()
+    if (!trimmed) return
+    const promptWithTags = ensureSystemTags(trimmed)
+
+    if (promptEditor.mode === 'create') {
+      createUserPreset({
+        name,
+        description: promptEditor.description.trim(),
+        systemPrompt: promptWithTags,
+      })
+    } else if (promptEditor.presetId) {
+      updateUserPreset(promptEditor.presetId, {
+        name,
+        description: promptEditor.description.trim(),
+        systemPrompt: promptWithTags,
+      })
+    }
+    setPromptEditor(null)
+  }
+
   // Restore default system prompt and persist immediately
   const handleRestoreDefaultPrompt = () => {
     const restoredWithoutTags = stripSystemTags(defaultSystemPrompt)
@@ -1230,9 +1316,8 @@ export function SettingsModal({
       const errors: string[] = []
 
       // Dynamically import project storage to avoid circular dependencies
-      const { projectStorage } = await import(
-        '@/services/cloud/project-storage'
-      )
+      const { projectStorage } =
+        await import('@/services/cloud/project-storage')
 
       for (let i = 0; i < parsedProjects.length; i++) {
         const project = parsedProjects[i]
@@ -1856,6 +1941,11 @@ ${encryptionKey.replace('key_', '')}
       label: 'Personalization',
       icon: UserIcon,
     },
+    {
+      id: 'prompts' as const,
+      label: 'Prompts',
+      icon: Squares2X2Icon,
+    },
     ...(isSignedIn
       ? [
           {
@@ -2222,88 +2312,6 @@ ${encryptionKey.replace('key_', '')}
 
                     {advancedSettingsOpen && (
                       <div className="space-y-4">
-                        {/* Custom System Prompt */}
-                        <div
-                          className={cn(
-                            'rounded-lg border border-border-subtle p-4',
-                            isDarkMode ? 'bg-surface-sidebar' : 'bg-white',
-                          )}
-                        >
-                          <div className="space-y-3">
-                            <div className="flex items-center justify-between">
-                              <div className="font-aeonik text-sm font-medium text-content-primary">
-                                Custom System Prompt
-                              </div>
-                              <label className="relative inline-flex cursor-pointer items-center">
-                                <input
-                                  type="checkbox"
-                                  checked={isUsingCustomPrompt}
-                                  onChange={(e) =>
-                                    handleToggleCustomPrompt(e.target.checked)
-                                  }
-                                  className="peer sr-only"
-                                />
-                                <div className="peer h-5 w-9 rounded-full border border-border-subtle bg-content-muted/40 after:absolute after:left-[2px] after:top-[2px] after:h-4 after:w-4 after:rounded-full after:bg-content-muted/70 after:shadow-sm after:transition-all after:content-[''] peer-checked:bg-brand-accent-light peer-checked:after:translate-x-full peer-checked:after:bg-white peer-focus:outline-none" />
-                              </label>
-                            </div>
-                            {isUsingCustomPrompt && (
-                              <>
-                                <div className="font-aeonik-fono text-xs text-content-muted">
-                                  Override the default system prompt to
-                                  customize how Tin behaves.
-                                </div>
-                                <textarea
-                                  value={stripSystemTags(customSystemPrompt)}
-                                  onChange={(e) =>
-                                    handleCustomPromptChange(e.target.value)
-                                  }
-                                  onBlur={handleCustomPromptBlur}
-                                  placeholder="Enter your custom system prompt..."
-                                  rows={6}
-                                  className={cn(
-                                    'w-full resize-none rounded-md border px-3 py-2 font-mono text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500',
-                                    isDarkMode
-                                      ? 'border-border-strong bg-surface-chat text-content-secondary placeholder:text-content-muted'
-                                      : 'border-border-subtle bg-surface-sidebar text-content-primary placeholder:text-content-muted',
-                                  )}
-                                />
-                                <div className="rounded-lg border border-border-subtle bg-surface-chat p-3">
-                                  <div className="font-aeonik-fono text-xs text-content-muted">
-                                    <span
-                                      className={cn(
-                                        'font-aeonik font-medium',
-                                        isDarkMode
-                                          ? 'text-emerald-400'
-                                          : 'text-emerald-600',
-                                      )}
-                                    >
-                                      Tip:
-                                    </span>{' '}
-                                    Use placeholders like {'{USER_PREFERENCES}'}
-                                    , {'{LANGUAGE}'}, {'{CURRENT_DATETIME}'},
-                                    and {'{TIMEZONE}'} to tell the model about
-                                    your preferences, timezone, and the current
-                                    time and date.
-                                  </div>
-                                </div>
-                                <div className="flex justify-center">
-                                  <button
-                                    onClick={handleRestoreDefaultPrompt}
-                                    className={cn(
-                                      'rounded-md px-3 py-1.5 text-xs transition-all hover:underline',
-                                      isDarkMode
-                                        ? 'text-red-400 hover:text-red-300'
-                                        : 'text-red-600 hover:text-red-500',
-                                    )}
-                                  >
-                                    Restore default prompt
-                                  </button>
-                                </div>
-                              </>
-                            )}
-                          </div>
-                        </div>
-
                         {/* Web Search PII Detection */}
                         <div
                           className={cn(
@@ -2758,6 +2766,186 @@ ${encryptionKey.replace('key_', '')}
                   >
                     Reset all fields
                   </button>
+                </>
+              )}
+
+              {/* Prompts Tab */}
+              {activeTab === 'prompts' && (
+                <>
+                  {promptEditor ? (
+                    <div
+                      className={cn(
+                        'overflow-hidden rounded-lg border border-border-subtle',
+                        isDarkMode ? 'bg-surface-sidebar' : 'bg-white',
+                      )}
+                    >
+                      <PresetEditor
+                        editor={promptEditor}
+                        onChange={setPromptEditor}
+                        onCancel={() => setPromptEditor(null)}
+                        onSave={handleSavePromptEditor}
+                      />
+                    </div>
+                  ) : (
+                    <>
+                      {/* Default System Prompt */}
+                      <div className="space-y-3">
+                        <h3 className="font-aeonik text-sm font-medium text-content-secondary">
+                          Default System Prompt
+                        </h3>
+                        <div
+                          className={cn(
+                            'rounded-lg border border-border-subtle p-4',
+                            isDarkMode ? 'bg-surface-sidebar' : 'bg-white',
+                          )}
+                        >
+                          <div className="space-y-3">
+                            <div className="flex items-center justify-between">
+                              <div className="mr-3 flex-1">
+                                <div className="font-aeonik text-sm font-medium text-content-primary">
+                                  Custom default prompt
+                                </div>
+                                <div className="font-aeonik-fono text-xs text-content-muted">
+                                  Override the system prompt for chats that
+                                  don&apos;t have a preset selected.
+                                </div>
+                              </div>
+                              <label className="relative inline-flex cursor-pointer items-center">
+                                <input
+                                  type="checkbox"
+                                  checked={isUsingCustomPrompt}
+                                  onChange={(e) =>
+                                    handleToggleCustomPrompt(e.target.checked)
+                                  }
+                                  className="peer sr-only"
+                                />
+                                <div className="peer h-5 w-9 rounded-full border border-border-subtle bg-content-muted/40 after:absolute after:left-[2px] after:top-[2px] after:h-4 after:w-4 after:rounded-full after:bg-content-muted/70 after:shadow-sm after:transition-all after:content-[''] peer-checked:bg-brand-accent-light peer-checked:after:translate-x-full peer-checked:after:bg-white peer-focus:outline-none" />
+                              </label>
+                            </div>
+                            {isUsingCustomPrompt && (
+                              <>
+                                <textarea
+                                  value={stripSystemTags(customSystemPrompt)}
+                                  onChange={(e) =>
+                                    handleCustomPromptChange(e.target.value)
+                                  }
+                                  onBlur={handleCustomPromptBlur}
+                                  placeholder="Enter your custom system prompt..."
+                                  rows={6}
+                                  className={cn(
+                                    'w-full resize-none rounded-md border px-3 py-2 font-mono text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500',
+                                    isDarkMode
+                                      ? 'border-border-strong bg-surface-chat text-content-secondary placeholder:text-content-muted'
+                                      : 'border-border-subtle bg-surface-sidebar text-content-primary placeholder:text-content-muted',
+                                  )}
+                                />
+                                <div className="rounded-lg border border-border-subtle bg-surface-chat p-3">
+                                  <div className="font-aeonik-fono text-xs text-content-muted">
+                                    <span
+                                      className={cn(
+                                        'font-aeonik font-medium',
+                                        isDarkMode
+                                          ? 'text-emerald-400'
+                                          : 'text-emerald-600',
+                                      )}
+                                    >
+                                      Tip:
+                                    </span>{' '}
+                                    Use placeholders like {'{USER_PREFERENCES}'}
+                                    , {'{LANGUAGE}'}, {'{CURRENT_DATETIME}'},
+                                    and {'{TIMEZONE}'} to tell the model about
+                                    your preferences, timezone, and the current
+                                    time and date.
+                                  </div>
+                                </div>
+                                <div className="flex justify-center">
+                                  <button
+                                    onClick={handleRestoreDefaultPrompt}
+                                    className={cn(
+                                      'rounded-md px-3 py-1.5 text-xs transition-all hover:underline',
+                                      isDarkMode
+                                        ? 'text-red-400 hover:text-red-300'
+                                        : 'text-red-600 hover:text-red-500',
+                                    )}
+                                  >
+                                    Restore default prompt
+                                  </button>
+                                </div>
+                              </>
+                            )}
+                          </div>
+                        </div>
+                      </div>
+
+                      {/* Built-in Prompts */}
+                      <div className="space-y-3">
+                        <h3 className="font-aeonik text-sm font-medium text-content-secondary">
+                          Built-in Prompts
+                        </h3>
+                        <p className="font-aeonik-fono text-xs text-content-muted">
+                          Bundled with Tinfoil. Duplicate one to customize it.
+                        </p>
+                        <div className="space-y-2">
+                          {builtInPresets.map((preset) => (
+                            <PresetRow
+                              key={preset.id}
+                              preset={preset}
+                              isDarkMode={isDarkMode}
+                              onDuplicate={() => handleDuplicatePreset(preset)}
+                            />
+                          ))}
+                        </div>
+                      </div>
+
+                      {/* Your Prompts */}
+                      <div className="space-y-3">
+                        <div className="flex items-center justify-between">
+                          <h3 className="font-aeonik text-sm font-medium text-content-secondary">
+                            Your Prompts
+                          </h3>
+                          <button
+                            type="button"
+                            onClick={startCreatePreset}
+                            className={cn(
+                              'flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium transition-colors',
+                              isDarkMode
+                                ? 'text-content-secondary hover:bg-surface-chat hover:text-content-primary'
+                                : 'text-content-secondary hover:bg-surface-chat hover:text-content-primary',
+                            )}
+                          >
+                            <PlusIcon className="h-3.5 w-3.5" />
+                            New
+                          </button>
+                        </div>
+                        {userPresets.length === 0 ? (
+                          <div
+                            className={cn(
+                              'rounded-lg border border-dashed border-border-subtle p-4 text-center text-xs text-content-muted',
+                              isDarkMode ? 'bg-surface-sidebar' : 'bg-white',
+                            )}
+                          >
+                            No custom prompts yet. Click &quot;New&quot; above
+                            or duplicate a built-in prompt to start.
+                          </div>
+                        ) : (
+                          <div className="space-y-2">
+                            {userPresets.map((preset) => (
+                              <PresetRow
+                                key={preset.id}
+                                preset={preset}
+                                isDarkMode={isDarkMode}
+                                onEdit={() => startEditPreset(preset)}
+                                onDuplicate={() =>
+                                  handleDuplicatePreset(preset)
+                                }
+                                onDelete={() => handleDeletePreset(preset)}
+                              />
+                            ))}
+                          </div>
+                        )}
+                      </div>
+                    </>
+                  )}
                 </>
               )}
 
@@ -4128,6 +4316,76 @@ ${encryptionKey.replace('key_', '')}
           </div>
         </div>
       )}
+    </div>
+  )
+}
+
+type PresetRowProps = {
+  preset: PromptPreset
+  isDarkMode: boolean
+  onEdit?: () => void
+  onDuplicate: () => void
+  onDelete?: () => void
+}
+
+function PresetRow({
+  preset,
+  isDarkMode,
+  onEdit,
+  onDuplicate,
+  onDelete,
+}: PresetRowProps) {
+  const Icon = preset.Icon
+  return (
+    <div
+      className={cn(
+        'flex items-start gap-3 rounded-lg border border-border-subtle p-3',
+        isDarkMode ? 'bg-surface-sidebar' : 'bg-white',
+      )}
+    >
+      <span className="mt-0.5 flex h-7 w-7 flex-none items-center justify-center rounded-md bg-surface-chat text-content-secondary">
+        <Icon className="h-4 w-4" />
+      </span>
+      <div className="flex min-w-0 flex-1 flex-col">
+        <span className="truncate text-sm font-medium text-content-primary">
+          {preset.name}
+        </span>
+        {preset.description && (
+          <span className="mt-0.5 line-clamp-2 text-xs text-content-secondary">
+            {preset.description}
+          </span>
+        )}
+      </div>
+      <div className="flex flex-none items-center gap-1">
+        {onEdit && (
+          <button
+            type="button"
+            onClick={onEdit}
+            aria-label={`Edit ${preset.name}`}
+            className="rounded-md p-1.5 text-content-secondary transition-colors hover:bg-surface-chat hover:text-content-primary"
+          >
+            <PencilSquareIcon className="h-4 w-4" />
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={onDuplicate}
+          aria-label={`Duplicate ${preset.name}`}
+          className="rounded-md p-1.5 text-content-secondary transition-colors hover:bg-surface-chat hover:text-content-primary"
+        >
+          <PlusIcon className="h-4 w-4" />
+        </button>
+        {onDelete && (
+          <button
+            type="button"
+            onClick={onDelete}
+            aria-label={`Delete ${preset.name}`}
+            className="rounded-md p-1.5 text-red-500 transition-colors hover:bg-red-500/10"
+          >
+            <TrashIcon className="h-4 w-4" />
+          </button>
+        )}
+      </div>
     </div>
   )
 }

--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -78,6 +78,7 @@ import { IoShieldCheckmark } from 'react-icons/io5'
 import { PiSignIn } from 'react-icons/pi'
 import { RiLightbulbFill, RiShieldKeyholeFill } from 'react-icons/ri'
 import QRCode from 'react-qr-code'
+import { ConfirmDialog } from './components/confirm-dialog'
 import { CONSTANTS } from './constants'
 import { normalizeChatFont, type ChatFont } from './hooks/use-chat-font'
 import { usePromptLibrary } from './hooks/use-prompt-library'
@@ -303,6 +304,8 @@ export function SettingsModal({
   const [promptEditor, setPromptEditor] = useState<PresetEditorState | null>(
     null,
   )
+  const [presetPendingDelete, setPresetPendingDelete] =
+    useState<PromptPreset | null>(null)
 
   // Active tab state
   const [activeTab, setActiveTab] = useState<SettingsTab>(
@@ -834,13 +837,14 @@ export function SettingsModal({
 
   const handleDeletePreset = (preset: PromptPreset) => {
     if (preset.isBuiltIn) return
-    if (
-      typeof window !== 'undefined' &&
-      !window.confirm(`Delete "${preset.name}"? This cannot be undone.`)
-    ) {
-      return
-    }
+    setPresetPendingDelete(preset)
+  }
+
+  const handleConfirmDeletePreset = () => {
+    const preset = presetPendingDelete
+    if (!preset) return
     deleteUserPreset(preset.id)
+    setPresetPendingDelete(null)
   }
 
   const handleSavePromptEditor = () => {
@@ -4316,6 +4320,20 @@ ${encryptionKey.replace('key_', '')}
           </div>
         </div>
       )}
+
+      <ConfirmDialog
+        isOpen={presetPendingDelete !== null}
+        title="Delete prompt?"
+        description={
+          presetPendingDelete
+            ? `"${presetPendingDelete.name}" will be permanently removed. This cannot be undone.`
+            : undefined
+        }
+        confirmLabel="Delete"
+        variant="destructive"
+        onConfirm={handleConfirmDeletePreset}
+        onCancel={() => setPresetPendingDelete(null)}
+      />
     </div>
   )
 }

--- a/src/components/chat/types.ts
+++ b/src/components/chat/types.ts
@@ -177,6 +177,9 @@ export type Chat = {
   pendingSave?: boolean
   // Project association - when set, chat belongs to a project
   projectId?: string
+  // Prompt library preset association - when set, this preset's system
+  // prompt overrides the default for this chat.
+  presetId?: string
   // For code execution.
   codeExecutionAccessToken?: string
 }

--- a/src/components/url-hash-settings-handler.tsx
+++ b/src/components/url-hash-settings-handler.tsx
@@ -40,6 +40,7 @@ export function UrlHashSettingsHandler({
         'general',
         'chat',
         'personalization',
+        'prompts',
         'cloud-sync',
         'import',
         'export',

--- a/src/constants/storage-keys.ts
+++ b/src/constants/storage-keys.ts
@@ -93,6 +93,8 @@ export const USER_PREFS_CUSTOM_PROMPT_ENABLED =
   'tinfoil-user-prefs-custom-prompt-enabled'
 export const USER_PREFS_CUSTOM_SYSTEM_PROMPT =
   'tinfoil-user-prefs-custom-system-prompt'
+export const USER_PREFS_CUSTOM_PROMPT_PRESETS =
+  'tinfoil-user-prefs-custom-prompt-presets'
 export const USER_PREFS_PROJECT_UPLOAD = 'tinfoil-user-prefs-project-upload'
 
 // --- localStorage: Sync/data state -----------------------------------------


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a prompt library with built‑in and custom presets so you can set a per‑chat system prompt. Adds quick picks on the welcome screen and mobile, shows the active preset above the input, and adds a Prompts settings tab to manage defaults and presets.

- **New Features**
  - Per‑chat preset override stored on `Chat.presetId`; persists across the temporary chat toggle and takes precedence over the custom prompt.
  - Prompt Library modal to browse built‑ins and create/edit/duplicate/delete custom prompts, rename inline from the detail view, and confirm deletes with a styled dialog; responsive on mobile.
  - Quick preset suggestions on the welcome screen and above the input on mobile (“More” opens the library) plus an active preset pill above the input with change and clear actions.
  - Prompts tab in Settings to edit the default system prompt and manage presets with a shared editor; new `usePromptLibrary` hook handles CRUD and cross‑tab updates.
  - Built‑in presets: Tutor, Code Reviewer, Writing Coach, Brainstorming Partner, Translator, Role‑play, Concise Assistant.

<sup>Written for commit 2638f16663dd40c9469b6c1d233a96db3d9b70a8. Summary will update on new commits. <a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/384?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

