### PR TITLE
Fix input area send button and cutoff

### DIFF
--- a/src/components/chat/chat-input.tsx
+++ b/src/components/chat/chat-input.tsx
@@ -121,11 +121,19 @@ export function ChatInput({
       const min = Number.parseInt(inputMinHeight, 10) || 0
       // Cap the textarea to the visual viewport (which shrinks when the
       // on-screen keyboard opens) so the toolbar row with the send button
-      // always stays visible below it.
+      // always stays visible below it. Measure everything else rendered in
+      // the input area (toolbar, paddings, suggestion chips, banners,
+      // attachment previews) so the cap adapts to what is actually shown,
+      // e.g. the extra suggestions row on the initial query screen.
       const viewportHeight = window.visualViewport?.height ?? window.innerHeight
+      const inputArea = el.closest('[data-chat-input-area]')
+      const chromeHeight = inputArea
+        ? inputArea.getBoundingClientRect().height -
+          el.getBoundingClientRect().height
+        : CONSTANTS.INPUT_VIEWPORT_RESERVED_PX
       const available = Math.min(
         CONSTANTS.INPUT_MAX_HEIGHT_PX,
-        viewportHeight - CONSTANTS.INPUT_VIEWPORT_RESERVED_PX,
+        viewportHeight - chromeHeight - CONSTANTS.INPUT_VIEWPORT_TOP_GAP_PX,
       )
       // Snap the cap to a whole number of text lines so scrolled-out content
       // is clipped flush at a line boundary instead of mid-line.

--- a/src/components/chat/chat-input.tsx
+++ b/src/components/chat/chat-input.tsx
@@ -119,7 +119,21 @@ export function ChatInput({
       if (!el) return
 
       const min = Number.parseInt(inputMinHeight, 10) || 0
-      const max = 240
+      // Cap the textarea to the visual viewport (which shrinks when the
+      // on-screen keyboard opens) so the toolbar row with the send button
+      // always stays visible below it.
+      const viewportHeight = window.visualViewport?.height ?? window.innerHeight
+      const available = Math.min(
+        CONSTANTS.INPUT_MAX_HEIGHT_PX,
+        viewportHeight - CONSTANTS.INPUT_VIEWPORT_RESERVED_PX,
+      )
+      // Snap the cap to a whole number of text lines so scrolled-out content
+      // is clipped flush at a line boundary instead of mid-line.
+      const lineHeight = Number.parseFloat(getComputedStyle(el).lineHeight)
+      const max =
+        Number.isFinite(lineHeight) && lineHeight > 0
+          ? Math.max(Math.floor(available / lineHeight), 1) * lineHeight
+          : available
 
       // Reset to 0 so the browser recomputes content height.
       // Using '0' instead of 'auto' forces scrollHeight to reflect the
@@ -248,6 +262,17 @@ export function ChatInput({
     return () => cancelAnimationFrame(raf)
     // Include `textareaResetNonce` so a remount recalculates height immediately.
   }, [input, inputRef, resizeTextarea, textareaResetNonce])
+
+  // Recompute the height cap when the visual viewport changes (e.g. the
+  // on-screen keyboard opens or closes) so long text never pushes the send
+  // button out of view.
+  useEffect(() => {
+    const vv = typeof window !== 'undefined' ? window.visualViewport : null
+    if (!vv) return
+    const onViewportResize = () => resizeTextarea(inputRef.current)
+    vv.addEventListener('resize', onViewportResize)
+    return () => vv.removeEventListener('resize', onViewportResize)
+  }, [inputRef, resizeTextarea])
 
   // Focus textarea on initial mount only (not on remounts after sending)
   useEffect(() => {
@@ -888,12 +913,7 @@ export function ChatInput({
 
                 if (!listMarkerMatch) {
                   setTimeout(() => {
-                    textarea.style.height = 'auto'
-                    const max = 240
-                    const raw = textarea.scrollHeight
-                    const min = Number.parseInt(inputMinHeight, 10) || 0
-                    const next = Math.max(min, Math.min(raw, max))
-                    textarea.style.height = `${next}px`
+                    resizeTextarea(textarea)
                     textarea.scrollTop = textarea.scrollHeight
                   }, 0)
                 } else {
@@ -943,12 +963,7 @@ export function ChatInput({
                       cursorPosition + 1 + indent.length + newMarker.length + 1
 
                     setTimeout(() => {
-                      textarea.style.height = 'auto'
-                      const max = 240
-                      const raw = textarea.scrollHeight
-                      const min = Number.parseInt(inputMinHeight, 10) || 0
-                      const next = Math.max(min, Math.min(raw, max))
-                      textarea.style.height = `${next}px`
+                      resizeTextarea(textarea)
                       textarea.selectionStart = textarea.selectionEnd =
                         newCursorPos
                       textarea.scrollTop = textarea.scrollHeight
@@ -968,7 +983,7 @@ export function ChatInput({
             )}
             style={{
               minHeight: inputMinHeight,
-              maxHeight: '240px',
+              maxHeight: `${CONSTANTS.INPUT_MAX_HEIGHT_PX}px`,
             }}
           />
 

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -3113,6 +3113,7 @@ export function ChatInterface({
                 (currentChat?.messages && currentChat.messages.length > 0)) && (
                 <div
                   ref={inputAreaRef}
+                  data-chat-input-area
                   className="pointer-events-none absolute inset-x-0 bottom-0 isolate z-30 px-4 pb-4"
                   style={{
                     minHeight: '80px',

--- a/src/components/chat/constants.ts
+++ b/src/components/chat/constants.ts
@@ -4,10 +4,12 @@ export const CONSTANTS = {
   INPUT_MIN_HEIGHT: '28px',
   // Maximum height of the chat input textarea before it scrolls internally
   INPUT_MAX_HEIGHT_PX: 240,
-  // Vertical space reserved for the input card chrome (paddings, toolbar row,
-  // send button) so the whole input fits in the visual viewport above the
-  // on-screen keyboard when the textarea is at its maximum height
+  // Fallback estimate of the input card chrome height (paddings, toolbar row,
+  // send button) used when the input area wrapper cannot be measured
   INPUT_VIEWPORT_RESERVED_PX: 160,
+  // Minimum breathing room kept above the input area within the visual
+  // viewport so it never covers the entire screen above the keyboard
+  INPUT_VIEWPORT_TOP_GAP_PX: 24,
   CHAT_INPUT_BOTTOM_GAP_PX: 32,
   CHAT_INPUT_FADE_HEIGHT_PX: 80,
   CHAT_INPUT_FADE_SOLID_AT_PX: 72,

--- a/src/components/chat/constants.ts
+++ b/src/components/chat/constants.ts
@@ -2,6 +2,12 @@ export const CONSTANTS = {
   LOADING_TIMEOUT: 500,
   MOBILE_BREAKPOINT: 768,
   INPUT_MIN_HEIGHT: '28px',
+  // Maximum height of the chat input textarea before it scrolls internally
+  INPUT_MAX_HEIGHT_PX: 240,
+  // Vertical space reserved for the input card chrome (paddings, toolbar row,
+  // send button) so the whole input fits in the visual viewport above the
+  // on-screen keyboard when the textarea is at its maximum height
+  INPUT_VIEWPORT_RESERVED_PX: 160,
   CHAT_INPUT_BOTTOM_GAP_PX: 32,
   CHAT_INPUT_FADE_HEIGHT_PX: 80,
   CHAT_INPUT_FADE_SOLID_AT_PX: 72,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the chat input so long messages never push the send button off-screen on mobile and prevents the textarea from covering the screen when the keyboard opens. The input now caps its height to the visible viewport and updates as the viewport changes.

- **Bug Fixes**
  - Compute a dynamic max height from `visualViewport` minus measured input chrome; snap to full line heights with fallbacks.
  - Recalculate on `visualViewport.resize` so the send button stays visible as the keyboard opens/closes.
  - Mark the input wrapper with `data-chat-input-area` and set `maxHeight` via `CONSTANTS.INPUT_MAX_HEIGHT_PX`.
  - Use shared `resizeTextarea` in auto-list formatting; add `INPUT_MAX_HEIGHT_PX`, `INPUT_VIEWPORT_RESERVED_PX`, and `INPUT_VIEWPORT_TOP_GAP_PX`.

<sup>Written for commit 378054822514d859210d924a8298821d8d2f2604. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/395?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

