### PR TITLE
Add support for JWT tokens for signed in users 

### DIFF
--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -846,8 +846,15 @@ export function ChatInterface({
     setIsPromptLibraryModalOpen(false)
   }, [])
 
+  // Only the free-tier daily quota gates sending and the subscribe prompt. The
+  // per-account hourly cap (subscribers) reuses the same indicator channel but
+  // must not block the queue or prompt subscribing; those sends fail fast with
+  // an in-chat rate-limit message and recover once the hourly window resets.
   const isRateLimited = useCallback(
-    () => Boolean(rateLimit && rateLimit.remaining <= 0),
+    () =>
+      Boolean(
+        rateLimit && rateLimit.remaining <= 0 && rateLimit.kind !== 'hourly',
+      ),
     [rateLimit],
   )
 
@@ -2038,6 +2045,7 @@ export function ChatInterface({
     if (
       rateLimit &&
       rateLimit.remaining <= 0 &&
+      rateLimit.kind !== 'hourly' &&
       !rateLimitModalDismissedRef.current
     ) {
       setIsSubscribePromptOpen(true)
@@ -2048,7 +2056,7 @@ export function ChatInterface({
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
 
-    if (rateLimit && rateLimit.remaining <= 0) {
+    if (rateLimit && rateLimit.remaining <= 0 && rateLimit.kind !== 'hourly') {
       setIsSubscribePromptOpen(true)
       return
     }

--- a/src/components/chat/hooks/use-chat-messaging.ts
+++ b/src/components/chat/hooks/use-chat-messaging.ts
@@ -746,6 +746,7 @@ export function useChatMessaging({
           const isRateLimitError =
             lowerMsg.includes('rate limit') ||
             lowerMsg.includes('request limit') ||
+            lowerMsg.includes('usage limit') ||
             lowerMsg.includes('insufficient_quota')
 
           if (isRateLimitError) {

--- a/src/components/chat/hooks/use-chat-messaging.ts
+++ b/src/components/chat/hooks/use-chat-messaging.ts
@@ -743,6 +743,9 @@ export function useChatMessaging({
           const errorMsg =
             error instanceof Error ? error.message : 'Unknown error occurred'
           const lowerMsg = errorMsg.toLowerCase()
+          const isHourlyRateLimitError =
+            lowerMsg.includes('hourly usage limit') ||
+            lowerMsg.includes('hourly limit')
           const isRateLimitError =
             lowerMsg.includes('rate limit') ||
             lowerMsg.includes('request limit') ||
@@ -755,7 +758,8 @@ export function useChatMessaging({
               content: `Error: ${errorMsg}`,
               timestamp: new Date(),
               isError: true,
-              isRateLimitError: true,
+              isRateLimitError: !isHourlyRateLimitError,
+              isHourlyRateLimitError,
             }
 
             // Use the current chat ID from ref which has the correct (possibly server) ID

--- a/src/components/chat/rate-limit-banner.tsx
+++ b/src/components/chat/rate-limit-banner.tsx
@@ -22,6 +22,13 @@ export function shouldShowRateLimitBanner(
   )
 }
 
+function formatResetTime(resetsAt: string): string | null {
+  if (!resetsAt) return null
+  const at = new Date(resetsAt)
+  if (Number.isNaN(at.getTime())) return null
+  return at.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })
+}
+
 export function RateLimitBanner({
   rateLimit,
   isDarkMode,
@@ -29,6 +36,8 @@ export function RateLimitBanner({
   pillClassName,
 }: RateLimitBannerProps) {
   const exhausted = rateLimit.remaining <= 0
+  const isHourly = rateLimit.kind === 'hourly'
+  const resetLabel = formatResetTime(rateLimit.resetsAt)
 
   return (
     <div
@@ -49,9 +58,11 @@ export function RateLimitBanner({
         )}
       >
         <span className="font-aeonik text-xs font-medium">
-          {exhausted
-            ? "You've used all your free requests for today"
-            : `You have ${rateLimit.remaining} free request${rateLimit.remaining === 1 ? '' : 's'} left today`}
+          {isHourly
+            ? `You've reached your hourly usage limit${resetLabel ? ` — resets at ${resetLabel}` : ''}`
+            : exhausted
+              ? "You've used all your free requests for today"
+              : `You have ${rateLimit.remaining} free request${rateLimit.remaining === 1 ? '' : 's'} left today`}
         </span>
       </div>
     </div>

--- a/src/components/chat/renderers/default/DefaultMessageRenderer.tsx
+++ b/src/components/chat/renderers/default/DefaultMessageRenderer.tsx
@@ -47,6 +47,8 @@ const DefaultMessageComponent = ({
   const userMessageContentRef = React.useRef<HTMLDivElement>(null)
   const editTextareaRef = React.useRef<HTMLTextAreaElement>(null)
   const editButtonRef = React.useRef<HTMLButtonElement>(null)
+  const isLimitError =
+    message.isRateLimitError || message.isHourlyRateLimitError
 
   const citationUrlTitles = React.useMemo(() => {
     if (!message.annotations || message.annotations.length === 0)
@@ -426,10 +428,24 @@ const DefaultMessageComponent = ({
                     isUser ? 'max-w-[95%]' : 'w-full',
                     isUser &&
                       'rounded-2xl bg-surface-message-user/90 px-4 py-2 shadow-sm backdrop-blur-sm',
-                    message.isRateLimitError &&
+                    isLimitError &&
                       'rounded-lg border-2 border-brand-accent-dark/30 bg-brand-accent-dark/5 px-4 py-3',
                   )}
                 >
+                  {message.isHourlyRateLimitError && (
+                    <div className="flex flex-col gap-3">
+                      <div className="flex items-center gap-2">
+                        <GoClockFill className="h-5 w-5 flex-shrink-0 text-brand-accent-dark dark:text-brand-accent-light" />
+                        <span className="font-semibold text-brand-accent-dark dark:text-brand-accent-light">
+                          Hourly usage limit reached
+                        </span>
+                      </div>
+                      <p className="text-sm text-brand-accent-dark/70 dark:text-brand-accent-light/70">
+                        You&apos;ve reached your hourly usage limit. Please try
+                        again when the usage window resets.
+                      </p>
+                    </div>
+                  )}
                   {message.isRateLimitError && (
                     <div className="flex flex-col gap-3">
                       <div className="flex items-center gap-2">
@@ -454,7 +470,7 @@ const DefaultMessageComponent = ({
                       </button>
                     </div>
                   )}
-                  {!message.isRateLimitError && (
+                  {!isLimitError && (
                     <>
                       <div className="relative">
                         <div

--- a/src/components/chat/types.ts
+++ b/src/components/chat/types.ts
@@ -138,6 +138,7 @@ export type Message = {
   thinkingDuration?: number // Duration in seconds
   isError?: boolean
   isRateLimitError?: boolean
+  isHourlyRateLimitError?: boolean
   urlFetches?: URLFetchState[]
   webSearch?: WebSearchState
   webSearchBeforeThinking?: boolean // True if web search started before thinking

--- a/src/services/inference/tinfoil-client.ts
+++ b/src/services/inference/tinfoil-client.ts
@@ -101,11 +101,25 @@ async function fetchChatJWT(
   }
 
   if (response.ok) {
-    const data = await response.json()
-    return {
-      key: data.key,
-      expiresAt: data.expires_at ? new Date(data.expires_at).getTime() : null,
+    try {
+      const data = await response.json()
+      if (typeof data?.key === 'string' && data.key !== '') {
+        const expiresAtMs = data.expires_at
+          ? new Date(data.expires_at).getTime()
+          : null
+        return {
+          key: data.key,
+          expiresAt:
+            expiresAtMs !== null && !Number.isNaN(expiresAtMs)
+              ? expiresAtMs
+              : null,
+        }
+      }
+    } catch {
+      // Malformed / non-JSON 200 body: treat as a miss and fall back to the
+      // opaque /api/keys/chat path rather than throwing.
     }
+    return null
   }
 
   const parsedError = parseErrorBody(await response.text())

--- a/src/services/inference/tinfoil-client.ts
+++ b/src/services/inference/tinfoil-client.ts
@@ -18,6 +18,12 @@ export interface RateLimitInfo {
   maxRequests: number
   remaining: number
   resetsAt: string
+  /**
+   * Which limit this represents. Absent or `free_daily` is the anonymous/
+   * free-tier daily request limit; `hourly` is the per-account hourly usage
+   * cap that subscribers hit (surfaced through the same indicator channel).
+   */
+  kind?: 'free_daily' | 'hourly'
 }
 
 const SESSION_TOKEN_EXPIRY_BUFFER_MS = 5 * 60 * 1000
@@ -123,6 +129,37 @@ async function fetchSessionToken(): Promise<string> {
         error: errorText,
       },
     })
+
+    let parsedError: {
+      error?: string
+      code?: string
+      resets_at?: string
+    } | null = null
+    try {
+      parsedError = JSON.parse(errorText)
+    } catch {
+      parsedError = null
+    }
+
+    // Per-account hourly usage cap: surface it through the shared rate-limit
+    // channel so the existing banner renders, and throw a message the chat
+    // recognizes as a rate limit rather than a generic failure.
+    if (
+      response.status === 429 ||
+      parsedError?.code === 'HOURLY_LIMIT_REACHED'
+    ) {
+      cachedRateLimit = {
+        maxRequests: 0,
+        remaining: 0,
+        resetsAt: parsedError?.resets_at ?? '',
+        kind: 'hourly',
+      }
+      dispatchRateLimitUpdate()
+      throw new Error(
+        parsedError?.error ?? 'You have reached your hourly usage limit.',
+      )
+    }
+
     throw new Error(`Failed to get session token: ${response.status}`)
   }
 
@@ -138,6 +175,7 @@ async function fetchSessionToken(): Promise<string> {
       maxRequests: data.rate_limit.max_requests,
       remaining: data.rate_limit.remaining,
       resetsAt: data.rate_limit.resets_at,
+      kind: 'free_daily',
     }
   } else {
     cachedRateLimit = null

--- a/src/services/inference/tinfoil-client.ts
+++ b/src/services/inference/tinfoil-client.ts
@@ -26,7 +26,7 @@ export interface RateLimitInfo {
   kind?: 'free_daily' | 'hourly'
 }
 
-const SESSION_TOKEN_EXPIRY_BUFFER_MS = 5 * 60 * 1000
+const SESSION_TOKEN_EXPIRY_BUFFER_MS = 1 * 60 * 1000
 const AUTH_INIT_WAIT_MS = 3000
 
 let clientInstance: OpenAI | null = null

--- a/src/services/inference/tinfoil-client.ts
+++ b/src/services/inference/tinfoil-client.ts
@@ -45,6 +45,76 @@ function dispatchRateLimitUpdate(): void {
   }
 }
 
+type ServerErrorBody = {
+  error?: string
+  code?: string
+  resets_at?: string
+}
+
+function parseErrorBody(errorText: string): ServerErrorBody | null {
+  try {
+    return JSON.parse(errorText) as ServerErrorBody
+  } catch {
+    return null
+  }
+}
+
+function isHourlyLimit(
+  status: number,
+  parsedError: ServerErrorBody | null,
+): boolean {
+  return status === 429 || parsedError?.code === 'HOURLY_LIMIT_REACHED'
+}
+
+// Surfaces the per-account hourly usage cap through the shared rate-limit
+// channel (so the banner renders) and throws a message the chat recognizes as a
+// rate limit rather than a generic failure. Never returns.
+function surfaceHourlyLimit(parsedError: ServerErrorBody | null): never {
+  cachedRateLimit = {
+    maxRequests: 0,
+    remaining: 0,
+    resetsAt: parsedError?.resets_at ?? '',
+    kind: 'hourly',
+  }
+  dispatchRateLimitUpdate()
+  throw new Error(
+    parsedError?.error ?? 'You have reached your hourly usage limit.',
+  )
+}
+
+// Mints a stateless JWT inference token for a signed-in user via
+// /api/chat/token. Returns the token on success, or null on any non-rate-limit
+// failure (no active subscription, endpoint disabled, network error) so the
+// caller falls back to the opaque /api/keys/chat path. A subscriber over the
+// hourly cap is surfaced here and not fallen back, so the cap cannot be bypassed
+// through the opaque path.
+async function fetchChatJWT(
+  authBearer: string,
+): Promise<{ key: string; expiresAt: number | null } | null> {
+  let response: Response
+  try {
+    response = await fetch(`${API_BASE_URL}/api/chat/token`, {
+      headers: { Authorization: `Bearer ${authBearer}` },
+    })
+  } catch {
+    return null
+  }
+
+  if (response.ok) {
+    const data = await response.json()
+    return {
+      key: data.key,
+      expiresAt: data.expires_at ? new Date(data.expires_at).getTime() : null,
+    }
+  }
+
+  const parsedError = parseErrorBody(await response.text())
+  if (isHourlyLimit(response.status, parsedError)) {
+    surfaceHourlyLimit(parsedError)
+  }
+  return null
+}
+
 async function fetchSessionToken(): Promise<string> {
   if (IS_DEV) {
     return DEV_API_KEY
@@ -108,6 +178,21 @@ async function fetchSessionToken(): Promise<string> {
     cachedSessionTokenExpiresAt = null
   }
 
+  // Signed-in clients mint a stateless JWT inference token via /api/chat/token.
+  // Anonymous users (and signed-in users without an active subscription) fall
+  // back to the opaque /api/keys/chat path below.
+  if (authBearer) {
+    const jwt = await fetchChatJWT(authBearer)
+    if (jwt !== null) {
+      cachedSessionToken = jwt.key
+      cachedSessionTokenWasAuthenticated = true
+      cachedSessionTokenExpiresAt = jwt.expiresAt
+      cachedRateLimit = null
+      dispatchRateLimitUpdate()
+      return jwt.key
+    }
+  }
+
   // Build request headers: include auth if we resolved a bearer above
   const headers: Record<string, string> = {}
   if (authBearer) {
@@ -130,34 +215,13 @@ async function fetchSessionToken(): Promise<string> {
       },
     })
 
-    let parsedError: {
-      error?: string
-      code?: string
-      resets_at?: string
-    } | null = null
-    try {
-      parsedError = JSON.parse(errorText)
-    } catch {
-      parsedError = null
-    }
+    const parsedError = parseErrorBody(errorText)
 
     // Per-account hourly usage cap: surface it through the shared rate-limit
     // channel so the existing banner renders, and throw a message the chat
     // recognizes as a rate limit rather than a generic failure.
-    if (
-      response.status === 429 ||
-      parsedError?.code === 'HOURLY_LIMIT_REACHED'
-    ) {
-      cachedRateLimit = {
-        maxRequests: 0,
-        remaining: 0,
-        resetsAt: parsedError?.resets_at ?? '',
-        kind: 'hourly',
-      }
-      dispatchRateLimitUpdate()
-      throw new Error(
-        parsedError?.error ?? 'You have reached your hourly usage limit.',
-      )
+    if (isHourlyLimit(response.status, parsedError)) {
+      surfaceHourlyLimit(parsedError)
     }
 
     throw new Error(`Failed to get session token: ${response.status}`)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Show a clear hourly usage limit message with the local reset time and keep upgrade prompts gated only by the free daily quota. Use JWT chat tokens for signed-in users and refresh them with a 1‑minute buffer.

- **New Features**
  - Show an hourly limit banner with “resets at HH:MM”; publish `kind: 'hourly'` updates (free uses `kind: 'free_daily'`); don’t gate sends or show subscribe prompts on hourly—show a small in‑chat notice instead.
  - Use `/api/chat/token` for signed‑in users; fall back to `/api/keys/chat` on invalid or failed token responses; enforce hourly caps at token mint and surface them via `kind: 'hourly'` without falling back.

<sup>Written for commit 5526d66ec829de9d75371ca09bd3d24f2147bb2a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/392?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

