### PR TITLE
Fix mobile layout

### DIFF
--- a/src/components/chat/WelcomeScreen.tsx
+++ b/src/components/chat/WelcomeScreen.tsx
@@ -561,11 +561,17 @@ export const WelcomeScreen = memo(function WelcomeScreen({
                     const m = models?.find(
                       (mm) => mm.modelName === selectedModel,
                     )
-                    if (!isReasoningModel(m)) return undefined
+                    const supportsEffort = supportsReasoningEffort(m)
+                    const supportsToggle = supportsThinkingToggle(m)
+                    if (
+                      !isReasoningModel(m) ||
+                      (!supportsEffort && !supportsToggle)
+                    )
+                      return undefined
                     return (
                       <ReasoningEffortSelector
-                        supportsEffort={supportsReasoningEffort(m)}
-                        supportsToggle={supportsThinkingToggle(m)}
+                        supportsEffort={supportsEffort}
+                        supportsToggle={supportsToggle}
                         reasoningEffort={reasoningEffort}
                         onEffortChange={setReasoningEffort}
                         thinkingEnabled={thinkingEnabled}

--- a/src/components/chat/WelcomeScreen.tsx
+++ b/src/components/chat/WelcomeScreen.tsx
@@ -362,7 +362,7 @@ export const WelcomeScreen = memo(function WelcomeScreen({
                   return !prev
                 })
               }}
-              className={`group flex w-full items-center gap-2 py-1.5 text-base text-content-secondary transition-colors hover:text-content-primary md:justify-start ${privacyExpanded ? 'justify-start' : 'justify-center'}`}
+              className={`group flex w-full items-center gap-1.5 py-1.5 text-sm text-content-secondary transition-colors hover:text-content-primary sm:gap-2 sm:text-base md:justify-start ${privacyExpanded ? 'justify-start' : 'justify-center'}`}
             >
               <motion.span
                 className="inline-flex shrink-0"
@@ -382,7 +382,9 @@ export const WelcomeScreen = memo(function WelcomeScreen({
                   aria-hidden="true"
                 />
               </motion.span>
-              <span>Your chats are private by design</span>
+              <span className="shrink-0 whitespace-nowrap">
+                Your chats are private by design
+              </span>
               <svg
                 className={`h-3.5 w-3.5 shrink-0 opacity-50 transition-transform duration-300 ${privacyExpanded ? 'rotate-180' : ''}`}
                 fill="none"

--- a/src/components/chat/chat-input.tsx
+++ b/src/components/chat/chat-input.tsx
@@ -1070,6 +1070,18 @@ export function ChatInput({
                           )}
                         </button>
                       )}
+                      {contextUsage && (
+                        <div className="flex w-full items-center gap-3 px-3 py-2 text-left text-sm text-content-primary">
+                          <span className="flex-1">Context</span>
+                          <ContextUsageIndicator usage={contextUsage} />
+                        </div>
+                      )}
+                      {reasoningSelectorButton && (
+                        <div className="flex w-full items-center gap-3 px-3 py-2 text-left text-sm text-content-primary">
+                          <span className="flex-1">Thinking</span>
+                          {reasoningSelectorButton}
+                        </div>
+                      )}
                     </div>
                   </>
                 )}
@@ -1164,9 +1176,16 @@ export function ChatInput({
             </div>
 
             <div className="flex items-center gap-2">
-              {contextUsage && <ContextUsageIndicator usage={contextUsage} />}
+              {contextUsage && (
+                <ContextUsageIndicator
+                  usage={contextUsage}
+                  className="hidden md:flex"
+                />
+              )}
               {modelSelectorButton && <div>{modelSelectorButton}</div>}
-              {reasoningSelectorButton && <div>{reasoningSelectorButton}</div>}
+              {reasoningSelectorButton && (
+                <div className="hidden md:block">{reasoningSelectorButton}</div>
+              )}
               {isPremium && audioModel && (
                 <button
                   type="button"

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -3267,11 +3267,17 @@ export function ChatInterface({
                           const m = models.find(
                             (mm) => mm.modelName === selectedModel,
                           )
-                          if (!isReasoningModel(m)) return undefined
+                          const supportsEffort = supportsReasoningEffort(m)
+                          const supportsToggle = supportsThinkingToggle(m)
+                          if (
+                            !isReasoningModel(m) ||
+                            (!supportsEffort && !supportsToggle)
+                          )
+                            return undefined
                           return (
                             <ReasoningEffortSelector
-                              supportsEffort={supportsReasoningEffort(m)}
-                              supportsToggle={supportsThinkingToggle(m)}
+                              supportsEffort={supportsEffort}
+                              supportsToggle={supportsToggle}
                               reasoningEffort={reasoningEffort}
                               onEffortChange={setReasoningEffort}
                               thinkingEnabled={thinkingEnabled}

--- a/src/components/chat/components/context-usage-indicator.tsx
+++ b/src/components/chat/components/context-usage-indicator.tsx
@@ -26,7 +26,13 @@ function formatTokens(tokens: number): string {
  * current conversation occupies. Once usage passes 100%, older messages get
  * archived and are no longer sent to the model.
  */
-export function ContextUsageIndicator({ usage }: { usage: ContextUsage }) {
+export function ContextUsageIndicator({
+  usage,
+  className,
+}: {
+  usage: ContextUsage
+  className?: string
+}) {
   const percentage = Math.min(Math.round(usage.percentage), 100)
 
   const isNearLimit = percentage >= WARNING_THRESHOLD_PERCENT
@@ -38,7 +44,7 @@ export function ContextUsageIndicator({ usage }: { usage: ContextUsage }) {
     : `Context window ${percentage}% used (~${formatTokens(usage.usedTokens)} of ${formatTokens(usage.limitTokens)} tokens)`
 
   return (
-    <div className="group relative hidden items-center md:flex">
+    <div className={cn('group relative flex items-center', className)}>
       <span
         role="status"
         aria-label={tooltip}

--- a/src/components/chat/components/context-usage-indicator.tsx
+++ b/src/components/chat/components/context-usage-indicator.tsx
@@ -38,7 +38,7 @@ export function ContextUsageIndicator({ usage }: { usage: ContextUsage }) {
     : `Context window ${percentage}% used (~${formatTokens(usage.usedTokens)} of ${formatTokens(usage.limitTokens)} tokens)`
 
   return (
-    <div className="group relative flex items-center">
+    <div className="group relative hidden items-center md:flex">
       <span
         role="status"
         aria-label={tooltip}

--- a/src/components/chat/components/prompt-preset-suggestions.tsx
+++ b/src/components/chat/components/prompt-preset-suggestions.tsx
@@ -1,6 +1,5 @@
 import { cn } from '@/components/ui/utils'
-import { ChevronDownIcon, Squares2X2Icon } from '@heroicons/react/24/outline'
-import { useState } from 'react'
+import { Squares2X2Icon } from '@heroicons/react/24/outline'
 import { BUILT_IN_PROMPT_PRESETS } from '../prompts/built-in-presets'
 import type { PromptPreset } from '../prompts/types'
 
@@ -17,7 +16,6 @@ export function PromptPresetSuggestions({
   onSetActive,
   onOpenLibrary,
 }: PromptPresetSuggestionsProps) {
-  const [isMobileExpanded, setIsMobileExpanded] = useState(false)
   const suggested = BUILT_IN_PROMPT_PRESETS.slice(0, SUGGESTION_COUNT)
   const pillBase =
     'inline-flex h-14 w-full items-center justify-center gap-1.5 rounded-lg border px-3 text-sm transition-colors md:h-auto md:w-auto md:py-1.5'
@@ -64,24 +62,12 @@ export function PromptPresetSuggestions({
       <div className="md:hidden">
         <button
           type="button"
-          onClick={() => setIsMobileExpanded((expanded) => !expanded)}
-          aria-expanded={isMobileExpanded}
-          className="flex h-14 w-full items-center justify-between rounded-lg border border-border-subtle bg-surface-chat-background px-4 text-sm text-content-secondary transition-colors hover:bg-surface-chat hover:text-content-primary"
+          onClick={onOpenLibrary}
+          className="flex h-14 w-full items-center justify-center gap-1.5 rounded-lg border border-border-subtle bg-surface-chat-background px-4 text-sm text-content-secondary transition-colors hover:bg-surface-chat hover:text-content-primary"
         >
+          <Squares2X2Icon className="h-3.5 w-3.5" aria-hidden="true" />
           <span>Prompts</span>
-          <ChevronDownIcon
-            className={cn(
-              'h-4 w-4 transition-transform',
-              isMobileExpanded ? 'rotate-180' : '',
-            )}
-            aria-hidden="true"
-          />
         </button>
-        {isMobileExpanded && (
-          <div className="mt-2 grid auto-rows-fr grid-cols-1 gap-2">
-            {renderSuggestions()}
-          </div>
-        )}
       </div>
       <div className="hidden auto-rows-fr grid-cols-1 gap-2 md:flex md:flex-wrap md:items-center md:justify-center">
         {renderSuggestions()}

--- a/src/components/chat/components/prompt-preset-suggestions.tsx
+++ b/src/components/chat/components/prompt-preset-suggestions.tsx
@@ -21,7 +21,7 @@ export function PromptPresetSuggestions({
     'inline-flex h-14 w-full items-center justify-center gap-1.5 rounded-lg border px-3 text-sm transition-colors md:h-auto md:w-auto md:py-1.5'
 
   return (
-    <div className="grid auto-rows-fr grid-cols-2 gap-2 md:flex md:flex-wrap md:items-center md:justify-center">
+    <div className="grid auto-rows-fr grid-cols-1 gap-2 md:flex md:flex-wrap md:items-center md:justify-center">
       {suggested.map((preset) => {
         const Icon = preset.Icon
         const isActive = activePreset?.id === preset.id

--- a/src/components/chat/components/prompt-preset-suggestions.tsx
+++ b/src/components/chat/components/prompt-preset-suggestions.tsx
@@ -59,11 +59,11 @@ export function PromptPresetSuggestions({
 
   return (
     <>
-      <div className="md:hidden">
+      <div className="flex justify-center md:hidden">
         <button
           type="button"
           onClick={onOpenLibrary}
-          className="flex h-14 w-full items-center justify-center gap-1.5 rounded-lg border border-border-subtle bg-surface-chat-background px-4 text-sm text-content-secondary transition-colors hover:bg-surface-chat hover:text-content-primary"
+          className="flex h-10 items-center justify-center gap-1.5 rounded-lg border border-border-subtle bg-surface-chat-background px-4 text-sm text-content-secondary transition-colors hover:bg-surface-chat hover:text-content-primary"
         >
           <Squares2X2Icon className="h-3.5 w-3.5" aria-hidden="true" />
           <span>Prompts</span>

--- a/src/components/chat/components/prompt-preset-suggestions.tsx
+++ b/src/components/chat/components/prompt-preset-suggestions.tsx
@@ -1,5 +1,6 @@
 import { cn } from '@/components/ui/utils'
-import { Squares2X2Icon } from '@heroicons/react/24/outline'
+import { ChevronDownIcon, Squares2X2Icon } from '@heroicons/react/24/outline'
+import { useState } from 'react'
 import { BUILT_IN_PROMPT_PRESETS } from '../prompts/built-in-presets'
 import type { PromptPreset } from '../prompts/types'
 
@@ -16,12 +17,13 @@ export function PromptPresetSuggestions({
   onSetActive,
   onOpenLibrary,
 }: PromptPresetSuggestionsProps) {
+  const [isMobileExpanded, setIsMobileExpanded] = useState(false)
   const suggested = BUILT_IN_PROMPT_PRESETS.slice(0, SUGGESTION_COUNT)
   const pillBase =
     'inline-flex h-14 w-full items-center justify-center gap-1.5 rounded-lg border px-3 text-sm transition-colors md:h-auto md:w-auto md:py-1.5'
 
-  return (
-    <div className="grid auto-rows-fr grid-cols-1 gap-2 md:flex md:flex-wrap md:items-center md:justify-center">
+  const renderSuggestions = () => (
+    <>
       {suggested.map((preset) => {
         const Icon = preset.Icon
         const isActive = activePreset?.id === preset.id
@@ -54,6 +56,36 @@ export function PromptPresetSuggestions({
         <Squares2X2Icon className="h-3.5 w-3.5" aria-hidden="true" />
         <span>More</span>
       </button>
-    </div>
+    </>
+  )
+
+  return (
+    <>
+      <div className="md:hidden">
+        <button
+          type="button"
+          onClick={() => setIsMobileExpanded((expanded) => !expanded)}
+          aria-expanded={isMobileExpanded}
+          className="flex h-14 w-full items-center justify-between rounded-lg border border-border-subtle bg-surface-chat-background px-4 text-sm text-content-secondary transition-colors hover:bg-surface-chat hover:text-content-primary"
+        >
+          <span>Prompts</span>
+          <ChevronDownIcon
+            className={cn(
+              'h-4 w-4 transition-transform',
+              isMobileExpanded ? 'rotate-180' : '',
+            )}
+            aria-hidden="true"
+          />
+        </button>
+        {isMobileExpanded && (
+          <div className="mt-2 grid auto-rows-fr grid-cols-1 gap-2">
+            {renderSuggestions()}
+          </div>
+        )}
+      </div>
+      <div className="hidden auto-rows-fr grid-cols-1 gap-2 md:flex md:flex-wrap md:items-center md:justify-center">
+        {renderSuggestions()}
+      </div>
+    </>
   )
 }

--- a/src/components/chat/prompt-library-modal.tsx
+++ b/src/components/chat/prompt-library-modal.tsx
@@ -442,12 +442,12 @@ function PresetDetail({
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
-      <div className="flex flex-none items-start justify-between gap-4 border-b border-border-subtle px-6 py-4">
-        <div className="flex min-w-0 items-start gap-3">
+      <div className="flex flex-none items-start justify-between gap-4 border-b border-border-subtle px-4 py-4 md:px-6">
+        <div className="flex min-w-0 flex-1 items-start gap-3">
           <span className="flex h-10 w-10 flex-none items-center justify-center rounded-lg bg-surface-chat text-content-secondary">
             <Icon className="h-5 w-5" aria-hidden="true" />
           </span>
-          <div className="min-w-0">
+          <div className="min-w-0 flex-1">
             {isEditingName && !preset.isBuiltIn ? (
               <input
                 type="text"
@@ -471,7 +471,7 @@ function PresetDetail({
             ) : (
               <h3
                 className={cn(
-                  'truncate rounded-md px-1.5 py-0.5 text-base font-semibold text-content-primary',
+                  'line-clamp-2 rounded-md px-1.5 py-0.5 text-base font-semibold text-content-primary md:truncate',
                   !preset.isBuiltIn && 'cursor-text hover:bg-surface-chat',
                 )}
                 title={preset.isBuiltIn ? undefined : 'Click to rename'}
@@ -500,12 +500,32 @@ function PresetDetail({
                 {preset.description}
               </p>
             )}
+            <div className="mt-3 flex items-center px-1.5 md:hidden">
+              {isActive ? (
+                <button
+                  type="button"
+                  onClick={onClearActive}
+                  className="w-full rounded-lg border border-border-subtle bg-surface-chat-background px-3 py-2 text-sm font-medium text-content-primary transition-colors hover:bg-surface-chat"
+                >
+                  Stop using
+                </button>
+              ) : (
+                <button
+                  type="button"
+                  onClick={onUseThis}
+                  className="flex w-full items-center justify-center gap-1.5 whitespace-nowrap rounded-lg bg-brand-accent-dark px-3 py-2 text-sm font-semibold text-white transition-colors hover:bg-brand-accent-dark/90"
+                >
+                  <SparklesIcon className="h-4 w-4" />
+                  Use for this chat
+                </button>
+              )}
+            </div>
             <span className="mt-1 inline-block px-1.5 text-[11px] uppercase tracking-wide text-content-muted">
               {preset.isBuiltIn ? 'Built-in' : 'Custom'}
             </span>
           </div>
         </div>
-        <div className="flex flex-none items-center gap-2">
+        <div className="hidden flex-none items-center gap-2 md:flex md:justify-end">
           {isActive ? (
             <button
               type="button"
@@ -518,7 +538,7 @@ function PresetDetail({
             <button
               type="button"
               onClick={onUseThis}
-              className="flex items-center gap-1.5 rounded-lg bg-brand-accent-dark px-3 py-2 text-sm font-semibold text-white transition-colors hover:bg-brand-accent-dark/90"
+              className="flex w-full items-center justify-center gap-1.5 whitespace-nowrap rounded-lg bg-brand-accent-dark px-3 py-2 text-sm font-semibold text-white transition-colors hover:bg-brand-accent-dark/90 md:w-auto"
             >
               <SparklesIcon className="h-4 w-4" />
               Use for this chat


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the mobile chat layout to prevent overflow and cramped controls. Moves context/thinking into the action sheet on small screens, adds a centered mobile “Prompts” button for the library, hides thinking when unsupported, and improves prompt detail actions on mobile.

- **Bug Fixes**
  - Welcome screen: smaller text/gaps on mobile; keeps “Your chats are private by design” on one line; prevents icon/label shifting.
  - Chat input: shows “Context” and “Thinking” with labels in the action sheet on mobile; hides both in the toolbar until md; doesn’t render thinking controls if the model supports neither effort nor toggle.
  - Context usage indicator: now accepts optional `className` for responsive visibility.
  - Prompt preset suggestions: on mobile, replace pills with a centered “Prompts” button that opens the library; on desktop, show suggestions inline.
  - Prompt library modal: better mobile layout with tighter padding, multiline title, and in-pane “Use for this chat”/“Stop using” buttons (full-width on mobile); desktop actions stay in the header.

<sup>Written for commit f60687f4b3e83bbbb76e4a10e721d6580a43142a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/399?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

