### PR TITLE
Fix chat migration when the key set is unchanged

### DIFF
--- a/src/constants/storage-keys.ts
+++ b/src/constants/storage-keys.ts
@@ -116,6 +116,15 @@ export const SYNC_PROFILE_DIRTY = 'tinfoil-sync-profile-dirty'
 // orphan rows server-side; the next sync repopulates fresh plaintext.
 export const MIGRATION_LEGACY_CLOUD_CHATS_EVICTED =
   'tinfoil-migration-legacy-cloud-chats-evicted'
+// Per-user fingerprint (suffixed with the clerk user id) of the
+// migration candidate key set whose last completed migrate-all sweep
+// left rows blocked under every key this client holds. While the
+// fingerprint matches the current key set the client skips re-kicking a
+// doomed sweep on each page load; a changed key set (a newly recovered
+// key) no longer matches, so the sweep runs again. Cleared once a sweep
+// reports everything migrated.
+export const MIGRATION_EXHAUSTED_KEYSET_PREFIX =
+  'tinfoil-migration-exhausted-keyset-'
 
 // --- localStorage: Development ---------------------------------------------
 export const DEV_ENABLE_DEBUG_LOGS = 'tinfoil-dev-enable-debug-logs'

--- a/src/services/cloud/cek-encoding.ts
+++ b/src/services/cloud/cek-encoding.ts
@@ -130,26 +130,37 @@ export function migrationKeys(): PullKey[] {
  * safe to persist. Callers use it to tell whether the set of keys the
  * migration sweep can try has changed since the last attempt, so a
  * doomed sweep is not re-driven on every page load with an unchanged
- * key set. Returns null when no primary key is loaded.
+ * key set. Returns null when no primary key is loaded or its bytes are
+ * unreadable.
  */
 export async function migrationKeySetFingerprint(): Promise<string | null> {
   const primary = encryptionService.getKey()
   if (!primary) return null
-  const keys = [
-    primary,
-    ...encryptionService.getStoredAlternatives().filter((a) => a !== primary),
-  ]
-  const ids: string[] = []
-  for (const k of keys) {
-    const bytes = encryptionService.getAlternativeKeyBytes(k)
+  // Mirror migrationKeys(): without a readable primary there is no
+  // candidate key set, so the fingerprint must be null rather than one
+  // built from alternatives alone. Otherwise the gate's retry decision
+  // would diverge from the sweep, which never runs without a primary at
+  // keys[0].
+  const primaryBytes = encryptionService.getAlternativeKeyBytes(primary)
+  if (!primaryBytes) return null
+  let primaryId: string
+  try {
+    primaryId = await deriveKeyIdHex(primaryBytes)
+  } catch {
+    return null
+  }
+  const ids: string[] = [primaryId]
+  const alternatives = encryptionService.getStoredAlternatives()
+  for (const alt of alternatives) {
+    if (alt === primary) continue
+    const bytes = encryptionService.getAlternativeKeyBytes(alt)
     if (!bytes) continue
     try {
       ids.push(await deriveKeyIdHex(bytes))
     } catch {
-      // Skip an unreadable key rather than abort the whole fingerprint.
+      // Skip an unreadable alternative rather than abort the fingerprint.
     }
   }
-  if (ids.length === 0) return null
   ids.sort()
   return ids.join(',')
 }

--- a/src/services/cloud/cek-encoding.ts
+++ b/src/services/cloud/cek-encoding.ts
@@ -121,3 +121,35 @@ export function migrationKeys(): PullKey[] {
   }
   return out
 }
+
+/**
+ * Stable, non-secret fingerprint of the migration candidate key set
+ * (primary plus alternatives) the way `migrationKeys()` assembles it.
+ * Derived from each key's controlplane key_id (a hex digest, never the
+ * raw CEK), sorted and joined so the value is order-independent and
+ * safe to persist. Callers use it to tell whether the set of keys the
+ * migration sweep can try has changed since the last attempt, so a
+ * doomed sweep is not re-driven on every page load with an unchanged
+ * key set. Returns null when no primary key is loaded.
+ */
+export async function migrationKeySetFingerprint(): Promise<string | null> {
+  const primary = encryptionService.getKey()
+  if (!primary) return null
+  const keys = [
+    primary,
+    ...encryptionService.getStoredAlternatives().filter((a) => a !== primary),
+  ]
+  const ids: string[] = []
+  for (const k of keys) {
+    const bytes = encryptionService.getAlternativeKeyBytes(k)
+    if (!bytes) continue
+    try {
+      ids.push(await deriveKeyIdHex(bytes))
+    } catch {
+      // Skip an unreadable key rather than abort the whole fingerprint.
+    }
+  }
+  if (ids.length === 0) return null
+  ids.sort()
+  return ids.join(',')
+}

--- a/src/services/cloud/cloud-storage.ts
+++ b/src/services/cloud/cloud-storage.ts
@@ -113,9 +113,9 @@ export interface UploadChatResult {
 
 /**
  * Plaintext envelope-v2 JSON returned by the sync enclave. The `2`
- * here mirrors the wire `tinfoil-sync-envelope-v2` AAD (see
- * syncplan.md §5) — the row is sealed under v2 on the controlplane,
- * the enclave unsealed it, so what we hand back is plaintext.
+ * here mirrors the wire `tinfoil-sync-envelope-v2` AAD — the row is
+ * sealed under v2 on the controlplane, the enclave unsealed it, so
+ * what we hand back is plaintext.
  */
 export type RawChatContent = {
   plaintext: string

--- a/src/services/cloud/cloud-sync.ts
+++ b/src/services/cloud/cloud-sync.ts
@@ -1,5 +1,7 @@
 import { PAGINATION } from '@/config'
 import {
+  AUTH_ACTIVE_USER_ID,
+  MIGRATION_EXHAUSTED_KEYSET_PREFIX,
   SYNC_ALL_CHATS_STATUS,
   SYNC_CHAT_STATUS,
   SYNC_PROJECT_CHAT_STATUS_PREFIX,
@@ -25,6 +27,7 @@ import {
 import { IF_MATCH_SENTINELS } from '../sync-enclave/wire-contract'
 import {
   hasPrimaryKey,
+  migrationKeySetFingerprint,
   primaryKeyIdHexOrNull,
   requirePrimaryKeyB64,
   requirePrimaryKeyBytes,
@@ -37,7 +40,10 @@ import {
   type ChatSyncStatus,
   type UploadChatOptions,
 } from './cloud-storage'
-import { runLegacyBlobMigrationAndFinalize } from './legacy-blob-migration'
+import {
+  runLegacyBlobMigrationAndFinalize,
+  type MigrationReport,
+} from './legacy-blob-migration'
 import { runLegacyChatEvictionIfNeeded } from './legacy-chat-eviction'
 import { projectStorage } from './project-storage'
 import { streamingTracker } from './streaming-tracker'
@@ -1125,6 +1131,24 @@ export class CloudSyncService {
     if (!hasPrimaryKey()) {
       return
     }
+    // Don't re-drive a sweep that already exhausted this exact candidate
+    // key set. When a prior completed sweep left rows blocked under every
+    // key this client holds, retrying with the same keys fails those rows
+    // identically and re-stamps them on the controlplane — the per-open
+    // sync_migration_failure storm. The gate clears itself the moment the
+    // key set changes (a newly recovered key has a different fingerprint),
+    // so a genuinely actionable retry still runs. Computed before the
+    // network key-current lookup so the skip stays cheap. The server 24h
+    // cooldown remains as a backstop.
+    const activeUserId = this.readActiveUserId()
+    const keysetFp = await migrationKeySetFingerprint()
+    if (
+      keysetFp &&
+      activeUserId &&
+      this.loadExhaustedMigrationKeyset(activeUserId) === keysetFp
+    ) {
+      return
+    }
     // Only migrate once the local primary CEK is the controlplane's
     // registered current key. migrate-all re-seals every legacy row
     // under that CEK via Rewrap, which the controlplane rejects with
@@ -1184,6 +1208,7 @@ export class CloudSyncService {
             totalBlocked: report.totalBlocked,
           },
         })
+        this.recordMigrationKeysetOutcome(activeUserId, keysetFp, report)
         await runLegacyChatEvictionIfNeeded()
         // Eviction deletes local rows but the server still has them,
         // so the cached `(count, lastUpdated)` snapshot now lies. Drop
@@ -1207,6 +1232,65 @@ export class CloudSyncService {
           action: 'kickLegacyBlobMigration',
         })
       })
+  }
+
+  /**
+   * Active clerk user id this browser is signed in as, or null. Scopes
+   * the per-user migration key-set fingerprint so a different account on
+   * the same browser never inherits another user's gate.
+   */
+  private readActiveUserId(): string | null {
+    if (typeof window === 'undefined') return null
+    try {
+      return localStorage.getItem(AUTH_ACTIVE_USER_ID)
+    } catch {
+      return null
+    }
+  }
+
+  /**
+   * Persisted fingerprint of the candidate key set whose last completed
+   * sweep left rows blocked, or null when none is recorded.
+   */
+  private loadExhaustedMigrationKeyset(userId: string): string | null {
+    if (typeof window === 'undefined') return null
+    try {
+      return localStorage.getItem(
+        `${MIGRATION_EXHAUSTED_KEYSET_PREFIX}${userId}`,
+      )
+    } catch {
+      return null
+    }
+  }
+
+  /**
+   * Persist or clear the exhausted-key-set fingerprint from a sweep
+   * result. A completed sweep (no retryable rows remaining) that still
+   * leaves rows blocked marks this exact key set exhausted, so later page
+   * loads skip the doomed re-sweep until the key set changes; a sweep
+   * that drained everything clears the gate. A partial sweep (retryable
+   * rows remaining) leaves the gate untouched so the next sync keeps
+   * making progress.
+   */
+  private recordMigrationKeysetOutcome(
+    userId: string | null,
+    keysetFp: string | null,
+    report: MigrationReport,
+  ): void {
+    if (typeof window === 'undefined' || !userId) return
+    const storageKey = `${MIGRATION_EXHAUSTED_KEYSET_PREFIX}${userId}`
+    try {
+      if (report.fullyMigrated && report.totalBlocked === 0) {
+        localStorage.removeItem(storageKey)
+        return
+      }
+      if (report.fullyMigrated && report.totalBlocked > 0 && keysetFp) {
+        localStorage.setItem(storageKey, keysetFp)
+      }
+    } catch {
+      // A localStorage failure is non-fatal: the gate simply does not
+      // engage and the server-side 24h cooldown remains the backstop.
+    }
   }
 
   /**

--- a/src/services/cloud/project-storage.ts
+++ b/src/services/cloud/project-storage.ts
@@ -331,8 +331,8 @@ export class ProjectStorageService {
       )
     }
 
-    // syncplan §16.6: a UI-driven single-row delete passes
-    // `if_match=null`. The enclave retries on STALE_BLOB up to three
+    // A UI-driven single-row delete passes `if_match=null`. The
+    // enclave retries on STALE_BLOB up to three
     // times, so we do not need to fetch the current etag first. The
     // previous approach scanned only the first 500 list-status rows
     // and silently no-op'd when the target lived past the boundary.
@@ -369,7 +369,7 @@ export class ProjectStorageService {
         // the page fetch and the delete (concurrent write from another
         // device). Passing ifMatch=null avoids spurious STALE_BLOB
         // failures that would leave the batch partially completed.
-        // Mirrors the single-row deleteProject path; see syncplan §16.6.
+        // Mirrors the single-row deleteProject path.
         await enclaveDeleteRow({
           scope: PROJECT_SCOPE,
           id: update.id,
@@ -682,8 +682,8 @@ export class ProjectStorageService {
     }
 
     const id = projectDocumentId(projectId, documentId)
-    // syncplan §16.6: a UI-driven single-row delete passes
-    // `if_match=null`. The PROJECT_DOCUMENT_SCOPE pools every
+    // A UI-driven single-row delete passes `if_match=null`. The
+    // PROJECT_DOCUMENT_SCOPE pools every
     // project's documents under one user, so the previous
     // first-page-only list-status lookup was even more likely to
     // miss the target than the project case.

--- a/src/services/sync-enclave/key-bundle.ts
+++ b/src/services/sync-enclave/key-bundle.ts
@@ -2,8 +2,8 @@
  * Wrap / unwrap the user's content encryption key (CEK) under a
  * passkey-PRF-derived KEK, in the shape the sync enclave expects.
  *
- * The enclave wire format (see syncplan.md §6, BundleBody in
- * sync-api.ts) carries one wrapped CEK per registered passkey
+ * The enclave wire format (BundleBody in sync-api.ts) carries one
+ * wrapped CEK per registered passkey
  * credential. There is no list of "alternative" keys: the enclave is
  * the single source of truth, and legacy alternatives are left to
  * Phase 4 opportunistic migration.

--- a/tests/services/cloud/cek-encoding.test.ts
+++ b/tests/services/cloud/cek-encoding.test.ts
@@ -200,11 +200,23 @@ describe('cek-encoding', () => {
       expect(await migrationKeySetFingerprint()).toBeNull()
     })
 
-    it('skips keys whose bytes are unreadable', async () => {
+    it('skips alternatives whose bytes are unreadable', async () => {
       mockGetKey.mockReturnValue('key_primary')
       mockGetStoredAlternatives.mockReturnValue(['key_missing'])
       const fp = await migrationKeySetFingerprint()
       expect(fp).toBe('id_10')
+    })
+
+    it('returns null when the primary bytes are unreadable, even with readable alternatives', async () => {
+      // Mirrors migrationKeys(), which returns [] without a readable
+      // primary: the fingerprint must not be built from alternatives
+      // alone, or the gate would diverge from the sweep.
+      mockGetKey.mockReturnValue('key_primary')
+      mockGetStoredAlternatives.mockReturnValue(['key_alt1'])
+      mockGetAlternativeKeyBytes.mockImplementation((k) =>
+        k === 'key_alt1' ? bytesByKey.key_alt1 : null,
+      )
+      expect(await migrationKeySetFingerprint()).toBeNull()
     })
   })
 })

--- a/tests/services/cloud/cek-encoding.test.ts
+++ b/tests/services/cloud/cek-encoding.test.ts
@@ -14,7 +14,16 @@ vi.mock('@/services/encryption/encryption-service', () => ({
   },
 }))
 
+// Map each candidate CEK to a deterministic id by its fill byte so the
+// fingerprint test exercises the helper's sorting/dedup/join logic
+// without depending on the crypto-backed key-id derivation.
+vi.mock('@/services/sync-enclave/key-bundle', () => ({
+  deriveKeyIdHex: async (cek: Uint8Array) =>
+    `id_${cek[0].toString(16).padStart(2, '0')}`,
+}))
+
 import {
+  migrationKeySetFingerprint,
   migrationKeys,
   pullKey,
   requirePrimaryKeyB64,
@@ -140,6 +149,62 @@ describe('cek-encoding', () => {
       expect(keys).toHaveLength(1)
       expect(atob(keys[0].key).charCodeAt(0)).toBe(0x42)
       expect(mockGetKeyBytesOrThrow).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('migrationKeySetFingerprint', () => {
+    const bytesByKey: Record<string, Uint8Array> = {
+      key_primary: new Uint8Array(32).fill(0x10),
+      key_alt1: new Uint8Array(32).fill(0x20),
+      key_alt2: new Uint8Array(32).fill(0x30),
+    }
+
+    beforeEach(() => {
+      mockGetAlternativeKeyBytes.mockImplementation(
+        (k) => bytesByKey[k] ?? null,
+      )
+    })
+
+    it('fingerprints the sorted ids of the primary and unique alternatives', async () => {
+      mockGetKey.mockReturnValue('key_primary')
+      mockGetStoredAlternatives.mockReturnValue([
+        'key_alt2',
+        'key_alt1',
+        'key_primary',
+      ])
+      const fp = await migrationKeySetFingerprint()
+      expect(fp).toBe('id_10,id_20,id_30')
+    })
+
+    it('is order-independent: the same key set yields the same fingerprint', async () => {
+      mockGetKey.mockReturnValue('key_primary')
+      mockGetStoredAlternatives.mockReturnValue(['key_alt1', 'key_alt2'])
+      const a = await migrationKeySetFingerprint()
+      mockGetStoredAlternatives.mockReturnValue(['key_alt2', 'key_alt1'])
+      const b = await migrationKeySetFingerprint()
+      expect(a).toBe(b)
+    })
+
+    it('changes when a new key joins the candidate set', async () => {
+      mockGetKey.mockReturnValue('key_primary')
+      mockGetStoredAlternatives.mockReturnValue(['key_alt1'])
+      const before = await migrationKeySetFingerprint()
+      mockGetStoredAlternatives.mockReturnValue(['key_alt1', 'key_alt2'])
+      const after = await migrationKeySetFingerprint()
+      expect(after).not.toBe(before)
+    })
+
+    it('returns null when no primary key is loaded', async () => {
+      mockGetKey.mockReturnValue(null)
+      mockGetStoredAlternatives.mockReturnValue([])
+      expect(await migrationKeySetFingerprint()).toBeNull()
+    })
+
+    it('skips keys whose bytes are unreadable', async () => {
+      mockGetKey.mockReturnValue('key_primary')
+      mockGetStoredAlternatives.mockReturnValue(['key_missing'])
+      const fp = await migrationKeySetFingerprint()
+      expect(fp).toBe('id_10')
     })
   })
 })

--- a/tests/services/cloud/cloud-sync.test.ts
+++ b/tests/services/cloud/cloud-sync.test.ts
@@ -35,6 +35,7 @@ const mockRequirePrimaryKeyB64 = vi.fn()
 const mockRequirePrimaryKeyBytes = vi.fn()
 const mockPull = vi.fn()
 const mockMigrationKeys = vi.fn()
+const mockMigrationKeySetFingerprint = vi.fn(async () => null)
 const mockGetCachedPrfResult = vi.fn()
 const mockDeriveKeyEncryptionKey = vi.fn()
 const mockLoadPasskeyCredentials = vi.fn()
@@ -118,6 +119,8 @@ vi.mock('@/services/cloud/cek-encoding', () => ({
   requirePrimaryKeyBytes: (...args: any[]) =>
     mockRequirePrimaryKeyBytes(...args),
   migrationKeys: (...args: any[]) => mockMigrationKeys(...args),
+  migrationKeySetFingerprint: (...args: any[]) =>
+    mockMigrationKeySetFingerprint(...args),
 }))
 
 vi.mock('@/services/passkey/passkey-service', () => ({


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stop re-running the legacy chat migration when the user's key set hasn't changed. This prevents repeated sync_migration_failure spam and avoids useless API work.

- **Bug Fixes**
  - Added `migrationKeySetFingerprint()` to compute a stable fingerprint of the primary + alternative CEKs; returns null when the primary is missing or unreadable so the retry gate is bypassed in that case.
  - Persist the exhausted key-set fingerprint per user in `localStorage` under `MIGRATION_EXHAUSTED_KEYSET_PREFIX` + `AUTH_ACTIVE_USER_ID`; skip migrate-all while unchanged.
  - Record outcomes: set fingerprint when a completed sweep still has blocked rows; clear when everything is migrated; leave unchanged for partial sweeps.
  - Gate check runs before network key-current lookup to keep it fast; server 24h cooldown remains as backstop.
  - Tests added for fingerprinting (including unreadable primary) and the skip logic.

- **Refactors**
  - Removed references to a retired sync planning doc in comments.

<sup>Written for commit 207bb77337b6c94d015abb2e7fa185c6ea6e89b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/398?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

