### PR TITLE
fix: prevent concurrent favicon renders from invalidating each other

### DIFF
--- a/src/components/ui/favicon.tsx
+++ b/src/components/ui/favicon.tsx
@@ -9,13 +9,6 @@ import { useEffect, useState } from 'react'
 const RESOLVED_FAVICON_URLS = new Map<string, string>()
 const FAILED_FAVICONS = new Set<string>()
 
-function releaseCachedFavicon(url: string) {
-  const cached = RESOLVED_FAVICON_URLS.get(url)
-  if (!cached) return
-  URL.revokeObjectURL(cached)
-  RESOLVED_FAVICON_URLS.delete(url)
-}
-
 type FaviconState = 'loading' | 'ready' | 'error'
 
 interface ResolvedFavicon {
@@ -84,14 +77,18 @@ export function Favicon({
           setResolved({ src: '', state: 'error' })
           return
         }
-        const contentType = metadata.faviconContentType ?? 'image/x-icon'
-        const blob = new Blob([metadata.faviconBytes], { type: contentType })
-        const objectURL = URL.createObjectURL(blob)
-        const previous = RESOLVED_FAVICON_URLS.get(url)
-        if (previous && previous !== objectURL) {
-          URL.revokeObjectURL(previous)
+        // Reuse a cached object URL when one already exists for this
+        // page. Two concurrent Favicon instances (for example a preview
+        // and the dialog list) would otherwise each create a fresh
+        // object URL and revoke the other's, leaving one of them
+        // pointing at an invalid blob.
+        let objectURL = RESOLVED_FAVICON_URLS.get(url)
+        if (!objectURL) {
+          const contentType = metadata.faviconContentType ?? 'image/x-icon'
+          const blob = new Blob([metadata.faviconBytes], { type: contentType })
+          objectURL = URL.createObjectURL(blob)
+          RESOLVED_FAVICON_URLS.set(url, objectURL)
         }
-        RESOLVED_FAVICON_URLS.set(url, objectURL)
         setResolved({ src: objectURL, state: 'ready' })
       })
       .catch(() => {
@@ -119,7 +116,6 @@ export function Favicon({
       }}
       onError={() => {
         FAILED_FAVICONS.add(url)
-        releaseCachedFavicon(url)
         setResolved({ src: '', state: 'error' })
         onResolveError?.()
       }}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevent a race condition in favicon rendering by reusing a cached object URL per page. This stops concurrent `Favicon` instances from revoking each other’s blob URLs and showing broken icons.

- **Bug Fixes**
  - Create the object URL once per `url` and reuse it from `RESOLVED_FAVICON_URLS`.
  - Remove `releaseCachedFavicon` and avoid revoking previously created URLs.
  - Don’t revoke on image error; mark as failed and keep other instances intact.

<sup>Written for commit a1fbfba8ffd9df3bb9ba994645428ad87ea72cf7. Summary will update on new commits. <a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/386?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

