### PR TITLE
fix: reuse attested client for document uploads

### DIFF
--- a/src/components/chat/document-uploader.tsx
+++ b/src/components/chat/document-uploader.tsx
@@ -1,5 +1,6 @@
 import { getAIModels } from '@/config/models'
 import {
+  getSecureFetch,
   getSessionToken,
   getTinfoilClient,
 } from '@/services/inference/tinfoil-client'
@@ -15,7 +16,6 @@ import {
   scaleAndEncodeImage,
 } from '@/utils/preprocessing'
 import { useState } from 'react'
-import { SecureClient } from 'tinfoil'
 import { CONSTANTS } from './constants'
 import type { DocumentPage, DocumentProcessingResult } from './types'
 
@@ -303,23 +303,21 @@ export const useDocumentUploader = (
         : endpoint
 
       const apiKey = await getSessionToken()
-      const client = new SecureClient()
+      const secureFetch = await getSecureFetch()
       const controller = new AbortController()
       const timeoutId = setTimeout(
         () => controller.abort(),
         CONSTANTS.DOCUMENT_PROCESSING_TIMEOUT_MS,
       )
 
-      const response = await client
-        .fetch(fetchEndpoint, {
-          method: 'POST',
-          headers: {
-            Authorization: `Bearer ${apiKey}`,
-          },
-          body: formData,
-          signal: controller.signal,
-        })
-        .finally(() => clearTimeout(timeoutId))
+      const response = await secureFetch(fetchEndpoint, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+        },
+        body: formData,
+        signal: controller.signal,
+      }).finally(() => clearTimeout(timeoutId))
 
       // Handle 204 No Content response
       if (response.status === 204) {

--- a/src/services/inference/tinfoil-client.ts
+++ b/src/services/inference/tinfoil-client.ts
@@ -280,6 +280,22 @@ export async function getSessionToken(): Promise<string> {
 }
 
 /**
+ * Returns a fetch bound to the shared attested SecureClient so callers
+ * outside the OpenAI SDK (e.g. document upload) can reuse the same
+ * verified channel instead of running attestation a second time.
+ *
+ * Falls back to the global fetch in dev mode, where requests are routed
+ * through the local proxy and SecureClient is intentionally not created.
+ */
+export async function getSecureFetch(): Promise<typeof fetch> {
+  await ensureInitialized()
+  if (!secureClient) {
+    return fetch
+  }
+  return secureClient.fetch
+}
+
+/**
  * Lazily build the OpenAI client (and SecureClient on prod) the first
  * time anything needs them, and rebuild on session-token rotation.
  */


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Reuse the attested `SecureClient` for document uploads to avoid re-attestation and keep a single verified channel. This reduces upload latency in production and falls back to `fetch` in dev.

- **Bug Fixes**
  - Added `getSecureFetch()` in `tinfoil-client` to return the shared attested client’s `fetch` (or global `fetch` in dev).
  - Updated `document-uploader` to use `getSecureFetch()` instead of creating a new `SecureClient`; timeout and auth behavior unchanged.

<sup>Written for commit 0ce48d4df0a0c74bda79078caf6d5c232c16e3da. Summary will update on new commits. <a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/388?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

