### PR TITLE
Sync conflict last write wins

### DIFF
--- a/src/constants/storage-keys.ts
+++ b/src/constants/storage-keys.ts
@@ -109,6 +109,9 @@ export const SYNC_PROJECT_CHAT_STATUS_PREFIX =
   'tinfoil-sync-project-chat-status-'
 export const SYNC_PROFILE_STATUS = 'tinfoil-sync-profile-status'
 export const SYNC_PROFILE_DIRTY = 'tinfoil-sync-profile-dirty'
+// Content modification time of the pending local profile edit, used to
+// arbitrate last-write-wins against a concurrently-updated remote.
+export const SYNC_PROFILE_CHANGED_AT = 'tinfoil-sync-profile-changed-at'
 
 // --- localStorage: Migration flags -----------------------------------------
 // Set the first time a build evicts locally-cached cloud chats that the

--- a/src/hooks/use-profile-sync.ts
+++ b/src/hooks/use-profile-sync.ts
@@ -57,16 +57,20 @@ export function useProfileSync() {
   }, [])
 
   // Edit time of the pending local profile change, used to arbitrate
-  // last-write-wins against the remote. Falls back to now so a local
-  // edit is never treated as older than the remote it is replacing.
-  const getLocalProfileChangedAt = useCallback((): string => {
+  // last-write-wins against the remote. Returns undefined when the edit
+  // time is unknown (e.g. a dirty flag left by an older build, or
+  // partially cleared storage) so unknown-age local data cannot win the
+  // arbitration and clobber a genuinely newer remote: conflict
+  // resolution then defers to the remote, while a non-conflicting push
+  // still stamps the current time.
+  const getLocalProfileChangedAt = useCallback((): string | undefined => {
     if (typeof window !== 'undefined') {
       const stored = localStorage.getItem(SYNC_PROFILE_CHANGED_AT)
       if (stored && !Number.isNaN(new Date(stored).getTime())) {
         return stored
       }
     }
-    return new Date().toISOString()
+    return undefined
   }, [])
 
   // Listen for cloud sync setting changes

--- a/src/hooks/use-profile-sync.ts
+++ b/src/hooks/use-profile-sync.ts
@@ -1,5 +1,6 @@
 import { CLOUD_SYNC } from '@/config'
 import {
+  SYNC_PROFILE_CHANGED_AT,
   SYNC_PROFILE_DIRTY,
   SYNC_PROFILE_STATUS,
 } from '@/constants/storage-keys'
@@ -43,6 +44,7 @@ export function useProfileSync() {
     hasPendingChanges.current = true
     if (typeof window !== 'undefined') {
       localStorage.setItem(SYNC_PROFILE_DIRTY, 'true')
+      localStorage.setItem(SYNC_PROFILE_CHANGED_AT, new Date().toISOString())
     }
   }, [])
 
@@ -50,7 +52,21 @@ export function useProfileSync() {
     hasPendingChanges.current = false
     if (typeof window !== 'undefined') {
       localStorage.removeItem(SYNC_PROFILE_DIRTY)
+      localStorage.removeItem(SYNC_PROFILE_CHANGED_AT)
     }
+  }, [])
+
+  // Edit time of the pending local profile change, used to arbitrate
+  // last-write-wins against the remote. Falls back to now so a local
+  // edit is never treated as older than the remote it is replacing.
+  const getLocalProfileChangedAt = useCallback((): string => {
+    if (typeof window !== 'undefined') {
+      const stored = localStorage.getItem(SYNC_PROFILE_CHANGED_AT)
+      if (stored && !Number.isNaN(new Date(stored).getTime())) {
+        return stored
+      }
+    }
+    return new Date().toISOString()
   }, [])
 
   // Listen for cloud sync setting changes
@@ -276,10 +292,13 @@ export function useProfileSync() {
         // Mark that we have pending changes only when we're actually going to sync
         hasPendingChanges.current = true
 
-        // Include the last synced version so the service can increment it
+        // Include the last synced version so the service can increment
+        // it, plus the edit time so conflict resolution can arbitrate
+        // last-write-wins against the remote.
         const profileWithVersion = {
           ...localSettings,
           version: lastSyncedVersion.current,
+          updatedAt: getLocalProfileChangedAt(),
         }
 
         const result = await profileSync.saveProfile(profileWithVersion)
@@ -289,7 +308,21 @@ export function useProfileSync() {
           if (result.version !== undefined) {
             lastSyncedVersion.current = result.version
           }
-          lastSyncedProfile.current = localSettings
+
+          if (result.remoteProfile) {
+            // A concurrently-updated device won the last-write race;
+            // adopt its settings locally so both devices converge
+            // instead of keeping our now-stale edit.
+            isApplyingRemoteProfile.current = true
+            try {
+              applySettingsToLocal(result.remoteProfile)
+            } finally {
+              isApplyingRemoteProfile.current = false
+            }
+            lastSyncedProfile.current = result.remoteProfile
+          } else {
+            lastSyncedProfile.current = localSettings
+          }
           clearLocalProfileChanged()
 
           logInfo('Profile synced to cloud', {
@@ -297,6 +330,7 @@ export function useProfileSync() {
             action: 'syncToCloud',
             metadata: {
               version: lastSyncedVersion.current,
+              adoptedRemote: !!result.remoteProfile,
             },
           })
         }
@@ -307,7 +341,7 @@ export function useProfileSync() {
         })
       }
     }, 2000) // 2 second debounce
-  }, [clearLocalProfileChanged, isSignedIn])
+  }, [clearLocalProfileChanged, getLocalProfileChangedAt, isSignedIn])
 
   // Initial sync when authenticated and periodic sync (only if cloud sync is enabled)
   useEffect(() => {

--- a/src/services/cloud/cloud-sync.ts
+++ b/src/services/cloud/cloud-sync.ts
@@ -882,15 +882,24 @@ export class CloudSyncService {
         return
       }
 
-      // Remote is the last write — force the overwrite (bypassing the
-      // §H6 CAS) since we have just established it is the winner.
+      // Remote is the last write — overwrite local with it. Bind the
+      // write to the local snapshot we arbitrated against so an
+      // interleaved edit during the remote download is not clobbered;
+      // such an edit makes this a no-op and the next cycle re-arbitrates
+      // with the now-fresher local copy. `allowLocallyModified` lets the
+      // overwrite proceed over the in-conflict (still locallyModified)
+      // row that the remote has already beaten.
       const applied = await indexedDBStorage.applyRemoteChatIfFresh({
         chat: remoteChat,
         syncVersion: remoteChat.syncVersion ?? 0,
-        expectedLocalUpdatedAt: undefined,
+        expectedLocalUpdatedAt: localChat ? localChat.updatedAt : null,
+        allowLocallyModified: true,
       })
       if (applied.applied) {
         chatEvents.emit({ reason: 'sync', ids: [chatId] })
+        // The conflict is resolved; clear any prior failure badge so a
+        // chat that failed an earlier cycle no longer shows as unsynced.
+        reportChatSynced(chatId)
       }
       logInfo('Conflict resolved by pulling remote', {
         component: 'CloudSync',

--- a/src/services/cloud/cloud-sync.ts
+++ b/src/services/cloud/cloud-sync.ts
@@ -41,7 +41,7 @@ import {
   reportSyncPaused,
   reportSyncSuccess,
 } from './sync-health'
-import { isUploadableChat } from './sync-predicates'
+import { isUploadableChat, remoteWinsLastWrite } from './sync-predicates'
 import { SyncStatusCache } from './sync-status-cache'
 import { UploadCoalescer } from './upload-coalescer'
 
@@ -860,14 +860,10 @@ export class CloudSyncService {
         return
       }
 
-      const remoteTime = new Date(remoteChat.updatedAt).getTime()
-      const localTime = localChat
-        ? new Date(localChat.updatedAt).getTime()
-        : Number.NaN
-      const remoteWins =
-        !localChat ||
-        Number.isNaN(localTime) ||
-        (!Number.isNaN(remoteTime) && remoteTime > localTime)
+      const remoteWins = remoteWinsLastWrite(
+        localChat?.updatedAt,
+        remoteChat.updatedAt,
+      )
 
       if (!remoteWins) {
         await indexedDBStorage.rebaseSyncVersion(

--- a/src/services/cloud/cloud-sync.ts
+++ b/src/services/cloud/cloud-sync.ts
@@ -828,24 +828,78 @@ export class CloudSyncService {
   }
 
   /**
-   * Last-write-wins conflict resolution (§C5). Pulls the remote chat
-   * fresh from the enclave and overwrites the local copy, clearing
-   * `locallyModified` so the chat exits the stuck-row retry loop. If
-   * the pull itself fails, the chat stays `locallyModified` and the
-   * next sync cycle will retry — but at least we are no longer
-   * burning enclave calls in a tight retry storm.
+   * Last-write-wins conflict resolution (§C5), arbitrated by content
+   * modification time so the winner is the same on every device.
+   *
+   * On a STALE_BLOB / SYNC_CONFLICT the server holds a version our
+   * upload was not based on. We download that remote row and compare
+   * its `updatedAt` against the local copy:
+   *
+   *   - Remote is strictly newer (or we have no local copy): the
+   *     remote is the last write, so overwrite local with it.
+   *   - Local is at least as fresh: OUR edit is the last write, so we
+   *     must NOT clobber unsynced local messages with the older remote
+   *     snapshot. Rebase the local row onto the server's current
+   *     version (so the next If-Match matches) and re-upload, letting
+   *     local win the race instead of looping on STALE_BLOB forever.
+   *
+   * If the pull itself fails, the chat stays `locallyModified` and the
+   * next sync cycle retries.
    */
   private async resolveConflictByPullingRemote(chatId: string): Promise<void> {
     try {
-      const result = await ingestRemoteChats([{ id: chatId }], {
-        fetchMissingContent: true,
-        eventReason: 'sync',
-        forceOverwriteLocal: true,
+      const [localChat, remoteChat] = await Promise.all([
+        indexedDBStorage.getChat(chatId),
+        cloudStorage.downloadChat(chatId),
+      ])
+
+      // The remote row vanished (concurrent delete). Leave the local
+      // copy untouched; it stays `locallyModified` and the deletion
+      // reconciles on the next sync cycle.
+      if (!remoteChat) {
+        return
+      }
+
+      const remoteTime = new Date(remoteChat.updatedAt).getTime()
+      const localTime = localChat
+        ? new Date(localChat.updatedAt).getTime()
+        : Number.NaN
+      const remoteWins =
+        !localChat ||
+        Number.isNaN(localTime) ||
+        (!Number.isNaN(remoteTime) && remoteTime > localTime)
+
+      if (!remoteWins) {
+        await indexedDBStorage.rebaseSyncVersion(
+          chatId,
+          remoteChat.syncVersion ?? 0,
+        )
+        logInfo('Conflict resolved by re-uploading fresher local copy', {
+          component: 'CloudSync',
+          action: 'resolveConflictByPullingRemote',
+          metadata: { chatId },
+        })
+        // Re-enqueue rather than await: we are inside the coalescer
+        // worker, which will pick up the dirty flag and re-run the
+        // upload with the rebased version.
+        void this.backupChat(chatId)
+        return
+      }
+
+      // Remote is the last write — force the overwrite (bypassing the
+      // §H6 CAS) since we have just established it is the winner.
+      const applied = await indexedDBStorage.applyRemoteChatIfFresh({
+        chat: remoteChat,
+        syncVersion: remoteChat.syncVersion ?? 0,
+        expectedLocalUpdatedAt: undefined,
       })
+      if (applied.applied) {
+        chatEvents.emit({ reason: 'sync', ids: [chatId] })
+      }
       logInfo('Conflict resolved by pulling remote', {
         component: 'CloudSync',
         action: 'resolveConflictByPullingRemote',
-        metadata: { chatId, applied: result.savedIds.length > 0 },
+        metadata: { chatId, applied: applied.applied },
       })
     } catch (err) {
       logError('Failed to resolve conflict by pulling remote', err, {

--- a/src/services/cloud/profile-sync.ts
+++ b/src/services/cloud/profile-sync.ts
@@ -12,6 +12,7 @@ import { WIRE_CODES } from '../sync-enclave/wire-contract'
 import { pullKey, requirePrimaryKeyB64 } from './cek-encoding'
 import type { ProfileSyncStatus } from './cloud-storage'
 import { ProfileDataSchema } from './schemas'
+import { remoteWinsLastWrite } from './sync-predicates'
 
 const PROFILE_SCOPE = 'profile'
 const PROFILE_ROW_ID = 'profile'
@@ -166,7 +167,11 @@ export class ProfileSyncService {
   // Save profile to cloud
   async saveProfile(
     profile: ProfileData,
-  ): Promise<{ success: boolean; version?: number }> {
+  ): Promise<{
+    success: boolean
+    version?: number
+    remoteProfile?: ProfileData
+  }> {
     try {
       if (!(await this.isAuthenticated())) {
         logInfo('Skipping profile save - not authenticated', {
@@ -194,7 +199,9 @@ export class ProfileSyncService {
       ): Promise<{ success: boolean; version?: number }> => {
         const profileWithMetadata: ProfileData = {
           ...profile,
-          updatedAt: new Date().toISOString(),
+          // Preserve the caller's edit time so other devices can
+          // arbitrate last-write-wins; only stamp now when absent.
+          updatedAt: profile.updatedAt ?? new Date().toISOString(),
           version: baseVersion + 1,
         }
 
@@ -240,15 +247,37 @@ export class ProfileSyncService {
         if (!isStaleBlobConflict(pushError)) {
           throw pushError
         }
-        // Optimistic-concurrency conflict: our base version is behind
-        // the server, or we tried to create a profile that already
-        // exists. Re-read the current version and retry once so local
-        // settings win instead of looping on STALE_BLOB forever.
-        logInfo('Profile push conflicted; rebasing on current version', {
+        // Optimistic-concurrency conflict: the server holds a version
+        // our push was not based on. Re-read it and arbitrate
+        // last-write-wins by content modification time.
+        logInfo('Profile push conflicted; arbitrating last-write-wins', {
           component: 'ProfileSync',
           action: 'saveProfile',
         })
         const remote = await this.fetchProfile()
+
+        if (
+          remote &&
+          remoteWinsLastWrite(profile.updatedAt, remote.updatedAt)
+        ) {
+          // The remote is the strictly newer write. Adopt it instead of
+          // clobbering, and hand it back so the caller can apply it
+          // locally; both devices then converge on the same settings.
+          logInfo('Profile conflict resolved by adopting newer remote', {
+            component: 'ProfileSync',
+            action: 'saveProfile',
+          })
+          this.cachedProfile = remote
+          return {
+            success: true,
+            version: remote.version,
+            remoteProfile: remote,
+          }
+        }
+
+        // Our local edit is the last write. Rebase onto the server's
+        // current version and re-push so local wins instead of looping
+        // on STALE_BLOB forever.
         return await pushAtVersion(remote?.version ?? 0)
       }
     } catch (error) {

--- a/src/services/cloud/sync-predicates.ts
+++ b/src/services/cloud/sync-predicates.ts
@@ -88,3 +88,37 @@ export function shouldIngestRemoteChat(
 
   return false
 }
+
+/**
+ * Last-write-wins arbitration by content modification time, shared by
+ * every scope's conflict resolution (chats, profile) so the winner is
+ * the same on every device.
+ *
+ * Returns true when the remote copy is the last write and should
+ * overwrite local; false when the local copy is at least as fresh and
+ * must be preserved (re-uploaded).
+ *
+ * A missing or unparseable local timestamp means we cannot prove local
+ * is fresher, so remote wins. A missing or unparseable remote timestamp
+ * lets local win, since we have a concrete local edit time to trust.
+ *
+ * @param localUpdatedAt The local copy's content modification time
+ * @param remoteUpdatedAt The remote copy's content modification time
+ * @returns true if the remote copy should overwrite local
+ */
+export function remoteWinsLastWrite(
+  localUpdatedAt?: string | null,
+  remoteUpdatedAt?: string | null,
+): boolean {
+  const localTime = localUpdatedAt
+    ? new Date(localUpdatedAt).getTime()
+    : Number.NaN
+  if (Number.isNaN(localTime)) {
+    return true
+  }
+
+  const remoteTime = remoteUpdatedAt
+    ? new Date(remoteUpdatedAt).getTime()
+    : Number.NaN
+  return !Number.isNaN(remoteTime) && remoteTime > localTime
+}

--- a/src/services/storage/indexed-db.ts
+++ b/src/services/storage/indexed-db.ts
@@ -753,12 +753,19 @@ export class IndexedDBStorage {
    *
    * Pass `expectedLocalUpdatedAt: undefined` to force the write
    * (e.g. last-write-wins conflict resolution).
+   *
+   * Pass `allowLocallyModified: true` to keep the timestamp CAS while
+   * permitting an overwrite of a `locallyModified` row. Last-write-wins
+   * conflict resolution uses this: the remote has already been judged
+   * the winner, but the apply must still no-op if the local row changed
+   * since that judgement (a TOCTOU edit during the remote download).
    */
   async applyRemoteChatIfFresh(opts: {
     chat: Chat
     syncVersion: number
     expectedLocalUpdatedAt: string | null | undefined
     setLoadedAt?: boolean
+    allowLocallyModified?: boolean
   }): Promise<{ applied: boolean }> {
     return this.enqueueSave('applyRemoteChatIfFresh', async () => {
       const db = await this.ensureDB()
@@ -772,7 +779,7 @@ export class IndexedDBStorage {
         } else if (
           !existing ||
           existing.updatedAt !== opts.expectedLocalUpdatedAt ||
-          existing.locallyModified === true
+          (existing.locallyModified === true && !opts.allowLocallyModified)
         ) {
           return { applied: false }
         }

--- a/src/services/storage/indexed-db.ts
+++ b/src/services/storage/indexed-db.ts
@@ -649,6 +649,39 @@ export class IndexedDBStorage {
   }
 
   /**
+   * Rebase a chat's sync version onto the server's current version
+   * while KEEPING `locallyModified` set. Used by last-write-wins
+   * conflict resolution (§C5) when the local copy is the fresher
+   * write: the next upload's If-Match must match the server's current
+   * ETag so the CAS succeeds and the local content wins, instead of
+   * looping on STALE_BLOB forever. Unlike `markAsSynced`, this never
+   * clears the dirty flag, so the chat is still uploaded.
+   */
+  async rebaseSyncVersion(id: string, syncVersion: number): Promise<void> {
+    return this.enqueueSave('rebaseSyncVersion', async () => {
+      const db = await this.ensureDB()
+      const chat = await this.getChatInternal(id)
+      if (!chat) {
+        return
+      }
+
+      chat.syncVersion = syncVersion
+      chat.locallyModified = true
+
+      await new Promise<void>((resolve, reject) => {
+        const transaction = db.transaction([CHATS_STORE], 'readwrite')
+        const store = transaction.objectStore(CHATS_STORE)
+        transaction.oncomplete = () => resolve()
+        transaction.onerror = () =>
+          reject(new Error('Failed to rebase sync version'))
+        const request = store.put(chat)
+        request.onerror = () =>
+          reject(new Error('Failed to rebase sync version'))
+      })
+    })
+  }
+
+  /**
    * Atomic upload finalization (§C6 / §H5).
    *
    * Runs inside `saveQueue` so it is serialized with any concurrent

--- a/tests/services/cloud/cloud-sync.test.ts
+++ b/tests/services/cloud/cloud-sync.test.ts
@@ -48,6 +48,8 @@ const mockIsStreaming = vi.fn()
 const mockOnStreamEnd = vi.fn()
 
 const mockChatEventsEmit = vi.fn()
+const mockReportChatSynced = vi.fn()
+const mockReportChatSyncFailed = vi.fn()
 const mockIngestRemoteChats = vi.fn()
 const mockSyncRemoteDeletions = vi.fn()
 const mockCanWriteToCloud = vi.fn()
@@ -155,6 +157,14 @@ vi.mock('@/services/storage/chat-events', () => ({
   chatEvents: {
     emit: (...args: any[]) => mockChatEventsEmit(...args),
   },
+}))
+
+vi.mock('@/services/cloud/sync-health', () => ({
+  reportChatSynced: (...args: any[]) => mockReportChatSynced(...args),
+  reportChatSyncFailed: (...args: any[]) => mockReportChatSyncFailed(...args),
+  reportKeyActionRequired: vi.fn(),
+  reportSyncPaused: vi.fn(),
+  reportSyncSuccess: vi.fn(),
 }))
 
 vi.mock('@/services/cloud/chat-ingestion', () => ({
@@ -971,17 +981,52 @@ describe('CloudSyncService', () => {
       await service.waitForUpload('conflict-1')
       await flush()
 
+      // The overwrite is bound to the local snapshot we arbitrated
+      // against (CAS), not forced, so a TOCTOU edit during the download
+      // cannot be clobbered.
       expect(mockApplyRemoteChatIfFresh).toHaveBeenCalledWith(
         expect.objectContaining({
           syncVersion: 9,
-          expectedLocalUpdatedAt: undefined,
+          expectedLocalUpdatedAt: '2024-06-01T00:00:00.000Z',
+          allowLocallyModified: true,
         }),
       )
       expect(mockChatEventsEmit).toHaveBeenCalledWith({
         reason: 'sync',
         ids: ['conflict-1'],
       })
+      // A successful resolution clears any prior failure badge.
+      expect(mockReportChatSynced).toHaveBeenCalledWith('conflict-1')
       expect(mockRebaseSyncVersion).not.toHaveBeenCalled()
+    })
+
+    it('preserves an interleaved local edit when the CAS no longer matches', async () => {
+      mockGetChat.mockResolvedValue(localChat('2024-06-01T00:00:00.000Z', 1))
+      mockDownloadChat.mockResolvedValue({
+        id: 'conflict-1',
+        title: 'Conflict',
+        messages: [
+          { role: 'user', content: 'hi' },
+          { role: 'assistant', content: 'remote is ahead' },
+        ],
+        createdAt: '2024-01-01T00:00:00.000Z',
+        updatedAt: '2024-06-01T00:00:10.000Z',
+        syncVersion: 9,
+      })
+      // The local row changed during the remote download, so the CAS
+      // ingest reports it did not apply.
+      mockApplyRemoteChatIfFresh.mockResolvedValue({ applied: false })
+      mockUploadChat.mockRejectedValueOnce(staleBlob())
+
+      const service = new CloudSyncService()
+      await service.backupChat('conflict-1')
+      await service.waitForUpload('conflict-1')
+      await flush()
+
+      // No overwrite event and no synced report: the chat stays
+      // locallyModified for the next cycle to re-arbitrate.
+      expect(mockChatEventsEmit).not.toHaveBeenCalled()
+      expect(mockReportChatSynced).not.toHaveBeenCalled()
     })
 
     it('leaves the local copy untouched when the remote row is gone', async () => {

--- a/tests/services/cloud/cloud-sync.test.ts
+++ b/tests/services/cloud/cloud-sync.test.ts
@@ -1,5 +1,6 @@
 import { SYNC_CHAT_STATUS } from '@/constants/storage-keys'
 import { CloudSyncService } from '@/services/cloud/cloud-sync'
+import { SyncEnclaveError } from '@/services/sync-enclave/sync-enclave-client'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mockGetAllChats = vi.fn()
@@ -11,11 +12,13 @@ const mockSaveExistingChat = vi.fn()
 const mockMarkAsSynced = vi.fn()
 const mockFinalizeUpload = vi.fn()
 const mockApplyRemoteChatIfFresh = vi.fn()
+const mockRebaseSyncVersion = vi.fn()
 const mockResetSyncMetadataForAllChats = vi.fn()
 const mockDeleteChat = vi.fn()
 
 const mockIsAuthenticated = vi.fn()
 const mockUploadChat = vi.fn()
+const mockDownloadChat = vi.fn()
 const mockGetChatSyncStatus = vi.fn()
 const mockGetAllChatsSyncStatus = vi.fn()
 const mockGetAllChatsUpdatedSince = vi.fn()
@@ -66,6 +69,7 @@ vi.mock('@/services/storage/indexed-db', () => ({
     finalizeUpload: (...args: any[]) => mockFinalizeUpload(...args),
     applyRemoteChatIfFresh: (...args: any[]) =>
       mockApplyRemoteChatIfFresh(...args),
+    rebaseSyncVersion: (...args: any[]) => mockRebaseSyncVersion(...args),
     resetSyncMetadataForAllChats: (...args: any[]) =>
       mockResetSyncMetadataForAllChats(...args),
     getChat: (...args: any[]) => mockGetChat(...args),
@@ -77,6 +81,7 @@ vi.mock('@/services/cloud/cloud-storage', () => ({
   cloudStorage: {
     isAuthenticated: (...args: any[]) => mockIsAuthenticated(...args),
     uploadChat: (...args: any[]) => mockUploadChat(...args),
+    downloadChat: (...args: any[]) => mockDownloadChat(...args),
     getChatSyncStatus: (...args: any[]) => mockGetChatSyncStatus(...args),
     getAllChatsSyncStatus: (...args: any[]) =>
       mockGetAllChatsSyncStatus(...args),
@@ -176,6 +181,7 @@ describe('CloudSyncService', () => {
     mockMarkAsSynced.mockResolvedValue(undefined)
     mockFinalizeUpload.mockResolvedValue(undefined)
     mockApplyRemoteChatIfFresh.mockResolvedValue({ applied: true })
+    mockRebaseSyncVersion.mockResolvedValue(undefined)
     mockResetSyncMetadataForAllChats.mockResolvedValue(undefined)
     mockDeleteChat.mockResolvedValue(undefined)
     mockGetKey.mockReturnValue(null)
@@ -203,6 +209,7 @@ describe('CloudSyncService', () => {
     mockRunLegacyChatEviction.mockResolvedValue(undefined)
     mockIsAuthenticated.mockResolvedValue(true)
     mockUploadChat.mockResolvedValue({ syncVersion: null, rewrites: [] })
+    mockDownloadChat.mockResolvedValue(null)
     mockGetChatSyncStatus.mockResolvedValue({ count: 0, lastUpdated: null })
     mockGetAllChatsSyncStatus.mockResolvedValue({
       count: 0,
@@ -888,6 +895,107 @@ describe('CloudSyncService', () => {
 
       expect(mockListProjectChats).toHaveBeenCalledTimes(2)
       expect(result).toEqual({ uploaded: 0, downloaded: 0, errors: [] })
+    })
+  })
+
+  describe('conflict resolution (last-write-wins by modification time)', () => {
+    const flush = () => new Promise((resolve) => setTimeout(resolve, 0))
+    const staleBlob = () =>
+      new SyncEnclaveError('stale blob', 409, 'STALE_BLOB')
+
+    const localChat = (updatedAt: string, syncVersion = 1) => ({
+      id: 'conflict-1',
+      title: 'Conflict',
+      messages: [
+        { role: 'user', content: 'hi' },
+        { role: 'assistant', content: 'hello' },
+        { role: 'user', content: 'newest local turn' },
+      ],
+      createdAt: '2024-01-01T00:00:00.000Z',
+      updatedAt,
+      syncVersion,
+      locallyModified: true,
+    })
+
+    it('re-uploads the local copy when it is fresher than the remote', async () => {
+      // Local has a later edit than the server snapshot that caused the
+      // STALE_BLOB. LWW by time means our edit is the last write, so we
+      // must NOT pull the older remote over it.
+      mockGetChat.mockResolvedValue(localChat('2024-06-01T00:00:05.000Z', 1))
+      mockDownloadChat.mockResolvedValue({
+        id: 'conflict-1',
+        title: 'Conflict',
+        messages: [{ role: 'user', content: 'hi' }],
+        createdAt: '2024-01-01T00:00:00.000Z',
+        updatedAt: '2024-06-01T00:00:00.000Z',
+        syncVersion: 7,
+      })
+      // First upload conflicts; the rebased re-upload succeeds.
+      mockUploadChat
+        .mockRejectedValueOnce(staleBlob())
+        .mockResolvedValue({ syncVersion: 8, rewrites: [] })
+
+      const service = new CloudSyncService()
+      await service.backupChat('conflict-1')
+      // Drive the conflicting upload and the rebased re-upload, which
+      // runs on a fresh coalescer worker after the dirty re-enqueue.
+      for (let i = 0; i < 5; i++) {
+        await service.waitForUpload('conflict-1')
+        await flush()
+      }
+
+      // Rebased onto the server's current version so the next If-Match
+      // matches, and the local row was never clobbered.
+      expect(mockRebaseSyncVersion).toHaveBeenCalledWith('conflict-1', 7)
+      expect(mockApplyRemoteChatIfFresh).not.toHaveBeenCalled()
+      expect(mockUploadChat).toHaveBeenCalledTimes(2)
+    })
+
+    it('overwrites the local copy when the remote is strictly newer', async () => {
+      mockGetChat.mockResolvedValue(localChat('2024-06-01T00:00:00.000Z', 1))
+      mockDownloadChat.mockResolvedValue({
+        id: 'conflict-1',
+        title: 'Conflict',
+        messages: [
+          { role: 'user', content: 'hi' },
+          { role: 'assistant', content: 'remote is ahead' },
+        ],
+        createdAt: '2024-01-01T00:00:00.000Z',
+        updatedAt: '2024-06-01T00:00:10.000Z',
+        syncVersion: 9,
+      })
+      mockUploadChat.mockRejectedValueOnce(staleBlob())
+
+      const service = new CloudSyncService()
+      await service.backupChat('conflict-1')
+      await service.waitForUpload('conflict-1')
+      await flush()
+
+      expect(mockApplyRemoteChatIfFresh).toHaveBeenCalledWith(
+        expect.objectContaining({
+          syncVersion: 9,
+          expectedLocalUpdatedAt: undefined,
+        }),
+      )
+      expect(mockChatEventsEmit).toHaveBeenCalledWith({
+        reason: 'sync',
+        ids: ['conflict-1'],
+      })
+      expect(mockRebaseSyncVersion).not.toHaveBeenCalled()
+    })
+
+    it('leaves the local copy untouched when the remote row is gone', async () => {
+      mockGetChat.mockResolvedValue(localChat('2024-06-01T00:00:00.000Z', 1))
+      mockDownloadChat.mockResolvedValue(null)
+      mockUploadChat.mockRejectedValueOnce(staleBlob())
+
+      const service = new CloudSyncService()
+      await service.backupChat('conflict-1')
+      await service.waitForUpload('conflict-1')
+      await flush()
+
+      expect(mockApplyRemoteChatIfFresh).not.toHaveBeenCalled()
+      expect(mockRebaseSyncVersion).not.toHaveBeenCalled()
     })
   })
 

--- a/tests/services/cloud/profile-sync.test.ts
+++ b/tests/services/cloud/profile-sync.test.ts
@@ -44,7 +44,7 @@ describe('ProfileSyncService', () => {
     mockPush.mockResolvedValue({ ok: true, etag: '8', key_id: 'aa'.repeat(16) })
   })
 
-  it('rebases on the current version after a stale-blob conflict', async () => {
+  it('re-pushes the fresher local profile after a stale-blob conflict', async () => {
     mockPush
       .mockRejectedValueOnce(
         new SyncEnclaveError('STALE_BLOB', 412, 'STALE_BLOB'),
@@ -59,19 +59,63 @@ describe('ProfileSyncService', () => {
         {
           ok: true,
           etag: '9',
-          plaintext: btoa(JSON.stringify({ nickname: 'Remote' })),
+          plaintext: btoa(
+            JSON.stringify({
+              nickname: 'Remote',
+              updatedAt: '2026-06-16T09:00:00.000Z',
+            }),
+          ),
         },
       ],
     })
 
     const service = new ProfileSyncService()
-    const result = await service.saveProfile({ nickname: 'Sacha', version: 0 })
+    const result = await service.saveProfile({
+      nickname: 'Sacha',
+      version: 0,
+      updatedAt: '2026-06-16T10:00:00.000Z',
+    })
 
     expect(result.success).toBe(true)
     expect(result.version).toBe(10)
+    expect(result.remoteProfile).toBeUndefined()
     expect(mockPush).toHaveBeenCalledTimes(2)
     expect(mockPush.mock.calls[0][0]).toMatchObject({ ifMatch: null })
     expect(mockPush.mock.calls[1][0]).toMatchObject({ ifMatch: '9' })
+  })
+
+  it('adopts the newer remote profile on a stale-blob conflict', async () => {
+    mockPush.mockRejectedValueOnce(
+      new SyncEnclaveError('STALE_BLOB', 412, 'STALE_BLOB'),
+    )
+    mockPull.mockResolvedValue({
+      items: [
+        {
+          ok: true,
+          etag: '9',
+          plaintext: btoa(
+            JSON.stringify({
+              nickname: 'Remote',
+              updatedAt: '2026-06-16T11:00:00.000Z',
+            }),
+          ),
+        },
+      ],
+    })
+
+    const service = new ProfileSyncService()
+    const result = await service.saveProfile({
+      nickname: 'Sacha',
+      version: 0,
+      updatedAt: '2026-06-16T10:00:00.000Z',
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.version).toBe(9)
+    expect(result.remoteProfile).toMatchObject({ nickname: 'Remote' })
+    // The remote write wins, so the local copy is not re-uploaded.
+    expect(mockPush).toHaveBeenCalledTimes(1)
+    expect(service.getCachedProfile()).toMatchObject({ nickname: 'Remote' })
   })
 
   it('saves profile updates with the caller last-synced etag', async () => {

--- a/tests/services/cloud/sync-predicates.test.ts
+++ b/tests/services/cloud/sync-predicates.test.ts
@@ -12,6 +12,7 @@
 
 import {
   isUploadableChat,
+  remoteWinsLastWrite,
   shouldIngestRemoteChat,
 } from '@/services/cloud/sync-predicates'
 import type { StoredChat } from '@/services/storage/indexed-db'
@@ -209,6 +210,37 @@ describe('Sync Predicates', () => {
         locallyModified: true,
       } as StoredChat
       expect(shouldIngestRemoteChat(remote, local)).toBe(true)
+    })
+  })
+
+  describe('remoteWinsLastWrite', () => {
+    const older = '2024-01-01T00:00:00.000Z'
+    const newer = '2024-01-02T00:00:00.000Z'
+
+    it('lets remote win when it is strictly newer', () => {
+      expect(remoteWinsLastWrite(older, newer)).toBe(true)
+    })
+
+    it('lets local win when it is strictly newer', () => {
+      expect(remoteWinsLastWrite(newer, older)).toBe(false)
+    })
+
+    it('lets local win on a timestamp tie', () => {
+      expect(remoteWinsLastWrite(older, older)).toBe(false)
+    })
+
+    it('lets remote win when local has no timestamp', () => {
+      expect(remoteWinsLastWrite(undefined, newer)).toBe(true)
+      expect(remoteWinsLastWrite(null, newer)).toBe(true)
+    })
+
+    it('lets remote win when local timestamp is unparseable', () => {
+      expect(remoteWinsLastWrite('not-a-date', newer)).toBe(true)
+    })
+
+    it('lets local win when remote has no usable timestamp', () => {
+      expect(remoteWinsLastWrite(older, undefined)).toBe(false)
+      expect(remoteWinsLastWrite(older, 'not-a-date')).toBe(false)
     })
   })
 

--- a/tests/services/cloud/upload-coalescer.test.ts
+++ b/tests/services/cloud/upload-coalescer.test.ts
@@ -342,9 +342,18 @@ describe('UploadCoalescer', () => {
         .mockRejectedValueOnce(new Error('Fail'))
         .mockResolvedValue(undefined)
 
+      // Pin the jitter to its upper bound so the backoff window is
+      // deterministic. A random delay of 0 would let the first retry
+      // fire inside advanceTimersByTimeAsync(0) below — before the
+      // enqueue during backoff — completing the worker and triggering
+      // an extra upload.
       const coalescer = new UploadCoalescer(uploadFn, {
         baseDelayMs: 1000,
         maxRetries: 3,
+        scheduler: {
+          sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+          random: () => 0.9999,
+        },
       })
 
       coalescer.enqueue('chat-1')


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Resolve sync conflicts with last-write-wins using `updatedAt` for chats and profile so devices converge on the newest change and avoid STALE_BLOB loops or stale overwrites.

- **Bug Fixes**
  - Chats: on conflict, fetch remote and compare `updatedAt`. If local is newer, rebase `syncVersion` and re-upload; if remote is newer, overwrite local via timestamp CAS (preserves interleaved edits) and emit `sync`; if remote is missing, keep local.
  - Profile: track local edit time via `SYNC_PROFILE_CHANGED_AT` and include it on save. On conflict, adopt the newer remote or re-push the fresher local; `use-profile-sync` applies a returned remote and clears the dirty state.
  - Tests: made upload backoff deterministic to avoid flakiness.

- **Refactors**
  - Added shared `remoteWinsLastWrite(updatedAt)` comparator.
  - IndexedDB: introduced `rebaseSyncVersion()` and extended `applyRemoteChatIfFresh()` with timestamp CAS and `allowLocallyModified` to safely apply a remote winner.

<sup>Written for commit 86aba56fcb4f527106820112d62403522337e8ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/403?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

