### PR TITLE
Let legacy users sync to the cloud again

### DIFF
--- a/src/services/cloud/cloud-key-authorization.ts
+++ b/src/services/cloud/cloud-key-authorization.ts
@@ -40,6 +40,7 @@ import {
   CloudKeySetupError,
   validateCurrentPrimaryKey,
 } from './cloud-key-preflight'
+import { adoptLocalKeyForMigration } from './ensure-current-key'
 import { reportKeyHealthy } from './sync-health'
 
 export type CloudKeyAuthorizationMode = 'validated' | 'explicit_start_fresh'
@@ -105,10 +106,19 @@ export async function canWriteToCloud(): Promise<boolean> {
   if (validation.remoteState === 'empty' && isCloudSyncEnabled()) {
     const registered = await registerKeyForEmptyRemote()
     if (!registered) return false
+  } else if (validation.needsAdoption && isCloudSyncEnabled()) {
+    // Legacy v1→v2 data with no registered key: the controlplane
+    // rejects every push as a stale key until the local CEK is adopted
+    // as the current key. Adopt it here so the write path establishes
+    // its own precondition, instead of optimistically storming
+    // STALE_KEY while it waits for the out-of-band migration kick.
+    const adopted = await adoptLocalKeyForMigration()
+    if (!adopted) return false
   }
-  // The enclave confirmed the local key is authoritative and, for an
-  // empty remote, registration succeeded — only now is any surfaced
-  // key problem known to be stale, so clear the sync-health gate.
+  // The enclave confirmed the local key is authoritative and any
+  // required registration/adoption succeeded — only now is any
+  // surfaced key problem known to be stale, so clear the sync-health
+  // gate.
   reportKeyHealthy()
   return true
 }

--- a/src/services/cloud/cloud-key-preflight.ts
+++ b/src/services/cloud/cloud-key-preflight.ts
@@ -29,6 +29,13 @@ export interface CloudKeyValidationResult {
   canWrite: boolean
   probe: CloudKeyValidationProbe
   message?: string
+  /**
+   * Set when the remote holds legacy data but no registered current
+   * key. The local CEK can write, but only after it is adopted as the
+   * current key — otherwise every push is rejected as a stale key. The
+   * write gate uses this to adopt before pushing.
+   */
+  needsAdoption?: boolean
 }
 
 /**
@@ -118,6 +125,7 @@ export async function validateCurrentPrimaryKey(): Promise<CloudKeyValidationRes
       remoteState: 'exists',
       canWrite: true,
       probe: 'none',
+      needsAdoption: true,
     }
   }
 

--- a/src/services/cloud/cloud-sync.ts
+++ b/src/services/cloud/cloud-sync.ts
@@ -7,30 +7,16 @@ import {
   SYNC_PROJECT_CHAT_STATUS_PREFIX,
 } from '@/constants/storage-keys'
 import { logError, logInfo, logWarning } from '@/utils/error-handling'
-import { loadPasskeyCredentials } from '../passkey/passkey-key-storage'
-import {
-  deriveKeyEncryptionKey,
-  getCachedPrfResult,
-} from '../passkey/passkey-service'
 import { chatEvents } from '../storage/chat-events'
 import { deletedChatsTracker } from '../storage/deleted-chats-tracker'
 import { indexedDBStorage, type StoredChat } from '../storage/indexed-db'
 import { decideRecovery } from '../sync-enclave/enclave-error-recovery'
-import { wrapCekForCredential } from '../sync-enclave/key-bundle'
 import { passkeyEvents } from '../sync-enclave/passkey-events'
-import {
-  keyCurrent,
-  newIdempotencyKey,
-  registerKey,
-  type KeyRegisterBundleInput,
-} from '../sync-enclave/sync-api'
-import { IF_MATCH_SENTINELS } from '../sync-enclave/wire-contract'
+import { keyCurrent, newIdempotencyKey } from '../sync-enclave/sync-api'
 import {
   hasPrimaryKey,
   migrationKeySetFingerprint,
   primaryKeyIdHexOrNull,
-  requirePrimaryKeyB64,
-  requirePrimaryKeyBytes,
 } from './cek-encoding'
 import { processRemoteChat } from './chat-codec'
 import { ingestRemoteChats, syncRemoteDeletions } from './chat-ingestion'
@@ -40,6 +26,7 @@ import {
   type ChatSyncStatus,
   type UploadChatOptions,
 } from './cloud-storage'
+import { adoptLocalKeyForMigration } from './ensure-current-key'
 import {
   runLegacyBlobMigrationAndFinalize,
   type MigrationReport,
@@ -1184,7 +1171,7 @@ export class CloudSyncService {
     // under several historical keys — as total mismatches, silently
     // blocking any migration at all.
     if (!currentKeyId && current.has_data && localKeyId) {
-      if (await this.adoptLocalKeyForMigration()) {
+      if (await adoptLocalKeyForMigration()) {
         currentKeyId = localKeyId
       }
     }
@@ -1290,94 +1277,6 @@ export class CloudSyncService {
     } catch {
       // A localStorage failure is non-fatal: the gate simply does not
       // engage and the server-side 24h cooldown remains the backstop.
-    }
-  }
-
-  /**
-   * Register the local primary CEK as the controlplane's current key for
-   * a user who has legacy data but no registered key. Without this a
-   * v1→v2 user who never registered their key — they have no passkey, or
-   * only an un-promoted legacy passkey — could never migrate: nothing
-   * registers their CEK, so every rewrap is gated out.
-   *
-   * Registered with created_via='recovery', which the controlplane
-   * accepts non-destructively over legacy (key_id NULL) rows. When this
-   * device holds a cached passkey PRF for a credential still on the
-   * user's account, the CEK is wrapped under it and registered with an
-   * initial bundle so the adopted key is passkey-recoverable from day
-   * one; otherwise it is registered bundleless and a legacy passkey
-   * wrapping this same CEK stays promotable afterwards (its bundle is
-   * added on the next recovery), so adopting never strands a backup.
-   * register-key's if_match='*' fails safely on a concurrent register.
-   * Returns true when the key was adopted.
-   */
-  private async adoptLocalKeyForMigration(): Promise<boolean> {
-    let keyB64: string
-    try {
-      keyB64 = requirePrimaryKeyB64()
-    } catch {
-      return false
-    }
-    const initialBundle = await this.initialBundleFromCachedPrf()
-    try {
-      await registerKey({
-        keyB64,
-        ifMatch: IF_MATCH_SENTINELS.AnyKey,
-        createdVia: 'recovery',
-        idempotencyKey: newIdempotencyKey(),
-        ...(initialBundle ? { initialBundle } : {}),
-      })
-    } catch (err) {
-      logError('Failed to adopt local key for migration', err, {
-        component: 'CloudSync',
-        action: 'adoptLocalKeyForMigration',
-      })
-      return false
-    }
-    logInfo('Adopted local key as current to enable migration', {
-      component: 'CloudSync',
-      action: 'adoptLocalKeyForMigration',
-      metadata: { withInitialBundle: initialBundle != null },
-    })
-    passkeyEvents.emit({ type: 'bundle-state-maybe-changed' })
-    return true
-  }
-
-  /**
-   * Best-effort initial bundle for key adoption: wrap the CEK being
-   * registered under the KEK derived from this device's cached passkey
-   * PRF. Adoption must never be blocked by bundle problems, so every
-   * failure path returns null and the caller registers bundleless.
-   *
-   * The cached credential is only trusted when it still appears in the
-   * user's stored credentials — a stale cache (passkey deleted or
-   * re-created) must not attach an unopenable bundle, which would make
-   * the account look passkey-recoverable when it is not.
-   */
-  private async initialBundleFromCachedPrf(): Promise<KeyRegisterBundleInput | null> {
-    try {
-      const cached = getCachedPrfResult()
-      if (!cached) return null
-      const entries = await loadPasskeyCredentials()
-      if (!entries.some((e) => e.id === cached.credentialId)) return null
-      const kek = await deriveKeyEncryptionKey(cached.prfOutput)
-      const bundle = await wrapCekForCredential({
-        credentialId: cached.credentialId,
-        kek,
-        cek: requirePrimaryKeyBytes(),
-      })
-      return {
-        credentialId: bundle.credentialId,
-        kekIvHex: bundle.kekIvHex,
-        encryptedKeysHex: bundle.wrappedKeyHex,
-      }
-    } catch (err) {
-      logWarning('Could not build initial bundle for key adoption', {
-        component: 'CloudSync',
-        action: 'initialBundleFromCachedPrf',
-        metadata: { error: err instanceof Error ? err.message : String(err) },
-      })
-      return null
     }
   }
 

--- a/src/services/cloud/ensure-current-key.ts
+++ b/src/services/cloud/ensure-current-key.ts
@@ -1,0 +1,147 @@
+/**
+ * Single source of truth for adopting the local primary CEK as the
+ * controlplane's registered current key.
+ *
+ * Adoption is a hard precondition of every cloud write: the
+ * controlplane rejects a push with STALE_KEY until a `user_keys` row
+ * exists. Historically only the out-of-band migration kick adopted a
+ * legacy v1→v2 user's key, so a missed kick wedged the account in a
+ * STALE_KEY storm with no self-heal. Both the write gate
+ * (`canWriteToCloud`) and the migration kick route adoption through
+ * here, so the write path can establish the precondition it depends
+ * on instead of optimistically storming the controlplane.
+ */
+
+import { logError, logInfo, logWarning } from '@/utils/error-handling'
+import { loadPasskeyCredentials } from '../passkey/passkey-key-storage'
+import {
+  deriveKeyEncryptionKey,
+  getCachedPrfResult,
+} from '../passkey/passkey-service'
+import { wrapCekForCredential } from '../sync-enclave/key-bundle'
+import { passkeyEvents } from '../sync-enclave/passkey-events'
+import {
+  newIdempotencyKey,
+  registerKey,
+  type KeyRegisterBundleInput,
+} from '../sync-enclave/sync-api'
+import { IF_MATCH_SENTINELS } from '../sync-enclave/wire-contract'
+import { requirePrimaryKeyB64, requirePrimaryKeyBytes } from './cek-encoding'
+
+let inflightAdoption: { keyB64: string; promise: Promise<boolean> } | null =
+  null
+
+/**
+ * Register the local primary CEK as the controlplane's current key for
+ * a user who has legacy data but no registered key. Without this a
+ * v1→v2 user who never registered their key — they have no passkey, or
+ * only an un-promoted legacy passkey — could never migrate: nothing
+ * registers their CEK, so every rewrap is gated out.
+ *
+ * Registered with created_via='recovery', which the controlplane
+ * accepts non-destructively over legacy (key_id NULL) rows. When this
+ * device holds a cached passkey PRF for a credential still on the
+ * user's account, the CEK is wrapped under it and registered with an
+ * initial bundle so the adopted key is passkey-recoverable from day
+ * one; otherwise it is registered bundleless and a legacy passkey
+ * wrapping this same CEK stays promotable afterwards (its bundle is
+ * added on the next recovery), so adopting never strands a backup.
+ * register-key's if_match='*' fails safely on a concurrent register.
+ * Returns true when the key was adopted.
+ */
+export async function adoptLocalKeyForMigration(): Promise<boolean> {
+  let keyB64: string
+  try {
+    keyB64 = requirePrimaryKeyB64()
+  } catch {
+    return false
+  }
+  // Dedupe concurrent adoptions per key. The upload coalescer fires the
+  // write gate for many chats at once; without this they would each
+  // race a register-key, and every loser of the if_match='*' CAS would
+  // defer its push. Sharing one in-flight registration lets the whole
+  // batch proceed the moment the single winner lands. A different key
+  // (e.g. after the user changes it) gets its own registration.
+  if (inflightAdoption?.keyB64 === keyB64) {
+    return inflightAdoption.promise
+  }
+  const entry: { keyB64: string; promise: Promise<boolean> } = {
+    keyB64,
+    promise: Promise.resolve(false),
+  }
+  entry.promise = (async () => {
+    try {
+      return await registerAdoptedKey(keyB64)
+    } finally {
+      if (inflightAdoption === entry) {
+        inflightAdoption = null
+      }
+    }
+  })()
+  inflightAdoption = entry
+  return entry.promise
+}
+
+async function registerAdoptedKey(keyB64: string): Promise<boolean> {
+  const initialBundle = await initialBundleFromCachedPrf()
+  try {
+    await registerKey({
+      keyB64,
+      ifMatch: IF_MATCH_SENTINELS.AnyKey,
+      createdVia: 'recovery',
+      idempotencyKey: newIdempotencyKey(),
+      ...(initialBundle ? { initialBundle } : {}),
+    })
+  } catch (err) {
+    logError('Failed to adopt local key for migration', err, {
+      component: 'CloudSync',
+      action: 'adoptLocalKeyForMigration',
+    })
+    return false
+  }
+  logInfo('Adopted local key as current to enable migration', {
+    component: 'CloudSync',
+    action: 'adoptLocalKeyForMigration',
+    metadata: { withInitialBundle: initialBundle != null },
+  })
+  passkeyEvents.emit({ type: 'bundle-state-maybe-changed' })
+  return true
+}
+
+/**
+ * Best-effort initial bundle for key adoption: wrap the CEK being
+ * registered under the KEK derived from this device's cached passkey
+ * PRF. Adoption must never be blocked by bundle problems, so every
+ * failure path returns null and the caller registers bundleless.
+ *
+ * The cached credential is only trusted when it still appears in the
+ * user's stored credentials — a stale cache (passkey deleted or
+ * re-created) must not attach an unopenable bundle, which would make
+ * the account look passkey-recoverable when it is not.
+ */
+async function initialBundleFromCachedPrf(): Promise<KeyRegisterBundleInput | null> {
+  try {
+    const cached = getCachedPrfResult()
+    if (!cached) return null
+    const entries = await loadPasskeyCredentials()
+    if (!entries.some((e) => e.id === cached.credentialId)) return null
+    const kek = await deriveKeyEncryptionKey(cached.prfOutput)
+    const bundle = await wrapCekForCredential({
+      credentialId: cached.credentialId,
+      kek,
+      cek: requirePrimaryKeyBytes(),
+    })
+    return {
+      credentialId: bundle.credentialId,
+      kekIvHex: bundle.kekIvHex,
+      encryptedKeysHex: bundle.wrappedKeyHex,
+    }
+  } catch (err) {
+    logWarning('Could not build initial bundle for key adoption', {
+      component: 'CloudSync',
+      action: 'initialBundleFromCachedPrf',
+      metadata: { error: err instanceof Error ? err.message : String(err) },
+    })
+    return null
+  }
+}

--- a/tests/services/cloud/cloud-key-authorization.test.ts
+++ b/tests/services/cloud/cloud-key-authorization.test.ts
@@ -3,6 +3,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 const mockValidateCurrentPrimaryKey = vi.fn()
 const mockKeyCurrent = vi.fn()
 const mockRegisterKey = vi.fn()
+const mockAdoptLocalKey = vi.fn()
+
+vi.mock('@/services/cloud/ensure-current-key', () => ({
+  adoptLocalKeyForMigration: (...args: unknown[]) => mockAdoptLocalKey(...args),
+}))
 
 vi.mock('@/services/cloud/cloud-key-preflight', () => ({
   CloudKeySetupError: class extends Error {
@@ -66,6 +71,8 @@ describe('cloud-key-authorization', () => {
     mockValidateCurrentPrimaryKey.mockReset()
     mockKeyCurrent.mockReset()
     mockRegisterKey.mockReset()
+    mockAdoptLocalKey.mockReset()
+    mockAdoptLocalKey.mockResolvedValue(true)
     mockPersistedPrimaryKeyB64.mockReset()
     mockPersistedPrimaryKeyB64.mockReturnValue(TEST_KEY_B64)
     localStorage.setItem(AUTH_ACTIVE_USER_ID, USER_ID)
@@ -135,6 +142,44 @@ describe('cloud-key-authorization', () => {
 
       expect(await canWriteToCloud()).toBe(true)
       expect(mockRegisterKey).not.toHaveBeenCalled()
+    })
+
+    it('adopts the local key before writing legacy data with no registered key', async () => {
+      mockValidateCurrentPrimaryKey.mockResolvedValue({
+        remoteState: 'exists',
+        canWrite: true,
+        probe: 'none',
+        needsAdoption: true,
+      })
+
+      expect(await canWriteToCloud()).toBe(true)
+      expect(mockAdoptLocalKey).toHaveBeenCalledTimes(1)
+    })
+
+    it('defers writes when legacy-data adoption fails', async () => {
+      mockAdoptLocalKey.mockResolvedValue(false)
+      mockValidateCurrentPrimaryKey.mockResolvedValue({
+        remoteState: 'exists',
+        canWrite: true,
+        probe: 'none',
+        needsAdoption: true,
+      })
+
+      expect(await canWriteToCloud()).toBe(false)
+      expect(mockAdoptLocalKey).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not adopt the legacy key when cloud sync is disabled', async () => {
+      localStorage.removeItem(SETTINGS_CLOUD_SYNC_ENABLED)
+      mockValidateCurrentPrimaryKey.mockResolvedValue({
+        remoteState: 'exists',
+        canWrite: true,
+        probe: 'none',
+        needsAdoption: true,
+      })
+
+      expect(await canWriteToCloud()).toBe(true)
+      expect(mockAdoptLocalKey).not.toHaveBeenCalled()
     })
 
     it('does not register a staged key that has not been committed', async () => {

--- a/tests/services/cloud/cloud-key-preflight.test.ts
+++ b/tests/services/cloud/cloud-key-preflight.test.ts
@@ -136,6 +136,7 @@ describe('cloud-key-preflight', () => {
 
       expect(result.remoteState).toBe('exists')
       expect(result.canWrite).toBe(true)
+      expect(result.needsAdoption).toBe(true)
     })
 
     it('accepts a staged key on a fresh device with no persisted keys', async () => {
@@ -165,6 +166,7 @@ describe('cloud-key-preflight', () => {
       const result = await validateCurrentPrimaryKey()
       expect(result.remoteState).toBe('exists')
       expect(result.canWrite).toBe(true)
+      expect(result.needsAdoption).toBeFalsy()
     })
 
     it('blocks writes when local KeyID does not match the enclave KeyID', async () => {

--- a/tests/services/cloud/ensure-current-key.test.ts
+++ b/tests/services/cloud/ensure-current-key.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockRegisterKey = vi.fn()
+const mockGetCachedPrf = vi.fn<() => unknown>()
+const mockEmit = vi.fn()
+
+const TEST_KEY_B64 = vi.hoisted(() => {
+  let bin = ''
+  for (let i = 0; i < 32; i++) bin += String.fromCharCode(i + 1)
+  return btoa(bin)
+})
+
+vi.mock('@/utils/error-handling', () => ({
+  logError: vi.fn(),
+  logInfo: vi.fn(),
+  logWarning: vi.fn(),
+}))
+
+vi.mock('@/services/cloud/cek-encoding', () => ({
+  requirePrimaryKeyB64: () => TEST_KEY_B64,
+  requirePrimaryKeyBytes: () => new Uint8Array(32),
+}))
+
+vi.mock('@/services/sync-enclave/sync-api', async () => {
+  const real = await vi.importActual<
+    typeof import('@/services/sync-enclave/sync-api')
+  >('@/services/sync-enclave/sync-api')
+  return {
+    ...real,
+    registerKey: (...args: unknown[]) => mockRegisterKey(...args),
+    newIdempotencyKey: () => 'idem-test',
+  }
+})
+
+vi.mock('@/services/passkey/passkey-service', () => ({
+  getCachedPrfResult: () => mockGetCachedPrf(),
+  deriveKeyEncryptionKey: vi.fn(),
+}))
+
+vi.mock('@/services/passkey/passkey-key-storage', () => ({
+  loadPasskeyCredentials: vi.fn(async () => []),
+}))
+
+vi.mock('@/services/sync-enclave/key-bundle', () => ({
+  wrapCekForCredential: vi.fn(),
+}))
+
+vi.mock('@/services/sync-enclave/passkey-events', () => ({
+  passkeyEvents: { emit: (...args: unknown[]) => mockEmit(...args) },
+}))
+
+import { adoptLocalKeyForMigration } from '@/services/cloud/ensure-current-key'
+
+describe('ensure-current-key adoptLocalKeyForMigration', () => {
+  beforeEach(() => {
+    mockRegisterKey.mockReset()
+    mockGetCachedPrf.mockReset()
+    mockGetCachedPrf.mockReturnValue(null)
+    mockEmit.mockReset()
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('registers the local CEK bundleless with created_via=recovery and if_match=*', async () => {
+    mockRegisterKey.mockResolvedValue({ ok: true, key_id: 'kid' })
+
+    const ok = await adoptLocalKeyForMigration()
+
+    expect(ok).toBe(true)
+    expect(mockRegisterKey).toHaveBeenCalledTimes(1)
+    const arg = mockRegisterKey.mock.calls[0][0]
+    expect(arg.createdVia).toBe('recovery')
+    expect(arg.ifMatch).toBe('*')
+    expect(arg.keyB64).toBe(TEST_KEY_B64)
+    expect(arg.initialBundle).toBeUndefined()
+  })
+
+  it('returns false when registration is rejected', async () => {
+    mockRegisterKey.mockRejectedValue(new Error('conflict'))
+    expect(await adoptLocalKeyForMigration()).toBe(false)
+  })
+
+  it('collapses concurrent adoptions for the same key into one registration', async () => {
+    mockRegisterKey.mockResolvedValue({ ok: true, key_id: 'kid' })
+
+    const [ra, rb] = await Promise.all([
+      adoptLocalKeyForMigration(),
+      adoptLocalKeyForMigration(),
+    ])
+
+    expect(ra).toBe(true)
+    expect(rb).toBe(true)
+    expect(mockRegisterKey).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Restores cloud sync for legacy users by adopting the local CEK as the current key before any write, preventing STALE_KEY loops. Centralizes adoption logic in a new `ensure-current-key` service and wires it into the write gate and migration flow.

- **Bug Fixes**
  - Gate writes on legacy remotes that lack a registered key; adopt via `adoptLocalKeyForMigration()` before pushing.
  - Defer writes if adoption fails; clear sync-health only after successful registration/adoption.
  - Skip adoption when cloud sync is disabled.

- **Refactors**
  - Moved adoption and initial-bundle logic from `cloud-sync.ts` to `ensure-current-key.ts`, with per-key coalescing to avoid duplicate registrations.
  - Preflight exposes `needsAdoption` when remote has legacy data but no current key.
  - Added focused tests for write gating and adoption paths.

<sup>Written for commit 25bebd9a3478996dc841ab1eafa8969c2b648dd8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/400?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

