### PR TITLE
Defer cloud key adoption during staged-key ceremonies

### DIFF
--- a/src/services/cloud/cloud-key-authorization.ts
+++ b/src/services/cloud/cloud-key-authorization.ts
@@ -40,7 +40,10 @@ import {
   CloudKeySetupError,
   validateCurrentPrimaryKey,
 } from './cloud-key-preflight'
-import { adoptLocalKeyForMigration } from './ensure-current-key'
+import {
+  adoptLocalKeyForMigration,
+  resetInflightAdoption,
+} from './ensure-current-key'
 import { reportKeyHealthy } from './sync-health'
 
 export type CloudKeyAuthorizationMode = 'validated' | 'explicit_start_fresh'
@@ -260,6 +263,7 @@ export async function registerStartFreshKeyIfNeeded(): Promise<void> {
 export function clearCloudKeyAuthorization(userId?: string | null): void {
   if (typeof window === 'undefined') return
   emptyRemoteRegistration = null
+  resetInflightAdoption()
   const resolvedUserId = userId ?? getActiveUserId()
   if (!resolvedUserId) return
   localStorage.removeItem(storageKey(resolvedUserId))

--- a/src/services/cloud/ensure-current-key.ts
+++ b/src/services/cloud/ensure-current-key.ts
@@ -26,10 +26,25 @@ import {
   type KeyRegisterBundleInput,
 } from '../sync-enclave/sync-api'
 import { IF_MATCH_SENTINELS } from '../sync-enclave/wire-contract'
-import { requirePrimaryKeyB64, requirePrimaryKeyBytes } from './cek-encoding'
+import {
+  persistedPrimaryKeyB64,
+  requirePrimaryKeyB64,
+  requirePrimaryKeyBytes,
+} from './cek-encoding'
 
 let inflightAdoption: { keyB64: string; promise: Promise<boolean> } | null =
   null
+
+/**
+ * Drop any in-flight adoption registration. Called on logout / auth
+ * change so a registration started for the previous user can never be
+ * handed back to the next session. The per-key dedupe guard already
+ * prevents reuse across different keys, but a registration that never
+ * settles (network hang) would otherwise pin a stale promise.
+ */
+export function resetInflightAdoption(): void {
+  inflightAdoption = null
+}
 
 /**
  * Register the local primary CEK as the controlplane's current key for
@@ -48,14 +63,26 @@ let inflightAdoption: { keyB64: string; promise: Promise<boolean> } | null =
  * added on the next recovery), so adopting never strands a backup.
  * register-key's if_match='*' fails safely on a concurrent register.
  * Returns true when the key was adopted.
+ *
+ * Only the committed primary key is ever registered, and only when it
+ * matches the active in-memory CEK. During a key-activation ceremony
+ * the new key is staged in memory only; registering a staged
+ * (uncommitted) key — or binding the committed key while writes encrypt
+ * under the staged one — would point the server at a key the client may
+ * roll back or that the upload won't use, causing a key mismatch and
+ * blocked writes. Defer until the staged key commits or the ceremony
+ * rolls back, so the registered key and the write key always agree.
  */
 export async function adoptLocalKeyForMigration(): Promise<boolean> {
-  let keyB64: string
+  const keyB64 = persistedPrimaryKeyB64()
+  if (!keyB64) return false
+  let activeKeyB64: string
   try {
-    keyB64 = requirePrimaryKeyB64()
+    activeKeyB64 = requirePrimaryKeyB64()
   } catch {
     return false
   }
+  if (activeKeyB64 !== keyB64) return false
   // Dedupe concurrent adoptions per key. The upload coalescer fires the
   // write gate for many chats at once; without this they would each
   // race a register-key, and every loser of the if_match='*' CAS would

--- a/tests/services/cloud/cloud-key-authorization.test.ts
+++ b/tests/services/cloud/cloud-key-authorization.test.ts
@@ -7,6 +7,7 @@ const mockAdoptLocalKey = vi.fn()
 
 vi.mock('@/services/cloud/ensure-current-key', () => ({
   adoptLocalKeyForMigration: (...args: unknown[]) => mockAdoptLocalKey(...args),
+  resetInflightAdoption: vi.fn(),
 }))
 
 vi.mock('@/services/cloud/cloud-key-preflight', () => ({

--- a/tests/services/cloud/cloud-sync.test.ts
+++ b/tests/services/cloud/cloud-sync.test.ts
@@ -116,6 +116,7 @@ vi.mock('@/services/cloud/cek-encoding', () => ({
   hasPrimaryKey: () => mockGetKey() != null,
   primaryKeyIdHexOrNull: (...args: any[]) => mockPrimaryKeyIdHex(...args),
   requirePrimaryKeyB64: (...args: any[]) => mockRequirePrimaryKeyB64(...args),
+  persistedPrimaryKeyB64: (...args: any[]) => mockRequirePrimaryKeyB64(...args),
   requirePrimaryKeyBytes: (...args: any[]) =>
     mockRequirePrimaryKeyBytes(...args),
   migrationKeys: (...args: any[]) => mockMigrationKeys(...args),

--- a/tests/services/cloud/ensure-current-key.test.ts
+++ b/tests/services/cloud/ensure-current-key.test.ts
@@ -16,8 +16,12 @@ vi.mock('@/utils/error-handling', () => ({
   logWarning: vi.fn(),
 }))
 
+const mockRequirePrimaryKeyB64 = vi.fn<() => string>()
+const mockPersistedPrimaryKeyB64 = vi.fn<() => string | null>()
+
 vi.mock('@/services/cloud/cek-encoding', () => ({
-  requirePrimaryKeyB64: () => TEST_KEY_B64,
+  requirePrimaryKeyB64: () => mockRequirePrimaryKeyB64(),
+  persistedPrimaryKeyB64: () => mockPersistedPrimaryKeyB64(),
   requirePrimaryKeyBytes: () => new Uint8Array(32),
 }))
 
@@ -57,6 +61,10 @@ describe('ensure-current-key adoptLocalKeyForMigration', () => {
     mockGetCachedPrf.mockReset()
     mockGetCachedPrf.mockReturnValue(null)
     mockEmit.mockReset()
+    mockRequirePrimaryKeyB64.mockReset()
+    mockRequirePrimaryKeyB64.mockReturnValue(TEST_KEY_B64)
+    mockPersistedPrimaryKeyB64.mockReset()
+    mockPersistedPrimaryKeyB64.mockReturnValue(TEST_KEY_B64)
   })
 
   afterEach(() => {
@@ -80,6 +88,22 @@ describe('ensure-current-key adoptLocalKeyForMigration', () => {
   it('returns false when registration is rejected', async () => {
     mockRegisterKey.mockRejectedValue(new Error('conflict'))
     expect(await adoptLocalKeyForMigration()).toBe(false)
+  })
+
+  it('defers without registering when no committed key exists', async () => {
+    mockPersistedPrimaryKeyB64.mockReturnValue(null)
+    expect(await adoptLocalKeyForMigration()).toBe(false)
+    expect(mockRegisterKey).not.toHaveBeenCalled()
+  })
+
+  it('defers without registering when a staged key differs from the committed key', async () => {
+    // Mid-ceremony: the active in-memory CEK is a newly staged key that
+    // has not been committed yet. Registering the committed key while
+    // the upload would encrypt under the staged one must be refused.
+    mockRequirePrimaryKeyB64.mockReturnValue('c3RhZ2VkLWtleS1ub3QtY29tbWl0dGVk')
+    mockPersistedPrimaryKeyB64.mockReturnValue(TEST_KEY_B64)
+    expect(await adoptLocalKeyForMigration()).toBe(false)
+    expect(mockRegisterKey).not.toHaveBeenCalled()
   })
 
   it('collapses concurrent adoptions for the same key into one registration', async () => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Defers cloud key adoption during staged-key activation so we only register the committed primary key and avoid key mismatches that block writes. Also clears any in-flight adoption on logout/auth changes to prevent stale registrations.

- **Bug Fixes**
  - `adoptLocalKeyForMigration` now registers only when `persistedPrimaryKeyB64()` exists and matches `requirePrimaryKeyB64()`. Otherwise it defers.
  - Added `resetInflightAdoption()` and call it from `clearCloudKeyAuthorization()` to drop any stale in-flight adoption.
  - Tests cover deferring when no committed key exists and when staged/committed keys differ; updated mocks accordingly.

<sup>Written for commit f42a79ba804c534920b5a711b810ab2daab32783. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/401?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

