### PR TITLE
Make the chat more accessible 

### DIFF
--- a/src/components/chat/WelcomeScreen.tsx
+++ b/src/components/chat/WelcomeScreen.tsx
@@ -496,6 +496,7 @@ export const WelcomeScreen = memo(function WelcomeScreen({
                           data-model-selector
                           aria-haspopup="menu"
                           aria-expanded={expandedLabel === 'model'}
+                          aria-label={`Current model ${models.find((m) => m.modelName === selectedModel)?.name ?? ''}`}
                           onClick={(e) => {
                             e.preventDefault()
                             e.stopPropagation()

--- a/src/components/chat/WelcomeScreen.tsx
+++ b/src/components/chat/WelcomeScreen.tsx
@@ -354,6 +354,7 @@ export const WelcomeScreen = memo(function WelcomeScreen({
           >
             <button
               type="button"
+              aria-expanded={privacyExpanded}
               onClick={() => {
                 setPrivacyExpanded((prev) => {
                   if (!prev) setLockPop(true)
@@ -376,7 +377,10 @@ export const WelcomeScreen = memo(function WelcomeScreen({
                     : { duration: 0 }
                 }
               >
-                <BiSolidLock className="h-4 w-4 text-brand-accent-dark dark:text-brand-accent-light" />
+                <BiSolidLock
+                  className="h-4 w-4 text-brand-accent-dark dark:text-brand-accent-light"
+                  aria-hidden="true"
+                />
               </motion.span>
               <span>Your chats are private by design</span>
               <svg
@@ -384,6 +388,7 @@ export const WelcomeScreen = memo(function WelcomeScreen({
                 fill="none"
                 stroke="currentColor"
                 viewBox="0 0 24 24"
+                aria-hidden="true"
               >
                 <path
                   strokeLinecap="round"
@@ -489,6 +494,8 @@ export const WelcomeScreen = memo(function WelcomeScreen({
                         <button
                           type="button"
                           data-model-selector
+                          aria-haspopup="menu"
+                          aria-expanded={expandedLabel === 'model'}
                           onClick={(e) => {
                             e.preventDefault()
                             e.stopPropagation()
@@ -513,6 +520,7 @@ export const WelcomeScreen = memo(function WelcomeScreen({
                                   fill="none"
                                   stroke="currentColor"
                                   viewBox="0 0 24 24"
+                                  aria-hidden="true"
                                 >
                                   <path
                                     strokeLinecap="round"

--- a/src/components/chat/WelcomeScreen.tsx
+++ b/src/components/chat/WelcomeScreen.tsx
@@ -362,7 +362,7 @@ export const WelcomeScreen = memo(function WelcomeScreen({
                   return !prev
                 })
               }}
-              className={`group flex w-full items-center gap-2 text-base text-content-secondary transition-colors hover:text-content-primary md:justify-start ${privacyExpanded ? 'justify-start' : 'justify-center'}`}
+              className={`group flex w-full items-center gap-2 py-1.5 text-base text-content-secondary transition-colors hover:text-content-primary md:justify-start ${privacyExpanded ? 'justify-start' : 'justify-center'}`}
             >
               <motion.span
                 className="inline-flex shrink-0"
@@ -504,7 +504,7 @@ export const WelcomeScreen = memo(function WelcomeScreen({
                               handleLabelClick('model', () => {})
                             }
                           }}
-                          className="flex items-center gap-1 text-content-secondary transition-colors hover:text-content-primary"
+                          className="flex items-center gap-1 py-1.5 text-content-secondary transition-colors hover:text-content-primary"
                         >
                           {(() => {
                             const model = models.find(

--- a/src/components/chat/ask-sidebar.tsx
+++ b/src/components/chat/ask-sidebar.tsx
@@ -84,6 +84,7 @@ export function AskSidebar({
           isOpen ? 'translate-x-0' : 'translate-x-full',
         )}
         style={{ maxWidth: `${CONSTANTS.ASK_SIDEBAR_WIDTH_PX}px` }}
+        inert={!isOpen}
         aria-hidden={!isOpen}
       >
         {/* Header */}

--- a/src/components/chat/chat-announcer.tsx
+++ b/src/components/chat/chat-announcer.tsx
@@ -1,0 +1,62 @@
+import { useEffect, useRef } from 'react'
+import type { Message } from './types'
+
+const RESPONDING_ANNOUNCEMENT = 'Tin is responding'
+
+type ChatAnnouncerProps = {
+  messages: Message[]
+  isStreaming: boolean
+  isWaitingForResponse: boolean
+}
+
+/**
+ * Off-screen polite live region that makes streamed assistant responses
+ * perceivable to screen-reader users.
+ *
+ * Streaming text is intentionally NOT wrapped in a live region: announcing
+ * token-by-token restarts the utterance on every chunk. Instead this announces
+ * a short "responding" notice when generation starts and the full response once
+ * it completes. The text is written imperatively so the screen reader (an
+ * external system) is the only consumer and React never clobbers it.
+ */
+export function ChatAnnouncer({
+  messages,
+  isStreaming,
+  isWaitingForResponse,
+}: ChatAnnouncerProps) {
+  const liveRegionRef = useRef<HTMLDivElement>(null)
+  const wasGeneratingRef = useRef(false)
+
+  const isGenerating = isStreaming || isWaitingForResponse
+
+  useEffect(() => {
+    const wasGenerating = wasGeneratingRef.current
+    wasGeneratingRef.current = isGenerating
+
+    const region = liveRegionRef.current
+    if (!region) return
+
+    if (isGenerating && !wasGenerating) {
+      region.textContent = RESPONDING_ANNOUNCEMENT
+      return
+    }
+
+    if (!isGenerating && wasGenerating) {
+      const lastMessage = messages[messages.length - 1]
+      if (lastMessage?.role === 'assistant') {
+        const text = lastMessage.content?.trim()
+        if (text) region.textContent = text
+      }
+    }
+  }, [isGenerating, messages])
+
+  return (
+    <div
+      ref={liveRegionRef}
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      className="sr-only"
+    />
+  )
+}

--- a/src/components/chat/chat-input.tsx
+++ b/src/components/chat/chat-input.tsx
@@ -68,6 +68,9 @@ type ChatInputProps = {
 // Maximum number of characters displayed in the collapsed quote preview.
 const QUOTE_PREVIEW_MAX_LENGTH = 240
 
+const isDocumentSubmittable = (doc: ProcessedDocument) =>
+  !doc.isUploading && !doc.isGeneratingDescription && !doc.isUnsupported
+
 export function ChatInput({
   input,
   setInput,
@@ -195,6 +198,20 @@ export function ChatInput({
   const processingAttachmentCount = (processedDocuments ?? []).filter(
     (doc) => doc.isUploading || doc.isGeneratingDescription,
   ).length
+  const unsupportedAttachmentNames = (processedDocuments ?? [])
+    .filter((doc) => doc.isUnsupported)
+    .map((doc) => doc.name)
+  const unsupportedAttachmentStatus = unsupportedAttachmentNames.join(', ')
+  const recordingButtonLabel = isTranscribing
+    ? 'Transcribing audio'
+    : isRecording
+      ? 'Stop recording'
+      : 'Start recording'
+  const audioStatus = isTranscribing
+    ? 'Transcribing audio'
+    : isRecording
+      ? 'Recording audio'
+      : ''
   useEffect(() => {
     const region = uploadStatusRef.current
     if (!region) return
@@ -204,11 +221,21 @@ export function ChatInput({
           ? 'Processing attachment'
           : `Processing ${processingAttachmentCount} attachments`
       wasProcessingAttachmentsRef.current = true
+    } else if (unsupportedAttachmentNames.length > 0) {
+      region.textContent =
+        unsupportedAttachmentNames.length === 1
+          ? `Unsupported attachment: ${unsupportedAttachmentStatus}`
+          : `Unsupported attachments: ${unsupportedAttachmentStatus}`
+      wasProcessingAttachmentsRef.current = false
     } else if (wasProcessingAttachmentsRef.current) {
       region.textContent = 'Attachments ready'
       wasProcessingAttachmentsRef.current = false
     }
-  }, [processingAttachmentCount])
+  }, [
+    processingAttachmentCount,
+    unsupportedAttachmentNames.length,
+    unsupportedAttachmentStatus,
+  ])
 
   // Auto-resize textarea as content changes (typing, transcription, paste, etc.)
   // Layout effect avoids iOS Safari cases where `scrollHeight` lags a paint.
@@ -614,7 +641,7 @@ export function ChatInput({
                         'absolute right-1 top-1 z-10 flex h-5 w-5 items-center justify-center rounded-full border-[0.5px] border-white',
                         'bg-surface-chat text-content-secondary shadow-sm hover:bg-surface-chat-background hover:text-content-primary',
                       )}
-                      aria-label="Remove document"
+                      aria-label={`Remove ${doc.name}`}
                     >
                       <svg
                         xmlns="http://www.w3.org/2000/svg"
@@ -840,9 +867,7 @@ export function ChatInput({
                 e.preventDefault()
                 const hasDocuments =
                   processedDocuments &&
-                  processedDocuments.some(
-                    (doc) => !doc.isUploading && !doc.isGeneratingDescription,
-                  )
+                  processedDocuments.some((doc) => isDocumentSubmittable(doc))
                 const hasInput = input.trim().length > 0
                 const hasQuote = Boolean(quote)
                 if (!isTranscribing && (hasInput || hasDocuments || hasQuote)) {
@@ -948,6 +973,9 @@ export function ChatInput({
           />
 
           <div className="mt-3 flex items-center justify-between">
+            <span className="sr-only" role="status" aria-live="polite">
+              {audioStatus}
+            </span>
             <div className="flex items-center gap-1">
               {/* Mobile: + button with dropdown menu */}
               <div className="relative md:hidden">
@@ -1137,15 +1165,25 @@ export function ChatInput({
                       : 'rounded-lg bg-transparent p-2.5 text-content-secondary transition-colors hover:bg-surface-chat-background hover:text-content-primary md:p-1.5',
                   )}
                   style={{ WebkitTapHighlightColor: 'transparent' }}
-                  title={isRecording ? 'Stop recording' : 'Start recording'}
+                  title={recordingButtonLabel}
+                  aria-label={recordingButtonLabel}
                   disabled={isTranscribing}
                 >
                   {isRecording ? (
-                    <StopIcon className="h-6 w-6 md:h-5 md:w-5" />
+                    <StopIcon
+                      className="h-6 w-6 md:h-5 md:w-5"
+                      aria-hidden="true"
+                    />
                   ) : isTranscribing ? (
-                    <PiSpinner className="h-6 w-6 animate-spin text-current md:h-5 md:w-5" />
+                    <PiSpinner
+                      className="h-6 w-6 animate-spin text-current md:h-5 md:w-5"
+                      aria-hidden="true"
+                    />
                   ) : (
-                    <MicrophoneIcon className="h-6 w-6 md:h-5 md:w-5" />
+                    <MicrophoneIcon
+                      className="h-6 w-6 md:h-5 md:w-5"
+                      aria-hidden="true"
+                    />
                   )}
                 </button>
               )}
@@ -1154,9 +1192,7 @@ export function ChatInput({
                   loadingState === 'loading' || loadingState === 'retrying'
                 const hasCompletedDocuments = Boolean(
                   processedDocuments &&
-                  processedDocuments.some(
-                    (doc) => !doc.isUploading && !doc.isGeneratingDescription,
-                  ),
+                  processedDocuments.some((doc) => isDocumentSubmittable(doc)),
                 )
                 const hasSubmittableContent =
                   Boolean(input.trim()) ||

--- a/src/components/chat/chat-input.tsx
+++ b/src/components/chat/chat-input.tsx
@@ -719,7 +719,7 @@ export function ChatInput({
 
           <textarea
             id="chat-input"
-            aria-label="Message Tin"
+            aria-label="Message"
             ref={inputRef}
             key={textareaResetNonce}
             value={input}

--- a/src/components/chat/chat-input.tsx
+++ b/src/components/chat/chat-input.tsx
@@ -188,6 +188,28 @@ export function ChatInput({
     }
   }, [processedDocuments?.length])
 
+  // Announce attachment processing progress to screen readers without
+  // re-rendering: write directly into an off-screen live region.
+  const uploadStatusRef = useRef<HTMLSpanElement>(null)
+  const wasProcessingAttachmentsRef = useRef(false)
+  const processingAttachmentCount = (processedDocuments ?? []).filter(
+    (doc) => doc.isUploading || doc.isGeneratingDescription,
+  ).length
+  useEffect(() => {
+    const region = uploadStatusRef.current
+    if (!region) return
+    if (processingAttachmentCount > 0) {
+      region.textContent =
+        processingAttachmentCount === 1
+          ? 'Processing attachment'
+          : `Processing ${processingAttachmentCount} attachments`
+      wasProcessingAttachmentsRef.current = true
+    } else if (wasProcessingAttachmentsRef.current) {
+      region.textContent = 'Attachments ready'
+      wasProcessingAttachmentsRef.current = false
+    }
+  }, [processingAttachmentCount])
+
   // Auto-resize textarea as content changes (typing, transcription, paste, etc.)
   // Layout effect avoids iOS Safari cases where `scrollHeight` lags a paint.
   useIsomorphicLayoutEffect(() => {
@@ -559,6 +581,13 @@ export function ChatInput({
               )}
             </div>
           )}
+
+          <span
+            ref={uploadStatusRef}
+            className="sr-only"
+            role="status"
+            aria-live="polite"
+          />
 
           {processedDocuments && processedDocuments.length > 0 && (
             <div

--- a/src/components/chat/chat-input.tsx
+++ b/src/components/chat/chat-input.tsx
@@ -663,6 +663,7 @@ export function ChatInput({
 
           <textarea
             id="chat-input"
+            aria-label="Message Tin"
             ref={inputRef}
             key={textareaResetNonce}
             value={input}

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -86,6 +86,7 @@ import { UrlHashMessageHandler } from '../url-hash-message-handler'
 import { UrlHashSettingsHandler } from '../url-hash-settings-handler'
 import { ArtifactSidebar } from './artifact-sidebar'
 import { AskSidebar } from './ask-sidebar'
+import { ChatAnnouncer } from './chat-announcer'
 import { ChatInput } from './chat-input'
 import { ChatMessages } from './chat-messages'
 import { ChatSidebar } from './chat-sidebar'
@@ -721,6 +722,14 @@ export function ChatInterface({
   // Scroll to the last message (for the scroll button)
   const scrollToLastMessage = useCallback(() => {
     scrollToBottom(true)
+    // Move keyboard/screen-reader focus to the latest message so it is read
+    // out and becomes the navigation anchor. preventScroll avoids fighting the
+    // smooth scroll above.
+    const container = scrollContainerRef.current
+    if (!container) return
+    const messageEls = container.querySelectorAll('[data-message-role]')
+    const lastMessage = messageEls[messageEls.length - 1] as HTMLElement | null
+    lastMessage?.focus({ preventScroll: true })
   }, [scrollToBottom])
 
   const {
@@ -3010,6 +3019,11 @@ export function ChatInterface({
               }}
             />
             <div className="relative flex min-h-0 flex-1">
+              <ChatAnnouncer
+                messages={currentChat?.messages || []}
+                isStreaming={isStreaming}
+                isWaitingForResponse={isWaitingForResponse}
+              />
               {streamError && (
                 <StreamErrorBanner
                   message={streamError}
@@ -3021,6 +3035,8 @@ export function ChatInterface({
                 ref={scrollContainerRef}
                 onScroll={handleScroll}
                 data-scroll-container="main"
+                role="main"
+                aria-label="Conversation"
                 className="relative z-0 flex-1 overflow-y-auto bg-surface-chat-background"
                 style={
                   {

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -3204,7 +3204,7 @@ export function ChatInterface({
                                   e.stopPropagation()
                                   handleLabelClick('model', () => {})
                                 }}
-                                className="flex items-center gap-1 text-content-secondary transition-colors hover:text-content-primary"
+                                className="flex items-center gap-1 py-1.5 text-content-secondary transition-colors hover:text-content-primary"
                               >
                                 {(() => {
                                   const model = models.find(

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -3198,6 +3198,7 @@ export function ChatInterface({
                                 data-model-selector
                                 aria-haspopup="menu"
                                 aria-expanded={expandedLabel === 'model'}
+                                aria-label={`Current model ${models.find((m) => m.modelName === selectedModel)?.name ?? ''}`}
                                 onClick={(e) => {
                                   e.preventDefault()
                                   e.stopPropagation()

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -3196,6 +3196,8 @@ export function ChatInterface({
                               <button
                                 type="button"
                                 data-model-selector
+                                aria-haspopup="menu"
+                                aria-expanded={expandedLabel === 'model'}
                                 onClick={(e) => {
                                   e.preventDefault()
                                   e.stopPropagation()
@@ -3218,6 +3220,7 @@ export function ChatInterface({
                                         fill="none"
                                         stroke="currentColor"
                                         viewBox="0 0 24 24"
+                                        aria-hidden="true"
                                       >
                                         <path
                                           strokeLinecap="round"

--- a/src/components/chat/chat-list-item.tsx
+++ b/src/components/chat/chat-list-item.tsx
@@ -10,7 +10,7 @@ import {
   TrashIcon,
   XMarkIcon,
 } from '@heroicons/react/24/outline'
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useId, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { CiFloppyDisk } from 'react-icons/ci'
 import { FaLock } from '../icons/lazy-icons'
@@ -115,6 +115,7 @@ export function ChatListItem({
     'main',
   )
   const [menuPosition, setMenuPosition] = useState({ top: 0, left: 0 })
+  const mobileMenuId = useId()
   const mobileMenuButtonRef = useRef<HTMLButtonElement>(null)
   const mobileMenuPortalRef = useRef<HTMLDivElement>(null)
   const prevTitleRef = useRef(chat.title)
@@ -159,9 +160,24 @@ export function ChatListItem({
       }
     }
 
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') return
+      setIsMobileMenuOpen(false)
+      setMobileMenuView('main')
+      mobileMenuButtonRef.current?.focus()
+    }
+
     document.addEventListener('mousedown', handleClickOutside)
-    return () => document.removeEventListener('mousedown', handleClickOutside)
-  }, [isMobileMenuOpen])
+    document.addEventListener('keydown', handleKeyDown)
+    const frame = requestAnimationFrame(() => {
+      mobileMenuPortalRef.current?.querySelector('button')?.focus()
+    })
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside)
+      document.removeEventListener('keydown', handleKeyDown)
+      cancelAnimationFrame(frame)
+    }
+  }, [isMobileMenuOpen, mobileMenuView])
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
@@ -220,24 +236,12 @@ export function ChatListItem({
 
   return (
     <div
-      role="button"
-      tabIndex={0}
-      aria-current={isSelected ? 'true' : undefined}
       draggable={isDraggable}
-      onClick={onSelect}
-      onKeyDown={(e) => {
-        // Only handle events originating on the row itself, not bubbled from nested buttons
-        if (e.target !== e.currentTarget) return
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault()
-          onSelect()
-        }
-      }}
       onDragStart={handleDragStart}
       onDragEnd={handleDragEnd}
       className={cn(
         'group flex w-full items-center justify-between rounded-lg border border-transparent px-3 py-2 text-left text-sm transition-colors hover:border-border-subtle',
-        isDraggable ? 'cursor-grab' : 'cursor-pointer',
+        isDraggable && 'cursor-grab',
         isDragging && 'opacity-50',
         chat.decryptionFailed
           ? 'text-content-muted hover:bg-surface-chat'
@@ -250,8 +254,8 @@ export function ChatListItem({
               : 'text-content-secondary hover:bg-surface-sidebar',
       )}
     >
-      <div className="min-w-0 flex-1 pr-2">
-        {isEditing ? (
+      {isEditing ? (
+        <div className="min-w-0 flex-1 pr-2">
           <form
             onSubmit={handleSubmit}
             className="flex w-full items-center gap-2"
@@ -270,8 +274,9 @@ export function ChatListItem({
               type="submit"
               className="ml-auto flex-shrink-0 rounded p-1 text-green-500 transition-colors hover:bg-green-500/10"
               title="Save"
+              aria-label="Save chat title"
             >
-              <CheckIcon className="h-4 w-4" />
+              <CheckIcon className="h-4 w-4" aria-hidden="true" />
             </button>
             <button
               type="button"
@@ -281,17 +286,26 @@ export function ChatListItem({
               }}
               className="flex-shrink-0 rounded p-1 text-content-muted transition-colors hover:bg-surface-chat hover:text-content-secondary"
               title="Cancel"
+              aria-label="Cancel rename"
             >
-              <XMarkIcon className="h-4 w-4" />
+              <XMarkIcon className="h-4 w-4" aria-hidden="true" />
             </button>
           </form>
-        ) : (
+        </div>
+      ) : (
+        <button
+          type="button"
+          onClick={onSelect}
+          aria-current={isSelected ? 'true' : undefined}
+          className="min-w-0 flex-1 cursor-pointer rounded-md pr-2 text-left focus:outline-none focus:ring-2 focus:ring-brand-accent-dark dark:focus:ring-brand-accent-light"
+        >
           <>
             <div className="flex items-center gap-1.5">
               {showEncryptionStatus && chat.decryptionFailed && (
                 <FaLock
                   className="h-3.5 w-3.5 flex-shrink-0 text-orange-500"
                   title="Encrypted chat"
+                  aria-hidden="true"
                 />
               )}
               <div
@@ -318,6 +332,7 @@ export function ChatListItem({
                 <div
                   className="h-1.5 w-1.5 rounded-full bg-blue-500"
                   title="New chat"
+                  aria-hidden="true"
                 />
               )}
             </div>
@@ -346,7 +361,10 @@ export function ChatListItem({
                           <span className="text-xs text-content-muted">·</span>
                         )}
                         <span className="flex items-center gap-0.5 text-xs leading-none text-content-muted">
-                          <CiFloppyDisk className="h-3 w-3" />
+                          <CiFloppyDisk
+                            className="h-3 w-3"
+                            aria-hidden="true"
+                          />
                           Only saved locally
                         </span>
                       </>
@@ -356,7 +374,10 @@ export function ChatListItem({
                           <span className="text-xs text-content-muted">·</span>
                         )}
                         <span className="flex items-center gap-0.5 text-xs leading-none text-orange-500">
-                          <CloudArrowUpIcon className="h-3 w-3" />
+                          <CloudArrowUpIcon
+                            className="h-3 w-3"
+                            aria-hidden="true"
+                          />
                           Syncing with cloud
                         </span>
                       </>
@@ -366,12 +387,12 @@ export function ChatListItem({
               </div>
             )}
           </>
-        )}
-      </div>
+        </button>
+      )}
 
       {!isEditing && (
         <div className="flex flex-shrink-0 items-center gap-1.5">
-          <div className="hidden items-center opacity-0 transition-opacity md:flex md:group-focus-within:opacity-100 md:group-hover:opacity-100">
+          <div className="pointer-events-none hidden items-center opacity-0 transition-opacity md:flex md:group-focus-within:pointer-events-auto md:group-focus-within:opacity-100 md:group-hover:pointer-events-auto md:group-hover:opacity-100">
             {!chat.decryptionFailed && !chat.isBlankChat && (
               <button
                 className={cn(
@@ -408,6 +429,7 @@ export function ChatListItem({
             <div className="flex items-center md:hidden">
               <button
                 ref={mobileMenuButtonRef}
+                type="button"
                 className={cn(
                   'rounded p-1 transition-colors',
                   isDarkMode
@@ -429,15 +451,22 @@ export function ChatListItem({
                   }
                 }}
                 title="More options"
+                aria-label="More chat options"
+                aria-haspopup="menu"
+                aria-expanded={isMobileMenuOpen}
+                aria-controls={isMobileMenuOpen ? mobileMenuId : undefined}
               >
-                <EllipsisVerticalIcon className="h-5 w-5" />
+                <EllipsisVerticalIcon className="h-5 w-5" aria-hidden="true" />
               </button>
 
               {/* Mobile dropdown menu - rendered via portal to escape overflow constraints */}
               {isMobileMenuOpen &&
                 createPortal(
                   <div
+                    id={mobileMenuId}
                     ref={mobileMenuPortalRef}
+                    role="menu"
+                    aria-label={`Actions for ${displayTitle}`}
                     className={cn(
                       'fixed z-[9999] min-w-[200px] rounded-lg border py-1 shadow-lg',
                       isDarkMode
@@ -455,6 +484,8 @@ export function ChatListItem({
                         {/* Rename */}
                         {!chat.decryptionFailed && (
                           <button
+                            type="button"
+                            role="menuitem"
                             className={cn(
                               'flex w-full items-center gap-3 px-3 py-2.5 text-left text-sm transition-colors',
                               isDarkMode
@@ -468,7 +499,10 @@ export function ChatListItem({
                               onStartEdit()
                             }}
                           >
-                            <PencilSquareIcon className="h-4 w-4" />
+                            <PencilSquareIcon
+                              className="h-4 w-4"
+                              aria-hidden="true"
+                            />
                             Rename
                           </button>
                         )}
@@ -479,6 +513,9 @@ export function ChatListItem({
                           !chat.decryptionFailed &&
                           projects.length > 0 && (
                             <button
+                              type="button"
+                              role="menuitem"
+                              aria-haspopup="menu"
                               className={cn(
                                 'flex w-full items-center justify-between px-3 py-2.5 text-left text-sm transition-colors',
                                 isDarkMode
@@ -491,7 +528,10 @@ export function ChatListItem({
                               }}
                             >
                               <span className="flex items-center gap-3">
-                                <FolderIcon className="h-4 w-4" />
+                                <FolderIcon
+                                  className="h-4 w-4"
+                                  aria-hidden="true"
+                                />
                                 Move to project
                               </span>
                               <svg
@@ -499,6 +539,7 @@ export function ChatListItem({
                                 fill="none"
                                 stroke="currentColor"
                                 viewBox="0 0 24 24"
+                                aria-hidden="true"
                               >
                                 <path
                                   strokeLinecap="round"
@@ -513,6 +554,8 @@ export function ChatListItem({
                         {/* Move out of project */}
                         {onRemoveFromProject && !chat.decryptionFailed && (
                           <button
+                            type="button"
+                            role="menuitem"
                             className={cn(
                               'flex w-full items-center gap-3 px-3 py-2.5 text-left text-sm transition-colors',
                               isDarkMode
@@ -526,7 +569,10 @@ export function ChatListItem({
                               onRemoveFromProject()
                             }}
                           >
-                            <FolderIcon className="h-4 w-4" />
+                            <FolderIcon
+                              className="h-4 w-4"
+                              aria-hidden="true"
+                            />
                             Move out of project
                           </button>
                         )}
@@ -536,6 +582,8 @@ export function ChatListItem({
                           onConvertToCloud &&
                           !chat.decryptionFailed && (
                             <button
+                              type="button"
+                              role="menuitem"
                               className={cn(
                                 'flex w-full items-center gap-3 px-3 py-2.5 text-left text-sm transition-colors',
                                 isDarkMode
@@ -549,7 +597,10 @@ export function ChatListItem({
                                 onConvertToCloud()
                               }}
                             >
-                              <CloudIcon className="h-4 w-4" />
+                              <CloudIcon
+                                className="h-4 w-4"
+                                aria-hidden="true"
+                              />
                               Move to cloud
                             </button>
                           )}
@@ -559,6 +610,8 @@ export function ChatListItem({
                           onConvertToLocal &&
                           !chat.decryptionFailed && (
                             <button
+                              type="button"
+                              role="menuitem"
                               className={cn(
                                 'flex w-full items-center gap-3 px-3 py-2.5 text-left text-sm transition-colors',
                                 isDarkMode
@@ -572,13 +625,18 @@ export function ChatListItem({
                                 onConvertToLocal()
                               }}
                             >
-                              <CiFloppyDisk className="h-4 w-4" />
+                              <CiFloppyDisk
+                                className="h-4 w-4"
+                                aria-hidden="true"
+                              />
                               Move to local
                             </button>
                           )}
 
                         {/* Delete */}
                         <button
+                          type="button"
+                          role="menuitem"
                           className={cn(
                             'flex w-full items-center gap-3 px-3 py-2.5 text-left text-sm transition-colors',
                             'text-red-500 hover:bg-red-500/10',
@@ -590,7 +648,7 @@ export function ChatListItem({
                             onRequestDelete()
                           }}
                         >
-                          <TrashIcon className="h-4 w-4" />
+                          <TrashIcon className="h-4 w-4" aria-hidden="true" />
                           Delete
                         </button>
                       </>
@@ -599,6 +657,8 @@ export function ChatListItem({
                         {/* Projects submenu */}
                         {/* Back button */}
                         <button
+                          type="button"
+                          role="menuitem"
                           className={cn(
                             'flex w-full items-center gap-2 border-b px-3 py-2.5 text-left text-sm font-medium transition-colors',
                             isDarkMode
@@ -615,6 +675,7 @@ export function ChatListItem({
                             fill="none"
                             stroke="currentColor"
                             viewBox="0 0 24 24"
+                            aria-hidden="true"
                           >
                             <path
                               strokeLinecap="round"
@@ -630,6 +691,8 @@ export function ChatListItem({
                         <div className="max-h-[200px] overflow-y-auto">
                           {projects.map((project) => (
                             <button
+                              type="button"
+                              role="menuitem"
                               key={project.id}
                               className={cn(
                                 'flex w-full items-center gap-3 px-3 py-2.5 text-left text-sm transition-colors',
@@ -644,7 +707,10 @@ export function ChatListItem({
                                 onMoveToProject?.(project.id)
                               }}
                             >
-                              <FolderIcon className="h-4 w-4 text-content-muted" />
+                              <FolderIcon
+                                className="h-4 w-4 text-content-muted"
+                                aria-hidden="true"
+                              />
                               <span className="truncate">{project.name}</span>
                             </button>
                           ))}

--- a/src/components/chat/chat-list-item.tsx
+++ b/src/components/chat/chat-list-item.tsx
@@ -222,6 +222,7 @@ export function ChatListItem({
     <div
       role="button"
       tabIndex={0}
+      aria-current={isSelected ? 'true' : undefined}
       draggable={isDraggable}
       onClick={onSelect}
       onKeyDown={(e) => {
@@ -257,6 +258,7 @@ export function ChatListItem({
             onClick={(e) => e.stopPropagation()}
           >
             <input
+              aria-label="Chat title"
               className="min-w-0 flex-1 rounded bg-surface-sidebar px-2 py-1 text-sm text-content-primary focus:outline-none focus:ring-2 focus:ring-blue-500"
               value={editingTitle}
               onChange={(e) => onTitleChange(e.target.value)}
@@ -369,7 +371,7 @@ export function ChatListItem({
 
       {!isEditing && (
         <div className="flex flex-shrink-0 items-center gap-1.5">
-          <div className="hidden items-center md:group-hover:flex">
+          <div className="hidden items-center opacity-0 transition-opacity md:flex md:group-focus-within:opacity-100 md:group-hover:opacity-100">
             {!chat.decryptionFailed && !chat.isBlankChat && (
               <button
                 className={cn(
@@ -379,9 +381,10 @@ export function ChatListItem({
                     : 'text-content-muted hover:bg-surface-sidebar hover:text-content-secondary',
                 )}
                 onClick={handleStartEdit}
+                aria-label="Rename chat"
                 title="Rename"
               >
-                <PencilSquareIcon className="h-4 w-4" />
+                <PencilSquareIcon className="h-4 w-4" aria-hidden="true" />
               </button>
             )}
             {!chat.isBlankChat && (
@@ -393,9 +396,10 @@ export function ChatListItem({
                     : 'text-content-muted hover:bg-surface-sidebar hover:text-content-secondary',
                 )}
                 onClick={handleRequestDelete}
+                aria-label="Delete chat"
                 title="Delete"
               >
-                <TrashIcon className="h-4 w-4" />
+                <TrashIcon className="h-4 w-4" aria-hidden="true" />
               </button>
             )}
           </div>

--- a/src/components/chat/chat-list.tsx
+++ b/src/components/chat/chat-list.tsx
@@ -167,9 +167,9 @@ export function ChatList({
   }
 
   return (
-    <div className="space-y-2 p-2">
+    <div role="list" className="space-y-2 p-2">
       {chats.map((chat) => (
-        <div key={getChatKey(chat)} className="relative">
+        <div key={getChatKey(chat)} role="listitem" className="relative">
           <ChatListItem
             chat={chat}
             isSelected={isSelected(chat)}

--- a/src/components/chat/chat-list.tsx
+++ b/src/components/chat/chat-list.tsx
@@ -167,64 +167,66 @@ export function ChatList({
   }
 
   return (
-    <div role="list" className="space-y-2 p-2">
-      {chats.map((chat) => (
-        <div key={getChatKey(chat)} role="listitem" className="relative">
-          <ChatListItem
-            chat={chat}
-            isSelected={isSelected(chat)}
-            isEditing={editingChatId === chat.id}
-            editingTitle={editingTitle}
-            isDarkMode={isDarkMode}
-            showEncryptionStatus={showEncryptionStatus}
-            showSyncStatus={showSyncStatus}
-            enableTitleAnimation={
-              enableTitleAnimation && manuallyEditedChatId !== chat.id
-            }
-            isDraggable={
-              isDraggable && !chat.isBlankChat && !chat.decryptionFailed
-            }
-            showMoveToProject={
-              showMoveToProject && !chat.isBlankChat && !chat.decryptionFailed
-            }
-            projects={projects}
-            onSelect={() => handleSelect(chat)}
-            onStartEdit={() => handleStartEdit(chat)}
-            onTitleChange={setEditingTitle}
-            onSaveTitle={() => handleSaveTitle(chat.id)}
-            onCancelEdit={handleCancelEdit}
-            onRequestDelete={() => setDeletingChatId(chat.id)}
-            onDragStart={onDragStart}
-            onDragEnd={onDragEnd}
-            onMoveToProject={
-              onMoveToProject
-                ? (projectId) => onMoveToProject(chat.id, projectId)
-                : undefined
-            }
-            onConvertToCloud={
-              onConvertToCloud ? () => onConvertToCloud(chat.id) : undefined
-            }
-            onConvertToLocal={
-              onConvertToLocal ? () => onConvertToLocal(chat.id) : undefined
-            }
-            onRemoveFromProject={
-              onRemoveFromProject
-                ? () => onRemoveFromProject(chat.id)
-                : undefined
-            }
-          />
-          {deletingChatId === chat.id && (
-            <DeleteConfirmation
-              onConfirm={() => handleConfirmDelete(chat.id)}
-              onCancel={() => setDeletingChatId(null)}
+    <>
+      <div role="list" className="space-y-2 p-2">
+        {chats.map((chat) => (
+          <div key={getChatKey(chat)} role="listitem" className="relative">
+            <ChatListItem
+              chat={chat}
+              isSelected={isSelected(chat)}
+              isEditing={editingChatId === chat.id}
+              editingTitle={editingTitle}
               isDarkMode={isDarkMode}
-              animated={animatedDeleteConfirmation}
+              showEncryptionStatus={showEncryptionStatus}
+              showSyncStatus={showSyncStatus}
+              enableTitleAnimation={
+                enableTitleAnimation && manuallyEditedChatId !== chat.id
+              }
+              isDraggable={
+                isDraggable && !chat.isBlankChat && !chat.decryptionFailed
+              }
+              showMoveToProject={
+                showMoveToProject && !chat.isBlankChat && !chat.decryptionFailed
+              }
+              projects={projects}
+              onSelect={() => handleSelect(chat)}
+              onStartEdit={() => handleStartEdit(chat)}
+              onTitleChange={setEditingTitle}
+              onSaveTitle={() => handleSaveTitle(chat.id)}
+              onCancelEdit={handleCancelEdit}
+              onRequestDelete={() => setDeletingChatId(chat.id)}
+              onDragStart={onDragStart}
+              onDragEnd={onDragEnd}
+              onMoveToProject={
+                onMoveToProject
+                  ? (projectId) => onMoveToProject(chat.id, projectId)
+                  : undefined
+              }
+              onConvertToCloud={
+                onConvertToCloud ? () => onConvertToCloud(chat.id) : undefined
+              }
+              onConvertToLocal={
+                onConvertToLocal ? () => onConvertToLocal(chat.id) : undefined
+              }
+              onRemoveFromProject={
+                onRemoveFromProject
+                  ? () => onRemoveFromProject(chat.id)
+                  : undefined
+              }
             />
-          )}
-        </div>
-      ))}
+            {deletingChatId === chat.id && (
+              <DeleteConfirmation
+                onConfirm={() => handleConfirmDelete(chat.id)}
+                onCancel={() => setDeletingChatId(null)}
+                isDarkMode={isDarkMode}
+                animated={animatedDeleteConfirmation}
+              />
+            )}
+          </div>
+        ))}
+      </div>
       {loadMoreButton}
-    </div>
+    </>
   )
 }
 

--- a/src/components/chat/chat-messages.tsx
+++ b/src/components/chat/chat-messages.tsx
@@ -364,6 +364,9 @@ export function ChatMessages({
 
   return (
     <div
+      role="log"
+      aria-label="Conversation"
+      aria-live="polite"
       className={`mx-auto w-full min-w-0 px-0 pb-6 pt-24 md:px-4 ${CHAT_FONT_CLASSES[chatFont]}`}
     >
       {/* Archived Messages - only shown if there are more than the max prompt messages */}

--- a/src/components/chat/chat-sidebar.tsx
+++ b/src/components/chat/chat-sidebar.tsx
@@ -1078,7 +1078,6 @@ export function ChatSidebar({
                 role="button"
                 tabIndex={0}
                 aria-expanded={isProjectsExpanded}
-                aria-label="Projects"
                 onClick={() => {
                   const newExpanded = !isProjectsExpanded
                   setIsProjectsExpanded(newExpanded)
@@ -1557,9 +1556,14 @@ export function ChatSidebar({
                 >
                   {/* Tabs for Cloud/Local chats - show when signed in, cloud sync enabled, and local-only mode enabled */}
                   {isSignedIn && cloudSyncEnabled && localOnlyModeEnabled && (
-                    <div className="relative mx-4 mt-2 flex rounded-lg bg-surface-chat p-1">
+                    <div
+                      className="relative mx-4 mt-2 flex rounded-lg bg-surface-chat p-1"
+                      role="tablist"
+                      aria-label="Chat storage"
+                    >
                       {/* Sliding background indicator */}
                       <div
+                        aria-hidden="true"
                         className={cn(
                           'absolute inset-y-1 w-[calc(50%-4px)] rounded-md shadow-sm transition-all duration-200 ease-in-out',
                           isDarkMode ? 'bg-surface-sidebar' : 'bg-white',
@@ -1571,6 +1575,10 @@ export function ChatSidebar({
                       />
 
                       <button
+                        id="chat-cloud-tab"
+                        role="tab"
+                        aria-selected={activeTab === 'cloud'}
+                        aria-controls="chat-storage-panel"
                         onClick={() => setActiveTab('cloud')}
                         onDragOver={(e) => {
                           if (
@@ -1637,6 +1645,10 @@ export function ChatSidebar({
                         Cloud
                       </button>
                       <button
+                        id="chat-local-tab"
+                        role="tab"
+                        aria-selected={activeTab === 'local'}
+                        aria-controls="chat-storage-panel"
                         onClick={() => setActiveTab('local')}
                         onDragOver={(e) => {
                           if (
@@ -1755,6 +1767,11 @@ export function ChatSidebar({
                 className="flex-1 overflow-hidden"
               >
                 <div
+                  id="chat-storage-panel"
+                  role="tabpanel"
+                  aria-labelledby={
+                    activeTab === 'cloud' ? 'chat-cloud-tab' : 'chat-local-tab'
+                  }
                   ref={chatListRef}
                   onDragOver={(e) => {
                     if (

--- a/src/components/chat/chat-sidebar.tsx
+++ b/src/components/chat/chat-sidebar.tsx
@@ -710,7 +710,8 @@ export function ChatSidebar({
     <>
       {/* Collapsed sidebar rail - always visible on desktop when sidebar is closed */}
       {!isMobile && !isOpen && (
-        <div
+        <nav
+          aria-label="Chat history"
           className={cn(
             'fixed left-0 top-0 z-40 flex h-dvh flex-col border-r',
             'border-border-subtle bg-surface-sidebar text-content-primary',
@@ -822,11 +823,13 @@ export function ChatSidebar({
               </span>
             </div>
           </div>
-        </div>
+        </nav>
       )}
 
       {/* Expanded sidebar wrapper */}
-      <div
+      <nav
+        aria-label="Chat history"
+        inert={!isOpen}
         className={cn(
           'fixed z-40 flex h-dvh flex-col overflow-hidden border-r',
           // On mobile: slide in/out. On desktop: always positioned, just toggle width
@@ -866,9 +869,10 @@ export function ChatSidebar({
                 id="settings-button"
                 type="button"
                 onClick={onSettingsClick}
+                aria-label="Settings"
                 className="rounded p-1.5 text-content-muted transition-all duration-200 hover:text-content-secondary"
               >
-                <Cog6ToothIcon className="h-5 w-5" />
+                <Cog6ToothIcon className="h-5 w-5" aria-hidden="true" />
               </button>
               <span className="pointer-events-none absolute left-1/2 top-full z-50 mt-1 -translate-x-1/2 whitespace-nowrap rounded border border-border-subtle bg-surface-chat-background px-2 py-1 text-xs text-content-primary opacity-0 shadow-sm transition-opacity group-hover:opacity-100">
                 Settings
@@ -1073,6 +1077,8 @@ export function ChatSidebar({
               <div
                 role="button"
                 tabIndex={0}
+                aria-expanded={isProjectsExpanded}
+                aria-label="Projects"
                 onClick={() => {
                   const newExpanded = !isProjectsExpanded
                   setIsProjectsExpanded(newExpanded)
@@ -1475,6 +1481,8 @@ export function ChatSidebar({
             <div
               role="button"
               tabIndex={0}
+              aria-expanded={isChatHistoryExpanded}
+              aria-label="Chats"
               onClick={() => setIsChatHistoryExpanded(!isChatHistoryExpanded)}
               onKeyDown={(e) => {
                 if (e.key === 'Enter' || e.key === ' ') {
@@ -1980,7 +1988,7 @@ export function ChatSidebar({
             </p>
           </div>
         </div>
-      </div>
+      </nav>
 
       {/* Mobile overlay */}
       {isOpen && (

--- a/src/components/chat/components/confirm-dialog.tsx
+++ b/src/components/chat/components/confirm-dialog.tsx
@@ -34,6 +34,7 @@ export function ConfirmDialog({
         <AlertDialogPrimitive.Content
           onEscapeKeyDown={(e) => {
             e.preventDefault()
+            e.stopPropagation()
             onCancel()
           }}
           className="fixed left-1/2 top-1/2 z-[60] w-[92vw] max-w-md -translate-x-1/2 -translate-y-1/2 rounded-xl border border-border-subtle bg-surface-sidebar p-5 shadow-xl focus:outline-none"

--- a/src/components/chat/components/confirm-dialog.tsx
+++ b/src/components/chat/components/confirm-dialog.tsx
@@ -1,5 +1,5 @@
 import { cn } from '@/components/ui/utils'
-import { useEffect, useRef } from 'react'
+import * as AlertDialogPrimitive from '@radix-ui/react-alert-dialog'
 
 type ConfirmDialogProps = {
   isOpen: boolean
@@ -22,79 +22,57 @@ export function ConfirmDialog({
   onConfirm,
   onCancel,
 }: ConfirmDialogProps) {
-  const cancelButtonRef = useRef<HTMLButtonElement | null>(null)
-
-  useEffect(() => {
-    if (!isOpen) return
-    cancelButtonRef.current?.focus()
-
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        e.preventDefault()
-        e.stopImmediatePropagation()
-        onCancel()
-      }
-    }
-    document.addEventListener('keydown', handleKeyDown, { capture: true })
-    return () =>
-      document.removeEventListener('keydown', handleKeyDown, { capture: true })
-  }, [isOpen, onCancel])
-
-  if (!isOpen) return null
-
   const isDestructive = variant === 'destructive'
 
   return (
-    <div
-      className="fixed inset-0 z-[60] flex items-center justify-center"
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="confirm-dialog-title"
-      aria-describedby={description ? 'confirm-dialog-description' : undefined}
-    >
-      <div
-        className="fixed inset-0 bg-black/60"
-        onClick={onCancel}
-        aria-hidden="true"
-      />
-      <div className="relative z-10 w-[92vw] max-w-md rounded-xl border border-border-subtle bg-surface-sidebar p-5 shadow-xl">
-        <h3
-          id="confirm-dialog-title"
-          className="text-base font-semibold text-content-primary"
+    <AlertDialogPrimitive.Root open={isOpen}>
+      <AlertDialogPrimitive.Portal>
+        <AlertDialogPrimitive.Overlay
+          className="fixed inset-0 z-[60] bg-black/60"
+          onClick={onCancel}
+        />
+        <AlertDialogPrimitive.Content
+          onEscapeKeyDown={(e) => {
+            e.preventDefault()
+            onCancel()
+          }}
+          className="fixed left-1/2 top-1/2 z-[60] w-[92vw] max-w-md -translate-x-1/2 -translate-y-1/2 rounded-xl border border-border-subtle bg-surface-sidebar p-5 shadow-xl focus:outline-none"
         >
-          {title}
-        </h3>
-        {description && (
-          <p
-            id="confirm-dialog-description"
-            className="mt-2 text-sm text-content-secondary"
-          >
-            {description}
-          </p>
-        )}
-        <div className="mt-5 flex justify-end gap-2">
-          <button
-            ref={cancelButtonRef}
-            type="button"
-            onClick={onCancel}
-            className="rounded-lg border border-border-subtle bg-surface-chat-background px-3 py-2 text-sm font-medium text-content-primary transition-colors hover:bg-surface-chat"
-          >
-            {cancelLabel}
-          </button>
-          <button
-            type="button"
-            onClick={onConfirm}
-            className={cn(
-              'rounded-lg px-3 py-2 text-sm font-semibold text-white transition-colors',
-              isDestructive
-                ? 'bg-red-600 hover:bg-red-700'
-                : 'bg-brand-accent-dark hover:bg-brand-accent-dark/90',
-            )}
-          >
-            {confirmLabel}
-          </button>
-        </div>
-      </div>
-    </div>
+          <AlertDialogPrimitive.Title className="text-base font-semibold text-content-primary">
+            {title}
+          </AlertDialogPrimitive.Title>
+          {description && (
+            <AlertDialogPrimitive.Description className="mt-2 text-sm text-content-secondary">
+              {description}
+            </AlertDialogPrimitive.Description>
+          )}
+          <div className="mt-5 flex justify-end gap-2">
+            <AlertDialogPrimitive.Cancel asChild>
+              <button
+                type="button"
+                onClick={onCancel}
+                className="rounded-lg border border-border-subtle bg-surface-chat-background px-3 py-2 text-sm font-medium text-content-primary transition-colors hover:bg-surface-chat"
+              >
+                {cancelLabel}
+              </button>
+            </AlertDialogPrimitive.Cancel>
+            <AlertDialogPrimitive.Action asChild>
+              <button
+                type="button"
+                onClick={onConfirm}
+                className={cn(
+                  'rounded-lg px-3 py-2 text-sm font-semibold text-white transition-colors',
+                  isDestructive
+                    ? 'bg-red-600 hover:bg-red-700'
+                    : 'bg-brand-accent-dark hover:bg-brand-accent-dark/90',
+                )}
+              >
+                {confirmLabel}
+              </button>
+            </AlertDialogPrimitive.Action>
+          </div>
+        </AlertDialogPrimitive.Content>
+      </AlertDialogPrimitive.Portal>
+    </AlertDialogPrimitive.Root>
   )
 }

--- a/src/components/chat/components/prompt-preset-suggestions.tsx
+++ b/src/components/chat/components/prompt-preset-suggestions.tsx
@@ -38,7 +38,7 @@ export function PromptPresetSuggestions({
                 : 'border-border-subtle bg-surface-chat-background text-content-secondary hover:bg-surface-chat hover:text-content-primary',
             )}
           >
-            <Icon className="h-3.5 w-3.5" />
+            <Icon className="h-3.5 w-3.5" aria-hidden="true" />
             <span>{preset.name}</span>
           </button>
         )
@@ -51,7 +51,7 @@ export function PromptPresetSuggestions({
           'border-border-subtle bg-surface-chat-background text-content-secondary hover:bg-surface-chat hover:text-content-primary',
         )}
       >
-        <Squares2X2Icon className="h-3.5 w-3.5" />
+        <Squares2X2Icon className="h-3.5 w-3.5" aria-hidden="true" />
         <span>More</span>
       </button>
     </div>

--- a/src/components/chat/hooks/use-chat-state.ts
+++ b/src/components/chat/hooks/use-chat-state.ts
@@ -226,47 +226,59 @@ export function useChatState({
   // Update ref with cancelGeneration function
   cancelGenerationRef.current = cancelGeneration
 
-  // Add effect to handle clicks outside the model/reasoning selectors
+  // Add effect to handle dismissing the model/reasoning selectors
   useEffect(() => {
     if (expandedLabel === 'model' || expandedLabel === 'reasoning') {
+      const triggerSelector =
+        expandedLabel === 'model'
+          ? '[data-model-selector]'
+          : '[data-reasoning-selector]'
+      const menuSelector =
+        expandedLabel === 'model'
+          ? '[data-model-menu]'
+          : '[data-reasoning-menu]'
+
+      const getSelectorElements = () => ({
+        trigger: document.querySelector<HTMLElement>(triggerSelector),
+        menu: document.querySelector<HTMLElement>(menuSelector),
+      })
+
+      const isOutsideSelector = (target: EventTarget | null) => {
+        if (!(target instanceof Node)) return false
+        const { trigger, menu } = getSelectorElements()
+        return (
+          trigger && menu && !trigger.contains(target) && !menu.contains(target)
+        )
+      }
+
       const handleClickOutside = (event: MouseEvent) => {
-        if (expandedLabel === 'model') {
-          const modelSelectorButton = document.querySelector(
-            '[data-model-selector]',
-          )
-          const modelSelectorMenu = document.querySelector('[data-model-menu]')
+        if (isOutsideSelector(event.target)) {
+          setExpandedLabel(null)
+        }
+      }
 
-          if (
-            modelSelectorButton &&
-            modelSelectorMenu &&
-            !modelSelectorButton.contains(event.target as Node) &&
-            !modelSelectorMenu.contains(event.target as Node)
-          ) {
-            setExpandedLabel(null)
-          }
-        } else if (expandedLabel === 'reasoning') {
-          const reasoningSelectorButton = document.querySelector(
-            '[data-reasoning-selector]',
-          )
-          const reasoningSelectorMenu = document.querySelector(
-            '[data-reasoning-menu]',
-          )
+      const handleFocusOutside = (event: FocusEvent) => {
+        if (isOutsideSelector(event.target)) {
+          setExpandedLabel(null)
+        }
+      }
 
-          if (
-            reasoningSelectorButton &&
-            reasoningSelectorMenu &&
-            !reasoningSelectorButton.contains(event.target as Node) &&
-            !reasoningSelectorMenu.contains(event.target as Node)
-          ) {
-            setExpandedLabel(null)
-          }
+      const handleKeyDown = (event: KeyboardEvent) => {
+        if (event.key === 'Escape') {
+          event.preventDefault()
+          setExpandedLabel(null)
+          getSelectorElements().trigger?.focus()
         }
       }
 
       document.addEventListener('mousedown', handleClickOutside)
+      document.addEventListener('focusin', handleFocusOutside)
+      document.addEventListener('keydown', handleKeyDown)
 
       return () => {
         document.removeEventListener('mousedown', handleClickOutside)
+        document.removeEventListener('focusin', handleFocusOutside)
+        document.removeEventListener('keydown', handleKeyDown)
       }
     }
   }, [expandedLabel, setExpandedLabel])

--- a/src/components/chat/model-selector.tsx
+++ b/src/components/chat/model-selector.tsx
@@ -155,6 +155,12 @@ export function ModelSelector({
     return `/model-icons/${model.image}`
   }
 
+  const focusTrigger = () => {
+    requestAnimationFrame(() => {
+      document.querySelector<HTMLElement>('[data-model-selector]')?.focus()
+    })
+  }
+
   const renderModelItem = (model: BaseModel) => {
     const isSelected = model.modelName === selectedModel
     return (
@@ -168,12 +174,14 @@ export function ModelSelector({
           e.preventDefault()
           e.stopPropagation()
           onSelect(model.modelName as AIModel)
+          focusTrigger()
         }}
         onTouchEnd={(e) => {
           e.stopPropagation()
           if (isScrollingRef.current) return
           e.preventDefault()
           onSelect(model.modelName as AIModel)
+          focusTrigger()
         }}
       >
         <div className="relative flex h-5 w-5 flex-none items-center justify-center">

--- a/src/components/chat/model-selector.tsx
+++ b/src/components/chat/model-selector.tsx
@@ -161,6 +161,8 @@ export function ModelSelector({
       <button
         type="button"
         key={model.modelName}
+        role="menuitemradio"
+        aria-checked={isSelected}
         className={`relative flex w-full items-center gap-3 rounded-md px-3 py-2.5 text-left text-sm transition-colors ${isSelected ? 'text-content-primary' : 'cursor-pointer text-content-secondary hover:bg-surface-card/70'}`}
         onClick={(e) => {
           e.preventDefault()
@@ -193,7 +195,10 @@ export function ModelSelector({
           </span>
         </div>
         {isSelected && (
-          <CheckIcon className="h-4 w-4 flex-none text-brand-accent-dark dark:text-brand-accent-light" />
+          <CheckIcon
+            className="h-4 w-4 flex-none text-brand-accent-dark dark:text-brand-accent-light"
+            aria-hidden="true"
+          />
         )}
       </button>
     )
@@ -203,6 +208,8 @@ export function ModelSelector({
     <div
       ref={menuRef}
       data-model-menu
+      role="menu"
+      aria-label="Select a model"
       className={`absolute z-50 w-[280px] overflow-y-auto rounded-lg border border-border-subtle bg-surface-chat p-2 font-aeonik-fono text-content-secondary shadow-lg ${dynamicStyles.bottom ? 'mb-2' : 'mt-2'}`}
       style={{
         maxHeight: dynamicStyles.maxHeight,
@@ -229,6 +236,7 @@ export function ModelSelector({
           <div className="mx-3 my-1 border-t border-border-subtle" />
           <button
             type="button"
+            aria-expanded={showOtherModels}
             className="flex w-full items-center justify-between rounded-md px-3 py-2.5 text-left text-sm font-medium text-content-secondary transition-colors hover:bg-surface-card/70"
             onClick={(e) => {
               e.preventDefault()
@@ -240,6 +248,7 @@ export function ModelSelector({
             <span>Other models</span>
             <ChevronDownIcon
               className={`h-4 w-4 text-content-muted transition-transform ${showOtherModels ? 'rotate-180' : ''}`}
+              aria-hidden="true"
             />
           </button>
 

--- a/src/components/chat/prompt-library-modal.tsx
+++ b/src/components/chat/prompt-library-modal.tsx
@@ -10,7 +10,7 @@ import {
   XMarkIcon,
 } from '@heroicons/react/24/outline'
 import * as DialogPrimitive from '@radix-ui/react-dialog'
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useId, useMemo, useRef, useState } from 'react'
 import { ConfirmDialog } from './components/confirm-dialog'
 import { CONSTANTS } from './constants'
 import { usePromptLibrary } from './hooks/use-prompt-library'
@@ -200,9 +200,10 @@ export function PromptLibraryModal({
             : 'border-border-subtle bg-surface-chat-background hover:bg-surface-chat',
         )}
         aria-pressed={isActive}
+        aria-current={isSelected ? 'true' : undefined}
       >
         <span className="mt-0.5 flex h-7 w-7 flex-none items-center justify-center rounded-md bg-surface-chat text-content-secondary">
-          <Icon className="h-4 w-4" />
+          <Icon className="h-4 w-4" aria-hidden="true" />
         </span>
         <span className="flex min-w-0 flex-1 flex-col pr-5">
           <span className="truncate text-sm font-medium text-content-primary">
@@ -414,6 +415,7 @@ function PresetDetail({
   const Icon = preset.Icon
   const [isEditingName, setIsEditingName] = useState(false)
   const [nameDraft, setNameDraft] = useState(preset.name)
+  const systemPromptLabelId = useId()
 
   const commitRename = () => {
     setIsEditingName(false)
@@ -430,7 +432,7 @@ function PresetDetail({
       <div className="flex flex-none items-start justify-between gap-4 border-b border-border-subtle px-6 py-4">
         <div className="flex min-w-0 items-start gap-3">
           <span className="flex h-10 w-10 flex-none items-center justify-center rounded-lg bg-surface-chat text-content-secondary">
-            <Icon className="h-5 w-5" />
+            <Icon className="h-5 w-5" aria-hidden="true" />
           </span>
           <div className="min-w-0">
             {isEditingName && !preset.isBuiltIn ? (
@@ -544,10 +546,17 @@ function PresetDetail({
       </div>
 
       <div className="flex min-h-0 flex-1 flex-col px-6 py-4">
-        <span className="mb-2 text-xs font-medium uppercase tracking-wide text-content-muted">
+        <span
+          id={systemPromptLabelId}
+          className="mb-2 text-xs font-medium uppercase tracking-wide text-content-muted"
+        >
           System prompt
         </span>
-        <pre className="flex-1 overflow-auto whitespace-pre-wrap rounded-lg border border-border-subtle bg-surface-chat-background p-4 font-mono text-[13px] text-content-primary">
+        <pre
+          tabIndex={0}
+          aria-labelledby={systemPromptLabelId}
+          className="flex-1 overflow-auto whitespace-pre-wrap rounded-lg border border-border-subtle bg-surface-chat-background p-4 font-mono text-[13px] text-content-primary"
+        >
           {preset.systemPrompt}
         </pre>
       </div>

--- a/src/components/chat/prompt-library-modal.tsx
+++ b/src/components/chat/prompt-library-modal.tsx
@@ -9,6 +9,7 @@ import {
   TrashIcon,
   XMarkIcon,
 } from '@heroicons/react/24/outline'
+import * as DialogPrimitive from '@radix-ui/react-dialog'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { ConfirmDialog } from './components/confirm-dialog'
 import { CONSTANTS } from './constants'
@@ -71,18 +72,6 @@ export function PromptLibraryModal({
       wasOpenRef.current = true
     }
   }, [isOpen, activePresetId, builtInPresets])
-
-  useEffect(() => {
-    if (!isOpen) return
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape' && !editor) {
-        e.preventDefault()
-        onClose()
-      }
-    }
-    document.addEventListener('keydown', handleKeyDown)
-    return () => document.removeEventListener('keydown', handleKeyDown)
-  }, [isOpen, onClose, editor])
 
   const selectedPreset = useMemo<PromptPreset | null>(() => {
     if (!selectedId) return null
@@ -236,136 +225,153 @@ export function PromptLibraryModal({
   }
 
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center"
-      style={{ left: `${leftOffset}px`, right: `${rightOffset}px` }}
-    >
-      <div
-        className="fixed inset-0 bg-black/50"
-        onClick={editor ? undefined : onClose}
-        style={{ left: 0, right: 0 }}
-      />
-
-      <div
-        className="relative z-10 flex h-[85dvh] w-[92vw] max-w-5xl flex-col rounded-xl border border-border-subtle bg-surface-sidebar shadow-xl"
-        style={{
-          maxWidth: `min(1024px, calc(92vw - ${leftOffset + rightOffset}px))`,
+    <>
+      <DialogPrimitive.Root
+        open
+        onOpenChange={(nextOpen) => {
+          if (!nextOpen) onClose()
         }}
       >
-        <div className="flex items-center justify-between border-b border-border-subtle px-4 py-3 md:px-6 md:py-4">
-          <div className="flex min-w-0 items-center gap-2">
-            {mobileView === 'detail' && (
-              <button
-                type="button"
-                onClick={() => {
-                  if (editor) {
-                    setEditor(null)
-                  }
-                  setMobileView('list')
-                }}
-                className="-ml-1 flex h-8 w-8 items-center justify-center rounded-lg text-content-secondary transition-colors hover:bg-surface-chat md:hidden"
-                aria-label="Back to library"
-              >
-                <ArrowLeftIcon className="h-5 w-5" />
-              </button>
-            )}
-            <Squares2X2Icon className="hidden h-5 w-5 text-content-secondary md:block" />
-            <h2 className="truncate text-base font-semibold text-content-primary md:text-lg">
-              Prompt Library
-            </h2>
-          </div>
-          <button
-            onClick={onClose}
-            className="rounded-lg p-1.5 text-content-secondary transition-colors hover:bg-surface-chat"
-            aria-label="Close prompt library"
-          >
-            <XMarkIcon className="h-5 w-5" />
-          </button>
-        </div>
-
-        <div className="flex min-h-0 flex-1 overflow-hidden">
+        <DialogPrimitive.Portal>
+          <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-black/50" />
           <div
-            className={cn(
-              'flex min-h-0 w-full flex-none flex-col md:w-[300px] md:border-r md:border-border-subtle',
-              mobileView === 'detail' ? 'hidden md:flex' : 'flex',
-            )}
+            className="fixed inset-0 z-50 flex items-center justify-center"
+            style={{ left: `${leftOffset}px`, right: `${rightOffset}px` }}
           >
-            <div className="flex min-h-0 flex-1 flex-col overflow-y-auto pb-8">
-              <div className="flex items-center justify-between px-4 pt-4">
-                <span className="text-xs font-medium uppercase tracking-wide text-content-muted">
-                  Built-in
-                </span>
-              </div>
-              <div className="flex flex-col gap-1.5 px-3 pb-2 pt-2">
-                {builtInPresets.map(renderPresetCard)}
-              </div>
-
-              <div className="mt-2 flex items-center justify-between px-4 pt-2">
-                <span className="text-xs font-medium uppercase tracking-wide text-content-muted">
-                  Your prompts
-                </span>
+            <DialogPrimitive.Content
+              aria-describedby={undefined}
+              onEscapeKeyDown={(e) => {
+                if (editor) e.preventDefault()
+              }}
+              onInteractOutside={(e) => {
+                if (editor) e.preventDefault()
+              }}
+              className="relative z-10 flex h-[85dvh] w-[92vw] max-w-5xl flex-col rounded-xl border border-border-subtle bg-surface-sidebar shadow-xl focus:outline-none"
+              style={{
+                maxWidth: `min(1024px, calc(92vw - ${leftOffset + rightOffset}px))`,
+              }}
+            >
+              <div className="flex items-center justify-between border-b border-border-subtle px-4 py-3 md:px-6 md:py-4">
+                <div className="flex min-w-0 items-center gap-2">
+                  {mobileView === 'detail' && (
+                    <button
+                      type="button"
+                      onClick={() => {
+                        if (editor) {
+                          setEditor(null)
+                        }
+                        setMobileView('list')
+                      }}
+                      className="-ml-1 flex h-8 w-8 items-center justify-center rounded-lg text-content-secondary transition-colors hover:bg-surface-chat md:hidden"
+                      aria-label="Back to library"
+                    >
+                      <ArrowLeftIcon className="h-5 w-5" aria-hidden="true" />
+                    </button>
+                  )}
+                  <Squares2X2Icon
+                    className="hidden h-5 w-5 text-content-secondary md:block"
+                    aria-hidden="true"
+                  />
+                  <DialogPrimitive.Title className="truncate text-base font-semibold text-content-primary md:text-lg">
+                    Prompt Library
+                  </DialogPrimitive.Title>
+                </div>
                 <button
-                  type="button"
-                  onClick={startCreate}
-                  className="flex items-center gap-1 rounded-md px-1.5 py-0.5 text-xs font-medium text-content-secondary transition-colors hover:bg-surface-chat hover:text-content-primary"
+                  onClick={onClose}
+                  className="rounded-lg p-1.5 text-content-secondary transition-colors hover:bg-surface-chat"
+                  aria-label="Close prompt library"
                 >
-                  <PlusIcon className="h-3.5 w-3.5" />
-                  New
+                  <XMarkIcon className="h-5 w-5" aria-hidden="true" />
                 </button>
               </div>
-              <div className="flex flex-col gap-1.5 px-3 pt-2">
-                {userPresets.length === 0 ? (
-                  <p className="px-1 pt-1 text-xs text-content-muted">
-                    No custom prompts yet. Click &quot;New&quot; to create one.
-                  </p>
-                ) : (
-                  userPresets.map(renderPresetCard)
-                )}
-              </div>
-            </div>
-          </div>
 
-          <div
-            className={cn(
-              'min-w-0 flex-1 flex-col',
-              mobileView === 'list' ? 'hidden md:flex' : 'flex',
-            )}
-          >
-            {editor ? (
-              <PresetEditor
-                editor={editor}
-                onChange={setEditor}
-                onCancel={() => {
-                  setEditor(null)
-                  setMobileView('list')
-                }}
-                onSave={() => {
-                  handleEditorSave()
-                  setMobileView('detail')
-                }}
-              />
-            ) : selectedPreset ? (
-              <PresetDetail
-                key={selectedPreset.id}
-                preset={selectedPreset}
-                isActive={activePresetId === selectedPreset.id}
-                onUseThis={handleUseThis}
-                onClearActive={handleClearActive}
-                onEdit={() => startEdit(selectedPreset)}
-                onDuplicate={() => handleDuplicate(selectedPreset)}
-                onDelete={() => handleDelete(selectedPreset)}
-                onRename={(name) => handleRename(selectedPreset, name)}
-              />
-            ) : (
-              <div className="flex flex-1 items-center justify-center p-6">
-                <p className="text-sm text-content-muted">
-                  Select a prompt to view its details.
-                </p>
+              <div className="flex min-h-0 flex-1 overflow-hidden">
+                <div
+                  className={cn(
+                    'flex min-h-0 w-full flex-none flex-col md:w-[300px] md:border-r md:border-border-subtle',
+                    mobileView === 'detail' ? 'hidden md:flex' : 'flex',
+                  )}
+                >
+                  <div className="flex min-h-0 flex-1 flex-col overflow-y-auto pb-8">
+                    <div className="flex items-center justify-between px-4 pt-4">
+                      <span className="text-xs font-medium uppercase tracking-wide text-content-muted">
+                        Built-in
+                      </span>
+                    </div>
+                    <div className="flex flex-col gap-1.5 px-3 pb-2 pt-2">
+                      {builtInPresets.map(renderPresetCard)}
+                    </div>
+
+                    <div className="mt-2 flex items-center justify-between px-4 pt-2">
+                      <span className="text-xs font-medium uppercase tracking-wide text-content-muted">
+                        Your prompts
+                      </span>
+                      <button
+                        type="button"
+                        onClick={startCreate}
+                        className="flex items-center gap-1 rounded-md px-1.5 py-0.5 text-xs font-medium text-content-secondary transition-colors hover:bg-surface-chat hover:text-content-primary"
+                      >
+                        <PlusIcon className="h-3.5 w-3.5" />
+                        New
+                      </button>
+                    </div>
+                    <div className="flex flex-col gap-1.5 px-3 pt-2">
+                      {userPresets.length === 0 ? (
+                        <p className="px-1 pt-1 text-xs text-content-muted">
+                          No custom prompts yet. Click &quot;New&quot; to create
+                          one.
+                        </p>
+                      ) : (
+                        userPresets.map(renderPresetCard)
+                      )}
+                    </div>
+                  </div>
+                </div>
+
+                <div
+                  className={cn(
+                    'min-w-0 flex-1 flex-col',
+                    mobileView === 'list' ? 'hidden md:flex' : 'flex',
+                  )}
+                >
+                  {editor ? (
+                    <PresetEditor
+                      editor={editor}
+                      onChange={setEditor}
+                      onCancel={() => {
+                        setEditor(null)
+                        setMobileView('list')
+                      }}
+                      onSave={() => {
+                        handleEditorSave()
+                        setMobileView('detail')
+                      }}
+                    />
+                  ) : selectedPreset ? (
+                    <PresetDetail
+                      key={selectedPreset.id}
+                      preset={selectedPreset}
+                      isActive={activePresetId === selectedPreset.id}
+                      onUseThis={handleUseThis}
+                      onClearActive={handleClearActive}
+                      onEdit={() => startEdit(selectedPreset)}
+                      onDuplicate={() => handleDuplicate(selectedPreset)}
+                      onDelete={() => handleDelete(selectedPreset)}
+                      onRename={(name) => handleRename(selectedPreset, name)}
+                    />
+                  ) : (
+                    <div className="flex flex-1 items-center justify-center p-6">
+                      <p className="text-sm text-content-muted">
+                        Select a prompt to view its details.
+                      </p>
+                    </div>
+                  )}
+                </div>
               </div>
-            )}
+            </DialogPrimitive.Content>
           </div>
-        </div>
-      </div>
+        </DialogPrimitive.Portal>
+      </DialogPrimitive.Root>
 
       <ConfirmDialog
         isOpen={presetPendingDelete !== null}
@@ -380,7 +386,7 @@ export function PromptLibraryModal({
         onConfirm={handleConfirmDelete}
         onCancel={() => setPresetPendingDelete(null)}
       />
-    </div>
+    </>
   )
 }
 
@@ -432,6 +438,7 @@ function PresetDetail({
                 type="text"
                 value={nameDraft}
                 autoFocus
+                aria-label="Prompt name"
                 onChange={(e) => setNameDraft(e.target.value)}
                 onBlur={commitRename}
                 onKeyDown={(e) => {
@@ -453,10 +460,21 @@ function PresetDetail({
                   !preset.isBuiltIn && 'cursor-text hover:bg-surface-chat',
                 )}
                 title={preset.isBuiltIn ? undefined : 'Click to rename'}
+                role={preset.isBuiltIn ? undefined : 'button'}
+                tabIndex={preset.isBuiltIn ? undefined : 0}
+                aria-label={preset.isBuiltIn ? undefined : 'Rename prompt'}
                 onClick={() => {
                   if (preset.isBuiltIn) return
                   setNameDraft(preset.name)
                   setIsEditingName(true)
+                }}
+                onKeyDown={(e) => {
+                  if (preset.isBuiltIn) return
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault()
+                    setNameDraft(preset.name)
+                    setIsEditingName(true)
+                  }
                 }}
               >
                 {preset.name}

--- a/src/components/chat/prompt-library-modal.tsx
+++ b/src/components/chat/prompt-library-modal.tsx
@@ -73,6 +73,18 @@ export function PromptLibraryModal({
     }
   }, [isOpen, activePresetId, builtInPresets])
 
+  useEffect(() => {
+    if (!isOpen) return
+    const appRoot = document.getElementById('__next')
+    if (!appRoot) return
+    appRoot.setAttribute('inert', '')
+    appRoot.setAttribute('aria-hidden', 'true')
+    return () => {
+      appRoot.removeAttribute('inert')
+      appRoot.removeAttribute('aria-hidden')
+    }
+  }, [isOpen])
+
   const selectedPreset = useMemo<PromptPreset | null>(() => {
     if (!selectedId) return null
     return allPresets.find((p) => p.id === selectedId) ?? null
@@ -240,6 +252,7 @@ export function PromptLibraryModal({
             style={{ left: `${leftOffset}px`, right: `${rightOffset}px` }}
           >
             <DialogPrimitive.Content
+              aria-modal="true"
               aria-describedby={undefined}
               onEscapeKeyDown={(e) => {
                 if (editor) e.preventDefault()

--- a/src/components/chat/rate-limit-banner.tsx
+++ b/src/components/chat/rate-limit-banner.tsx
@@ -38,6 +38,8 @@ export function RateLimitBanner({
       )}
     >
       <div
+        role="status"
+        aria-live={exhausted ? 'assertive' : 'polite'}
         className={cn(
           'pointer-events-auto flex items-center gap-2 rounded-b-xl border-x border-b px-4 py-1.5 transition-colors',
           isDarkMode

--- a/src/components/chat/reasoning-effort-selector.tsx
+++ b/src/components/chat/reasoning-effort-selector.tsx
@@ -215,6 +215,12 @@ function ReasoningPopover({
     }
   }, [preferredPosition])
 
+  const focusTrigger = () => {
+    requestAnimationFrame(() => {
+      document.querySelector<HTMLElement>('[data-reasoning-selector]')?.focus()
+    })
+  }
+
   return (
     <div
       ref={menuRef}
@@ -252,6 +258,7 @@ function ReasoningPopover({
             }
             onEffortChange(option.value)
             onClose()
+            focusTrigger()
           }
           return (
             <button
@@ -300,6 +307,7 @@ function ReasoningPopover({
             e.stopPropagation()
             onThinkingEnabledChange(true)
             onClose()
+            focusTrigger()
           }}
           onTouchEnd={(e) => {
             e.stopPropagation()
@@ -307,6 +315,7 @@ function ReasoningPopover({
             e.preventDefault()
             onThinkingEnabledChange(true)
             onClose()
+            focusTrigger()
           }}
         >
           <span className="font-medium">On</span>
@@ -331,6 +340,7 @@ function ReasoningPopover({
             e.stopPropagation()
             onThinkingEnabledChange(false)
             onClose()
+            focusTrigger()
           }}
           onTouchEnd={(e) => {
             e.stopPropagation()
@@ -338,6 +348,7 @@ function ReasoningPopover({
             e.preventDefault()
             onThinkingEnabledChange(false)
             onClose()
+            focusTrigger()
           }}
         >
           <span className="font-medium">Off</span>

--- a/src/components/chat/reasoning-effort-selector.tsx
+++ b/src/components/chat/reasoning-effort-selector.tsx
@@ -81,6 +81,8 @@ export function ReasoningEffortSelector({
         )}
         title={buttonTitle}
         aria-label={buttonTitle}
+        aria-haspopup="menu"
+        aria-expanded={isOpen}
       >
         <ReasoningIcon active={isThinkingActive} />
         <ChevronDownIcon
@@ -217,6 +219,8 @@ function ReasoningPopover({
     <div
       ref={menuRef}
       data-reasoning-menu
+      role="menu"
+      aria-label="Thinking options"
       className={cn(
         'absolute z-50 w-[200px] overflow-y-auto rounded-lg border border-border-subtle bg-surface-chat p-1 font-aeonik-fono text-content-secondary shadow-lg',
         dynamicStyles.bottom ? 'mb-2' : 'mt-2',
@@ -253,6 +257,8 @@ function ReasoningPopover({
             <button
               key={option.value}
               type="button"
+              role="menuitemradio"
+              aria-checked={isActive}
               className={cn(
                 'flex w-full flex-col rounded-md border px-3 py-2 text-left text-sm transition-colors',
                 isActive
@@ -281,6 +287,8 @@ function ReasoningPopover({
       {supportsToggle && !supportsEffort && (
         <button
           type="button"
+          role="menuitemradio"
+          aria-checked={thinkingEnabled}
           className={cn(
             'flex w-full flex-col rounded-md border px-3 py-2 text-left text-sm transition-colors',
             thinkingEnabled
@@ -310,6 +318,8 @@ function ReasoningPopover({
       {supportsToggle && (
         <button
           type="button"
+          role="menuitemradio"
+          aria-checked={!thinkingEnabled}
           className={cn(
             'flex w-full flex-col rounded-md border px-3 py-2 text-left text-sm transition-colors',
             !thinkingEnabled

--- a/src/components/chat/renderers/components/CodeExecProcess.tsx
+++ b/src/components/chat/renderers/components/CodeExecProcess.tsx
@@ -239,6 +239,7 @@ export const CodeExecProcess = memo(function CodeExecProcess({
       <button
         type="button"
         onClick={() => setIsExpanded((v) => !v)}
+        aria-expanded={isExpanded}
         className="hover:bg-surface-secondary/50 group -mx-1 flex w-full cursor-pointer items-start gap-1.5 rounded-md px-1 py-1 text-left transition-colors"
       >
         <span className="mt-[5px] h-3.5 w-3.5 shrink-0" aria-hidden="true">
@@ -274,6 +275,7 @@ export const CodeExecProcess = memo(function CodeExecProcess({
       </button>
 
       <div
+        inert={!isExpanded}
         className="grid overflow-hidden transition-[grid-template-rows] duration-300 ease-out"
         style={{ gridTemplateRows: isExpanded ? '1fr' : '0fr' }}
       >

--- a/src/components/chat/renderers/components/CodeExecProcess.tsx
+++ b/src/components/chat/renderers/components/CodeExecProcess.tsx
@@ -175,6 +175,8 @@ function ToolCallRow({ call }: { call: ToolCallState }) {
       </div>
       {displayContent && (
         <pre
+          tabIndex={0}
+          aria-label={`${label} output`}
           className={`ml-6 max-h-60 overflow-auto rounded-md px-3 py-2 text-xs leading-relaxed ${
             isBash
               ? 'bg-surface-chat-background font-mono text-content-primary/70'

--- a/src/components/chat/renderers/components/ExpandableTable.tsx
+++ b/src/components/chat/renderers/components/ExpandableTable.tsx
@@ -67,7 +67,13 @@ export function ExpandableTable({ children }: ExpandableTableProps) {
             }
       }
     >
-      <div ref={containerRef} className="relative z-0 overflow-x-auto">
+      <div
+        ref={containerRef}
+        tabIndex={0}
+        role="group"
+        aria-label="Table, scroll horizontally to see more"
+        className="relative z-0 overflow-x-auto"
+      >
         <table
           className="divide-y divide-border-subtle"
           style={isMobile ? undefined : { minWidth: 'max-content' }}
@@ -81,25 +87,27 @@ export function ExpandableTable({ children }: ExpandableTableProps) {
           <button
             type="button"
             onClick={toggle}
+            aria-expanded={isExpanded}
             className={`${chevronBase} absolute left-1.5 top-1/2 -translate-y-1/2 ${expanded ? 'opacity-0 transition-opacity group-hover/table:opacity-100' : ''}`}
             aria-label={collapsed ? 'Expand table' : 'Collapse table'}
           >
             {collapsed ? (
-              <ChevronLeftIcon className="h-4 w-4" />
+              <ChevronLeftIcon className="h-4 w-4" aria-hidden="true" />
             ) : (
-              <ChevronRightIcon className="h-4 w-4" />
+              <ChevronRightIcon className="h-4 w-4" aria-hidden="true" />
             )}
           </button>
           <button
             type="button"
             onClick={toggle}
+            aria-expanded={isExpanded}
             className={`${chevronBase} absolute right-1.5 top-1/2 -translate-y-1/2 ${expanded ? 'opacity-0 transition-opacity group-hover/table:opacity-100' : ''}`}
             aria-label={collapsed ? 'Expand table' : 'Collapse table'}
           >
             {collapsed ? (
-              <ChevronRightIcon className="h-4 w-4" />
+              <ChevronRightIcon className="h-4 w-4" aria-hidden="true" />
             ) : (
-              <ChevronLeftIcon className="h-4 w-4" />
+              <ChevronLeftIcon className="h-4 w-4" aria-hidden="true" />
             )}
           </button>
         </div>

--- a/src/components/chat/renderers/components/ExpandableTable.tsx
+++ b/src/components/chat/renderers/components/ExpandableTable.tsx
@@ -46,7 +46,7 @@ export function ExpandableTable({ children }: ExpandableTableProps) {
   const toggle = () => setIsExpanded((prev) => !prev)
 
   const chevronBase =
-    'pointer-events-auto flex h-7 w-7 items-center justify-center rounded-full border border-border-subtle bg-white text-content-secondary shadow hover:text-content-primary dark:bg-zinc-800'
+    'pointer-events-auto flex h-7 w-7 items-center justify-center rounded-full border border-border-subtle bg-white text-content-secondary shadow hover:text-content-primary focus:outline-none focus:ring-2 focus:ring-brand-accent-dark dark:bg-zinc-800 dark:focus:ring-brand-accent-light'
 
   const collapsed = canExpand && !isExpanded
   const expanded = canExpand && isExpanded
@@ -88,7 +88,7 @@ export function ExpandableTable({ children }: ExpandableTableProps) {
             type="button"
             onClick={toggle}
             aria-expanded={isExpanded}
-            className={`${chevronBase} absolute left-1.5 top-1/2 -translate-y-1/2 ${expanded ? 'opacity-0 transition-opacity group-hover/table:opacity-100' : ''}`}
+            className={`${chevronBase} absolute left-1.5 top-1/2 -translate-y-1/2 ${expanded ? 'opacity-0 transition-opacity focus:opacity-100 group-focus-within/table:opacity-100 group-hover/table:opacity-100' : ''}`}
             aria-label={collapsed ? 'Expand table' : 'Collapse table'}
           >
             {collapsed ? (
@@ -101,7 +101,7 @@ export function ExpandableTable({ children }: ExpandableTableProps) {
             type="button"
             onClick={toggle}
             aria-expanded={isExpanded}
-            className={`${chevronBase} absolute right-1.5 top-1/2 -translate-y-1/2 ${expanded ? 'opacity-0 transition-opacity group-hover/table:opacity-100' : ''}`}
+            className={`${chevronBase} absolute right-1.5 top-1/2 -translate-y-1/2 ${expanded ? 'opacity-0 transition-opacity focus:opacity-100 group-focus-within/table:opacity-100 group-hover/table:opacity-100' : ''}`}
             aria-label={collapsed ? 'Expand table' : 'Collapse table'}
           >
             {collapsed ? (

--- a/src/components/chat/renderers/components/GeneratingTable.tsx
+++ b/src/components/chat/renderers/components/GeneratingTable.tsx
@@ -3,7 +3,10 @@ import { PiSpinner } from 'react-icons/pi'
 
 export const GeneratingTable = memo(function GeneratingTable() {
   return (
-    <div className="my-4 flex h-12 items-center gap-2 rounded-lg border border-border-subtle bg-transparent px-4">
+    <div
+      role="status"
+      className="my-4 flex h-12 items-center gap-2 rounded-lg border border-border-subtle bg-transparent px-4"
+    >
       <PiSpinner
         className="h-3.5 w-3.5 animate-spin text-content-primary"
         aria-hidden

--- a/src/components/chat/renderers/components/MessageActions.tsx
+++ b/src/components/chat/renderers/components/MessageActions.tsx
@@ -61,7 +61,7 @@ export const MessageActions = memo(function MessageActions({
       <button
         type="button"
         onClick={handleCopy}
-        className={`flex items-center gap-1.5 rounded px-2 py-1.5 text-xs font-medium transition-all ${
+        className={`flex items-center gap-1.5 rounded px-2 py-2 text-xs font-medium transition-all ${
           isCopied
             ? 'bg-green-500/10 text-green-600 dark:bg-green-500/20 dark:text-green-400'
             : 'text-content-secondary hover:bg-surface-chat-background hover:text-content-primary'

--- a/src/components/chat/renderers/components/StreamingTracerDot.tsx
+++ b/src/components/chat/renderers/components/StreamingTracerDot.tsx
@@ -16,7 +16,7 @@ export function StreamingTracerDot({
 
   return (
     <span
-      className={`inline-block size-2.5 shrink-0 animate-pulse rounded-full bg-current [contain:paint] [vertical-align:0.1em] [will-change:opacity] ${toneClass} ${className}`}
+      className={`inline-block size-2.5 shrink-0 animate-pulse rounded-full bg-current [contain:paint] [vertical-align:0.1em] [will-change:opacity] motion-reduce:animate-none ${toneClass} ${className}`}
       role="status"
       aria-label={label}
     />

--- a/src/components/chat/renderers/components/ThoughtProcess.tsx
+++ b/src/components/chat/renderers/components/ThoughtProcess.tsx
@@ -260,7 +260,7 @@ export const ThoughtProcess = memo(function ThoughtProcess({
         className="hover:bg-surface-secondary/50 group -mx-1 flex min-w-0 max-w-full items-center gap-1.5 rounded-md px-1 py-1 text-left transition-colors"
       >
         <svg
-          className={`h-3.5 w-3.5 shrink-0 transform text-content-primary/40 transition-transform ${isExpanded ? 'rotate-90' : ''}`}
+          className={`h-3.5 w-3.5 shrink-0 transform text-content-primary/40 transition-transform motion-reduce:transition-none ${isExpanded ? 'rotate-90' : ''}`}
           fill="none"
           viewBox="0 0 24 24"
           stroke="currentColor"
@@ -280,7 +280,7 @@ export const ThoughtProcess = memo(function ThoughtProcess({
               {thoughtSummary ? (
                 <div className="flex min-w-0 items-center gap-1.5">
                   <span
-                    className="block animate-shimmer truncate bg-clip-text text-base font-medium text-transparent"
+                    className="block animate-shimmer truncate bg-clip-text text-base font-medium text-transparent motion-reduce:animate-none"
                     style={{
                       backgroundImage: isDarkMode
                         ? 'linear-gradient(90deg, #9ca3af 0%, #e5e7eb 25%, #f9fafb 50%, #e5e7eb 75%, #9ca3af 100%)'
@@ -318,7 +318,7 @@ export const ThoughtProcess = memo(function ThoughtProcess({
         ref={scrollContainerRef}
         id={contentId}
         inert={!isExpanded}
-        className="overflow-hidden transition-all duration-300 ease-out"
+        className="overflow-hidden transition-all duration-300 ease-out motion-reduce:transition-none"
         style={{
           maxHeight: isExpanded ? `${contentHeight}px` : '0px',
         }}

--- a/src/components/chat/renderers/components/ThoughtProcess.tsx
+++ b/src/components/chat/renderers/components/ThoughtProcess.tsx
@@ -8,7 +8,7 @@ import {
 } from '@/utils/latex-processing'
 import { preprocessMarkdown } from '@/utils/markdown-preprocessing'
 import { sanitizeUrl } from '@braintree/sanitize-url'
-import { memo, useCallback, useEffect, useRef, useState } from 'react'
+import { memo, useCallback, useEffect, useId, useRef, useState } from 'react'
 import ReactMarkdown from 'react-markdown'
 import { useMathPlugins } from './use-math-plugins'
 
@@ -28,6 +28,7 @@ export const ThoughtProcess = memo(function ThoughtProcess({
   thinkingDuration,
 }: ThoughtProcessProps) {
   const [isExpanded, setIsExpanded] = useState(false)
+  const contentId = useId()
 
   const contentRef = useRef<HTMLDivElement>(null)
   const scrollContainerRef = useRef<HTMLDivElement>(null)
@@ -254,6 +255,8 @@ export const ThoughtProcess = memo(function ThoughtProcess({
       <button
         type="button"
         onClick={handleToggle}
+        aria-expanded={isExpanded}
+        aria-controls={contentId}
         className="hover:bg-surface-secondary/50 group -mx-1 flex min-w-0 max-w-full items-center gap-1.5 rounded-md px-1 py-1 text-left transition-colors"
       >
         <svg
@@ -313,6 +316,8 @@ export const ThoughtProcess = memo(function ThoughtProcess({
 
       <div
         ref={scrollContainerRef}
+        id={contentId}
+        inert={!isExpanded}
         className="overflow-hidden transition-all duration-300 ease-out"
         style={{
           maxHeight: isExpanded ? `${contentHeight}px` : '0px',

--- a/src/components/chat/renderers/components/URLFetchProcess.tsx
+++ b/src/components/chat/renderers/components/URLFetchProcess.tsx
@@ -104,6 +104,7 @@ export const URLFetchProcess = memo(function URLFetchProcess({
       <button
         type="button"
         onClick={() => setIsExpanded((v) => !v)}
+        aria-expanded={isExpanded}
         className="hover:bg-surface-secondary/50 group -mx-1 flex w-full cursor-pointer items-center gap-1.5 rounded-md px-1 py-1 text-left transition-colors"
       >
         <span className="h-3.5 w-3.5 shrink-0" aria-hidden="true">
@@ -132,6 +133,7 @@ export const URLFetchProcess = memo(function URLFetchProcess({
       </button>
 
       <div
+        inert={!isExpanded}
         className="grid overflow-hidden transition-[grid-template-rows] duration-300 ease-out"
         style={{ gridTemplateRows: isExpanded ? '1fr' : '0fr' }}
       >

--- a/src/components/chat/renderers/components/WebSearchProcess.tsx
+++ b/src/components/chat/renderers/components/WebSearchProcess.tsx
@@ -111,6 +111,7 @@ const SingleWebSearchProcess = memo(function SingleWebSearchProcess({
         type="button"
         onClick={handleToggle}
         disabled={!hasSources}
+        aria-expanded={hasSources ? isExpanded : undefined}
         className={`group -mx-1 flex items-start gap-1.5 rounded-md px-1 py-1 text-left transition-colors ${
           hasSources
             ? 'hover:bg-surface-secondary/50 cursor-pointer'
@@ -186,6 +187,7 @@ const SingleWebSearchProcess = memo(function SingleWebSearchProcess({
 
       {hasSources && (
         <div
+          inert={!isExpanded}
           className="grid overflow-hidden transition-[grid-template-rows] duration-300 ease-out"
           style={{ gridTemplateRows: isExpanded ? '1fr' : '0fr' }}
         >
@@ -271,6 +273,7 @@ const GroupedWebSearchProcess = memo(function GroupedWebSearchProcess({
       <button
         type="button"
         onClick={() => setIsExpanded((v) => !v)}
+        aria-expanded={isExpanded}
         className="hover:bg-surface-secondary/50 group -mx-1 flex cursor-pointer items-start gap-1.5 rounded-md px-1 py-1 text-left transition-colors"
       >
         <span className="mt-[5px] h-3.5 w-3.5 shrink-0" aria-hidden="true">
@@ -309,6 +312,7 @@ const GroupedWebSearchProcess = memo(function GroupedWebSearchProcess({
       </button>
 
       <div
+        inert={!isExpanded}
         className="grid overflow-hidden transition-[grid-template-rows] duration-300 ease-out"
         style={{ gridTemplateRows: isExpanded ? '1fr' : '0fr' }}
       >

--- a/src/components/chat/renderers/components/markdown-components.tsx
+++ b/src/components/chat/renderers/components/markdown-components.tsx
@@ -170,6 +170,7 @@ export function createMarkdownComponents({
       return (
         <th
           {...props}
+          scope="col"
           className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-content-primary"
           style={{
             maxWidth: CONSTANTS.TABLE_COLUMN_MAX_WIDTH_PX,

--- a/src/components/chat/renderers/components/use-math-plugins.ts
+++ b/src/components/chat/renderers/components/use-math-plugins.ts
@@ -46,7 +46,7 @@ async function loadPlugins(): Promise<PluginState> {
             {
               throwOnError: false,
               strict: false,
-              output: 'html',
+              output: 'htmlAndMathml',
               errorColor: TINFOIL_COLORS.utility.destructive,
               trust: false,
             },

--- a/src/components/chat/renderers/default/DefaultMessageRenderer.tsx
+++ b/src/components/chat/renderers/default/DefaultMessageRenderer.tsx
@@ -46,6 +46,7 @@ const DefaultMessageComponent = ({
     React.useState(false)
   const userMessageContentRef = React.useRef<HTMLDivElement>(null)
   const editTextareaRef = React.useRef<HTMLTextAreaElement>(null)
+  const editButtonRef = React.useRef<HTMLButtonElement>(null)
 
   const citationUrlTitles = React.useMemo(() => {
     if (!message.annotations || message.annotations.length === 0)
@@ -162,6 +163,9 @@ const DefaultMessageComponent = ({
   const handleCancelEdit = React.useCallback(() => {
     setIsEditing(false)
     setEditContent(message.content || '')
+    setTimeout(() => {
+      editButtonRef.current?.focus()
+    }, 0)
   }, [message.content])
 
   const handleSubmitEdit = React.useCallback(() => {
@@ -532,6 +536,7 @@ const DefaultMessageComponent = ({
                 <div className="rounded-xl border border-border-subtle bg-surface-chat p-4">
                   <textarea
                     ref={editTextareaRef}
+                    aria-label="Edit message"
                     value={editContent}
                     onChange={(e) => setEditContent(e.target.value)}
                     onKeyDown={(e) => {
@@ -608,6 +613,7 @@ const DefaultMessageComponent = ({
                 {onEditMessage && (
                   <div className="group/edit relative">
                     <button
+                      ref={editButtonRef}
                       onClick={handleStartEdit}
                       aria-label="Edit message"
                       className="rounded-lg p-2 text-content-secondary transition-colors hover:bg-surface-chat-background hover:text-content-primary"
@@ -672,7 +678,7 @@ const DefaultMessageComponent = ({
                 <button
                   onClick={() => onRegenerateMessage(messageIndex - 1)}
                   aria-label="Regenerate response"
-                  className="flex items-center gap-1.5 rounded px-2 py-1.5 text-xs font-medium text-content-secondary transition-all hover:bg-surface-chat-background hover:text-content-primary"
+                  className="flex items-center gap-1.5 rounded px-2 py-2 text-xs font-medium text-content-secondary transition-all hover:bg-surface-chat-background hover:text-content-primary"
                 >
                   <ArrowPathIcon className="h-3.5 w-3.5" aria-hidden="true" />
                 </button>

--- a/src/components/chat/renderers/default/DefaultMessageRenderer.tsx
+++ b/src/components/chat/renderers/default/DefaultMessageRenderer.tsx
@@ -212,6 +212,9 @@ const DefaultMessageComponent = ({
     <div
       className={`relative mx-auto flex w-full max-w-3xl flex-col ${isUser ? 'items-end' : 'items-start'} group mb-6`}
       data-message-role={message.role}
+      role="article"
+      aria-label={isUser ? 'You said' : 'Tin said'}
+      tabIndex={-1}
     >
       {/* Display the quoted reply preview above the user's message */}
       {isUser && message.quote && !isEditing && (
@@ -592,9 +595,10 @@ const DefaultMessageComponent = ({
                   <div className="group/regen relative">
                     <button
                       onClick={handleRegenerate}
+                      aria-label="Regenerate response"
                       className="rounded-lg p-2 text-content-secondary transition-colors hover:bg-surface-chat-background hover:text-content-primary"
                     >
-                      <ArrowPathIcon className="h-4 w-4" />
+                      <ArrowPathIcon className="h-4 w-4" aria-hidden="true" />
                     </button>
                     <span className="pointer-events-none absolute -bottom-8 left-1/2 -translate-x-1/2 whitespace-nowrap rounded border border-border-subtle bg-surface-chat-background px-2 py-1 text-xs text-content-primary opacity-0 shadow-sm transition-opacity group-hover/regen:opacity-100">
                       Regenerate
@@ -605,9 +609,13 @@ const DefaultMessageComponent = ({
                   <div className="group/edit relative">
                     <button
                       onClick={handleStartEdit}
+                      aria-label="Edit message"
                       className="rounded-lg p-2 text-content-secondary transition-colors hover:bg-surface-chat-background hover:text-content-primary"
                     >
-                      <PencilSquareIcon className="h-4 w-4" />
+                      <PencilSquareIcon
+                        className="h-4 w-4"
+                        aria-hidden="true"
+                      />
                     </button>
                     <span className="pointer-events-none absolute -bottom-8 left-1/2 -translate-x-1/2 whitespace-nowrap rounded border border-border-subtle bg-surface-chat-background px-2 py-1 text-xs text-content-primary opacity-0 shadow-sm transition-opacity group-hover/edit:opacity-100">
                       Edit
@@ -617,6 +625,7 @@ const DefaultMessageComponent = ({
                 <div className="group/copy relative">
                   <button
                     onClick={handleCopyUser}
+                    aria-label={copiedUser ? 'Copied' : 'Copy message'}
                     className={`flex items-center gap-1.5 rounded-lg p-2 text-xs font-medium transition-all ${
                       copiedUser
                         ? 'bg-green-500/10 text-green-600 dark:bg-green-500/20 dark:text-green-400'
@@ -625,11 +634,11 @@ const DefaultMessageComponent = ({
                   >
                     {copiedUser ? (
                       <>
-                        <BsCheckLg className="h-4 w-4" />
+                        <BsCheckLg className="h-4 w-4" aria-hidden="true" />
                         <span>Copied!</span>
                       </>
                     ) : (
-                      <RxCopy className="h-4 w-4" />
+                      <RxCopy className="h-4 w-4" aria-hidden="true" />
                     )}
                   </button>
                   {!copiedUser && (
@@ -662,9 +671,10 @@ const DefaultMessageComponent = ({
               <div className="group/regen relative">
                 <button
                   onClick={() => onRegenerateMessage(messageIndex - 1)}
+                  aria-label="Regenerate response"
                   className="flex items-center gap-1.5 rounded px-2 py-1.5 text-xs font-medium text-content-secondary transition-all hover:bg-surface-chat-background hover:text-content-primary"
                 >
-                  <ArrowPathIcon className="h-3.5 w-3.5" />
+                  <ArrowPathIcon className="h-3.5 w-3.5" aria-hidden="true" />
                 </button>
                 <span className="pointer-events-none absolute -bottom-8 left-1/2 -translate-x-1/2 whitespace-nowrap rounded border border-border-subtle bg-surface-chat-background px-2 py-1 text-xs text-content-primary opacity-0 shadow-sm transition-opacity group-hover/regen:opacity-100">
                   Regenerate

--- a/src/components/chat/share-modal.tsx
+++ b/src/components/chat/share-modal.tsx
@@ -15,6 +15,7 @@ import {
   LockClosedIcon,
   XMarkIcon,
 } from '@heroicons/react/24/outline'
+import * as DialogPrimitive from '@radix-ui/react-dialog'
 import { useEffect, useRef, useState } from 'react'
 import { Card, CardContent } from '../ui/card'
 import {
@@ -316,181 +317,177 @@ export function ShareModal({
     : 0
 
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center"
-      style={{
-        left: `${leftOffset}px`,
-        right: `${rightOffset}px`,
+    <DialogPrimitive.Root
+      open
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen) onClose()
       }}
     >
-      {/* Backdrop - covers entire viewport */}
-      <div
-        className="fixed inset-0 bg-black/50"
-        onClick={onClose}
-        style={{
-          left: 0,
-          right: 0,
-        }}
-      />
+      <DialogPrimitive.Portal>
+        <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-black/50" />
+        <DialogPrimitive.Content
+          aria-describedby={undefined}
+          className="fixed left-[50%] top-[50%] z-50 flex h-[80vh] w-[90vw] max-w-4xl translate-x-[-50%] translate-y-[-50%] flex-col rounded-xl border border-border-subtle bg-surface-sidebar shadow-xl focus:outline-none"
+          style={{
+            maxWidth: `min(896px, calc(90vw - ${leftOffset + rightOffset}px))`,
+            marginLeft: `${(leftOffset - rightOffset) / 2}px`,
+          }}
+        >
+          {/* Header */}
+          <div className="flex items-center justify-between border-b border-border-subtle px-6 py-4">
+            <DialogPrimitive.Title className="text-lg font-semibold text-content-primary">
+              Share Conversation
+            </DialogPrimitive.Title>
+            <button
+              onClick={onClose}
+              aria-label="Close share dialog"
+              className="rounded-lg p-1.5 text-content-secondary transition-colors hover:bg-surface-chat"
+            >
+              <XMarkIcon className="h-5 w-5" aria-hidden="true" />
+            </button>
+          </div>
 
-      {/* Modal */}
-      <div
-        className="relative z-10 flex h-[80vh] w-[90vw] max-w-4xl flex-col rounded-xl border border-border-subtle bg-surface-sidebar shadow-xl"
-        style={{
-          maxWidth: `min(896px, calc(90vw - ${leftOffset + rightOffset}px))`,
-        }}
-      >
-        {/* Header */}
-        <div className="flex items-center justify-between border-b border-border-subtle px-6 py-4">
-          <h2 className="text-lg font-semibold text-content-primary">
-            Share Conversation
-          </h2>
-          <button
-            onClick={onClose}
-            className="rounded-lg p-1.5 text-content-secondary transition-colors hover:bg-surface-chat"
-          >
-            <XMarkIcon className="h-5 w-5" />
-          </button>
-        </div>
-
-        {/* Content */}
-        <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden p-6">
-          <TextureGrid />
-          <div className="relative z-10 flex min-h-0 flex-1 flex-col space-y-4">
-            {/* Shareable Link Access Card */}
-            <div className="flex-none">
-              <Card className="overflow-hidden border-border-subtle bg-surface-sidebar">
-                <CardContent className="p-0">
-                  <div className="flex items-start gap-4 p-4">
-                    <div className="mt-1 rounded-full bg-surface-chat p-2 text-content-secondary">
-                      {isShareEnabled ? (
-                        <GlobeAltIcon className="h-5 w-5" />
-                      ) : (
-                        <LockClosedIcon className="h-5 w-5" />
-                      )}
-                    </div>
-                    <div className="flex-1 space-y-4">
-                      <div className="space-y-1">
-                        <h3 className="text-sm font-medium text-content-primary">
-                          {isShareEnabled ? 'Shareable link access' : 'Private'}
-                        </h3>
-                        <p className="text-sm text-content-secondary">
-                          {isShareEnabled
-                            ? 'Anyone with the link can view'
-                            : 'Only you have access'}
-                        </p>
+          {/* Content */}
+          <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden p-6">
+            <TextureGrid />
+            <div className="relative z-10 flex min-h-0 flex-1 flex-col space-y-4">
+              {/* Shareable Link Access Card */}
+              <div className="flex-none">
+                <Card className="overflow-hidden border-border-subtle bg-surface-sidebar">
+                  <CardContent className="p-0">
+                    <div className="flex items-start gap-4 p-4">
+                      <div className="mt-1 rounded-full bg-surface-chat p-2 text-content-secondary">
+                        {isShareEnabled ? (
+                          <GlobeAltIcon className="h-5 w-5" />
+                        ) : (
+                          <LockClosedIcon className="h-5 w-5" />
+                        )}
                       </div>
-
-                      <label className="group flex cursor-pointer items-center gap-3">
-                        <div className="relative flex items-center">
-                          <input
-                            type="checkbox"
-                            checked={isShareEnabled}
-                            onChange={(e) =>
-                              setIsShareEnabled(e.target.checked)
-                            }
-                            className="peer h-5 w-5 cursor-pointer appearance-none rounded border border-border-subtle bg-surface-chat transition-all checked:border-brand-accent-dark checked:bg-brand-accent-dark"
-                          />
-                          <CheckIcon className="pointer-events-none absolute left-1/2 top-1/2 h-3.5 w-3.5 -translate-x-1/2 -translate-y-1/2 text-white opacity-0 peer-checked:opacity-100" />
+                      <div className="flex-1 space-y-4">
+                        <div className="space-y-1">
+                          <h3 className="text-sm font-medium text-content-primary">
+                            {isShareEnabled
+                              ? 'Shareable link access'
+                              : 'Private'}
+                          </h3>
+                          <p className="text-sm text-content-secondary">
+                            {isShareEnabled
+                              ? 'Anyone with the link can view'
+                              : 'Only you have access'}
+                          </p>
                         </div>
-                        <span className="text-sm font-medium text-content-primary">
-                          Make this conversation shareable with anyone who has
-                          the link
-                        </span>
-                      </label>
 
-                      {isShareEnabled && !shareUrl && (
-                        <div className="flex justify-start pt-2">
-                          <button
-                            onClick={handleShareLink}
-                            disabled={isUploading || !chatId}
-                            className="flex items-center justify-center gap-2 rounded-lg bg-brand-accent-dark px-6 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-brand-accent-dark/90 disabled:cursor-not-allowed disabled:opacity-50"
-                          >
-                            {isUploading ? (
-                              <>
-                                <span className="h-4 w-4 animate-spin rounded-full border-2 border-white/30 border-t-white" />
-                                Uploading...
-                              </>
-                            ) : (
-                              <>
-                                <LinkIcon className="h-4 w-4" />
-                                Create share link
-                              </>
-                            )}
-                          </button>
-                        </div>
-                      )}
+                        <label className="group flex cursor-pointer items-center gap-3">
+                          <div className="relative flex items-center">
+                            <input
+                              type="checkbox"
+                              checked={isShareEnabled}
+                              onChange={(e) =>
+                                setIsShareEnabled(e.target.checked)
+                              }
+                              className="peer h-5 w-5 cursor-pointer appearance-none rounded border border-border-subtle bg-surface-chat transition-all checked:border-brand-accent-dark checked:bg-brand-accent-dark"
+                            />
+                            <CheckIcon className="pointer-events-none absolute left-1/2 top-1/2 h-3.5 w-3.5 -translate-x-1/2 -translate-y-1/2 text-white opacity-0 peer-checked:opacity-100" />
+                          </div>
+                          <span className="text-sm font-medium text-content-primary">
+                            Make this conversation shareable with anyone who has
+                            the link
+                          </span>
+                        </label>
 
-                      {isShareEnabled && shareUrl && (
-                        <div className="flex items-center gap-2 pt-2">
-                          <input
-                            type="text"
-                            readOnly
-                            value={shareUrl}
-                            className="flex-1 rounded-lg border border-border-subtle bg-surface-chat px-3 py-2 text-sm text-content-primary"
-                            onClick={(e) => e.currentTarget.select()}
-                          />
-                          <button
-                            onClick={handleCopyShareUrl}
-                            className="flex items-center justify-center gap-2 rounded-lg bg-brand-accent-dark px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-brand-accent-dark/90"
-                          >
-                            {isLinkCopied ? (
-                              <>
-                                <CheckIcon className="h-4 w-4" />
-                                Copied!
-                              </>
-                            ) : (
-                              <>
-                                <DocumentDuplicateIcon className="h-4 w-4" />
-                                Copy
-                              </>
-                            )}
-                          </button>
-                        </div>
-                      )}
+                        {isShareEnabled && !shareUrl && (
+                          <div className="flex justify-start pt-2">
+                            <button
+                              onClick={handleShareLink}
+                              disabled={isUploading || !chatId}
+                              className="flex items-center justify-center gap-2 rounded-lg bg-brand-accent-dark px-6 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-brand-accent-dark/90 disabled:cursor-not-allowed disabled:opacity-50"
+                            >
+                              {isUploading ? (
+                                <>
+                                  <span className="h-4 w-4 animate-spin rounded-full border-2 border-white/30 border-t-white" />
+                                  Uploading...
+                                </>
+                              ) : (
+                                <>
+                                  <LinkIcon className="h-4 w-4" />
+                                  Create share link
+                                </>
+                              )}
+                            </button>
+                          </div>
+                        )}
+
+                        {isShareEnabled && shareUrl && (
+                          <div className="flex items-center gap-2 pt-2">
+                            <input
+                              type="text"
+                              readOnly
+                              value={shareUrl}
+                              className="flex-1 rounded-lg border border-border-subtle bg-surface-chat px-3 py-2 text-sm text-content-primary"
+                              onClick={(e) => e.currentTarget.select()}
+                            />
+                            <button
+                              onClick={handleCopyShareUrl}
+                              className="flex items-center justify-center gap-2 rounded-lg bg-brand-accent-dark px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-brand-accent-dark/90"
+                            >
+                              {isLinkCopied ? (
+                                <>
+                                  <CheckIcon className="h-4 w-4" />
+                                  Copied!
+                                </>
+                              ) : (
+                                <>
+                                  <DocumentDuplicateIcon className="h-4 w-4" />
+                                  Copy
+                                </>
+                              )}
+                            </button>
+                          </div>
+                        )}
+                      </div>
                     </div>
+                  </CardContent>
+                </Card>
+              </div>
+
+              {/* Raw Markdown Card */}
+              <Card className="flex min-h-0 flex-1 flex-col overflow-hidden border-border-subtle bg-surface-sidebar">
+                <div className="flex flex-none items-center justify-between border-b border-border-subtle/50 p-4">
+                  <h3 className="text-sm font-medium text-content-primary">
+                    Raw Markdown
+                  </h3>
+                  <div className="flex items-center gap-2">
+                    <button
+                      onClick={handleCopy}
+                      className="flex items-center gap-2 rounded-lg border border-border-subtle bg-surface-chat px-3 py-1.5 text-xs font-medium text-content-primary transition-colors hover:bg-surface-chat/80"
+                    >
+                      {isCopied ? (
+                        <>
+                          <CheckIcon className="h-3 w-3" />
+                          Copied!
+                        </>
+                      ) : (
+                        <>
+                          <DocumentDuplicateIcon className="h-3 w-3" />
+                          Copy to Clipboard
+                        </>
+                      )}
+                    </button>
                   </div>
-                </CardContent>
+                </div>
+                <div className="flex min-h-0 flex-1 flex-col p-4">
+                  <pre
+                    ref={contentRef}
+                    className="flex-1 overflow-auto whitespace-pre-wrap font-mono text-[13px] text-content-primary"
+                  >
+                    {markdown}
+                  </pre>
+                </div>
               </Card>
             </div>
-
-            {/* Raw Markdown Card */}
-            <Card className="flex min-h-0 flex-1 flex-col overflow-hidden border-border-subtle bg-surface-sidebar">
-              <div className="flex flex-none items-center justify-between border-b border-border-subtle/50 p-4">
-                <h3 className="text-sm font-medium text-content-primary">
-                  Raw Markdown
-                </h3>
-                <div className="flex items-center gap-2">
-                  <button
-                    onClick={handleCopy}
-                    className="flex items-center gap-2 rounded-lg border border-border-subtle bg-surface-chat px-3 py-1.5 text-xs font-medium text-content-primary transition-colors hover:bg-surface-chat/80"
-                  >
-                    {isCopied ? (
-                      <>
-                        <CheckIcon className="h-3 w-3" />
-                        Copied!
-                      </>
-                    ) : (
-                      <>
-                        <DocumentDuplicateIcon className="h-3 w-3" />
-                        Copy to Clipboard
-                      </>
-                    )}
-                  </button>
-                </div>
-              </div>
-              <div className="flex min-h-0 flex-1 flex-col p-4">
-                <pre
-                  ref={contentRef}
-                  className="flex-1 overflow-auto whitespace-pre-wrap font-mono text-[13px] text-content-primary"
-                >
-                  {markdown}
-                </pre>
-              </div>
-            </Card>
           </div>
-        </div>
-      </div>
-    </div>
+        </DialogPrimitive.Content>
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
   )
 }

--- a/src/components/chat/share-modal.tsx
+++ b/src/components/chat/share-modal.tsx
@@ -343,6 +343,7 @@ export function ShareModal({
       <DialogPrimitive.Portal>
         <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-black/50" />
         <DialogPrimitive.Content
+          aria-modal="true"
           aria-describedby={undefined}
           className="fixed left-[50%] top-[50%] z-50 flex h-[80vh] w-[90vw] max-w-4xl translate-x-[-50%] translate-y-[-50%] flex-col rounded-xl border border-border-subtle bg-surface-sidebar shadow-xl focus:outline-none"
           style={{
@@ -405,6 +406,7 @@ export function ShareModal({
                               onChange={(e) =>
                                 setIsShareEnabled(e.target.checked)
                               }
+                              aria-label="Make this conversation shareable with anyone who has the link"
                               className="peer h-5 w-5 cursor-pointer appearance-none rounded border border-border-subtle bg-surface-chat transition-all checked:border-brand-accent-dark checked:bg-brand-accent-dark"
                             />
                             <CheckIcon className="pointer-events-none absolute left-1/2 top-1/2 h-3.5 w-3.5 -translate-x-1/2 -translate-y-1/2 text-white opacity-0 peer-checked:opacity-100" />

--- a/src/components/chat/share-modal.tsx
+++ b/src/components/chat/share-modal.tsx
@@ -55,12 +55,15 @@ export function ShareModal({
   const [isShareEnabled, setIsShareEnabled] = useState(false)
   const [shareUrl, setShareUrl] = useState<string | null>(null)
   const contentRef = useRef<HTMLPreElement>(null)
+  const shareLinkInputRef = useRef<HTMLInputElement>(null)
+  const previousShareUrlRef = useRef<string | null>(null)
 
   // Reset modal state when chatId changes (different chat)
   useEffect(() => {
     setShareUrl(null)
     setIsShareEnabled(false)
     setIsLinkCopied(false)
+    previousShareUrlRef.current = null
   }, [chatId])
 
   // Reset transient state when modal closes
@@ -69,6 +72,13 @@ export function ShareModal({
       setIsLinkCopied(false)
     }
   }, [isOpen])
+
+  useEffect(() => {
+    if (shareUrl && previousShareUrlRef.current !== shareUrl) {
+      requestAnimationFrame(() => shareLinkInputRef.current?.focus())
+    }
+    previousShareUrlRef.current = shareUrl
+  }, [shareUrl])
 
   // Handle keyboard shortcuts
   useEffect(() => {
@@ -309,6 +319,13 @@ export function ShareModal({
   }
 
   const markdown = convertToMarkdown()
+  const shareStatus = isLinkCopied
+    ? 'Share link copied'
+    : shareUrl
+      ? 'Share link ready'
+      : isUploading
+        ? 'Creating share link'
+        : ''
 
   // Calculate the positioning to center within the chat area
   const leftOffset = isSidebarOpen ? CONSTANTS.CHAT_SIDEBAR_WIDTH_PX : 0
@@ -338,6 +355,9 @@ export function ShareModal({
             <DialogPrimitive.Title className="text-lg font-semibold text-content-primary">
               Share Conversation
             </DialogPrimitive.Title>
+            <span className="sr-only" role="status" aria-live="polite">
+              {shareStatus}
+            </span>
             <button
               onClick={onClose}
               aria-label="Close share dialog"
@@ -420,9 +440,11 @@ export function ShareModal({
                         {isShareEnabled && shareUrl && (
                           <div className="flex items-center gap-2 pt-2">
                             <input
+                              ref={shareLinkInputRef}
                               type="text"
                               readOnly
                               value={shareUrl}
+                              aria-label="Share link"
                               className="flex-1 rounded-lg border border-border-subtle bg-surface-chat px-3 py-2 text-sm text-content-primary"
                               onClick={(e) => e.currentTarget.select()}
                             />
@@ -478,6 +500,8 @@ export function ShareModal({
                 <div className="flex min-h-0 flex-1 flex-col p-4">
                   <pre
                     ref={contentRef}
+                    tabIndex={0}
+                    aria-label="Raw conversation markdown"
                     className="flex-1 overflow-auto whitespace-pre-wrap font-mono text-[13px] text-content-primary"
                   >
                     {markdown}

--- a/src/components/chat/stream-error-banner.tsx
+++ b/src/components/chat/stream-error-banner.tsx
@@ -40,7 +40,10 @@ export function StreamErrorBanner({
   }
 
   return (
-    <div className="pointer-events-none absolute left-0 right-0 top-2 z-10 flex w-full justify-center px-4">
+    <div
+      role="alert"
+      className="pointer-events-none absolute left-0 right-0 top-2 z-10 flex w-full justify-center px-4"
+    >
       <div
         className={cn(
           'pointer-events-auto w-full max-w-xl cursor-pointer overflow-hidden rounded-lg border shadow-lg backdrop-blur-sm transition-colors',
@@ -80,7 +83,7 @@ export function StreamErrorBanner({
               isDarkMode ? 'hover:bg-red-500/20' : 'hover:bg-red-500/10',
             )}
           >
-            <XMarkIcon className="h-4 w-4" />
+            <XMarkIcon className="h-4 w-4" aria-hidden="true" />
           </button>
         </div>
         {isExpanded && (

--- a/src/components/chat/stream-error-banner.tsx
+++ b/src/components/chat/stream-error-banner.tsx
@@ -46,34 +46,31 @@ export function StreamErrorBanner({
     >
       <div
         className={cn(
-          'pointer-events-auto w-full max-w-xl cursor-pointer overflow-hidden rounded-lg border shadow-lg backdrop-blur-sm transition-colors',
+          'pointer-events-auto w-full max-w-xl overflow-hidden rounded-lg border shadow-lg backdrop-blur-sm transition-colors',
           isDarkMode
             ? 'border-red-500/40 bg-red-950/60 text-red-200'
             : 'border-red-300 bg-red-50 text-red-700',
         )}
-        role="button"
-        onClick={toggleExpanded}
-        onKeyDown={(e) => {
-          if (e.key === 'Enter' || e.key === ' ') {
-            e.preventDefault()
-            toggleExpanded()
-          }
-        }}
-        tabIndex={0}
-        aria-expanded={isExpanded}
-        aria-label={
-          isExpanded ? 'Collapse error details' : 'Expand error details'
-        }
       >
         <div className="flex items-center gap-2 px-3 py-2">
-          <ChevronDownIcon
-            className={cn(
-              'h-4 w-4 flex-shrink-0 transition-transform',
-              isExpanded && 'rotate-180',
-            )}
-            aria-hidden="true"
-          />
-          <span className="flex-1 truncate text-sm font-semibold">{title}</span>
+          <button
+            type="button"
+            onClick={toggleExpanded}
+            className="flex min-w-0 flex-1 items-center gap-2 rounded text-left focus:outline-none focus:ring-2 focus:ring-red-500/50"
+            aria-expanded={isExpanded}
+            aria-label={`${isExpanded ? 'Collapse' : 'Expand'} error details: ${title}`}
+          >
+            <ChevronDownIcon
+              className={cn(
+                'h-4 w-4 flex-shrink-0 transition-transform',
+                isExpanded && 'rotate-180',
+              )}
+              aria-hidden="true"
+            />
+            <span className="flex-1 truncate text-sm font-semibold">
+              {title}
+            </span>
+          </button>
           <button
             type="button"
             onClick={handleDismiss}

--- a/src/components/chat/typing-animation.tsx
+++ b/src/components/chat/typing-animation.tsx
@@ -80,6 +80,7 @@ export function TypingAnimation({
     <span className="inline-flex items-baseline">
       <span>{currentText}</span>
       <span
+        aria-hidden="true"
         className={`ml-0.5 inline-block w-0.5 bg-content-primary ${showCursor ? 'opacity-100' : 'opacity-0'}`}
         style={{ height: '1.1em', transform: 'translateY(0.05em)' }}
       />

--- a/src/components/chat/verification-status-display.tsx
+++ b/src/components/chat/verification-status-display.tsx
@@ -175,6 +175,8 @@ export const VerificationStatusDisplay = memo(
                 <PiSpinner className="h-5 w-5 animate-spin text-content-secondary" />
               )}
               <span
+                role="status"
+                aria-live="polite"
                 className={`font-aeonik-fono ${
                   isComplete
                     ? isDarkMode
@@ -213,6 +215,7 @@ export const VerificationStatusDisplay = memo(
 
           {isComplete && (
             <div
+              inert={!isExpanded}
               className="overflow-hidden rounded-b-lg transition-all duration-300 ease-out"
               style={{
                 maxHeight: isExpanded ? '600px' : '0px',
@@ -271,6 +274,8 @@ export const VerificationStatusDisplay = memo(
               <PiSpinner className="h-5 w-5 animate-spin text-content-secondary" />
             )}
             <h3
+              role="status"
+              aria-live="polite"
               className={`text-xs font-medium ${
                 isComplete
                   ? 'text-emerald-500'

--- a/src/components/code-block.tsx
+++ b/src/components/code-block.tsx
@@ -995,15 +995,19 @@ export const CodeBlock = memo(function CodeBlock({
           />
         </div>
       )}
-      <div className="absolute right-2 top-2 z-10 hidden gap-1 group-hover:flex">
+      <div className="pointer-events-none absolute right-2 top-2 z-10 flex gap-1 opacity-0 transition-opacity group-focus-within:pointer-events-auto group-focus-within:opacity-100 group-hover:pointer-events-auto group-hover:opacity-100">
         {isMarkdown && viewMode === 'preview' && (
           <>
             <div className="group/md relative">
               <button
                 onClick={downloadMarkdown}
+                aria-label="Download as Markdown"
                 className="rounded-lg bg-surface-input p-2 hover:bg-surface-input/80"
               >
-                <BsFiletypeMd className="h-5 w-5 text-content-muted" />
+                <BsFiletypeMd
+                  className="h-5 w-5 text-content-muted"
+                  aria-hidden="true"
+                />
               </button>
               <span className="pointer-events-none absolute -top-8 left-1/2 hidden -translate-x-1/2 whitespace-nowrap rounded border border-border-subtle bg-surface-chat-background px-2 py-1 text-xs text-content-primary shadow-sm group-hover/md:block">
                 .md
@@ -1013,10 +1017,12 @@ export const CodeBlock = memo(function CodeBlock({
               <button
                 onClick={downloadPdf}
                 disabled={isGeneratingPdf}
+                aria-label="Download as PDF"
                 className="rounded-lg bg-surface-input p-2 hover:bg-surface-input/80 disabled:opacity-50"
               >
                 <BsFiletypePdf
                   className={`h-5 w-5 ${isGeneratingPdf ? 'animate-pulse' : ''} text-content-muted`}
+                  aria-hidden="true"
                 />
               </button>
               <span className="pointer-events-none absolute -top-8 left-1/2 hidden -translate-x-1/2 whitespace-nowrap rounded border border-border-subtle bg-surface-chat-background px-2 py-1 text-xs text-content-primary shadow-sm group-hover/pdf:block">
@@ -1028,6 +1034,7 @@ export const CodeBlock = memo(function CodeBlock({
         <div className="group/copy relative">
           <button
             onClick={copyToClipboard}
+            aria-label={copied ? 'Copied' : 'Copy code'}
             className="rounded-lg bg-surface-input p-2 hover:bg-surface-input/80"
           >
             {copied ? (
@@ -1037,6 +1044,7 @@ export const CodeBlock = memo(function CodeBlock({
                 strokeWidth="1.5"
                 stroke="currentColor"
                 viewBox="0 0 24 24"
+                aria-hidden="true"
               >
                 <path
                   strokeLinecap="round"
@@ -1051,6 +1059,7 @@ export const CodeBlock = memo(function CodeBlock({
                 strokeWidth="1.5"
                 stroke="currentColor"
                 viewBox="0 0 24 24"
+                aria-hidden="true"
               >
                 <path
                   strokeLinecap="round"

--- a/src/components/code-block.tsx
+++ b/src/components/code-block.tsx
@@ -21,6 +21,8 @@ const CodeIcon = () => (
     strokeWidth="2"
     strokeLinecap="round"
     strokeLinejoin="round"
+    aria-hidden="true"
+    focusable="false"
   >
     <polyline points="16 18 22 12 16 6" />
     <polyline points="8 6 2 12 8 18" />
@@ -36,6 +38,8 @@ const EyeIcon = () => (
     strokeWidth="2"
     strokeLinecap="round"
     strokeLinejoin="round"
+    aria-hidden="true"
+    focusable="false"
   >
     <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
     <circle cx="12" cy="12" r="3" />
@@ -51,6 +55,8 @@ const PlayIcon = () => (
     strokeWidth="2"
     strokeLinecap="round"
     strokeLinejoin="round"
+    aria-hidden="true"
+    focusable="false"
   >
     <polygon points="5 3 19 12 5 21 5 3" />
   </svg>
@@ -136,6 +142,7 @@ const ViewModeToggle = ({
             : 'text-content-muted hover:text-content-secondary'
         }`}
         aria-label={isExecutable ? 'Run' : 'Preview'}
+        aria-pressed={mode === 'preview'}
       >
         <PreviewIcon />
       </button>
@@ -149,6 +156,7 @@ const ViewModeToggle = ({
             : 'text-content-muted hover:text-content-secondary'
         }`}
         aria-label="View code"
+        aria-pressed={mode === 'code'}
       >
         <CodeIcon />
       </button>
@@ -708,11 +716,23 @@ const JsonTreeNode = ({
     )
   }
 
+  const nodeLabel = name ?? (isArray ? 'array' : 'object')
+
   return (
     <div>
-      <div
-        className="hover:bg-surface-secondary/50 flex cursor-pointer"
-        onClick={() => setIsExpanded(!isExpanded)}
+      <button
+        type="button"
+        disabled={!hasChildren}
+        aria-expanded={hasChildren ? isExpanded : undefined}
+        aria-label={
+          hasChildren
+            ? `${isExpanded ? 'Collapse' : 'Expand'} ${nodeLabel}`
+            : undefined
+        }
+        className={`flex w-full text-left disabled:cursor-default ${hasChildren ? 'hover:bg-surface-secondary/50 cursor-pointer' : ''}`}
+        onClick={() => {
+          if (hasChildren) setIsExpanded(!isExpanded)
+        }}
       >
         <span className="w-4 text-content-muted">
           {hasChildren ? (isExpanded ? '▼' : '▶') : ' '}
@@ -729,7 +749,7 @@ const JsonTreeNode = ({
             {!isLast && <span className="text-content-muted">,</span>}
           </>
         )}
-      </div>
+      </button>
       {isExpanded && (
         <>
           <div className="ml-4">

--- a/src/components/code-block.tsx
+++ b/src/components/code-block.tsx
@@ -1083,6 +1083,8 @@ export const CodeBlock = memo(function CodeBlock({
         />
       ) : isMarkdown ? (
         <pre
+          tabIndex={0}
+          aria-label={`Code block${language ? `, ${language}` : ''}`}
           className="font-mono text-sm"
           style={{
             borderRadius: '0.5rem',
@@ -1112,6 +1114,8 @@ export const CodeBlock = memo(function CodeBlock({
       ) : (
         <SyntaxHighlighter
           language={language}
+          tabIndex={0}
+          aria-label={`Code block${language ? `, ${language}` : ''}`}
           style={isDarkMode ? DARK_THEME : LIGHT_THEME}
           customStyle={{
             borderRadius: '0.5rem',

--- a/src/components/project/project-sidebar.tsx
+++ b/src/components/project/project-sidebar.tsx
@@ -609,6 +609,7 @@ export function ProjectSidebar({
       )}
 
       <div
+        inert={!isOpen}
         className={cn(
           'fixed z-40 flex h-dvh w-[85vw] flex-col overflow-hidden border-r',
           isOpen ? 'translate-x-0' : '-translate-x-full',

--- a/src/components/verification-sidebar.tsx
+++ b/src/components/verification-sidebar.tsx
@@ -166,6 +166,7 @@ export function VerifierSidebar({
   return (
     <>
       <div
+        inert={!isOpen}
         className={`${
           isOpen ? 'translate-x-0' : 'translate-x-full'
         } fixed right-0 top-0 z-40 flex h-full w-[85vw] overflow-hidden border-l border-border-subtle bg-surface-sidebar font-aeonik transition-all duration-200 ease-in-out`}
@@ -184,10 +185,12 @@ export function VerifierSidebar({
 
         <div className="absolute right-0 top-0 flex items-center justify-end p-4">
           <button
+            type="button"
             onClick={() => setIsOpen(false)}
+            aria-label="Close verification panel"
             className="rounded-lg border border-border-subtle bg-surface-chat p-2 text-content-secondary shadow-sm transition-all duration-200 hover:bg-surface-chat/80"
           >
-            <XMarkIcon className="h-5 w-5" />
+            <XMarkIcon className="h-5 w-5" aria-hidden="true" />
           </button>
         </div>
       </div>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Makes the chat more accessible with clear screen reader announcements, better keyboard navigation, and truly modal dialogs across chat, history, and tool UIs. Also fixes inconsistent Escape-to-close behavior, tightens status alerts, and enlarges small hit targets while respecting reduced motion.

- **New Features**
  - Screen-reader announcements: polite live region (`ChatAnnouncer`) for replies; conversation `role="log"`; status alerts for errors, verification, and rate limits; messages labeled “You said”/“Tin said”.
  - Keyboard navigation: chat list/history rail/menus/dialogs support Escape to close (fixed event handling); focus returns to triggers; collapsed content and side panels (chat, project, verification, ask) are `inert`; chat history uses nav landmarks.
  - Model/reasoning selectors: proper roles/states (`aria-haspopup`, `aria-expanded`, `role="menu"`, `menuitemradio`), outside-click/Escape dismissal, and focus restoration.
  - Tool steps: expanders expose `aria-expanded`; collapsed panels are `inert`; code exec outputs are labeled and focusable.
  - Dialogs: share, prompt library, and confirmations use accessible dialogs with focus trapping, proper labels, and true modality (background set `inert`).
  - Inputs/attachments: announce upload/progress and unsupported files by name; hide decorative icons with `aria-hidden`; clearer labels.
  - Rendering: tables add header scopes; math outputs HTML+MathML; code/table containers are focusable and labeled; streaming dot respects reduced motion.
  - Welcome screen: disclosure exposes `aria-expanded`; decorative icons hidden from assistive tech.
  - Message editing/actions: cancel restores focus to the Edit button; copy action has a larger hit target.

- **Dependencies**
  - Add `@radix-ui/react-dialog` and `@radix-ui/react-alert-dialog`.

<sup>Written for commit 9439cdf0a60ca2dbeeca15fc0d962c3e351ec487. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/391?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

