### PR TITLE
Stream thinking fragments

### DIFF
--- a/src/components/chat/hooks/streaming/event-normalizer.ts
+++ b/src/components/chat/hooks/streaming/event-normalizer.ts
@@ -31,16 +31,6 @@ import type { NormalizedEvent } from './types'
 
 type SSEJson = any
 
-/**
- * A reasoning resume after a tool boundary is only treated as real thinking
- * once it contains a letter or digit, so trailing punctuation/whitespace
- * crumbs of the previous reasoning don't open an empty "Thought for
- * 0.0 seconds" block. Resumes after a content interruption never open a new
- * block at all — they are late tails of the previous reasoning and are
- * merged back into it (see thinking_tail_delta).
- */
-const SUBSTANTIVE_REASONING_RE = /[\p{L}\p{N}]/u
-
 function extractReasoningContent(json: SSEJson): string | null {
   const delta =
     json.choices?.[0]?.delta?.reasoning_content ??
@@ -229,7 +219,6 @@ export function createEventNormalizer(): EventNormalizer {
   let initialBuffer = ''
   let isInThinking = false
   let isReasoningFormat = false
-  let pendingReasoningTail = ''
   // True while the last thinking block was closed by content (not by a
   // tool boundary). Reasoning arriving in that state is the late tail of
   // that block — routers/upstreams race the think-close boundary so the
@@ -342,21 +331,12 @@ export function createEventNormalizer(): EventNormalizer {
               content: reasoningContent,
             })
           } else {
-            // We were out of thinking (tool boundary). Hold the resume
-            // in a buffer and only reopen a thinking block once it
-            // contains substantive text, so trailing punctuation crumbs
-            // don't open an empty thinking block.
-            pendingReasoningTail += reasoningContent
-            if (SUBSTANTIVE_REASONING_RE.test(pendingReasoningTail)) {
-              isInThinking = true
-              thinkingClosedByContent = false
-              events.push({ type: 'thinking_start' })
-              events.push({
-                type: 'thinking_delta',
-                content: pendingReasoningTail,
-              })
-              pendingReasoningTail = ''
-            }
+            // Reasoning resumed after a tool boundary — a new thinking
+            // phase of the next model turn.
+            isInThinking = true
+            thinkingClosedByContent = false
+            events.push({ type: 'thinking_start' })
+            events.push({ type: 'thinking_delta', content: reasoningContent })
           }
         }
         // Content must be emitted regardless of thinking state: the
@@ -368,7 +348,6 @@ export function createEventNormalizer(): EventNormalizer {
             isInThinking = false
             thinkingClosedByContent = true
           }
-          pendingReasoningTail = ''
           events.push({ type: 'content_delta', content })
         }
         return events
@@ -381,7 +360,6 @@ export function createEventNormalizer(): EventNormalizer {
           isInThinking = false
           thinkingClosedByContent = true
         }
-        pendingReasoningTail = ''
         events.push({ type: 'content_delta', content })
         return events
       }

--- a/src/components/chat/hooks/streaming/event-normalizer.ts
+++ b/src/components/chat/hooks/streaming/event-normalizer.ts
@@ -32,11 +32,12 @@ import type { NormalizedEvent } from './types'
 type SSEJson = any
 
 /**
- * A reasoning resume is only treated as real thinking once it contains a
- * letter or digit. Routers interleave trailing punctuation/whitespace crumbs
- * of the previous reasoning (e.g. ". ") into the content stream, and opening
- * a thinking block for those splits the reply around an empty "Thought for
- * 0.0 seconds" block.
+ * A reasoning resume after a tool boundary is only treated as real thinking
+ * once it contains a letter or digit, so trailing punctuation/whitespace
+ * crumbs of the previous reasoning don't open an empty "Thought for
+ * 0.0 seconds" block. Resumes after a content interruption never open a new
+ * block at all — they are late tails of the previous reasoning and are
+ * merged back into it (see thinking_tail_delta).
  */
 const SUBSTANTIVE_REASONING_RE = /[\p{L}\p{N}]/u
 
@@ -229,6 +230,11 @@ export function createEventNormalizer(): EventNormalizer {
   let isInThinking = false
   let isReasoningFormat = false
   let pendingReasoningTail = ''
+  // True while the last thinking block was closed by content (not by a
+  // tool boundary). Reasoning arriving in that state is the late tail of
+  // that block — routers/upstreams race the think-close boundary so the
+  // final reasoning fragment can land after content started.
+  let thinkingClosedByContent = false
   const toolCallIndexToId = new Map<number, string>()
   const toolCallStartedIds = new Set<string>()
 
@@ -242,6 +248,7 @@ export function createEventNormalizer(): EventNormalizer {
           events.push({ type: 'thinking_end' })
           isInThinking = false
         }
+        thinkingClosedByContent = false
         events.push(...normalizeLegacyToolEvent(sseJson))
         return events
       }
@@ -259,6 +266,7 @@ export function createEventNormalizer(): EventNormalizer {
           events.push({ type: 'thinking_end' })
           isInThinking = false
         }
+        thinkingClosedByContent = false
         events.push(...toolCallEvents)
       }
       if (sseJson.choices?.[0]?.finish_reason === 'tool_calls') {
@@ -286,6 +294,7 @@ export function createEventNormalizer(): EventNormalizer {
           events.push({ type: 'thinking_end' })
           isInThinking = false
         }
+        thinkingClosedByContent = false
         for (const toolEvent of preprocessed.toolEvents) {
           events.push(...normalizeToolEvent(toolEvent, logger))
         }
@@ -303,6 +312,7 @@ export function createEventNormalizer(): EventNormalizer {
         isReasoningFormat = true
         isInThinking = true
         isFirstChunk = false
+        thinkingClosedByContent = false
         events.push({ type: 'thinking_start' })
         if (reasoningContent) {
           events.push({ type: 'thinking_delta', content: reasoningContent })
@@ -312,6 +322,7 @@ export function createEventNormalizer(): EventNormalizer {
         if (content) {
           events.push({ type: 'thinking_end' })
           isInThinking = false
+          thinkingClosedByContent = true
           events.push({ type: 'content_delta', content })
         }
         return events
@@ -322,14 +333,23 @@ export function createEventNormalizer(): EventNormalizer {
         if (reasoningContent) {
           if (isInThinking) {
             events.push({ type: 'thinking_delta', content: reasoningContent })
+          } else if (thinkingClosedByContent) {
+            // Late tail of the reasoning that content already closed.
+            // Merge it back into that block instead of opening a phantom
+            // "Thought for 0.0 seconds" block that splits the answer.
+            events.push({
+              type: 'thinking_tail_delta',
+              content: reasoningContent,
+            })
           } else {
-            // We were out of thinking (content interrupted). Hold the
-            // resume in a buffer and only reopen a thinking block once it
+            // We were out of thinking (tool boundary). Hold the resume
+            // in a buffer and only reopen a thinking block once it
             // contains substantive text, so trailing punctuation crumbs
-            // don't split the content timeline mid-word.
+            // don't open an empty thinking block.
             pendingReasoningTail += reasoningContent
             if (SUBSTANTIVE_REASONING_RE.test(pendingReasoningTail)) {
               isInThinking = true
+              thinkingClosedByContent = false
               events.push({ type: 'thinking_start' })
               events.push({
                 type: 'thinking_delta',
@@ -346,6 +366,7 @@ export function createEventNormalizer(): EventNormalizer {
           if (isInThinking) {
             events.push({ type: 'thinking_end' })
             isInThinking = false
+            thinkingClosedByContent = true
           }
           pendingReasoningTail = ''
           events.push({ type: 'content_delta', content })
@@ -358,6 +379,7 @@ export function createEventNormalizer(): EventNormalizer {
         if (isInThinking) {
           events.push({ type: 'thinking_end' })
           isInThinking = false
+          thinkingClosedByContent = true
         }
         pendingReasoningTail = ''
         events.push({ type: 'content_delta', content })

--- a/src/components/chat/hooks/streaming/process-stream.ts
+++ b/src/components/chat/hooks/streaming/process-stream.ts
@@ -91,6 +91,10 @@ export async function processStreamingResponse(
         timeline.appendThinking(event.content)
         break
 
+      case 'thinking_tail_delta':
+        timeline.appendThinkingTail(event.content)
+        break
+
       case 'thinking_end': {
         const duration = getThinkingDuration(ctx.thinkingStartTimeRef)
         timeline.endThinking(duration)

--- a/src/components/chat/hooks/streaming/timeline-builder.ts
+++ b/src/components/chat/hooks/streaming/timeline-builder.ts
@@ -46,6 +46,24 @@ export class TimelineBuilder {
     }
   }
 
+  /**
+   * Append a late reasoning fragment to the most recent thinking block
+   * without reopening it or disturbing the current content block, so the
+   * answer text keeps accumulating contiguously around it.
+   */
+  appendThinkingTail(text: string): void {
+    for (let i = this.blocks.length - 1; i >= 0; i--) {
+      const block = this.blocks[i]
+      if (block.type === 'thinking') {
+        this.blocks[i] = {
+          ...block,
+          content: block.content + text,
+        }
+        return
+      }
+    }
+  }
+
   endThinking(duration?: number): void {
     if (this.currentThinkingIdx < 0) return
     const block = this.blocks[this.currentThinkingIdx] as TimelineThinkingBlock

--- a/src/components/chat/hooks/streaming/types.ts
+++ b/src/components/chat/hooks/streaming/types.ts
@@ -14,6 +14,16 @@ import type { Chat, Message } from '../../types'
 export type ThinkingStartEvent = { type: 'thinking_start' }
 export type ThinkingDeltaEvent = { type: 'thinking_delta'; content: string }
 export type ThinkingEndEvent = { type: 'thinking_end' }
+/**
+ * A late fragment of an already-closed thinking block. Upstream reasoning
+ * parsers split the think-close boundary so the final reasoning fragment
+ * can arrive after the first content deltas; it belongs at the end of the
+ * previous thinking block, not in a new one.
+ */
+export type ThinkingTailDeltaEvent = {
+  type: 'thinking_tail_delta'
+  content: string
+}
 export type ContentDeltaEvent = { type: 'content_delta'; content: string }
 
 export type WebSearchEvent = {
@@ -75,6 +85,7 @@ export type NormalizedEvent =
   | ThinkingStartEvent
   | ThinkingDeltaEvent
   | ThinkingEndEvent
+  | ThinkingTailDeltaEvent
   | ContentDeltaEvent
   | WebSearchEvent
   | URLFetchEvent

--- a/tests/components/chat/streaming/event-normalizer.test.ts
+++ b/tests/components/chat/streaming/event-normalizer.test.ts
@@ -194,10 +194,20 @@ describe('EventNormalizer', () => {
       ])
 
       const types = events.map((e) => e.type)
-      // Should see: start, delta, end, content, start, delta, end, content
+      // Should see: start, delta, end, content, tail, content — reasoning
+      // arriving after content is the late tail of the previous thinking
+      // block, not a new one.
       expect(types[0]).toBe('thinking_start')
-      expect(types).toContain('content_delta')
-      expect(types.filter((t) => t === 'thinking_start').length).toBe(2)
+      expect(types.filter((t) => t === 'thinking_start').length).toBe(1)
+      expect(events).toContainEqual({
+        type: 'thinking_tail_delta',
+        content: 'thought2',
+      })
+      const text = events
+        .filter((e) => e.type === 'content_delta')
+        .map((e) => (e as any).content)
+        .join('')
+      expect(text).toBe('partial answerfinal')
     })
 
     it('handles reasoning with empty string (present but empty)', () => {
@@ -294,17 +304,81 @@ describe('EventNormalizer', () => {
       expect(text).toBe('Hello world')
     })
 
-    it('still restarts thinking when substantive reasoning resumes after content', () => {
+    it('merges substantive reasoning tails arriving after content into the previous thinking block', () => {
+      // Upstream splits the think-close boundary, so the final reasoning
+      // fragment (" for.") can land after the answer already started.
       const events = processAll([
-        reasoningChunk('thought1'),
-        { choices: [{ delta: { content: 'partial answer' } }] },
-        reasoningChunk('thought2'),
-        { choices: [{ delta: { content: 'final' } }] },
+        reasoningChunk('I should account'),
+        { choices: [{ delta: { content: 'The' } }] },
+        reasoningChunk(' for.'),
+        { choices: [{ delta: { content: ' main things were:' } }] },
+      ])
+
+      const types = events.map((e) => e.type)
+      expect(types.filter((t) => t === 'thinking_start').length).toBe(1)
+      expect(types.filter((t) => t === 'thinking_end').length).toBe(1)
+      expect(events).toContainEqual({
+        type: 'thinking_tail_delta',
+        content: ' for.',
+      })
+      const text = events
+        .filter((e) => e.type === 'content_delta')
+        .map((e) => (e as any).content)
+        .join('')
+      expect(text).toBe('The main things were:')
+    })
+
+    it('merges a reasoning tail carried on the same chunk as content', () => {
+      const events = processAll([
+        reasoningChunk('thinking about trade'),
+        { choices: [{ delta: { content: 'Answer start' } }] },
+        reasoningChunk('offs. ', ' **TCP** is reliable'),
+      ])
+
+      const types = events.map((e) => e.type)
+      expect(types.filter((t) => t === 'thinking_start').length).toBe(1)
+      expect(events).toContainEqual({
+        type: 'thinking_tail_delta',
+        content: 'offs. ',
+      })
+      const text = events
+        .filter((e) => e.type === 'content_delta')
+        .map((e) => (e as any).content)
+        .join('')
+      expect(text).toBe('Answer start **TCP** is reliable')
+    })
+
+    it('opens a new thinking block when reasoning resumes after a tool call', () => {
+      const events = processAll([
+        reasoningChunk('first thoughts'),
+        { choices: [{ delta: { content: 'Intro text' } }] },
+        {
+          choices: [
+            {
+              delta: {
+                tool_calls: [
+                  {
+                    index: 0,
+                    id: 'call_widget',
+                    type: 'function',
+                    function: {
+                      name: 'render_stat_cards',
+                      arguments: '{"stats":[]}',
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+        reasoningChunk('second phase thoughts'),
+        { choices: [{ delta: { content: 'Final answer' } }] },
       ])
 
       const types = events.map((e) => e.type)
       expect(types.filter((t) => t === 'thinking_start').length).toBe(2)
       expect(types.filter((t) => t === 'thinking_end').length).toBe(2)
+      expect(types).not.toContain('thinking_tail_delta')
     })
   })
 

--- a/tests/components/chat/streaming/timeline-builder.test.ts
+++ b/tests/components/chat/streaming/timeline-builder.test.ts
@@ -68,6 +68,35 @@ describe('TimelineBuilder', () => {
       expect(builder.snapshot()).toEqual([])
     })
 
+    it('appends a tail to the closed thinking block without splitting content', () => {
+      const builder = new TimelineBuilder()
+      builder.startThinking()
+      builder.appendThinking('I should account')
+      builder.endThinking(1.1)
+      builder.appendContent('The')
+      builder.appendThinkingTail(' for.')
+      builder.appendContent(' main things were:')
+
+      const blocks = builder.snapshot()
+      expect(blocks).toHaveLength(2)
+      const thinking = blocks[0] as TimelineThinkingBlock
+      expect(thinking.content).toBe('I should account for.')
+      expect(thinking.isThinking).toBe(false)
+      expect(thinking.duration).toBe(1.1)
+      const content = blocks[1] as TimelineContentBlock
+      expect(content.content).toBe('The main things were:')
+    })
+
+    it('ignores appendThinkingTail when no thinking block exists', () => {
+      const builder = new TimelineBuilder()
+      builder.appendContent('hello')
+      builder.appendThinkingTail('orphan tail')
+
+      const blocks = builder.snapshot()
+      expect(blocks).toHaveLength(1)
+      expect((blocks[0] as TimelineContentBlock).content).toBe('hello')
+    })
+
     it('ignores endThinking when no block is open', () => {
       const builder = new TimelineBuilder()
       // Should not throw


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevents late reasoning fragments from splitting answers. Late thinking is now merged into the previous thinking block, keeping content contiguous and avoiding phantom “thinking” blocks.

- **Bug Fixes**
  - Introduced `thinking_tail_delta` to attach late reasoning to the prior thinking block.
  - Added `appendThinkingTail` in the timeline to extend the last thinking block without reopening it.
  - Tracked `thinkingClosedByContent` to detect tails; only restarts thinking after tool-call boundaries.
  - Removed the old punctuation buffering workaround and expanded tests to cover tail handling.

<sup>Written for commit 8a139040d31151d4ff91e0f092fc84c724c5b1e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/397?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

