### PR TITLE
Prevent streamed replies from losing or splitting text

### DIFF
--- a/src/components/chat/hooks/streaming/event-normalizer.ts
+++ b/src/components/chat/hooks/streaming/event-normalizer.ts
@@ -297,22 +297,39 @@ export function createEventNormalizer(): EventNormalizer {
         if (reasoningContent) {
           events.push({ type: 'thinking_delta', content: reasoningContent })
         }
+        // Some routers attach content to the same chunk as reasoning;
+        // emit it so it isn't silently dropped.
+        if (content) {
+          events.push({ type: 'thinking_end' })
+          isInThinking = false
+          events.push({ type: 'content_delta', content })
+        }
         return events
       }
 
       if (isReasoningFormat && reasoningContent !== null) {
         // Continued reasoning chunks
         if (reasoningContent) {
-          // If we were out of thinking (content interrupted), restart
-          if (!isInThinking) {
+          // If we were out of thinking (content interrupted), restart —
+          // but not for whitespace-only tails, which would otherwise
+          // create an empty thinking block and split the content
+          // timeline mid-word.
+          if (!isInThinking && reasoningContent.trim()) {
             isInThinking = true
             events.push({ type: 'thinking_start' })
           }
-          events.push({ type: 'thinking_delta', content: reasoningContent })
+          if (isInThinking) {
+            events.push({ type: 'thinking_delta', content: reasoningContent })
+          }
         }
-        if (content && isInThinking) {
-          events.push({ type: 'thinking_end' })
-          isInThinking = false
+        // Content must be emitted regardless of thinking state: the
+        // router sends `reasoning_content: ""` alongside content on some
+        // chunks, and dropping those silently loses message text.
+        if (content) {
+          if (isInThinking) {
+            events.push({ type: 'thinking_end' })
+            isInThinking = false
+          }
           events.push({ type: 'content_delta', content })
         }
         return events

--- a/tests/components/chat/streaming/event-normalizer.test.ts
+++ b/tests/components/chat/streaming/event-normalizer.test.ts
@@ -209,6 +209,86 @@ describe('EventNormalizer', () => {
       const types = events.map((e) => e.type)
       expect(types[0]).toBe('thinking_start')
     })
+
+    it('emits content carried on the same chunk as the first reasoning', () => {
+      const events = processAll([
+        {
+          choices: [
+            { delta: { reasoning_content: 'quick thought. ', content: 'Hi' } },
+          ],
+        },
+        { choices: [{ delta: { content: ' there' } }] },
+      ])
+
+      const types = events.map((e) => e.type)
+      expect(types).toEqual([
+        'thinking_start',
+        'thinking_delta',
+        'thinking_end',
+        'content_delta',
+        'content_delta',
+      ])
+      expect((events[3] as any).content).toBe('Hi')
+    })
+
+    it('does not drop content on chunks carrying an empty reasoning field after thinking ended', () => {
+      const events = processAll([
+        reasoningChunk('thinking about the email...'),
+        {
+          choices: [
+            {
+              delta: { reasoning_content: '', content: 'It’s clear and poli' },
+            },
+          ],
+        },
+        {
+          choices: [
+            { delta: { reasoning_content: '', content: 'te, but hone' } },
+          ],
+        },
+        { choices: [{ delta: { content: 'stly?' } }] },
+      ])
+
+      const text = events
+        .filter((e) => e.type === 'content_delta')
+        .map((e) => (e as any).content)
+        .join('')
+      expect(text).toBe('It’s clear and polite, but honestly?')
+    })
+
+    it('does not restart thinking for whitespace-only reasoning tails after content started', () => {
+      const events = processAll([
+        reasoningChunk('thinking...'),
+        {
+          choices: [{ delta: { reasoning_content: '. ', content: 'It' } }],
+        },
+        {
+          choices: [{ delta: { reasoning_content: ' ', content: '’s clear' } }],
+        },
+        { choices: [{ delta: { content: ' and polite.' } }] },
+      ])
+
+      const types = events.map((e) => e.type)
+      expect(types.filter((t) => t === 'thinking_start').length).toBe(1)
+      const text = events
+        .filter((e) => e.type === 'content_delta')
+        .map((e) => (e as any).content)
+        .join('')
+      expect(text).toBe('It’s clear and polite.')
+    })
+
+    it('still restarts thinking when substantive reasoning resumes after content', () => {
+      const events = processAll([
+        reasoningChunk('thought1'),
+        { choices: [{ delta: { content: 'partial answer' } }] },
+        reasoningChunk('thought2'),
+        { choices: [{ delta: { content: 'final' } }] },
+      ])
+
+      const types = events.map((e) => e.type)
+      expect(types.filter((t) => t === 'thinking_start').length).toBe(2)
+      expect(types.filter((t) => t === 'thinking_end').length).toBe(2)
+    })
   })
 
   describe('annotations', () => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes dropped or split text in streamed replies by improving how reasoning and content deltas are normalized. This prevents mid-word splits and ensures content is never lost when routers mix `reasoning_content` and `content`.

- **Bug Fixes**
  - Emit `content_delta` when the first reasoning chunk also carries content; end `thinking` before content.
  - Always emit content even when `reasoning_content` is empty; avoids losing text from mixed chunks.
  - Do not restart `thinking` for whitespace-only reasoning tails; restart only when substantive reasoning resumes. Tests added for all cases.

<sup>Written for commit 64a9ead5e81a4a8aad711c53aa48fc1d819458ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/394?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

