### PR TITLE
fix: render favicons via data URLs to avoid blob lifecycle races

### DIFF
--- a/src/components/ui/favicon.tsx
+++ b/src/components/ui/favicon.tsx
@@ -1,12 +1,12 @@
 import { fetchLinkMetadata } from '@/services/inference/metadata-client'
 import { useEffect, useState } from 'react'
 
-// Module-level cache of favicon object URLs keyed by page URL. Keeps
-// remounts — for example, when react-markdown re-parses a streaming
-// message and recreates citation pills — from flashing back through
-// the loading placeholder before re-resolving an icon the browser has
-// already decoded.
-const RESOLVED_FAVICON_URLS = new Map<string, string>()
+// Module-level cache of resolved favicon data URLs keyed by page URL.
+// Keeps remounts — for example, when react-markdown re-parses a
+// streaming message and recreates citation pills — from flashing back
+// through the loading placeholder once the icon has already been
+// fetched.
+const RESOLVED_FAVICON_DATA_URLS = new Map<string, string>()
 const FAILED_FAVICONS = new Set<string>()
 
 type FaviconState = 'loading' | 'ready' | 'error'
@@ -17,17 +17,20 @@ interface ResolvedFavicon {
 }
 
 function initialResolved(url: string): ResolvedFavicon {
-  if (FAILED_FAVICONS.has(url)) return { src: '', state: 'error' }
-  const existing = RESOLVED_FAVICON_URLS.get(url)
+  const existing = RESOLVED_FAVICON_DATA_URLS.get(url)
   if (existing) return { src: existing, state: 'ready' }
+  if (FAILED_FAVICONS.has(url)) return { src: '', state: 'error' }
   return { src: '', state: 'loading' }
 }
 
 /**
  * Favicon <img> that loads the icon through the attested metadata
- * enclave. The bytes are fetched as part of the standard `/metadata`
- * response, decoded into a Blob, and exposed as an object URL so the
- * browser never reaches an external icon host directly.
+ * enclave. The bytes come back inlined in the `/metadata` response and
+ * are rendered as a `data:` URL so the browser never reaches an
+ * external icon host directly. Using a `data:` URL keeps the lifecycle
+ * trivial: there's no Blob to allocate and no `URL.createObjectURL`
+ * handle to revoke, so two concurrent components rendering the same
+ * favicon can never invalidate each other's source.
  */
 interface FaviconProps extends Omit<
   React.ImgHTMLAttributes<HTMLImageElement>,
@@ -63,7 +66,7 @@ export function Favicon({
     let cancelled = false
     setResolved(initialResolved(url))
 
-    if (FAILED_FAVICONS.has(url) || RESOLVED_FAVICON_URLS.has(url)) {
+    if (RESOLVED_FAVICON_DATA_URLS.has(url) || FAILED_FAVICONS.has(url)) {
       return () => {
         cancelled = true
       }
@@ -72,24 +75,13 @@ export function Favicon({
     fetchLinkMetadata(url)
       .then((metadata) => {
         if (cancelled) return
-        if (!metadata.faviconBytes) {
+        if (!metadata.faviconDataUrl) {
           FAILED_FAVICONS.add(url)
           setResolved({ src: '', state: 'error' })
           return
         }
-        // Reuse a cached object URL when one already exists for this
-        // page. Two concurrent Favicon instances (for example a preview
-        // and the dialog list) would otherwise each create a fresh
-        // object URL and revoke the other's, leaving one of them
-        // pointing at an invalid blob.
-        let objectURL = RESOLVED_FAVICON_URLS.get(url)
-        if (!objectURL) {
-          const contentType = metadata.faviconContentType ?? 'image/x-icon'
-          const blob = new Blob([metadata.faviconBytes], { type: contentType })
-          objectURL = URL.createObjectURL(blob)
-          RESOLVED_FAVICON_URLS.set(url, objectURL)
-        }
-        setResolved({ src: objectURL, state: 'ready' })
+        RESOLVED_FAVICON_DATA_URLS.set(url, metadata.faviconDataUrl)
+        setResolved({ src: metadata.faviconDataUrl, state: 'ready' })
       })
       .catch(() => {
         if (cancelled) return

--- a/src/services/inference/metadata-client.ts
+++ b/src/services/inference/metadata-client.ts
@@ -33,8 +33,15 @@ export interface LinkMetadata {
   description: string | null
   siteName: string | null
   image: string | null
-  faviconBytes: ArrayBuffer | null
-  faviconContentType: string | null
+  /**
+   * `data:` URL for the page's favicon, already encoded so consumers can
+   * drop it straight into an `<img src>` without managing a Blob or
+   * object URL lifecycle. The bytes never leave the original base64
+   * envelope, which sidesteps the race conditions that come with
+   * `URL.createObjectURL` / `URL.revokeObjectURL` when the same icon is
+   * rendered by multiple components.
+   */
+  faviconDataUrl: string | null
   cached: boolean
 }
 
@@ -116,25 +123,19 @@ async function doFetchLinkMetadata(url: string): Promise<LinkMetadata> {
     description: data.description,
     siteName: data.site_name,
     image: data.image,
-    faviconBytes: decodeBase64Bytes(data.favicon_bytes),
-    faviconContentType: data.favicon_content_type ?? null,
+    faviconDataUrl: buildFaviconDataUrl(
+      data.favicon_bytes,
+      data.favicon_content_type,
+    ),
     cached: data.cached,
   }
 }
 
-function decodeBase64Bytes(
-  value: string | null | undefined,
-): ArrayBuffer | null {
-  if (!value) return null
-  try {
-    const binary = atob(value)
-    const buffer = new ArrayBuffer(binary.length)
-    const bytes = new Uint8Array(buffer)
-    for (let i = 0; i < binary.length; i++) {
-      bytes[i] = binary.charCodeAt(i)
-    }
-    return buffer
-  } catch {
-    return null
-  }
+function buildFaviconDataUrl(
+  base64: string | null | undefined,
+  contentType: string | null | undefined,
+): string | null {
+  if (!base64) return null
+  const type = contentType ?? 'image/x-icon'
+  return `data:${type};base64,${base64}`
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Render favicons as data URLs returned by `/metadata` instead of Blob/object URLs to prevent lifecycle races and flicker when multiple components render the same icon.

- **Bug Fixes**
  - `LinkMetadata` now exposes `faviconDataUrl` (built from base64 + content type) and removes byte decoding.
  - `Favicon` caches and renders data URLs directly, avoiding `URL.createObjectURL`/`revokeObjectURL` conflicts across concurrent instances.

<sup>Written for commit 1b98c8b4ff2cdf54988b5def8506ba85871c8fce. Summary will update on new commits. <a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/387?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

