### PR TITLE
fix: load favicons through the attested enclave

### DIFF
--- a/src/components/ui/favicon.tsx
+++ b/src/components/ui/favicon.tsx
@@ -1,43 +1,50 @@
-import { getFaviconUrl } from '@/services/inference/metadata-client'
+import { fetchLinkMetadata } from '@/services/inference/metadata-client'
 import { useEffect, useState } from 'react'
 
-// Module-level memory of favicon URLs that have already loaded (or failed)
-// during this session. Keeps remounts — for example, when react-markdown
-// re-parses a streaming message and recreates citation pills — from
-// flashing back through the loading placeholder before re-resolving an
-// image the browser already has cached.
-const RESOLVED_FAVICONS = new Set<string>()
+// Module-level cache of favicon object URLs keyed by page URL. Keeps
+// remounts — for example, when react-markdown re-parses a streaming
+// message and recreates citation pills — from flashing back through
+// the loading placeholder before re-resolving an icon the browser has
+// already decoded.
+const RESOLVED_FAVICON_URLS = new Map<string, string>()
 const FAILED_FAVICONS = new Set<string>()
+
+function releaseCachedFavicon(url: string) {
+  const cached = RESOLVED_FAVICON_URLS.get(url)
+  if (!cached) return
+  URL.revokeObjectURL(cached)
+  RESOLVED_FAVICON_URLS.delete(url)
+}
 
 type FaviconState = 'loading' | 'ready' | 'error'
 
-function initialFaviconState(src: string | null): FaviconState {
-  if (!src) return 'error'
-  if (FAILED_FAVICONS.has(src)) return 'error'
-  if (RESOLVED_FAVICONS.has(src)) return 'ready'
-  return 'loading'
+interface ResolvedFavicon {
+  src: string
+  state: FaviconState
+}
+
+function initialResolved(url: string): ResolvedFavicon {
+  if (FAILED_FAVICONS.has(url)) return { src: '', state: 'error' }
+  const existing = RESOLVED_FAVICON_URLS.get(url)
+  if (existing) return { src: existing, state: 'ready' }
+  return { src: '', state: 'loading' }
 }
 
 /**
- * Favicon <img> that loads the icon through the enclave's `/favicon`
- * endpoint. Call sites previously pointed directly at
- * `icons.duckduckgo.com/ip3/<host>.ico`, which leaked every viewed link
- * to a third party. This component targets the enclave instead; the
- * enclave proxies to DuckDuckGo server-side and streams back bytes.
- *
- * Rendered state is local (load/error) because the browser fetches the
- * image directly — there is no JSON round-trip to manage.
+ * Favicon <img> that loads the icon through the attested metadata
+ * enclave. The bytes are fetched as part of the standard `/metadata`
+ * response, decoded into a Blob, and exposed as an object URL so the
+ * browser never reaches an external icon host directly.
  */
-interface FaviconProps
-  extends Omit<
-    React.ImgHTMLAttributes<HTMLImageElement>,
-    'src' | 'onError' | 'onLoad'
-  > {
-  /** Page URL; only the hostname is used for the lookup. */
+interface FaviconProps extends Omit<
+  React.ImgHTMLAttributes<HTMLImageElement>,
+  'src' | 'onError' | 'onLoad'
+> {
+  /** Page URL; metadata is fetched against this. */
   url: string
-  /** Rendered until the enclave response starts decoding. */
+  /** Rendered until the favicon bytes resolve. */
   placeholder?: React.ReactNode
-  /** Rendered when the image fails to load. */
+  /** Rendered when no bytes are available. */
   fallback?: React.ReactNode
   /** Called once the image has fully loaded. */
   onResolve?: () => void
@@ -55,45 +62,67 @@ export function Favicon({
   className,
   ...imgProps
 }: FaviconProps) {
-  const src = getFaviconUrl(url)
-  const [state, setState] = useState<FaviconState>(() =>
-    initialFaviconState(src),
+  const [resolved, setResolved] = useState<ResolvedFavicon>(() =>
+    initialResolved(url),
   )
 
-  // Reset state when the resolved URL changes so a previously-failed
-  // favicon does not lock this component into the fallback for a
-  // freshly-mounted URL.
   useEffect(() => {
-    setState(initialFaviconState(src))
-  }, [src])
+    let cancelled = false
+    setResolved(initialResolved(url))
 
-  if (!src) return <>{fallback}</>
-  if (state === 'error') return <>{fallback}</>
+    if (FAILED_FAVICONS.has(url) || RESOLVED_FAVICON_URLS.has(url)) {
+      return () => {
+        cancelled = true
+      }
+    }
+
+    fetchLinkMetadata(url)
+      .then((metadata) => {
+        if (cancelled) return
+        if (!metadata.faviconBytes) {
+          FAILED_FAVICONS.add(url)
+          setResolved({ src: '', state: 'error' })
+          return
+        }
+        const contentType = metadata.faviconContentType ?? 'image/x-icon'
+        const blob = new Blob([metadata.faviconBytes], { type: contentType })
+        const objectURL = URL.createObjectURL(blob)
+        const previous = RESOLVED_FAVICON_URLS.get(url)
+        if (previous && previous !== objectURL) {
+          URL.revokeObjectURL(previous)
+        }
+        RESOLVED_FAVICON_URLS.set(url, objectURL)
+        setResolved({ src: objectURL, state: 'ready' })
+      })
+      .catch(() => {
+        if (cancelled) return
+        FAILED_FAVICONS.add(url)
+        setResolved({ src: '', state: 'error' })
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [url])
+
+  if (resolved.state === 'error') return <>{fallback}</>
+  if (resolved.state === 'loading') return <>{placeholder}</>
 
   return (
-    <>
-      {state === 'loading' && placeholder}
-      <img
-        {...imgProps}
-        src={src}
-        alt={alt}
-        className={className}
-        style={
-          state === 'loading'
-            ? { display: 'none', ...imgProps.style }
-            : imgProps.style
-        }
-        onLoad={() => {
-          RESOLVED_FAVICONS.add(src)
-          setState('ready')
-          onResolve?.()
-        }}
-        onError={() => {
-          FAILED_FAVICONS.add(src)
-          setState('error')
-          onResolveError?.()
-        }}
-      />
-    </>
+    <img
+      {...imgProps}
+      src={resolved.src}
+      alt={alt}
+      className={className}
+      onLoad={() => {
+        onResolve?.()
+      }}
+      onError={() => {
+        FAILED_FAVICONS.add(url)
+        releaseCachedFavicon(url)
+        setResolved({ src: '', state: 'error' })
+        onResolveError?.()
+      }}
+    />
   )
 }

--- a/src/services/inference/metadata-client.ts
+++ b/src/services/inference/metadata-client.ts
@@ -4,10 +4,12 @@ import { SecureClient } from 'tinfoil'
 /**
  * Opengraph-metadata client.
  *
- * Fetches title/description/site_name/image/favicon for a URL from the
- * attested `opengraph-metadata.tinfoil.sh` enclave. Used by the GenUI
- * link-preview widget to replace model-generated fields with verified
- * values scraped server-side inside a Tinfoil CVM.
+ * Fetches title/description/site_name/image/favicon-bytes for a URL
+ * from the attested `opengraph-metadata.tinfoil.sh` enclave. Used by
+ * the GenUI link-preview widget to replace model-generated fields with
+ * verified values scraped server-side inside a Tinfoil CVM. Favicon
+ * bytes are inlined in the response so the browser never has to make a
+ * follow-up GET to an external icon host.
  */
 
 const METADATA_ENCLAVE = 'https://opengraph-metadata.tinfoil.sh'
@@ -31,7 +33,8 @@ export interface LinkMetadata {
   description: string | null
   siteName: string | null
   image: string | null
-  favicon: string | null
+  faviconBytes: ArrayBuffer | null
+  faviconContentType: string | null
   cached: boolean
 }
 
@@ -41,7 +44,8 @@ interface MetadataResponse {
   description: string | null
   site_name: string | null
   image: string | null
-  favicon: string | null
+  favicon_bytes?: string | null
+  favicon_content_type?: string | null
   cached: boolean
 }
 
@@ -112,31 +116,25 @@ async function doFetchLinkMetadata(url: string): Promise<LinkMetadata> {
     description: data.description,
     siteName: data.site_name,
     image: data.image,
-    favicon: data.favicon,
+    faviconBytes: decodeBase64Bytes(data.favicon_bytes),
+    faviconContentType: data.favicon_content_type ?? null,
     cached: data.cached,
   }
 }
 
-function getHostKey(url: string): string | null {
+function decodeBase64Bytes(
+  value: string | null | undefined,
+): ArrayBuffer | null {
+  if (!value) return null
   try {
-    return new URL(url).hostname.toLowerCase()
+    const binary = atob(value)
+    const buffer = new ArrayBuffer(binary.length)
+    const bytes = new Uint8Array(buffer)
+    for (let i = 0; i < binary.length; i++) {
+      bytes[i] = binary.charCodeAt(i)
+    }
+    return buffer
   } catch {
     return null
   }
-}
-
-/**
- * Build a direct `<img src>` URL pointing at the enclave's lightweight
- * `GET /favicon?host=...` endpoint.
- *
- * The browser loads the bytes in a single request. No JSON round-trip,
- * no async state in the UI. The enclave proxies to DuckDuckGo's icon
- * service server-side so the browser never talks to DuckDuckGo directly.
- *
- * Returns `null` for URLs whose hostname cannot be parsed.
- */
-export function getFaviconUrl(url: string): string | null {
-  const host = getHostKey(url)
-  if (!host) return null
-  return `${METADATA_ENCLAVE}/favicon?host=${encodeURIComponent(host)}`
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Load favicons through the attested metadata enclave by consuming inlined `favicon_bytes`, so the browser never hits third‑party icon hosts. Adds in-memory caching and robust cleanup to reduce flicker.

- **Bug Fixes**
  - `Favicon` now uses `fetchLinkMetadata` and builds an object URL from `faviconBytes` + `faviconContentType`; shows a placeholder while loading and a fallback if missing.
  - Caches object URLs per page URL; revokes/replaces stale URLs on error or update and tracks failures to avoid repeat fetches and remount flicker.
  - `metadata-client`: returns `faviconBytes` and `faviconContentType`, adds base64 decode, and removes `getFaviconUrl`.
  - Eliminates direct requests to `icons.duckduckgo.com`; all icon bytes come from the enclave.

<sup>Written for commit 34a125777ad89348f700d68006f705f8f977f8fe. Summary will update on new commits. <a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/385?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

