### PR TITLE
feat: use OAuth for chat inference tokens

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,11 @@ CLERK_SECRET_KEY=your_clerk_secret_key_here
 # Default: https://api.tinfoil.sh
 NEXT_PUBLIC_API_BASE_URL=https://api.tinfoil.sh
 
+# OAuth for first-party inference tokens
+NEXT_PUBLIC_TINFOIL_OAUTH_CLIENT_ID=your_oauth_client_id_here
+# Optional override when the registered redirect URI differs from the current origin.
+NEXT_PUBLIC_TINFOIL_OAUTH_REDIRECT_URI=
+
 # Local development mode
 # When true, bypasses TinfoilAI client and connects to a local router on localhost:8090
 NEXT_PUBLIC_DEV=false

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,28 @@
 // For Next.js, public environment variables are replaced at build time
 // We'll provide fallback values for development if not set
 export const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || ''
+const OAUTH_API_BASE_URL = API_BASE_URL || 'https://api.tinfoil.sh'
+
+export const OAUTH = {
+  CLIENT_ID: process.env.NEXT_PUBLIC_TINFOIL_OAUTH_CLIENT_ID || '',
+  AUTHORIZE_URL:
+    process.env.NEXT_PUBLIC_TINFOIL_OAUTH_AUTHORIZE_URL ||
+    'https://dash.tinfoil.sh/oauth/authorize',
+  TOKEN_URL:
+    process.env.NEXT_PUBLIC_TINFOIL_OAUTH_TOKEN_URL ||
+    `${OAUTH_API_BASE_URL}/oauth/token`,
+  REVOKE_URL:
+    process.env.NEXT_PUBLIC_TINFOIL_OAUTH_REVOKE_URL ||
+    `${OAUTH_API_BASE_URL}/oauth/revoke`,
+  REDIRECT_URI: process.env.NEXT_PUBLIC_TINFOIL_OAUTH_REDIRECT_URI || '',
+  SCOPE:
+    process.env.NEXT_PUBLIC_TINFOIL_OAUTH_SCOPE ||
+    'inference:chat offline_access',
+  CALLBACK_PATH: '/oauth/callback',
+  ACCESS_TOKEN_EXPIRY_BUFFER_MS: 60_000,
+  CODE_VERIFIER_BYTES: 32,
+  STATE_BYTES: 16,
+} as const
 
 // Local dev mode: bypass TinfoilAI client and connect to local router
 export const IS_DEV = process.env.NEXT_PUBLIC_DEV === 'true'

--- a/src/constants/storage-keys.ts
+++ b/src/constants/storage-keys.ts
@@ -18,6 +18,7 @@ export const SECRET_CLOUD_KEY_AUTHORIZATION_PREFIX =
 
 // --- localStorage: Auth ----------------------------------------------------
 export const AUTH_ACTIVE_USER_ID = 'tinfoil-auth-active-user-id'
+export const AUTH_OAUTH_REFRESH_TOKEN = 'tinfoil-auth-oauth-refresh-token'
 
 // --- localStorage: App settings --------------------------------------------
 export const SETTINGS_CLOUD_SYNC_ENABLED = 'tinfoil-settings-cloud-sync-enabled'
@@ -110,6 +111,16 @@ export const SYNC_PROFILE_DIRTY = 'tinfoil-sync-profile-dirty'
 export const DEV_ENABLE_DEBUG_LOGS = 'tinfoil-dev-enable-debug-logs'
 
 // --- sessionStorage: UI state ----------------------------------------------
+export const AUTH_OAUTH_ACCESS_TOKEN = 'tinfoil-auth-oauth-access-token'
+export const AUTH_OAUTH_ACCESS_TOKEN_EXPIRES_AT =
+  'tinfoil-auth-oauth-access-token-expires-at'
+export const AUTH_OAUTH_PENDING_CODE_VERIFIER =
+  'tinfoil-auth-oauth-pending-code-verifier'
+export const AUTH_OAUTH_PENDING_REDIRECT_URI =
+  'tinfoil-auth-oauth-pending-redirect-uri'
+export const AUTH_OAUTH_PENDING_RETURN_TO =
+  'tinfoil-auth-oauth-pending-return-to'
+export const AUTH_OAUTH_PENDING_STATE = 'tinfoil-auth-oauth-pending-state'
 export const UI_SIDEBAR_OPEN = 'tinfoil-ui-sidebar-open'
 export const UI_SIDEBAR_ACTIVE_TAB = 'tinfoil-ui-sidebar-active-tab'
 export const UI_SIDEBAR_PROJECTS_EXPANDED =

--- a/src/pages/oauth/callback.tsx
+++ b/src/pages/oauth/callback.tsx
@@ -1,0 +1,57 @@
+import { completeOAuthAuthorization } from '@/services/auth'
+import { logError } from '@/utils/error-handling'
+import { useRouter } from 'next/router'
+import { useEffect, useState } from 'react'
+
+export default function OAuthCallbackPage() {
+  const router = useRouter()
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!router.isReady || typeof window === 'undefined') return
+
+    let cancelled = false
+    completeOAuthAuthorization(window.location.href)
+      .then((returnTo) => {
+        if (!cancelled) {
+          void router.replace(returnTo)
+        }
+      })
+      .catch((err) => {
+        if (cancelled) return
+        logError('Failed to complete OAuth callback', err, {
+          component: 'OAuthCallbackPage',
+          action: 'completeOAuthAuthorization',
+        })
+        setError(err instanceof Error ? err.message : 'Authorization failed')
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [router])
+
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-surface-chat-background p-6 text-content-primary">
+      <div className="w-full max-w-md rounded-2xl border border-border-subtle bg-surface-card p-6 text-center shadow-sm">
+        <h1 className="font-aeonik text-xl font-semibold">
+          {error ? 'Unable to connect Tinfoil' : 'Connecting Tinfoil…'}
+        </h1>
+        <p className="mt-3 text-sm text-content-secondary">
+          {error
+            ? 'Please return to chat and try again.'
+            : 'You will be returned to chat automatically.'}
+        </p>
+        {error && (
+          <button
+            type="button"
+            onClick={() => void router.replace('/')}
+            className="mt-6 rounded-lg bg-brand-accent-dark px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-brand-accent-dark/90"
+          >
+            Return to chat
+          </button>
+        )}
+      </div>
+    </main>
+  )
+}

--- a/src/services/auth/index.ts
+++ b/src/services/auth/index.ts
@@ -1,1 +1,11 @@
 export { authTokenManager } from './auth-token-manager'
+export {
+  OAuthRedirectStartedError,
+  clearOAuthAccessTokenCache,
+  clearOAuthTokens,
+  completeOAuthAuthorization,
+  getOAuthAccessToken,
+  hasOAuthRefreshToken,
+  isOAuthTokenFlowEnabled,
+  revokeAndClearOAuthTokens,
+} from './oauth-token-manager'

--- a/src/services/auth/oauth-token-manager.ts
+++ b/src/services/auth/oauth-token-manager.ts
@@ -1,0 +1,388 @@
+import { OAUTH } from '@/config'
+import {
+  AUTH_OAUTH_ACCESS_TOKEN,
+  AUTH_OAUTH_ACCESS_TOKEN_EXPIRES_AT,
+  AUTH_OAUTH_PENDING_CODE_VERIFIER,
+  AUTH_OAUTH_PENDING_REDIRECT_URI,
+  AUTH_OAUTH_PENDING_RETURN_TO,
+  AUTH_OAUTH_PENDING_STATE,
+  AUTH_OAUTH_REFRESH_TOKEN,
+} from '@/constants/storage-keys'
+
+type StoredAccessToken = {
+  token: string
+  expiresAt: number
+}
+
+type TokenResponse = {
+  accessToken: string
+  expiresIn: number
+  refreshToken: string | null
+}
+
+class OAuthTokenEndpointError extends Error {
+  constructor(
+    readonly status: number,
+    readonly code: string | null,
+  ) {
+    super(code || `OAuth token request failed with ${status}`)
+    this.name = 'OAuthTokenEndpointError'
+  }
+}
+
+export class OAuthRedirectStartedError extends Error {
+  constructor() {
+    super('OAuth authorization redirect started')
+    this.name = 'OAuthRedirectStartedError'
+  }
+}
+
+let cachedAccessToken: StoredAccessToken | null = null
+let refreshInFlight: Promise<string | null> | null = null
+let authorizationInFlight = false
+
+function getLocalStorage(): Storage | null {
+  if (typeof window === 'undefined') return null
+  try {
+    return window.localStorage
+  } catch {
+    return null
+  }
+}
+
+function getSessionStorage(): Storage | null {
+  if (typeof window === 'undefined') return null
+  try {
+    return window.sessionStorage
+  } catch {
+    return null
+  }
+}
+
+function readLocal(key: string): string | null {
+  return getLocalStorage()?.getItem(key) ?? null
+}
+
+function writeLocal(key: string, value: string): void {
+  getLocalStorage()?.setItem(key, value)
+}
+
+function removeLocal(key: string): void {
+  getLocalStorage()?.removeItem(key)
+}
+
+function readSession(key: string): string | null {
+  return getSessionStorage()?.getItem(key) ?? null
+}
+
+function writeSession(key: string, value: string): void {
+  getSessionStorage()?.setItem(key, value)
+}
+
+function removeSession(key: string): void {
+  getSessionStorage()?.removeItem(key)
+}
+
+function isConfigured(): boolean {
+  return OAUTH.CLIENT_ID.trim().length > 0
+}
+
+function isExpiring(expiresAt: number): boolean {
+  return Date.now() > expiresAt - OAUTH.ACCESS_TOKEN_EXPIRY_BUFFER_MS
+}
+
+function readStoredAccessToken(): string | null {
+  if (cachedAccessToken && !isExpiring(cachedAccessToken.expiresAt)) {
+    return cachedAccessToken.token
+  }
+
+  const token = readSession(AUTH_OAUTH_ACCESS_TOKEN)
+  const expiresAt = Number(readSession(AUTH_OAUTH_ACCESS_TOKEN_EXPIRES_AT))
+  if (!token || !Number.isFinite(expiresAt) || isExpiring(expiresAt)) {
+    clearOAuthAccessTokenCache()
+    return null
+  }
+
+  cachedAccessToken = { token, expiresAt }
+  return token
+}
+
+function storeTokenResponse(response: TokenResponse): string {
+  const expiresAt = Date.now() + response.expiresIn * 1000
+  cachedAccessToken = { token: response.accessToken, expiresAt }
+  writeSession(AUTH_OAUTH_ACCESS_TOKEN, response.accessToken)
+  writeSession(AUTH_OAUTH_ACCESS_TOKEN_EXPIRES_AT, String(expiresAt))
+  if (response.refreshToken) {
+    writeLocal(AUTH_OAUTH_REFRESH_TOKEN, response.refreshToken)
+  }
+  return response.accessToken
+}
+
+function parseTokenResponse(payload: unknown): TokenResponse {
+  if (!payload || typeof payload !== 'object') {
+    throw new Error('Invalid OAuth token response')
+  }
+
+  const record = payload as Record<string, unknown>
+  const tokenType = record.token_type
+  if (typeof tokenType === 'string' && tokenType.toLowerCase() !== 'bearer') {
+    throw new Error('Unsupported OAuth token type')
+  }
+
+  const accessToken = record.access_token
+  if (typeof accessToken !== 'string' || accessToken.length === 0) {
+    throw new Error('OAuth token response did not include an access token')
+  }
+
+  const expiresIn =
+    typeof record.expires_in === 'number'
+      ? record.expires_in
+      : Number(record.expires_in)
+  if (!Number.isFinite(expiresIn) || expiresIn <= 0) {
+    throw new Error('OAuth token response did not include a valid expiry')
+  }
+
+  const refreshToken =
+    typeof record.refresh_token === 'string' && record.refresh_token.length > 0
+      ? record.refresh_token
+      : null
+
+  return { accessToken, expiresIn, refreshToken }
+}
+
+async function requestToken(params: URLSearchParams): Promise<string> {
+  const response = await fetch(OAUTH.TOKEN_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: params,
+  })
+  const body = await response.json().catch(() => null)
+
+  if (!response.ok) {
+    const code =
+      body && typeof body === 'object'
+        ? ((body as Record<string, unknown>).error as string | undefined)
+        : undefined
+    throw new OAuthTokenEndpointError(response.status, code ?? null)
+  }
+
+  return storeTokenResponse(parseTokenResponse(body))
+}
+
+function createTokenRequestParams(
+  grantType: 'authorization_code' | 'refresh_token',
+): URLSearchParams {
+  return new URLSearchParams({
+    grant_type: grantType,
+    client_id: OAUTH.CLIENT_ID,
+  })
+}
+
+async function refreshAccessToken(): Promise<string | null> {
+  const refreshToken = readLocal(AUTH_OAUTH_REFRESH_TOKEN)
+  if (!refreshToken) return null
+
+  const params = createTokenRequestParams('refresh_token')
+  params.set('refresh_token', refreshToken)
+
+  try {
+    return await requestToken(params)
+  } catch (error) {
+    if (
+      error instanceof OAuthTokenEndpointError &&
+      (error.code === 'invalid_grant' || error.code === 'invalid_client')
+    ) {
+      clearOAuthTokens()
+      return null
+    }
+    throw error
+  }
+}
+
+function base64UrlEncode(bytes: Uint8Array): string {
+  let binary = ''
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte)
+  }
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+function randomBase64Url(byteLength: number): string {
+  const bytes = new Uint8Array(byteLength)
+  globalThis.crypto.getRandomValues(bytes)
+  return base64UrlEncode(bytes)
+}
+
+async function createCodeChallenge(verifier: string): Promise<string> {
+  const data = new TextEncoder().encode(verifier)
+  const digest = await globalThis.crypto.subtle.digest('SHA-256', data)
+  return base64UrlEncode(new Uint8Array(digest))
+}
+
+function getRedirectUri(): string {
+  if (OAUTH.REDIRECT_URI) return OAUTH.REDIRECT_URI
+  if (typeof window === 'undefined') {
+    throw new Error('Cannot start OAuth authorization outside the browser')
+  }
+  return `${window.location.origin}${OAUTH.CALLBACK_PATH}`
+}
+
+function currentReturnPath(): string {
+  if (typeof window === 'undefined') return '/'
+  return `${window.location.pathname}${window.location.search}${window.location.hash}`
+}
+
+function safeReturnPath(path: string | null): string {
+  if (!path || !path.startsWith('/') || path.startsWith('//')) {
+    return '/'
+  }
+  return path
+}
+
+function clearPendingAuthorization(): void {
+  removeSession(AUTH_OAUTH_PENDING_CODE_VERIFIER)
+  removeSession(AUTH_OAUTH_PENDING_REDIRECT_URI)
+  removeSession(AUTH_OAUTH_PENDING_RETURN_TO)
+  removeSession(AUTH_OAUTH_PENDING_STATE)
+  authorizationInFlight = false
+}
+
+async function startAuthorization(
+  returnTo = currentReturnPath(),
+): Promise<never> {
+  if (!isConfigured()) {
+    throw new Error('OAuth client ID is not configured')
+  }
+  if (!globalThis.crypto?.getRandomValues || !globalThis.crypto?.subtle) {
+    throw new Error('OAuth PKCE requires Web Crypto support')
+  }
+  if (authorizationInFlight) {
+    throw new OAuthRedirectStartedError()
+  }
+
+  authorizationInFlight = true
+  const state = randomBase64Url(OAUTH.STATE_BYTES)
+  const codeVerifier = randomBase64Url(OAUTH.CODE_VERIFIER_BYTES)
+  const codeChallenge = await createCodeChallenge(codeVerifier)
+  const redirectUri = getRedirectUri()
+
+  writeSession(AUTH_OAUTH_PENDING_STATE, state)
+  writeSession(AUTH_OAUTH_PENDING_CODE_VERIFIER, codeVerifier)
+  writeSession(AUTH_OAUTH_PENDING_REDIRECT_URI, redirectUri)
+  writeSession(AUTH_OAUTH_PENDING_RETURN_TO, safeReturnPath(returnTo))
+
+  const params = new URLSearchParams({
+    response_type: 'code',
+    client_id: OAUTH.CLIENT_ID,
+    redirect_uri: redirectUri,
+    scope: OAUTH.SCOPE,
+    state,
+    code_challenge: codeChallenge,
+    code_challenge_method: 'S256',
+  })
+
+  window.location.assign(`${OAUTH.AUTHORIZE_URL}?${params.toString()}`)
+  throw new OAuthRedirectStartedError()
+}
+
+export function isOAuthTokenFlowEnabled(): boolean {
+  return isConfigured()
+}
+
+export function hasOAuthRefreshToken(): boolean {
+  return readLocal(AUTH_OAUTH_REFRESH_TOKEN) !== null
+}
+
+export async function getOAuthAccessToken(
+  returnTo?: string,
+): Promise<string | null> {
+  if (!isConfigured()) return null
+
+  const storedAccessToken = readStoredAccessToken()
+  if (storedAccessToken) return storedAccessToken
+
+  if (!refreshInFlight) {
+    refreshInFlight = refreshAccessToken().finally(() => {
+      refreshInFlight = null
+    })
+  }
+  const refreshedToken = await refreshInFlight
+  if (refreshedToken) return refreshedToken
+
+  return startAuthorization(returnTo)
+}
+
+export async function completeOAuthAuthorization(
+  currentUrl: string,
+): Promise<string> {
+  const url = new URL(currentUrl)
+  const expectedState = readSession(AUTH_OAUTH_PENDING_STATE)
+  const returnedState = url.searchParams.get('state')
+  const returnTo = safeReturnPath(readSession(AUTH_OAUTH_PENDING_RETURN_TO))
+
+  if (!expectedState || !returnedState || expectedState !== returnedState) {
+    clearPendingAuthorization()
+    throw new Error('Invalid OAuth state')
+  }
+
+  const error = url.searchParams.get('error')
+  if (error) {
+    clearPendingAuthorization()
+    throw new Error(error)
+  }
+
+  const code = url.searchParams.get('code')
+  const codeVerifier = readSession(AUTH_OAUTH_PENDING_CODE_VERIFIER)
+  const redirectUri = readSession(AUTH_OAUTH_PENDING_REDIRECT_URI)
+  if (!code || !codeVerifier || !redirectUri) {
+    clearPendingAuthorization()
+    throw new Error('OAuth callback is missing required parameters')
+  }
+
+  const params = createTokenRequestParams('authorization_code')
+  params.set('code', code)
+  params.set('code_verifier', codeVerifier)
+  params.set('redirect_uri', redirectUri)
+
+  await requestToken(params)
+  clearPendingAuthorization()
+  return returnTo
+}
+
+export function clearOAuthAccessTokenCache(): void {
+  cachedAccessToken = null
+  removeSession(AUTH_OAUTH_ACCESS_TOKEN)
+  removeSession(AUTH_OAUTH_ACCESS_TOKEN_EXPIRES_AT)
+}
+
+export function clearOAuthTokens(): void {
+  clearOAuthAccessTokenCache()
+  removeLocal(AUTH_OAUTH_REFRESH_TOKEN)
+  clearPendingAuthorization()
+}
+
+export async function revokeAndClearOAuthTokens(): Promise<void> {
+  const refreshToken = readLocal(AUTH_OAUTH_REFRESH_TOKEN)
+  const accessToken =
+    cachedAccessToken?.token ?? readSession(AUTH_OAUTH_ACCESS_TOKEN)
+  const token = refreshToken ?? accessToken
+
+  try {
+    if (token && isConfigured()) {
+      const params = new URLSearchParams({
+        client_id: OAUTH.CLIENT_ID,
+        token,
+      })
+      const response = await fetch(OAUTH.REVOKE_URL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: params,
+      })
+      if (!response.ok) {
+        throw new Error(`OAuth revoke failed with ${response.status}`)
+      }
+    }
+  } finally {
+    clearOAuthTokens()
+  }
+}

--- a/src/services/inference/tinfoil-client.ts
+++ b/src/services/inference/tinfoil-client.ts
@@ -1,5 +1,8 @@
 import { API_BASE_URL, DEV_API_KEY, IS_DEV } from '@/config'
-import { AUTH_ACTIVE_USER_ID } from '@/constants/storage-keys'
+import {
+  AUTH_ACTIVE_USER_ID,
+  SETTINGS_CACHED_SUBSCRIPTION_STATUS,
+} from '@/constants/storage-keys'
 import { logError } from '@/utils/error-handling'
 import {
   TINFOIL_EVENTS_HEADER,
@@ -12,7 +15,14 @@ import {
   SecureClient,
   type VerificationDocument,
 } from 'tinfoil'
-import { authTokenManager } from '../auth'
+import {
+  authTokenManager,
+  clearOAuthAccessTokenCache,
+  getOAuthAccessToken,
+  hasOAuthRefreshToken,
+  isOAuthTokenFlowEnabled,
+  OAuthRedirectStartedError,
+} from '../auth'
 
 export interface RateLimitInfo {
   maxRequests: number
@@ -32,6 +42,31 @@ let cachedSessionTokenWasAuthenticated = false
 let cachedRateLimit: RateLimitInfo | null = null
 let remainingBeforeRequest: number | null = null
 let refreshInFlight: Promise<void> | null = null
+
+function clearCachedSessionToken(): void {
+  cachedSessionToken = null
+  cachedSessionTokenExpiresAt = null
+}
+
+function hasCachedActiveChatSubscription(): boolean {
+  if (typeof window === 'undefined') return false
+  try {
+    const raw = localStorage.getItem(SETTINGS_CACHED_SUBSCRIPTION_STATUS)
+    if (!raw) return false
+    const parsed = JSON.parse(raw) as Record<string, unknown>
+    return parsed.chat_subscription_active === true
+  } catch {
+    return false
+  }
+}
+
+function shouldUseOAuthSessionToken(usedAuthHeader: boolean): boolean {
+  return (
+    usedAuthHeader &&
+    isOAuthTokenFlowEnabled() &&
+    (hasOAuthRefreshToken() || hasCachedActiveChatSubscription())
+  )
+}
 
 function dispatchRateLimitUpdate(): void {
   if (typeof window !== 'undefined') {
@@ -76,6 +111,28 @@ async function fetchSessionToken(): Promise<string> {
   }
   const usedAuthHeader = authBearer !== null
 
+  if (shouldUseOAuthSessionToken(usedAuthHeader)) {
+    clearCachedSessionToken()
+    if (cachedRateLimit !== null) {
+      cachedRateLimit = null
+      dispatchRateLimitUpdate()
+    }
+
+    try {
+      const token = await getOAuthAccessToken()
+      if (token) return token
+    } catch (error) {
+      if (error instanceof OAuthRedirectStartedError) {
+        throw error
+      }
+      logError('Failed to fetch OAuth session token', error, {
+        component: 'tinfoil-client',
+        action: 'fetchSessionToken',
+      })
+      throw error
+    }
+  }
+
   // If the cached token was fetched anonymously but we now have an
   // authenticated bearer, discard it so the next fetch goes out with
   // the user's token and returns the correct (possibly premium) rate
@@ -85,8 +142,7 @@ async function fetchSessionToken(): Promise<string> {
     !cachedSessionTokenWasAuthenticated &&
     usedAuthHeader
   ) {
-    cachedSessionToken = null
-    cachedSessionTokenExpiresAt = null
+    clearCachedSessionToken()
     cachedRateLimit = null
     dispatchRateLimitUpdate()
   }
@@ -98,8 +154,7 @@ async function fetchSessionToken(): Promise<string> {
     if (!isExpired) {
       return cachedSessionToken
     }
-    cachedSessionToken = null
-    cachedSessionTokenExpiresAt = null
+    clearCachedSessionToken()
   }
 
   // Build request headers: include auth if we resolved a bearer above
@@ -182,8 +237,7 @@ export async function refreshRateLimit(): Promise<void> {
   refreshInFlight = (async () => {
     const snapshot = remainingBeforeRequest
     remainingBeforeRequest = null
-    cachedSessionToken = null
-    cachedSessionTokenExpiresAt = null
+    clearCachedSessionToken()
     try {
       await fetchSessionToken()
       if (
@@ -214,12 +268,12 @@ export function resetTinfoilClient(): void {
   clientInstance = null
   secureClient = null
   lastSessionToken = null
-  cachedSessionToken = null
-  cachedSessionTokenExpiresAt = null
+  clearCachedSessionToken()
   cachedSessionTokenWasAuthenticated = false
   cachedRateLimit = null
   remainingBeforeRequest = null
   refreshInFlight = null
+  clearOAuthAccessTokenCache()
 }
 
 /**
@@ -230,8 +284,7 @@ export function resetTinfoilClient(): void {
  */
 export function invalidateAnonymousSessionCache(): void {
   if (cachedSessionTokenWasAuthenticated) return
-  cachedSessionToken = null
-  cachedSessionTokenExpiresAt = null
+  clearCachedSessionToken()
   if (cachedRateLimit !== null) {
     cachedRateLimit = null
     dispatchRateLimitUpdate()

--- a/src/utils/signout-cleanup.ts
+++ b/src/utils/signout-cleanup.ts
@@ -4,6 +4,7 @@ import {
   SECRET_PASSKEY_BACKED_UP,
   USER_ENCRYPTION_KEY,
 } from '@/constants/storage-keys'
+import { revokeAndClearOAuthTokens } from '@/services/auth'
 import { cloudSync } from '@/services/cloud/cloud-sync'
 import { profileSync } from '@/services/cloud/profile-sync'
 import { encryptionService } from '@/services/encryption/encryption-service'
@@ -29,6 +30,15 @@ async function clearAllUserData(options: ClearUserDataOptions): Promise<void> {
   // async work, so concurrent code cannot re-persist a stale key.
   if (!preserveEncryptionKey) {
     encryptionService.clearKey({ persist: true })
+  }
+
+  try {
+    await revokeAndClearOAuthTokens()
+  } catch (error) {
+    logError('Failed to revoke OAuth tokens during cleanup', error, {
+      component: context,
+      action: 'clearAllUserData',
+    })
   }
 
   // Reset renderer registry to clear any cached renderers

--- a/tests/services/oauth-token-manager.test.ts
+++ b/tests/services/oauth-token-manager.test.ts
@@ -1,0 +1,153 @@
+import {
+  AUTH_OAUTH_ACCESS_TOKEN,
+  AUTH_OAUTH_ACCESS_TOKEN_EXPIRES_AT,
+  AUTH_OAUTH_PENDING_CODE_VERIFIER,
+  AUTH_OAUTH_PENDING_REDIRECT_URI,
+  AUTH_OAUTH_PENDING_RETURN_TO,
+  AUTH_OAUTH_PENDING_STATE,
+  AUTH_OAUTH_REFRESH_TOKEN,
+} from '@/constants/storage-keys'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const OAUTH_CONFIG = {
+  CLIENT_ID: 'oauthc_webapp',
+  AUTHORIZE_URL: 'https://dash.example/oauth/authorize',
+  TOKEN_URL: 'https://api.example/oauth/token',
+  REVOKE_URL: 'https://api.example/oauth/revoke',
+  REDIRECT_URI: 'https://chat.example/oauth/callback',
+  SCOPE: 'inference:chat offline_access',
+  CALLBACK_PATH: '/oauth/callback',
+  ACCESS_TOKEN_EXPIRY_BUFFER_MS: 60_000,
+  CODE_VERIFIER_BYTES: 32,
+  STATE_BYTES: 16,
+}
+
+async function loadManager() {
+  vi.resetModules()
+  vi.doMock('@/config', () => ({ OAUTH: OAUTH_CONFIG }))
+  return import('@/services/auth/oauth-token-manager')
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+describe('oauth-token-manager', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    sessionStorage.clear()
+    vi.stubGlobal('fetch', vi.fn())
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.doUnmock('@/config')
+  })
+
+  it('refreshes an existing OAuth refresh token', async () => {
+    localStorage.setItem(AUTH_OAUTH_REFRESH_TOKEN, 'oauthr_old')
+    vi.mocked(fetch).mockResolvedValue(
+      jsonResponse({
+        access_token: 'chat_new',
+        token_type: 'Bearer',
+        expires_in: 900,
+        refresh_token: 'oauthr_new',
+      }),
+    )
+
+    const { getOAuthAccessToken } = await loadManager()
+    await expect(getOAuthAccessToken()).resolves.toBe('chat_new')
+
+    const [, init] = vi.mocked(fetch).mock.calls[0]
+    const body = init?.body as URLSearchParams
+    expect(fetch).toHaveBeenCalledWith(
+      OAUTH_CONFIG.TOKEN_URL,
+      expect.objectContaining({ method: 'POST' }),
+    )
+    expect(body.get('grant_type')).toBe('refresh_token')
+    expect(body.get('client_id')).toBe(OAUTH_CONFIG.CLIENT_ID)
+    expect(body.get('refresh_token')).toBe('oauthr_old')
+    expect(localStorage.getItem(AUTH_OAUTH_REFRESH_TOKEN)).toBe('oauthr_new')
+    expect(sessionStorage.getItem(AUTH_OAUTH_ACCESS_TOKEN)).toBe('chat_new')
+  })
+
+  it('exchanges an authorization callback for OAuth tokens', async () => {
+    sessionStorage.setItem(AUTH_OAUTH_PENDING_STATE, 'state123')
+    sessionStorage.setItem(AUTH_OAUTH_PENDING_CODE_VERIFIER, 'verifier123')
+    sessionStorage.setItem(
+      AUTH_OAUTH_PENDING_REDIRECT_URI,
+      OAUTH_CONFIG.REDIRECT_URI,
+    )
+    sessionStorage.setItem(
+      AUTH_OAUTH_PENDING_RETURN_TO,
+      '/chat/thread?model=test#latest',
+    )
+    vi.mocked(fetch).mockResolvedValue(
+      jsonResponse({
+        access_token: 'chat_callback',
+        token_type: 'Bearer',
+        expires_in: 900,
+        refresh_token: 'oauthr_callback',
+      }),
+    )
+
+    const { completeOAuthAuthorization } = await loadManager()
+    const returnTo = await completeOAuthAuthorization(
+      'https://chat.example/oauth/callback?code=code123&state=state123',
+    )
+
+    const [, init] = vi.mocked(fetch).mock.calls[0]
+    const body = init?.body as URLSearchParams
+    expect(returnTo).toBe('/chat/thread?model=test#latest')
+    expect(body.get('grant_type')).toBe('authorization_code')
+    expect(body.get('client_id')).toBe(OAUTH_CONFIG.CLIENT_ID)
+    expect(body.get('code')).toBe('code123')
+    expect(body.get('code_verifier')).toBe('verifier123')
+    expect(body.get('redirect_uri')).toBe(OAUTH_CONFIG.REDIRECT_URI)
+    expect(localStorage.getItem(AUTH_OAUTH_REFRESH_TOKEN)).toBe(
+      'oauthr_callback',
+    )
+    expect(sessionStorage.getItem(AUTH_OAUTH_PENDING_STATE)).toBeNull()
+  })
+
+  it('rejects callbacks with mismatched state', async () => {
+    sessionStorage.setItem(AUTH_OAUTH_PENDING_STATE, 'expected')
+
+    const { completeOAuthAuthorization } = await loadManager()
+    await expect(
+      completeOAuthAuthorization(
+        'https://chat.example/oauth/callback?code=code123&state=actual',
+      ),
+    ).rejects.toThrow('Invalid OAuth state')
+
+    expect(fetch).not.toHaveBeenCalled()
+    expect(sessionStorage.getItem(AUTH_OAUTH_PENDING_STATE)).toBeNull()
+  })
+
+  it('revokes the stored OAuth refresh token before clearing tokens', async () => {
+    localStorage.setItem(AUTH_OAUTH_REFRESH_TOKEN, 'oauthr_to_revoke')
+    sessionStorage.setItem(AUTH_OAUTH_ACCESS_TOKEN, 'chat_to_clear')
+    sessionStorage.setItem(
+      AUTH_OAUTH_ACCESS_TOKEN_EXPIRES_AT,
+      String(Date.now() + 900_000),
+    )
+    vi.mocked(fetch).mockResolvedValue(jsonResponse({}))
+
+    const { revokeAndClearOAuthTokens } = await loadManager()
+    await revokeAndClearOAuthTokens()
+
+    const [, init] = vi.mocked(fetch).mock.calls[0]
+    const body = init?.body as URLSearchParams
+    expect(fetch).toHaveBeenCalledWith(
+      OAUTH_CONFIG.REVOKE_URL,
+      expect.objectContaining({ method: 'POST' }),
+    )
+    expect(body.get('client_id')).toBe(OAUTH_CONFIG.CLIENT_ID)
+    expect(body.get('token')).toBe('oauthr_to_revoke')
+    expect(localStorage.getItem(AUTH_OAUTH_REFRESH_TOKEN)).toBeNull()
+    expect(sessionStorage.getItem(AUTH_OAUTH_ACCESS_TOKEN)).toBeNull()
+  })
+})

--- a/vercel.json
+++ b/vercel.json
@@ -35,7 +35,9 @@
       "destination": "/share/%5B%5B...slug%5D%5D.html"
     },
     { "source": "/newchat", "destination": "/newchat.html" },
-    { "source": "/newchat/", "destination": "/newchat.html" }
+    { "source": "/newchat/", "destination": "/newchat.html" },
+    { "source": "/oauth/callback", "destination": "/oauth/callback.html" },
+    { "source": "/oauth/callback/", "destination": "/oauth/callback.html" }
   ],
   "headers": [
     {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switches chat inference to OAuth (PKCE), issuing and refreshing first‑party tokens for chat. Integrates the flow into the client, adds a callback page, and revokes tokens on sign‑out.

- New Features
  - OAuth token manager with PKCE: `getOAuthAccessToken`, `completeOAuthAuthorization`, refresh, and revoke; access token in sessionStorage, refresh token in localStorage.
  - `tinfoil` client prefers OAuth tokens when enabled or user likely has an active chat subscription; handles redirect start, clears caches, and updates rate limits.
  - New `/oauth/callback` page and Vercel rewrites; exports `OAuthRedirectStartedError` and helpers for clearing tokens.
  - Config via `OAUTH` in `src/config.ts`; new storage keys; tests for token refresh, callback exchange, state validation, and revoke.

- Migration
  - Create an OAuth client in the Tinfoil dashboard and add env vars:
    - `NEXT_PUBLIC_TINFOIL_OAUTH_CLIENT_ID` (required)
    - `NEXT_PUBLIC_TINFOIL_OAUTH_REDIRECT_URI` (optional override; default is `${origin}/oauth/callback`)
  - Ensure the redirect URI includes `/oauth/callback` and is registered; deploy with updated `vercel.json` rewrites.

<sup>Written for commit 22db406673a4eaed0e8fe796e616752e028ebf8e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/390?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

