### PR TITLE
Sync custom prompts through profile settings

### DIFF
--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -1031,6 +1031,18 @@ export function ChatInterface({
     localStorage.setItem(SETTINGS_WEB_SEARCH_ENABLED, String(webSearchEnabled))
   }, [webSearchEnabled])
 
+  const handleWebSearchToggle = useCallback(() => {
+    setWebSearchEnabled((prev) => {
+      const next = !prev
+      window.dispatchEvent(
+        new CustomEvent('webSearchEnabledChanged', {
+          detail: { enabled: next },
+        }),
+      )
+      return next
+    })
+  }, [])
+
   // Persist code execution toggle to localStorage
   useEffect(() => {
     localStorage.setItem(
@@ -1038,6 +1050,51 @@ export function ChatInterface({
       String(codeExecutionEnabled),
     )
   }, [codeExecutionEnabled])
+
+  const handleCodeExecutionToggle = useCallback(() => {
+    setCodeExecutionEnabled((prev) => {
+      const next = !prev
+      window.dispatchEvent(
+        new CustomEvent('codeExecutionEnabledChanged', {
+          detail: { enabled: next },
+        }),
+      )
+      return next
+    })
+  }, [])
+
+  useEffect(() => {
+    const handleWebSearchChange = (
+      event: CustomEvent<{ enabled: boolean }>,
+    ) => {
+      setWebSearchEnabled(event.detail.enabled)
+    }
+    const handleCodeExecutionChange = (
+      event: CustomEvent<{ enabled: boolean }>,
+    ) => {
+      setCodeExecutionEnabled(event.detail.enabled)
+    }
+
+    window.addEventListener(
+      'webSearchEnabledChanged',
+      handleWebSearchChange as EventListener,
+    )
+    window.addEventListener(
+      'codeExecutionEnabledChanged',
+      handleCodeExecutionChange as EventListener,
+    )
+
+    return () => {
+      window.removeEventListener(
+        'webSearchEnabledChanged',
+        handleWebSearchChange as EventListener,
+      )
+      window.removeEventListener(
+        'codeExecutionEnabledChanged',
+        handleCodeExecutionChange as EventListener,
+      )
+    }
+  }, [])
 
   // Listen for PII check setting changes from settings modal
   useEffect(() => {
@@ -1573,6 +1630,7 @@ export function ChatInterface({
     createNewChat,
     currentChat?.id,
     currentChat?.isTemporary,
+    currentChat?.presetId,
     setCurrentChat,
   ])
 
@@ -3081,9 +3139,7 @@ export function ChatInterface({
                     onRegenerateMessage={regenerateMessage}
                     showScrollButton={showScrollButton}
                     webSearchEnabled={webSearchEnabled}
-                    onWebSearchToggle={() =>
-                      setWebSearchEnabled((prev) => !prev)
-                    }
+                    onWebSearchToggle={handleWebSearchToggle}
                     reasoningEffort={reasoningEffort}
                     setReasoningEffort={setReasoningEffort}
                     thinkingEnabled={thinkingEnabled}
@@ -3093,7 +3149,7 @@ export function ChatInterface({
                     }
                     onCodeExecutionToggle={
                       canEnableCodeExecution
-                        ? () => setCodeExecutionEnabled((prev) => !prev)
+                        ? handleCodeExecutionToggle
                         : undefined
                     }
                     onOpenVerifier={() => setIsVerifierSidebarOpen(true)}
@@ -3293,15 +3349,13 @@ export function ChatInterface({
                           )
                         })()}
                         webSearchEnabled={webSearchEnabled}
-                        onWebSearchToggle={() =>
-                          setWebSearchEnabled((prev) => !prev)
-                        }
+                        onWebSearchToggle={handleWebSearchToggle}
                         codeExecutionEnabled={
                           canEnableCodeExecution ? codeExecutionEnabled : false
                         }
                         onCodeExecutionToggle={
                           canEnableCodeExecution
-                            ? () => setCodeExecutionEnabled((prev) => !prev)
+                            ? handleCodeExecutionToggle
                             : undefined
                         }
                       />

--- a/src/components/chat/hooks/use-model-management.ts
+++ b/src/components/chat/hooks/use-model-management.ts
@@ -51,6 +51,15 @@ export function useModelManagement({
   const [verificationComplete, setVerificationComplete] = useState(false)
   const [verificationSuccess, setVerificationSuccess] = useState(false)
 
+  const persistSelectedModel = useCallback((modelName: AIModel) => {
+    localStorage.setItem(SETTINGS_SELECTED_MODEL, modelName)
+    window.dispatchEvent(
+      new CustomEvent('selectedModelChanged', {
+        detail: modelName,
+      }),
+    )
+  }, [])
+
   // Effect to validate selected model when models are available
   useEffect(() => {
     if (models.length > 0 && isClient && !hasValidated) {
@@ -83,6 +92,26 @@ export function useModelManagement({
     }
   }, [models, isClient, hasValidated, selectedModel])
 
+  useEffect(() => {
+    const handleSelectedModelChanged = (event: CustomEvent<string>): void => {
+      const modelName = event.detail as AIModel
+      if (!modelName || !isModelNameAvailable(modelName, models)) return
+      setSelectedModel(modelName)
+      setExpandedLabel(null)
+    }
+
+    window.addEventListener(
+      'selectedModelChanged',
+      handleSelectedModelChanged as EventListener,
+    )
+    return () => {
+      window.removeEventListener(
+        'selectedModelChanged',
+        handleSelectedModelChanged as EventListener,
+      )
+    }
+  }, [models])
+
   // Handle model selection
   const handleModelSelect = useCallback(
     (modelName: AIModel) => {
@@ -100,9 +129,9 @@ export function useModelManagement({
       setExpandedLabel(null)
 
       // Save to local storage
-      localStorage.setItem(SETTINGS_SELECTED_MODEL, modelName)
+      persistSelectedModel(modelName)
     },
-    [models],
+    [models, persistSelectedModel],
   )
 
   // Handle label click

--- a/src/components/chat/hooks/use-prompt-library.ts
+++ b/src/components/chat/hooks/use-prompt-library.ts
@@ -1,6 +1,6 @@
 import { USER_PREFS_CUSTOM_PROMPT_PRESETS } from '@/constants/storage-keys'
 import { logError } from '@/utils/error-handling'
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { PiNotePencil } from 'react-icons/pi'
 import { BUILT_IN_PROMPT_PRESETS } from '../prompts/built-in-presets'
 import type { PromptPreset, UserPromptPreset } from '../prompts/types'
@@ -113,7 +113,10 @@ export function usePromptLibrary(): UsePromptLibraryReturn {
 
   const userPresets: PromptPreset[] = userPresetsRaw.map(toPromptPreset)
 
-  const allPresets = [...BUILT_IN_PROMPT_PRESETS, ...userPresets]
+  const allPresets = useMemo(
+    () => [...BUILT_IN_PROMPT_PRESETS, ...userPresets],
+    [userPresets],
+  )
 
   const getPresetById = useCallback(
     (id: string | null | undefined): PromptPreset | null => {

--- a/src/components/chat/hooks/use-prompt-library.ts
+++ b/src/components/chat/hooks/use-prompt-library.ts
@@ -111,7 +111,10 @@ export function usePromptLibrary(): UsePromptLibraryReturn {
     }
   }, [])
 
-  const userPresets: PromptPreset[] = userPresetsRaw.map(toPromptPreset)
+  const userPresets: PromptPreset[] = useMemo(
+    () => userPresetsRaw.map(toPromptPreset),
+    [userPresetsRaw],
+  )
 
   const allPresets = useMemo(
     () => [...BUILT_IN_PROMPT_PRESETS, ...userPresets],

--- a/src/components/chat/hooks/use-reasoning-effort.ts
+++ b/src/components/chat/hooks/use-reasoning-effort.ts
@@ -20,9 +20,42 @@ export function useReasoningEffort() {
     }
   }, [])
 
+  useEffect(() => {
+    const handleReasoningSettingsChanged = (
+      event: CustomEvent<{
+        reasoningEffort?: ReasoningEffort
+      }>,
+    ) => {
+      const effort = event.detail.reasoningEffort
+      if (effort === 'low' || effort === 'medium' || effort === 'high') {
+        setReasoningEffortState(effort)
+      }
+    }
+
+    window.addEventListener(
+      'reasoningSettingsChanged',
+      handleReasoningSettingsChanged as EventListener,
+    )
+    return () => {
+      window.removeEventListener(
+        'reasoningSettingsChanged',
+        handleReasoningSettingsChanged as EventListener,
+      )
+    }
+  }, [])
+
   const setReasoningEffort = useCallback((effort: ReasoningEffort) => {
     setReasoningEffortState(effort)
     localStorage.setItem(SETTINGS_REASONING_EFFORT, effort)
+    window.dispatchEvent(
+      new CustomEvent('reasoningSettingsChanged', {
+        detail: {
+          reasoningEffort: effort,
+          thinkingEnabled:
+            localStorage.getItem(SETTINGS_THINKING_ENABLED) !== 'false',
+        },
+      }),
+    )
   }, [])
 
   return { reasoningEffort, setReasoningEffort }
@@ -48,6 +81,38 @@ export function useThinkingEnabled() {
   const setThinkingEnabled = useCallback((enabled: boolean) => {
     setThinkingEnabledState(enabled)
     localStorage.setItem(SETTINGS_THINKING_ENABLED, String(enabled))
+    window.dispatchEvent(
+      new CustomEvent('reasoningSettingsChanged', {
+        detail: {
+          reasoningEffort:
+            localStorage.getItem(SETTINGS_REASONING_EFFORT) ?? DEFAULT_EFFORT,
+          thinkingEnabled: enabled,
+        },
+      }),
+    )
+  }, [])
+
+  useEffect(() => {
+    const handleReasoningSettingsChanged = (
+      event: CustomEvent<{
+        thinkingEnabled?: boolean
+      }>,
+    ) => {
+      if (event.detail.thinkingEnabled !== undefined) {
+        setThinkingEnabledState(event.detail.thinkingEnabled)
+      }
+    }
+
+    window.addEventListener(
+      'reasoningSettingsChanged',
+      handleReasoningSettingsChanged as EventListener,
+    )
+    return () => {
+      window.removeEventListener(
+        'reasoningSettingsChanged',
+        handleReasoningSettingsChanged as EventListener,
+      )
+    }
   }, [])
 
   return { thinkingEnabled, setThinkingEnabled }

--- a/src/hooks/use-profile-sync.ts
+++ b/src/hooks/use-profile-sync.ts
@@ -382,6 +382,14 @@ export function useProfileSync() {
       'personalizationChanged',
       'languageChanged',
       'customSystemPromptChanged',
+      'promptLibraryChanged',
+      'selectedModelChanged',
+      'reasoningSettingsChanged',
+      'webSearchEnabledChanged',
+      'codeExecutionEnabledChanged',
+      'piiCheckEnabledChanged',
+      'chatFontChanged',
+      'projectUploadPreferenceChanged',
     ]
 
     events.forEach((event) => {

--- a/src/services/cloud/profile-settings-serializer.ts
+++ b/src/services/cloud/profile-settings-serializer.ts
@@ -1,20 +1,53 @@
 import {
+  SETTINGS_CHAT_FONT,
+  SETTINGS_CODE_EXECUTION_ENABLED,
+  SETTINGS_PII_CHECK_ENABLED,
+  SETTINGS_REASONING_EFFORT,
+  SETTINGS_SELECTED_MODEL,
   SETTINGS_THEME,
   SETTINGS_THEME_MODE,
+  SETTINGS_THINKING_ENABLED,
+  SETTINGS_WEB_SEARCH_ENABLED,
   USER_PREFS_ADDITIONAL_CONTEXT,
   USER_PREFS_CUSTOM_PROMPT_ENABLED,
+  USER_PREFS_CUSTOM_PROMPT_PRESETS,
   USER_PREFS_CUSTOM_SYSTEM_PROMPT,
   USER_PREFS_LANGUAGE,
   USER_PREFS_NICKNAME,
   USER_PREFS_PERSONALIZATION_ENABLED,
   USER_PREFS_PROFESSION,
+  USER_PREFS_PROJECT_UPLOAD,
   USER_PREFS_TRAITS,
 } from '@/constants/storage-keys'
-import type { ProfileData } from '@/services/cloud/profile-sync'
+import type {
+  ProfileData,
+  ProfilePromptPreset,
+} from '@/services/cloud/profile-sync'
 import { logWarning } from '@/utils/error-handling'
 import { ProfileDataSchema } from './schemas'
 
 const DEFAULT_PROFILE_LANGUAGE = 'English'
+
+function safeParsePromptPresets(raw: string | null): ProfilePromptPreset[] {
+  if (!raw) return []
+  try {
+    const parsed = JSON.parse(raw)
+    if (!Array.isArray(parsed)) return []
+    return parsed.filter(
+      (preset): preset is ProfilePromptPreset =>
+        preset &&
+        typeof preset === 'object' &&
+        typeof preset.id === 'string' &&
+        typeof preset.name === 'string' &&
+        typeof preset.description === 'string' &&
+        typeof preset.systemPrompt === 'string' &&
+        typeof preset.createdAt === 'number' &&
+        typeof preset.updatedAt === 'number',
+    )
+  } catch {
+    return []
+  }
+}
 
 /**
  * Check if two profile data objects differ in any meaningful field (excluding metadata).
@@ -35,7 +68,17 @@ export function hasProfileChanged(
     profile1.additionalContext !== profile2.additionalContext ||
     profile1.isUsingPersonalization !== profile2.isUsingPersonalization ||
     profile1.isUsingCustomPrompt !== profile2.isUsingCustomPrompt ||
-    profile1.customSystemPrompt !== profile2.customSystemPrompt
+    profile1.customSystemPrompt !== profile2.customSystemPrompt ||
+    JSON.stringify(profile1.customPromptPresets) !==
+      JSON.stringify(profile2.customPromptPresets) ||
+    profile1.selectedModel !== profile2.selectedModel ||
+    profile1.reasoningEffort !== profile2.reasoningEffort ||
+    profile1.thinkingEnabled !== profile2.thinkingEnabled ||
+    profile1.webSearchEnabled !== profile2.webSearchEnabled ||
+    profile1.codeExecutionEnabled !== profile2.codeExecutionEnabled ||
+    profile1.piiCheckEnabled !== profile2.piiCheckEnabled ||
+    profile1.chatFont !== profile2.chatFont ||
+    profile1.projectUploadPreference !== profile2.projectUploadPreference
   )
 }
 
@@ -105,6 +148,69 @@ export function loadLocalSettings(): ProfileData {
     settings.customSystemPrompt = customSystemPrompt
   }
 
+  const customPromptPresets = localStorage.getItem(
+    USER_PREFS_CUSTOM_PROMPT_PRESETS,
+  )
+  if (customPromptPresets !== null) {
+    settings.customPromptPresets = safeParsePromptPresets(customPromptPresets)
+  }
+
+  const selectedModel = localStorage.getItem(SETTINGS_SELECTED_MODEL)
+  if (selectedModel !== null) {
+    settings.selectedModel = selectedModel
+  }
+
+  const reasoningEffort = localStorage.getItem(SETTINGS_REASONING_EFFORT)
+  if (
+    reasoningEffort === 'low' ||
+    reasoningEffort === 'medium' ||
+    reasoningEffort === 'high'
+  ) {
+    settings.reasoningEffort = reasoningEffort
+  }
+
+  const thinkingEnabled = localStorage.getItem(SETTINGS_THINKING_ENABLED)
+  if (thinkingEnabled !== null) {
+    settings.thinkingEnabled = thinkingEnabled === 'true'
+  }
+
+  const webSearchEnabled = localStorage.getItem(SETTINGS_WEB_SEARCH_ENABLED)
+  if (webSearchEnabled !== null) {
+    settings.webSearchEnabled = webSearchEnabled === 'true'
+  }
+
+  const codeExecutionEnabled = localStorage.getItem(
+    SETTINGS_CODE_EXECUTION_ENABLED,
+  )
+  if (codeExecutionEnabled !== null) {
+    settings.codeExecutionEnabled = codeExecutionEnabled === 'true'
+  }
+
+  const piiCheckEnabled = localStorage.getItem(SETTINGS_PII_CHECK_ENABLED)
+  if (piiCheckEnabled !== null) {
+    settings.piiCheckEnabled = piiCheckEnabled === 'true'
+  }
+
+  const chatFont = localStorage.getItem(SETTINGS_CHAT_FONT)
+  if (
+    chatFont === 'system' ||
+    chatFont === 'serif' ||
+    chatFont === 'mono' ||
+    chatFont === 'dyslexic'
+  ) {
+    settings.chatFont = chatFont
+  }
+
+  const projectUploadPreference = localStorage.getItem(
+    USER_PREFS_PROJECT_UPLOAD,
+  )
+  if (
+    projectUploadPreference === 'project' ||
+    projectUploadPreference === 'chat'
+  ) {
+    settings.projectUploadPreference = projectUploadPreference
+  }
+
   return settings
 }
 
@@ -119,6 +225,13 @@ export function resetSettingsToLocalDefaults(): ProfileData {
     isUsingPersonalization: false,
     isUsingCustomPrompt: false,
     customSystemPrompt: '',
+    customPromptPresets: [],
+    reasoningEffort: 'medium',
+    thinkingEnabled: true,
+    webSearchEnabled: true,
+    codeExecutionEnabled: false,
+    piiCheckEnabled: true,
+    chatFont: 'system',
   }
 
   applySettingsToLocal(defaults)
@@ -227,6 +340,111 @@ export function applySettingsToLocal(settings: ProfileData): void {
     localStorage.setItem(
       USER_PREFS_CUSTOM_SYSTEM_PROMPT,
       settings.customSystemPrompt,
+    )
+  }
+
+  if (settings.customPromptPresets !== undefined) {
+    localStorage.setItem(
+      USER_PREFS_CUSTOM_PROMPT_PRESETS,
+      JSON.stringify(settings.customPromptPresets),
+    )
+    window.dispatchEvent(new CustomEvent('promptLibraryChanged'))
+  }
+
+  if (settings.selectedModel !== undefined) {
+    localStorage.setItem(SETTINGS_SELECTED_MODEL, settings.selectedModel)
+    window.dispatchEvent(
+      new CustomEvent('selectedModelChanged', {
+        detail: settings.selectedModel,
+      }),
+    )
+  }
+
+  const shouldApplyReasoning =
+    settings.reasoningEffort !== undefined ||
+    settings.thinkingEnabled !== undefined
+
+  if (settings.reasoningEffort !== undefined) {
+    localStorage.setItem(SETTINGS_REASONING_EFFORT, settings.reasoningEffort)
+  }
+
+  if (settings.thinkingEnabled !== undefined) {
+    localStorage.setItem(
+      SETTINGS_THINKING_ENABLED,
+      String(settings.thinkingEnabled),
+    )
+  }
+
+  if (shouldApplyReasoning) {
+    window.dispatchEvent(
+      new CustomEvent('reasoningSettingsChanged', {
+        detail: {
+          reasoningEffort:
+            settings.reasoningEffort ??
+            localStorage.getItem(SETTINGS_REASONING_EFFORT) ??
+            'medium',
+          thinkingEnabled:
+            settings.thinkingEnabled ??
+            localStorage.getItem(SETTINGS_THINKING_ENABLED) !== 'false',
+        },
+      }),
+    )
+  }
+
+  if (settings.webSearchEnabled !== undefined) {
+    localStorage.setItem(
+      SETTINGS_WEB_SEARCH_ENABLED,
+      String(settings.webSearchEnabled),
+    )
+    window.dispatchEvent(
+      new CustomEvent('webSearchEnabledChanged', {
+        detail: { enabled: settings.webSearchEnabled },
+      }),
+    )
+  }
+
+  if (settings.codeExecutionEnabled !== undefined) {
+    localStorage.setItem(
+      SETTINGS_CODE_EXECUTION_ENABLED,
+      String(settings.codeExecutionEnabled),
+    )
+    window.dispatchEvent(
+      new CustomEvent('codeExecutionEnabledChanged', {
+        detail: { enabled: settings.codeExecutionEnabled },
+      }),
+    )
+  }
+
+  if (settings.piiCheckEnabled !== undefined) {
+    localStorage.setItem(
+      SETTINGS_PII_CHECK_ENABLED,
+      String(settings.piiCheckEnabled),
+    )
+    window.dispatchEvent(
+      new CustomEvent('piiCheckEnabledChanged', {
+        detail: { enabled: settings.piiCheckEnabled },
+      }),
+    )
+  }
+
+  if (settings.chatFont !== undefined) {
+    localStorage.setItem(SETTINGS_CHAT_FONT, settings.chatFont)
+    window.dispatchEvent(
+      new CustomEvent('chatFontChanged', {
+        detail: settings.chatFont,
+      }),
+    )
+  }
+
+  if (settings.projectUploadPreference !== undefined) {
+    localStorage.setItem(
+      USER_PREFS_PROJECT_UPLOAD,
+      settings.projectUploadPreference,
+    )
+    window.dispatchEvent(
+      new CustomEvent('projectUploadPreferenceChanged', {
+        detail: settings.projectUploadPreference,
+      }),
     )
   }
 

--- a/src/services/cloud/profile-sync.ts
+++ b/src/services/cloud/profile-sync.ts
@@ -44,10 +44,30 @@ export interface ProfileData {
   // Custom system prompt settings
   isUsingCustomPrompt?: boolean
   customSystemPrompt?: string
+  customPromptPresets?: ProfilePromptPreset[]
+
+  // Shared chat defaults
+  selectedModel?: string
+  reasoningEffort?: 'low' | 'medium' | 'high'
+  thinkingEnabled?: boolean
+  webSearchEnabled?: boolean
+  codeExecutionEnabled?: boolean
+  piiCheckEnabled?: boolean
+  chatFont?: 'system' | 'serif' | 'mono' | 'dyslexic'
+  projectUploadPreference?: 'project' | 'chat'
 
   // Metadata
   version?: number
   updatedAt?: string
+}
+
+export interface ProfilePromptPreset {
+  id: string
+  name: string
+  description: string
+  systemPrompt: string
+  createdAt: number
+  updatedAt: number
 }
 
 export class ProfileSyncService {

--- a/src/services/cloud/schemas.ts
+++ b/src/services/cloud/schemas.ts
@@ -45,6 +45,28 @@ export const ProfileDataSchema = z
     isUsingPersonalization: z.boolean().optional(),
     isUsingCustomPrompt: z.boolean().optional(),
     customSystemPrompt: z.string().optional(),
+    customPromptPresets: z
+      .array(
+        z
+          .object({
+            id: z.string(),
+            name: z.string(),
+            description: z.string(),
+            systemPrompt: z.string(),
+            createdAt: z.number(),
+            updatedAt: z.number(),
+          })
+          .passthrough(),
+      )
+      .optional(),
+    selectedModel: z.string().optional(),
+    reasoningEffort: z.enum(['low', 'medium', 'high']).optional(),
+    thinkingEnabled: z.boolean().optional(),
+    webSearchEnabled: z.boolean().optional(),
+    codeExecutionEnabled: z.boolean().optional(),
+    piiCheckEnabled: z.boolean().optional(),
+    chatFont: z.enum(['system', 'serif', 'mono', 'dyslexic']).optional(),
+    projectUploadPreference: z.enum(['project', 'chat']).optional(),
     version: z.number().optional(),
     updatedAt: z.string().optional(),
   })

--- a/src/utils/project-upload-preference.ts
+++ b/src/utils/project-upload-preference.ts
@@ -21,6 +21,11 @@ export function setProjectUploadPreference(
   if (typeof window === 'undefined') return
   try {
     localStorage.setItem(USER_PREFS_PROJECT_UPLOAD, preference)
+    window.dispatchEvent(
+      new CustomEvent('projectUploadPreferenceChanged', {
+        detail: preference,
+      }),
+    )
   } catch {
     // Storage unavailable (e.g., Safari private mode) - silently fail
   }
@@ -30,6 +35,11 @@ export function clearProjectUploadPreference(): void {
   if (typeof window === 'undefined') return
   try {
     localStorage.removeItem(USER_PREFS_PROJECT_UPLOAD)
+    window.dispatchEvent(
+      new CustomEvent('projectUploadPreferenceChanged', {
+        detail: null,
+      }),
+    )
   } catch {
     // Storage unavailable - silently fail
   }

--- a/tests/services/cloud/profile-settings-serializer.test.ts
+++ b/tests/services/cloud/profile-settings-serializer.test.ts
@@ -1,9 +1,18 @@
 import {
+  SETTINGS_CHAT_FONT,
+  SETTINGS_CODE_EXECUTION_ENABLED,
+  SETTINGS_PII_CHECK_ENABLED,
+  SETTINGS_REASONING_EFFORT,
+  SETTINGS_SELECTED_MODEL,
+  SETTINGS_THINKING_ENABLED,
+  SETTINGS_WEB_SEARCH_ENABLED,
   USER_PREFS_ADDITIONAL_CONTEXT,
+  USER_PREFS_CUSTOM_PROMPT_PRESETS,
   USER_PREFS_CUSTOM_SYSTEM_PROMPT,
   USER_PREFS_NICKNAME,
   USER_PREFS_PERSONALIZATION_ENABLED,
   USER_PREFS_PROFESSION,
+  USER_PREFS_PROJECT_UPLOAD,
   USER_PREFS_TRAITS,
 } from '@/constants/storage-keys'
 import {
@@ -64,5 +73,80 @@ describe('profile-settings-serializer', () => {
     expect(localStorage.getItem(USER_PREFS_PERSONALIZATION_ENABLED)).toBe(
       'false',
     )
+  })
+
+  it('round-trips custom prompt presets and shared chat defaults', () => {
+    const presets = [
+      {
+        id: 'user:abc',
+        name: 'Reviewer',
+        description: 'Review code',
+        systemPrompt: '<system>\nReview carefully.\n</system>',
+        createdAt: 1,
+        updatedAt: 2,
+      },
+    ]
+
+    localStorage.setItem(
+      USER_PREFS_CUSTOM_PROMPT_PRESETS,
+      JSON.stringify(presets),
+    )
+    localStorage.setItem(SETTINGS_SELECTED_MODEL, 'gpt-oss-120b')
+    localStorage.setItem(SETTINGS_REASONING_EFFORT, 'high')
+    localStorage.setItem(SETTINGS_THINKING_ENABLED, 'false')
+    localStorage.setItem(SETTINGS_WEB_SEARCH_ENABLED, 'false')
+    localStorage.setItem(SETTINGS_CODE_EXECUTION_ENABLED, 'true')
+    localStorage.setItem(SETTINGS_PII_CHECK_ENABLED, 'false')
+    localStorage.setItem(SETTINGS_CHAT_FONT, 'mono')
+    localStorage.setItem(USER_PREFS_PROJECT_UPLOAD, 'project')
+
+    expect(loadLocalSettings()).toMatchObject({
+      customPromptPresets: presets,
+      selectedModel: 'gpt-oss-120b',
+      reasoningEffort: 'high',
+      thinkingEnabled: false,
+      webSearchEnabled: false,
+      codeExecutionEnabled: true,
+      piiCheckEnabled: false,
+      chatFont: 'mono',
+      projectUploadPreference: 'project',
+    })
+  })
+
+  it('applies synced prompt presets and shared chat defaults locally', () => {
+    const presets = [
+      {
+        id: 'user:def',
+        name: 'Tutor',
+        description: 'Teach concepts',
+        systemPrompt: '<system>\nTeach.\n</system>',
+        createdAt: 3,
+        updatedAt: 4,
+      },
+    ]
+
+    applySettingsToLocal({
+      customPromptPresets: presets,
+      selectedModel: 'gpt-oss-120b',
+      reasoningEffort: 'low',
+      thinkingEnabled: true,
+      webSearchEnabled: true,
+      codeExecutionEnabled: false,
+      piiCheckEnabled: true,
+      chatFont: 'serif',
+      projectUploadPreference: 'chat',
+    })
+
+    expect(localStorage.getItem(USER_PREFS_CUSTOM_PROMPT_PRESETS)).toBe(
+      JSON.stringify(presets),
+    )
+    expect(localStorage.getItem(SETTINGS_SELECTED_MODEL)).toBe('gpt-oss-120b')
+    expect(localStorage.getItem(SETTINGS_REASONING_EFFORT)).toBe('low')
+    expect(localStorage.getItem(SETTINGS_THINKING_ENABLED)).toBe('true')
+    expect(localStorage.getItem(SETTINGS_WEB_SEARCH_ENABLED)).toBe('true')
+    expect(localStorage.getItem(SETTINGS_CODE_EXECUTION_ENABLED)).toBe('false')
+    expect(localStorage.getItem(SETTINGS_PII_CHECK_ENABLED)).toBe('true')
+    expect(localStorage.getItem(SETTINGS_CHAT_FONT)).toBe('serif')
+    expect(localStorage.getItem(USER_PREFS_PROJECT_UPLOAD)).toBe('chat')
   })
 })


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Syncs custom prompt presets and shared chat defaults through profile settings so they follow you across devices and update live in the app. Adds serialization, event wiring, and tests for reliable cross-tab/device consistency.

- **New Features**
  - Syncs custom prompt presets plus shared chat defaults: selected model, reasoning effort, thinking, web search, code execution, PII check, chat font, and project upload preference.
  - Live updates across the app via `CustomEvent` listeners/dispatchers; Chat UI and hooks now react to changes (model, reasoning, web search, code exec, etc.).
  - Serializer loads/applies these fields, updates change detection, and extends the profile schema.
  - Tests added to validate round-tripping and local application of synced settings.

- **Bug Fixes**
  - Keeps prompt library updates efficient by memoizing preset mapping and merge with `useMemo` to prevent unnecessary re-renders.

<sup>Written for commit 11e83ee95e36c6a3f45ac22d5e18b1fae417b657. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/402?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

