### PR TITLE
Prompt subscription  via modal instead of sidebar

### DIFF
--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -2006,8 +2006,31 @@ export function ChatInterface({
     selectedModelDetails?.contextWindow,
   ])
 
-  const handleInputFocusWithRateLimitCheck = useCallback(() => {
+  // Tracks whether the user already saw and dismissed the rate-limit modal
+  // for the current depleted window. Without this, dismissing via the close
+  // button immediately refocuses the textarea and the focus handler would
+  // pop the same modal right back open.
+  const rateLimitModalDismissedRef = useRef(false)
+
+  useEffect(() => {
+    if (rateLimit && rateLimit.remaining > 0) {
+      rateLimitModalDismissedRef.current = false
+    }
+  }, [rateLimit])
+
+  const handleCloseSubscribePrompt = useCallback(() => {
+    setIsSubscribePromptOpen(false)
     if (rateLimit && rateLimit.remaining <= 0) {
+      rateLimitModalDismissedRef.current = true
+    }
+  }, [rateLimit])
+
+  const handleInputFocusWithRateLimitCheck = useCallback(() => {
+    if (
+      rateLimit &&
+      rateLimit.remaining <= 0 &&
+      !rateLimitModalDismissedRef.current
+    ) {
       setIsSubscribePromptOpen(true)
     }
     handleInputFocus()
@@ -2932,9 +2955,14 @@ export function ChatInterface({
               />
             ) : null}
 
-            {/* Rate Limit Banner */}
+            {/* Rate Limit Banner (desktop) — on mobile this renders as a
+                floating pill above the chat input instead. */}
             {shouldShowRateLimitBanner(rateLimit) && (
-              <RateLimitBanner rateLimit={rateLimit} isDarkMode={isDarkMode} />
+              <RateLimitBanner
+                rateLimit={rateLimit}
+                isDarkMode={isDarkMode}
+                className="hidden md:flex"
+              />
             )}
 
             {/* Decryption Progress Banner */}
@@ -3099,6 +3127,14 @@ export function ChatInterface({
                             onOpenLibrary={handleOpenPromptLibrary}
                           />
                         </div>
+                      )}
+                      {shouldShowRateLimitBanner(rateLimit) && (
+                        <RateLimitBanner
+                          rateLimit={rateLimit}
+                          isDarkMode={isDarkMode}
+                          className="mb-2 flex md:hidden"
+                          pillClassName="rounded-full border"
+                        />
                       )}
                       <MessageQueue
                         queue={queuedMessages}
@@ -3356,7 +3392,7 @@ export function ChatInterface({
 
       <SubscribePromptModal
         isOpen={isSubscribePromptOpen}
-        onClose={() => setIsSubscribePromptOpen(false)}
+        onClose={handleCloseSubscribePrompt}
         isSignedIn={!!isSignedIn}
       />
     </div>

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -21,7 +21,7 @@ import {
   snapshotAndDecrementRemaining,
   type RateLimitInfo,
 } from '@/services/inference/tinfoil-client'
-import { SignInButton, useAuth, useClerk, useUser } from '@clerk/nextjs'
+import { SignInButton, useAuth, useUser } from '@clerk/nextjs'
 import {
   ArrowDownIcon,
   ChatBubbleLeftRightIcon,
@@ -81,6 +81,7 @@ import {
 const useLayoutEffect =
   typeof window !== 'undefined' ? reactUseLayoutEffect : useEffect
 
+import { SubscribePromptModal } from '../modals/subscribe-prompt-modal'
 import { UrlHashMessageHandler } from '../url-hash-message-handler'
 import { UrlHashSettingsHandler } from '../url-hash-settings-handler'
 import { ArtifactSidebar } from './artifact-sidebar'
@@ -301,9 +302,9 @@ export function ChatInterface({
   // TODO: unflip this
   const canUseCodeExecution = false
   const { user } = useUser()
-  const { openSignIn } = useClerk()
   const [failedImages, setFailedImages] = useState<Record<string, boolean>>({})
   const [rateLimit, setRateLimit] = useState<RateLimitInfo | null>(null)
+  const [isSubscribePromptOpen, setIsSubscribePromptOpen] = useState(false)
 
   // Onboarding state (must be defined before usePasskeyBackup so we can gate it)
   const [showOnboarding, setShowOnboarding] = useState(false)
@@ -846,17 +847,8 @@ export function ChatInterface({
   }, [rateLimit])
 
   const handleQueueRateLimited = useCallback(() => {
-    if (!isSignedIn) {
-      void openSignIn()
-      return
-    }
-    setIsSidebarOpen(true)
-    window.dispatchEvent(
-      new CustomEvent('highlightSidebarBox', {
-        detail: { isPremium },
-      }),
-    )
-  }, [isSignedIn, openSignIn, setIsSidebarOpen, isPremium])
+    setIsSubscribePromptOpen(true)
+  }, [])
 
   // Queue of user messages submitted while the assistant is busy. The hook
   // observes `loadingState` and dispatches one queued message per idle
@@ -1058,22 +1050,13 @@ export function ChatInterface({
   // Handle upgrade requests from error CTA buttons
   useEffect(() => {
     const handleRequestUpgrade = () => {
-      if (!isSignedIn) {
-        void openSignIn()
-      } else {
-        setIsSidebarOpen(true)
-        window.dispatchEvent(
-          new CustomEvent('highlightSidebarBox', {
-            detail: { isPremium },
-          }),
-        )
-      }
+      setIsSubscribePromptOpen(true)
     }
     window.addEventListener('requestUpgrade', handleRequestUpgrade)
     return () => {
       window.removeEventListener('requestUpgrade', handleRequestUpgrade)
     }
-  }, [isSignedIn, isPremium, openSignIn, setIsSidebarOpen])
+  }, [])
 
   // Persist web search toggle to localStorage
   useEffect(() => {
@@ -2023,20 +2006,18 @@ export function ChatInterface({
     selectedModelDetails?.contextWindow,
   ])
 
+  const handleInputFocusWithRateLimitCheck = useCallback(() => {
+    if (rateLimit && rateLimit.remaining <= 0) {
+      setIsSubscribePromptOpen(true)
+    }
+    handleInputFocus()
+  }, [rateLimit, handleInputFocus])
+
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
 
     if (rateLimit && rateLimit.remaining <= 0) {
-      if (!isSignedIn) {
-        void openSignIn()
-      } else {
-        setIsSidebarOpen(true)
-        window.dispatchEvent(
-          new CustomEvent('highlightSidebarBox', {
-            detail: { isPremium },
-          }),
-        )
-      }
+      setIsSubscribePromptOpen(true)
       return
     }
 
@@ -3037,7 +3018,7 @@ export function ChatInterface({
                     retryInfo={retryInfo}
                     cancelGeneration={cancelGeneration}
                     inputRef={inputRef}
-                    handleInputFocus={handleInputFocus}
+                    handleInputFocus={handleInputFocusWithRateLimitCheck}
                     handleDocumentUpload={handleFileUpload}
                     processedDocuments={processedDocuments}
                     removeDocument={removeDocument}
@@ -3130,7 +3111,7 @@ export function ChatInterface({
                         loadingState={loadingState}
                         cancelGeneration={cancelGeneration}
                         inputRef={inputRef}
-                        handleInputFocus={handleInputFocus}
+                        handleInputFocus={handleInputFocusWithRateLimitCheck}
                         inputMinHeight={inputMinHeight}
                         isDarkMode={isDarkMode}
                         handleDocumentUpload={handleFileUpload}
@@ -3371,6 +3352,12 @@ export function ChatInterface({
         }}
         models={models}
         isDarkMode={isDarkMode}
+      />
+
+      <SubscribePromptModal
+        isOpen={isSubscribePromptOpen}
+        onClose={() => setIsSubscribePromptOpen(false)}
+        isSignedIn={!!isSignedIn}
       />
     </div>
   )

--- a/src/components/chat/chat-sidebar.tsx
+++ b/src/components/chat/chat-sidebar.tsx
@@ -1,4 +1,4 @@
-import { API_BASE_URL, PAGINATION } from '@/config'
+import { PAGINATION } from '@/config'
 import {
   SETTINGS_CLOUD_SYNC_EXPLICITLY_DISABLED,
   UI_EXPAND_PROJECTS_ON_MOUNT,
@@ -9,6 +9,7 @@ import {
 } from '@/constants/storage-keys'
 import { useProjects } from '@/hooks/use-projects'
 import { toast } from '@/hooks/use-toast'
+import { useUpgradeToPro } from '@/hooks/use-upgrade-to-pro'
 import { encryptionService } from '@/services/encryption/encryption-service'
 import { chatStorage } from '@/services/storage/chat-storage'
 import {
@@ -52,7 +53,6 @@ import { useDrag } from './drag-context'
 import { useProject } from '@/components/project/project-context'
 import { cn } from '@/components/ui/utils'
 import { useCloudPagination } from '@/hooks/use-cloud-pagination'
-import { authTokenManager } from '@/services/auth'
 import { type StoredChat } from '@/services/storage/indexed-db'
 import { getConversationTimestampFromId } from '@/utils/chat-timestamps'
 import { logError } from '@/utils/error-handling'
@@ -203,10 +203,11 @@ export function ChatSidebar({
   const chatListRef = useRef<HTMLDivElement>(null)
   const loadMoreSentinelRef = useRef<HTMLDivElement>(null)
   const [isIOS, setIsIOS] = useState(false)
-  const [upgradeLoading, setUpgradeLoading] = useState(false)
-  const [upgradeError, setUpgradeError] = useState<string | null>(null)
-  const [highlightBox, setHighlightBox] = useState(false)
-  const highlightTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const {
+    startUpgrade: handleUpgradeToPro,
+    upgradeLoading,
+    upgradeError,
+  } = useUpgradeToPro()
   const [activeTab, setActiveTab] = useState<'cloud' | 'local'>(() => {
     if (typeof window !== 'undefined') {
       const stored = sessionStorage.getItem(UI_SIDEBAR_ACTIVE_TAB)
@@ -358,27 +359,6 @@ export function ChatSidebar({
       setLocalOnlyModeEnabled(true)
     }
   }, [isSignedIn, cloudSyncEnabled, chats])
-
-  // Listen for highlight CTA events (triggered when user hits send at rate limit)
-  useEffect(() => {
-    const handleHighlight = () => {
-      setHighlightBox(true)
-      if (highlightTimeoutRef.current) {
-        clearTimeout(highlightTimeoutRef.current)
-      }
-      highlightTimeoutRef.current = setTimeout(() => {
-        setHighlightBox(false)
-        highlightTimeoutRef.current = null
-      }, 2400)
-    }
-    window.addEventListener('highlightSidebarBox', handleHighlight)
-    return () => {
-      window.removeEventListener('highlightSidebarBox', handleHighlight)
-      if (highlightTimeoutRef.current) {
-        clearTimeout(highlightTimeoutRef.current)
-      }
-    }
-  }, [])
 
   // Update blank chat's isLocalOnly when active tab changes
   useEffect(() => {
@@ -723,39 +703,6 @@ export function ChatSidebar({
     }
   }
 
-  const handleUpgradeToPro = useCallback(async () => {
-    setUpgradeError(null)
-    setUpgradeLoading(true)
-    try {
-      const token = await authTokenManager.getValidToken()
-
-      const returnUrl = encodeURIComponent(window.location.origin)
-      const response = await fetch(
-        `${API_BASE_URL}/api/billing/chat-checkout-link?returnUrl=${returnUrl}`,
-        {
-          headers: {
-            Authorization: `Bearer ${token}`,
-          },
-        },
-      )
-
-      if (!response.ok) {
-        throw new Error('Failed to generate checkout link')
-      }
-
-      const data = await response.json()
-      if (!data?.url) {
-        throw new Error('Checkout link unavailable')
-      }
-
-      window.location.href = data.url as string
-    } catch (error) {
-      setUpgradeError('Failed to start checkout. Please try again later.')
-    } finally {
-      setUpgradeLoading(false)
-    }
-  }, [])
-
   // Check if mobile
   const isMobile = windowWidth < MOBILE_BREAKPOINT
 
@@ -950,20 +897,12 @@ export function ChatSidebar({
           {/* Message for non-premium users (signed in or not) */}
           {!isPremium && (
             <div
-              className={`relative z-10 m-2 flex-none rounded-lg border p-4 transition-all duration-300 ${
-                highlightBox
-                  ? isDarkMode
-                    ? 'border-emerald-400/50 bg-emerald-900/30'
-                    : 'border-emerald-500/50 bg-emerald-100/60'
-                  : isDarkMode
-                    ? 'border-emerald-500/30 bg-emerald-950/20'
-                    : 'border-emerald-500/30 bg-emerald-50/50'
-              }`}
-              style={{
-                animation: highlightBox
-                  ? 'subtlePulse 1.2s ease-in-out infinite'
-                  : undefined,
-              }}
+              className={cn(
+                'relative z-10 m-2 flex-none rounded-lg border p-4 transition-all duration-300',
+                isDarkMode
+                  ? 'border-emerald-500/30 bg-emerald-950/20'
+                  : 'border-emerald-500/30 bg-emerald-50/50',
+              )}
             >
               <div className="flex-1">
                 <h4 className="mb-3 text-sm font-semibold text-content-primary">
@@ -2050,21 +1989,6 @@ export function ChatSidebar({
           onClick={() => setIsOpen(false)}
         />
       )}
-
-      {}
-      <style jsx global>{`
-        @keyframes subtlePulse {
-          0% {
-            opacity: 1;
-          }
-          50% {
-            opacity: 0.88;
-          }
-          100% {
-            opacity: 1;
-          }
-        }
-      `}</style>
     </>
   )
 }

--- a/src/components/chat/rate-limit-banner.tsx
+++ b/src/components/chat/rate-limit-banner.tsx
@@ -25,7 +25,7 @@ export function RateLimitBanner({
   const exhausted = rateLimit.remaining <= 0
 
   return (
-    <div className="pointer-events-none relative z-10 hidden w-full flex-none justify-center md:flex">
+    <div className="pointer-events-none relative z-10 flex w-full flex-none justify-center px-3">
       <div
         className={cn(
           'pointer-events-auto flex items-center gap-2 rounded-b-xl border-x border-b px-4 py-1.5 transition-colors',

--- a/src/components/chat/rate-limit-banner.tsx
+++ b/src/components/chat/rate-limit-banner.tsx
@@ -8,6 +8,10 @@ const RATE_LIMIT_WARNING_THRESHOLD = 3
 interface RateLimitBannerProps {
   rateLimit: RateLimitInfo
   isDarkMode: boolean
+  /** Tailwind classes applied to the outer wrapper (positioning, visibility). */
+  className?: string
+  /** Tailwind classes applied to the inner pill (e.g. corner radius). */
+  pillClassName?: string
 }
 
 export function shouldShowRateLimitBanner(
@@ -21,17 +25,25 @@ export function shouldShowRateLimitBanner(
 export function RateLimitBanner({
   rateLimit,
   isDarkMode,
+  className,
+  pillClassName,
 }: RateLimitBannerProps) {
   const exhausted = rateLimit.remaining <= 0
 
   return (
-    <div className="pointer-events-none relative z-10 flex w-full flex-none justify-center px-3">
+    <div
+      className={cn(
+        'pointer-events-none relative z-10 flex w-full flex-none justify-center px-3',
+        className,
+      )}
+    >
       <div
         className={cn(
           'pointer-events-auto flex items-center gap-2 rounded-b-xl border-x border-b px-4 py-1.5 transition-colors',
           isDarkMode
             ? 'border-amber-500/30 bg-amber-950/20 text-amber-400'
             : 'border-amber-300 bg-amber-50 text-amber-600',
+          pillClassName,
         )}
       >
         <span className="font-aeonik text-xs font-medium">

--- a/src/components/modals/subscribe-prompt-modal.tsx
+++ b/src/components/modals/subscribe-prompt-modal.tsx
@@ -1,0 +1,125 @@
+import { useUpgradeToPro } from '@/hooks/use-upgrade-to-pro'
+import { SignInButton } from '@clerk/nextjs'
+import { Dialog, Transition } from '@headlessui/react'
+import { XMarkIcon } from '@heroicons/react/24/outline'
+import { Fragment } from 'react'
+
+interface SubscribePromptModalProps {
+  isOpen: boolean
+  onClose: () => void
+  isSignedIn: boolean
+}
+
+export function SubscribePromptModal({
+  isOpen,
+  onClose,
+  isSignedIn,
+}: SubscribePromptModalProps) {
+  const { startUpgrade, upgradeLoading, upgradeError } = useUpgradeToPro()
+
+  return (
+    <Transition appear show={isOpen} as={Fragment}>
+      <Dialog as="div" className="relative z-50" onClose={onClose}>
+        <Transition.Child
+          as={Fragment}
+          enter="ease-out duration-300"
+          enterFrom="opacity-0"
+          enterTo="opacity-100"
+          leave="ease-in duration-200"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <div className="fixed inset-0 bg-black/50" />
+        </Transition.Child>
+
+        <div className="fixed inset-0 overflow-y-auto">
+          <div className="flex min-h-full items-center justify-center p-4 text-center">
+            <Transition.Child
+              as={Fragment}
+              enter="ease-out duration-300"
+              enterFrom="opacity-0 scale-95"
+              enterTo="opacity-100 scale-100"
+              leave="ease-in duration-200"
+              leaveFrom="opacity-100 scale-100"
+              leaveTo="opacity-0 scale-95"
+            >
+              <Dialog.Panel className="relative w-full max-w-md transform overflow-hidden rounded-2xl border border-border-subtle bg-surface-card p-6 text-left align-middle shadow-xl transition-all">
+                <button
+                  type="button"
+                  onClick={onClose}
+                  aria-label="Close"
+                  className="absolute right-3 top-3 rounded-full p-1.5 text-content-muted transition-colors hover:bg-surface-chat-background hover:text-content-primary"
+                >
+                  <XMarkIcon className="h-4 w-4" />
+                </button>
+
+                <Dialog.Title
+                  as="h2"
+                  className="mt-2 text-balance px-8 text-center font-aeonik text-xl font-bold text-content-primary"
+                >
+                  You&apos;ve used your free requests
+                </Dialog.Title>
+
+                <Dialog.Description className="mt-2 text-balance px-2 text-center text-sm text-content-secondary">
+                  Subscribe to keep chatting without daily request limits.
+                </Dialog.Description>
+
+                <p className="mt-3 text-center text-sm text-content-secondary">
+                  <span className="font-aeonik text-base font-semibold text-content-primary">
+                    $20
+                  </span>
+                  <span className="text-content-muted">/month</span>
+                  <span className="mx-2 text-content-muted">·</span>
+                  <span>Cancel anytime</span>
+                </p>
+
+                <div className="mt-6 space-y-2">
+                  {isSignedIn ? (
+                    <>
+                      <button
+                        type="button"
+                        onClick={() => {
+                          void startUpgrade()
+                        }}
+                        disabled={upgradeLoading}
+                        className="flex w-full items-center justify-center gap-2 rounded-lg bg-brand-accent-dark px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-brand-accent-dark/90 disabled:cursor-not-allowed disabled:opacity-60"
+                      >
+                        {upgradeLoading
+                          ? 'Redirecting…'
+                          : 'Subscribe to Premium'}
+                      </button>
+                      {upgradeError && (
+                        <p className="text-center text-xs text-destructive">
+                          {upgradeError}
+                        </p>
+                      )}
+                    </>
+                  ) : (
+                    <>
+                      <SignInButton mode="modal">
+                        <button
+                          type="button"
+                          className="flex w-full items-center justify-center gap-2 rounded-lg bg-brand-accent-dark px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-brand-accent-dark/90"
+                        >
+                          Subscribe to Premium
+                        </button>
+                      </SignInButton>
+                      <p className="text-center text-xs text-content-secondary">
+                        Already subscribed?{' '}
+                        <SignInButton mode="modal">
+                          <span className="cursor-pointer underline hover:text-content-primary">
+                            Log in
+                          </span>
+                        </SignInButton>
+                      </p>
+                    </>
+                  )}
+                </div>
+              </Dialog.Panel>
+            </Transition.Child>
+          </div>
+        </div>
+      </Dialog>
+    </Transition>
+  )
+}

--- a/src/components/modals/subscribe-prompt-modal.tsx
+++ b/src/components/modals/subscribe-prompt-modal.tsx
@@ -79,6 +79,7 @@ export function SubscribePromptModal({
                       <button
                         type="button"
                         onClick={() => {
+                          onClose()
                           void startUpgrade()
                         }}
                         disabled={upgradeLoading}
@@ -99,6 +100,7 @@ export function SubscribePromptModal({
                       <SignInButton mode="modal">
                         <button
                           type="button"
+                          onClick={onClose}
                           className="flex w-full items-center justify-center gap-2 rounded-lg bg-brand-accent-dark px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-brand-accent-dark/90"
                         >
                           Subscribe to Premium
@@ -107,7 +109,10 @@ export function SubscribePromptModal({
                       <p className="text-center text-xs text-content-secondary">
                         Already subscribed?{' '}
                         <SignInButton mode="modal">
-                          <span className="cursor-pointer underline hover:text-content-primary">
+                          <span
+                            onClick={onClose}
+                            className="cursor-pointer underline hover:text-content-primary"
+                          >
                             Log in
                           </span>
                         </SignInButton>

--- a/src/hooks/use-upgrade-to-pro.ts
+++ b/src/hooks/use-upgrade-to-pro.ts
@@ -1,0 +1,43 @@
+import { API_BASE_URL } from '@/config'
+import { authTokenManager } from '@/services/auth'
+import { useCallback, useState } from 'react'
+
+export function useUpgradeToPro() {
+  const [upgradeLoading, setUpgradeLoading] = useState(false)
+  const [upgradeError, setUpgradeError] = useState<string | null>(null)
+
+  const startUpgrade = useCallback(async () => {
+    setUpgradeError(null)
+    setUpgradeLoading(true)
+    try {
+      const token = await authTokenManager.getValidToken()
+
+      const returnUrl = encodeURIComponent(window.location.origin)
+      const response = await fetch(
+        `${API_BASE_URL}/api/billing/chat-checkout-link?returnUrl=${returnUrl}`,
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        },
+      )
+
+      if (!response.ok) {
+        throw new Error('Failed to generate checkout link')
+      }
+
+      const data = await response.json()
+      if (!data?.url) {
+        throw new Error('Checkout link unavailable')
+      }
+
+      window.location.href = data.url as string
+    } catch {
+      setUpgradeError('Failed to start checkout. Please try again later.')
+    } finally {
+      setUpgradeLoading(false)
+    }
+  }, [])
+
+  return { startUpgrade, upgradeLoading, upgradeError }
+}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -160,7 +160,15 @@ export default function App({ Component, pageProps }: AppProps) {
       <div
         className={`${aeonikFono.variable} ${aeonik.variable} ${openDyslexic.variable} ${lora.variable}`}
       >
-        <ClerkProvider telemetry={false} afterSignOutUrl="/">
+        <ClerkProvider
+          telemetry={false}
+          afterSignOutUrl="/"
+          appearance={{
+            elements: {
+              modalBackdrop: 'bg-black/50',
+            },
+          }}
+        >
           <AuthCleanupHandler />
           <Component {...pageProps} />
           <Toaster />


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Show a subscribe prompt modal when users hit the free-tier limit or click upgrade, replacing the sidebar upsell. Refines the rate-limit UI with a mobile banner and prevents the modal from reopening after a dismiss on input focus.

- New Features
  - Added `SubscribePromptModal` for upgrade prompts (signed-in and signed-out).
  - Introduced `use-upgrade-to-pro` to create a checkout link with loading/error states.
  - Chat opens the modal on rate-limit, on `requestUpgrade`, and on input focus when at limit.

- Refactors
  - Removed sidebar highlight upsell and related events/animations; replaced sidebar upgrade logic with `use-upgrade-to-pro`; aligned `@clerk/nextjs` modal backdrop with the app theme.
  - Polished rate-limit UX: banner now appears on mobile with separate desktop/desktop placement via `RateLimitBanner` `className`/`pillClassName`, and dismissing the modal won’t immediately reopen it on input refocus at limit.

<sup>Written for commit 985ecaa986ef468ce8133ecf27638dab4c906ab8. Summary will update on new commits. <a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/389?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

