### PR TITLE
Pin favorite prompts to the home screen

### DIFF
--- a/src/components/chat/components/prompt-preset-suggestions.tsx
+++ b/src/components/chat/components/prompt-preset-suggestions.tsx
@@ -18,10 +18,14 @@ export function PromptPresetSuggestions({
   onOpenLibrary,
 }: PromptPresetSuggestionsProps) {
   const { favoritePresets } = usePromptLibrary()
-  const suggested =
-    favoritePresets.length > 0
-      ? favoritePresets
-      : BUILT_IN_PROMPT_PRESETS.slice(0, SUGGESTION_COUNT)
+  // Lead with the user's pinned favorites, then backfill the remaining slots
+  // with default built-ins so the home screen always offers a full set.
+  const suggested: PromptPreset[] = [...favoritePresets]
+  const pinnedIds = new Set(favoritePresets.map((preset) => preset.id))
+  for (const preset of BUILT_IN_PROMPT_PRESETS) {
+    if (suggested.length >= SUGGESTION_COUNT) break
+    if (!pinnedIds.has(preset.id)) suggested.push(preset)
+  }
   const pillBase =
     'inline-flex h-14 w-full items-center justify-center gap-1.5 rounded-lg border px-3 text-sm transition-colors md:h-auto md:w-auto md:py-1.5'
 

--- a/src/components/chat/components/prompt-preset-suggestions.tsx
+++ b/src/components/chat/components/prompt-preset-suggestions.tsx
@@ -1,5 +1,6 @@
 import { cn } from '@/components/ui/utils'
 import { Squares2X2Icon } from '@heroicons/react/24/outline'
+import { usePromptLibrary } from '../hooks/use-prompt-library'
 import { BUILT_IN_PROMPT_PRESETS } from '../prompts/built-in-presets'
 import type { PromptPreset } from '../prompts/types'
 
@@ -16,7 +17,11 @@ export function PromptPresetSuggestions({
   onSetActive,
   onOpenLibrary,
 }: PromptPresetSuggestionsProps) {
-  const suggested = BUILT_IN_PROMPT_PRESETS.slice(0, SUGGESTION_COUNT)
+  const { favoritePresets } = usePromptLibrary()
+  const suggested =
+    favoritePresets.length > 0
+      ? favoritePresets
+      : BUILT_IN_PROMPT_PRESETS.slice(0, SUGGESTION_COUNT)
   const pillBase =
     'inline-flex h-14 w-full items-center justify-center gap-1.5 rounded-lg border px-3 text-sm transition-colors md:h-auto md:w-auto md:py-1.5'
 

--- a/src/components/chat/hooks/use-prompt-library.ts
+++ b/src/components/chat/hooks/use-prompt-library.ts
@@ -1,4 +1,7 @@
-import { USER_PREFS_CUSTOM_PROMPT_PRESETS } from '@/constants/storage-keys'
+import {
+  USER_PREFS_CUSTOM_PROMPT_PRESETS,
+  USER_PREFS_FAVORITE_PROMPT_PRESETS,
+} from '@/constants/storage-keys'
 import { logError } from '@/utils/error-handling'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { PiNotePencil } from 'react-icons/pi'
@@ -10,6 +13,8 @@ const COMPONENT = 'usePromptLibrary'
 const USER_PRESET_ID_PREFIX = 'user:'
 
 const PROMPT_LIBRARY_CHANGED_EVENT = 'promptLibraryChanged'
+
+export const MAX_FAVORITE_PRESETS = 3
 
 const DEFAULT_USER_PRESET_ICON = PiNotePencil
 
@@ -29,6 +34,11 @@ type UsePromptLibraryReturn = {
   ) => void
   deleteUserPreset: (id: string) => void
   duplicatePreset: (sourceId: string) => PromptPreset | null
+  favoritePresetIds: string[]
+  favoritePresets: PromptPreset[]
+  isFavorite: (id: string) => boolean
+  canAddFavorite: boolean
+  toggleFavorite: (id: string) => void
 }
 
 function safeReadUserPresets(): UserPromptPreset[] {
@@ -72,6 +82,37 @@ function safeWriteUserPresets(presets: UserPromptPreset[]): void {
   }
 }
 
+function safeReadFavoriteIds(): string[] {
+  if (typeof window === 'undefined') return []
+  try {
+    const raw = localStorage.getItem(USER_PREFS_FAVORITE_PROMPT_PRESETS)
+    if (!raw) return []
+    const parsed = JSON.parse(raw)
+    if (!Array.isArray(parsed)) return []
+    return parsed.filter((id): id is string => typeof id === 'string')
+  } catch (err) {
+    logError('Failed to parse favorite prompt presets', err, {
+      component: COMPONENT,
+    })
+    return []
+  }
+}
+
+function safeWriteFavoriteIds(ids: string[]): void {
+  if (typeof window === 'undefined') return
+  try {
+    localStorage.setItem(
+      USER_PREFS_FAVORITE_PROMPT_PRESETS,
+      JSON.stringify(ids),
+    )
+    window.dispatchEvent(new CustomEvent(PROMPT_LIBRARY_CHANGED_EVENT))
+  } catch (err) {
+    logError('Failed to persist favorite prompt presets', err, {
+      component: COMPONENT,
+    })
+  }
+}
+
 function generateUserPresetId(): string {
   const random = Math.random().toString(36).slice(2, 10)
   return `${USER_PRESET_ID_PREFIX}${Date.now().toString(36)}-${random}`
@@ -90,16 +131,23 @@ function toPromptPreset(stored: UserPromptPreset): PromptPreset {
 
 export function usePromptLibrary(): UsePromptLibraryReturn {
   const [userPresetsRaw, setUserPresetsRaw] = useState<UserPromptPreset[]>([])
+  const [favoritePresetIds, setFavoritePresetIds] = useState<string[]>([])
 
   useEffect(() => {
     setUserPresetsRaw(safeReadUserPresets())
+    setFavoritePresetIds(safeReadFavoriteIds())
 
     const handleChange = () => {
       setUserPresetsRaw(safeReadUserPresets())
+      setFavoritePresetIds(safeReadFavoriteIds())
     }
     const handleStorage = (event: StorageEvent) => {
-      if (event.key === USER_PREFS_CUSTOM_PROMPT_PRESETS) {
+      if (
+        event.key === USER_PREFS_CUSTOM_PROMPT_PRESETS ||
+        event.key === USER_PREFS_FAVORITE_PROMPT_PRESETS
+      ) {
         setUserPresetsRaw(safeReadUserPresets())
+        setFavoritePresetIds(safeReadFavoriteIds())
       }
     }
 
@@ -174,6 +222,10 @@ export function usePromptLibrary(): UsePromptLibraryReturn {
   const deleteUserPreset = useCallback((id: string) => {
     const next = safeReadUserPresets().filter((p) => p.id !== id)
     safeWriteUserPresets(next)
+    const favorites = safeReadFavoriteIds()
+    if (favorites.includes(id)) {
+      safeWriteFavoriteIds(favorites.filter((favoriteId) => favoriteId !== id))
+    }
   }, [])
 
   const duplicatePreset = useCallback(
@@ -197,6 +249,30 @@ export function usePromptLibrary(): UsePromptLibraryReturn {
     [createUserPreset],
   )
 
+  const favoritePresets = useMemo(
+    () =>
+      favoritePresetIds
+        .map((id) => allPresets.find((p) => p.id === id))
+        .filter((p): p is PromptPreset => p != null),
+    [favoritePresetIds, allPresets],
+  )
+
+  const isFavorite = useCallback(
+    (id: string) => favoritePresetIds.includes(id),
+    [favoritePresetIds],
+  )
+
+  const canAddFavorite = favoritePresetIds.length < MAX_FAVORITE_PRESETS
+
+  const toggleFavorite = useCallback((id: string) => {
+    const current = safeReadFavoriteIds()
+    if (current.includes(id)) {
+      safeWriteFavoriteIds(current.filter((favoriteId) => favoriteId !== id))
+    } else if (current.length < MAX_FAVORITE_PRESETS) {
+      safeWriteFavoriteIds([...current, id])
+    }
+  }, [])
+
   return {
     builtInPresets: BUILT_IN_PROMPT_PRESETS,
     userPresets,
@@ -206,5 +282,10 @@ export function usePromptLibrary(): UsePromptLibraryReturn {
     updateUserPreset,
     deleteUserPreset,
     duplicatePreset,
+    favoritePresetIds,
+    favoritePresets,
+    isFavorite,
+    canAddFavorite,
+    toggleFavorite,
   }
 }

--- a/src/components/chat/hooks/use-prompt-library.ts
+++ b/src/components/chat/hooks/use-prompt-library.ts
@@ -262,16 +262,28 @@ export function usePromptLibrary(): UsePromptLibraryReturn {
     [favoritePresetIds],
   )
 
-  const canAddFavorite = favoritePresetIds.length < MAX_FAVORITE_PRESETS
+  // Capacity is measured against favorites that actually resolve to a
+  // preset. Stale ids (e.g. a custom preset deleted on another device, or
+  // one not yet synced here) must never count toward the cap and block
+  // adding a valid favorite.
+  const canAddFavorite = favoritePresets.length < MAX_FAVORITE_PRESETS
 
-  const toggleFavorite = useCallback((id: string) => {
-    const current = safeReadFavoriteIds()
-    if (current.includes(id)) {
-      safeWriteFavoriteIds(current.filter((favoriteId) => favoriteId !== id))
-    } else if (current.length < MAX_FAVORITE_PRESETS) {
-      safeWriteFavoriteIds([...current, id])
-    }
-  }, [])
+  const toggleFavorite = useCallback(
+    (id: string) => {
+      const current = safeReadFavoriteIds()
+      if (current.includes(id)) {
+        safeWriteFavoriteIds(current.filter((favoriteId) => favoriteId !== id))
+        return
+      }
+      const resolvableCount = current.filter((favoriteId) =>
+        allPresets.some((preset) => preset.id === favoriteId),
+      ).length
+      if (resolvableCount < MAX_FAVORITE_PRESETS) {
+        safeWriteFavoriteIds([...current, id])
+      }
+    },
+    [allPresets],
+  )
 
   return {
     builtInPresets: BUILT_IN_PROMPT_PRESETS,

--- a/src/components/chat/prompt-library-modal.tsx
+++ b/src/components/chat/prompt-library-modal.tsx
@@ -6,14 +6,19 @@ import {
   PlusIcon,
   SparklesIcon,
   Squares2X2Icon,
+  StarIcon,
   TrashIcon,
   XMarkIcon,
 } from '@heroicons/react/24/outline'
+import { StarIcon as StarIconSolid } from '@heroicons/react/24/solid'
 import * as DialogPrimitive from '@radix-ui/react-dialog'
 import { useEffect, useId, useMemo, useRef, useState } from 'react'
 import { ConfirmDialog } from './components/confirm-dialog'
 import { CONSTANTS } from './constants'
-import { usePromptLibrary } from './hooks/use-prompt-library'
+import {
+  MAX_FAVORITE_PRESETS,
+  usePromptLibrary,
+} from './hooks/use-prompt-library'
 import {
   EMPTY_PRESET_EDITOR_STATE,
   PresetEditor,
@@ -48,6 +53,9 @@ export function PromptLibraryModal({
     updateUserPreset,
     deleteUserPreset,
     duplicatePreset,
+    isFavorite,
+    canAddFavorite,
+    toggleFavorite,
   } = usePromptLibrary()
 
   const [selectedId, setSelectedId] = useState<string | null>(
@@ -196,6 +204,7 @@ export function PromptLibraryModal({
   const renderPresetCard = (preset: PromptPreset) => {
     const isSelected = selectedId === preset.id
     const isActive = activePresetId === preset.id
+    const isPinned = isFavorite(preset.id)
     const Icon = preset.Icon
     return (
       <button
@@ -227,11 +236,21 @@ export function PromptLibraryModal({
             </span>
           )}
         </span>
-        {isActive && (
-          <CheckIcon
-            className="absolute right-2 top-2 h-3.5 w-3.5 text-brand-accent-dark dark:text-brand-accent-light"
-            aria-label="Active"
-          />
+        {(isPinned || isActive) && (
+          <span className="absolute right-2 top-2 flex items-center gap-1">
+            {isPinned && (
+              <StarIconSolid
+                className="h-3.5 w-3.5 text-yellow-500"
+                aria-label="Favorite"
+              />
+            )}
+            {isActive && (
+              <CheckIcon
+                className="h-3.5 w-3.5 text-brand-accent-dark dark:text-brand-accent-light"
+                aria-label="Active"
+              />
+            )}
+          </span>
         )}
       </button>
     )
@@ -366,6 +385,9 @@ export function PromptLibraryModal({
                       key={selectedPreset.id}
                       preset={selectedPreset}
                       isActive={activePresetId === selectedPreset.id}
+                      isFavorite={isFavorite(selectedPreset.id)}
+                      canAddFavorite={canAddFavorite}
+                      onToggleFavorite={() => toggleFavorite(selectedPreset.id)}
                       onUseThis={handleUseThis}
                       onClearActive={handleClearActive}
                       onEdit={() => startEdit(selectedPreset)}
@@ -407,6 +429,9 @@ export function PromptLibraryModal({
 type PresetDetailProps = {
   preset: PromptPreset
   isActive: boolean
+  isFavorite: boolean
+  canAddFavorite: boolean
+  onToggleFavorite: () => void
   onUseThis: () => void
   onClearActive: () => void
   onEdit: () => void
@@ -418,6 +443,9 @@ type PresetDetailProps = {
 function PresetDetail({
   preset,
   isActive,
+  isFavorite,
+  canAddFavorite,
+  onToggleFavorite,
   onUseThis,
   onClearActive,
   onEdit,
@@ -548,6 +576,32 @@ function PresetDetail({
       </div>
 
       <div className="flex flex-none items-center gap-2 border-b border-border-subtle px-6 py-2">
+        <button
+          type="button"
+          onClick={onToggleFavorite}
+          disabled={!isFavorite && !canAddFavorite}
+          title={
+            !isFavorite && !canAddFavorite
+              ? `You can pin up to ${MAX_FAVORITE_PRESETS} favorites`
+              : undefined
+          }
+          className={cn(
+            'flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium transition-colors',
+            isFavorite
+              ? 'text-yellow-600 hover:bg-yellow-500/10 dark:text-yellow-400'
+              : 'text-content-secondary hover:bg-surface-chat hover:text-content-primary',
+            !isFavorite &&
+              !canAddFavorite &&
+              'cursor-not-allowed opacity-50 hover:bg-transparent',
+          )}
+        >
+          {isFavorite ? (
+            <StarIconSolid className="h-3.5 w-3.5" />
+          ) : (
+            <StarIcon className="h-3.5 w-3.5" />
+          )}
+          {isFavorite ? 'Favorited' : 'Favorite'}
+        </button>
         {!preset.isBuiltIn && (
           <button
             type="button"

--- a/src/constants/storage-keys.ts
+++ b/src/constants/storage-keys.ts
@@ -99,6 +99,8 @@ export const USER_PREFS_CUSTOM_SYSTEM_PROMPT =
   'tinfoil-user-prefs-custom-system-prompt'
 export const USER_PREFS_CUSTOM_PROMPT_PRESETS =
   'tinfoil-user-prefs-custom-prompt-presets'
+export const USER_PREFS_FAVORITE_PROMPT_PRESETS =
+  'tinfoil-user-prefs-favorite-prompt-presets'
 export const USER_PREFS_PROJECT_UPLOAD = 'tinfoil-user-prefs-project-upload'
 
 // --- localStorage: Sync/data state -----------------------------------------

--- a/src/services/cloud/profile-settings-serializer.ts
+++ b/src/services/cloud/profile-settings-serializer.ts
@@ -12,6 +12,7 @@ import {
   USER_PREFS_CUSTOM_PROMPT_ENABLED,
   USER_PREFS_CUSTOM_PROMPT_PRESETS,
   USER_PREFS_CUSTOM_SYSTEM_PROMPT,
+  USER_PREFS_FAVORITE_PROMPT_PRESETS,
   USER_PREFS_LANGUAGE,
   USER_PREFS_NICKNAME,
   USER_PREFS_PERSONALIZATION_ENABLED,
@@ -49,6 +50,17 @@ function safeParsePromptPresets(raw: string | null): ProfilePromptPreset[] {
   }
 }
 
+function safeParseFavoritePresetIds(raw: string | null): string[] {
+  if (!raw) return []
+  try {
+    const parsed = JSON.parse(raw)
+    if (!Array.isArray(parsed)) return []
+    return parsed.filter((id): id is string => typeof id === 'string')
+  } catch {
+    return []
+  }
+}
+
 /**
  * Check if two profile data objects differ in any meaningful field (excluding metadata).
  */
@@ -71,6 +83,8 @@ export function hasProfileChanged(
     profile1.customSystemPrompt !== profile2.customSystemPrompt ||
     JSON.stringify(profile1.customPromptPresets) !==
       JSON.stringify(profile2.customPromptPresets) ||
+    JSON.stringify(profile1.favoritePromptPresetIds) !==
+      JSON.stringify(profile2.favoritePromptPresetIds) ||
     profile1.selectedModel !== profile2.selectedModel ||
     profile1.reasoningEffort !== profile2.reasoningEffort ||
     profile1.thinkingEnabled !== profile2.thinkingEnabled ||
@@ -155,6 +169,15 @@ export function loadLocalSettings(): ProfileData {
     settings.customPromptPresets = safeParsePromptPresets(customPromptPresets)
   }
 
+  const favoritePromptPresetIds = localStorage.getItem(
+    USER_PREFS_FAVORITE_PROMPT_PRESETS,
+  )
+  if (favoritePromptPresetIds !== null) {
+    settings.favoritePromptPresetIds = safeParseFavoritePresetIds(
+      favoritePromptPresetIds,
+    )
+  }
+
   const selectedModel = localStorage.getItem(SETTINGS_SELECTED_MODEL)
   if (selectedModel !== null) {
     settings.selectedModel = selectedModel
@@ -226,6 +249,7 @@ export function resetSettingsToLocalDefaults(): ProfileData {
     isUsingCustomPrompt: false,
     customSystemPrompt: '',
     customPromptPresets: [],
+    favoritePromptPresetIds: [],
     reasoningEffort: 'medium',
     thinkingEnabled: true,
     webSearchEnabled: true,
@@ -347,6 +371,14 @@ export function applySettingsToLocal(settings: ProfileData): void {
     localStorage.setItem(
       USER_PREFS_CUSTOM_PROMPT_PRESETS,
       JSON.stringify(settings.customPromptPresets),
+    )
+    window.dispatchEvent(new CustomEvent('promptLibraryChanged'))
+  }
+
+  if (settings.favoritePromptPresetIds !== undefined) {
+    localStorage.setItem(
+      USER_PREFS_FAVORITE_PROMPT_PRESETS,
+      JSON.stringify(settings.favoritePromptPresetIds),
     )
     window.dispatchEvent(new CustomEvent('promptLibraryChanged'))
   }

--- a/src/services/cloud/profile-sync.ts
+++ b/src/services/cloud/profile-sync.ts
@@ -45,6 +45,8 @@ export interface ProfileData {
   isUsingCustomPrompt?: boolean
   customSystemPrompt?: string
   customPromptPresets?: ProfilePromptPreset[]
+  // Ordered preset ids pinned as homescreen favorites (built-in or custom)
+  favoritePromptPresetIds?: string[]
 
   // Shared chat defaults
   selectedModel?: string

--- a/src/services/cloud/schemas.ts
+++ b/src/services/cloud/schemas.ts
@@ -59,6 +59,7 @@ export const ProfileDataSchema = z
           .passthrough(),
       )
       .optional(),
+    favoritePromptPresetIds: z.array(z.string()).optional(),
     selectedModel: z.string().optional(),
     reasoningEffort: z.enum(['low', 'medium', 'high']).optional(),
     thinkingEnabled: z.boolean().optional(),

--- a/tests/services/cloud/profile-settings-serializer.test.ts
+++ b/tests/services/cloud/profile-settings-serializer.test.ts
@@ -9,6 +9,7 @@ import {
   USER_PREFS_ADDITIONAL_CONTEXT,
   USER_PREFS_CUSTOM_PROMPT_PRESETS,
   USER_PREFS_CUSTOM_SYSTEM_PROMPT,
+  USER_PREFS_FAVORITE_PROMPT_PRESETS,
   USER_PREFS_NICKNAME,
   USER_PREFS_PERSONALIZATION_ENABLED,
   USER_PREFS_PROFESSION,
@@ -91,6 +92,10 @@ describe('profile-settings-serializer', () => {
       USER_PREFS_CUSTOM_PROMPT_PRESETS,
       JSON.stringify(presets),
     )
+    localStorage.setItem(
+      USER_PREFS_FAVORITE_PROMPT_PRESETS,
+      JSON.stringify(['builtin:tutor', 'user:abc']),
+    )
     localStorage.setItem(SETTINGS_SELECTED_MODEL, 'gpt-oss-120b')
     localStorage.setItem(SETTINGS_REASONING_EFFORT, 'high')
     localStorage.setItem(SETTINGS_THINKING_ENABLED, 'false')
@@ -102,6 +107,7 @@ describe('profile-settings-serializer', () => {
 
     expect(loadLocalSettings()).toMatchObject({
       customPromptPresets: presets,
+      favoritePromptPresetIds: ['builtin:tutor', 'user:abc'],
       selectedModel: 'gpt-oss-120b',
       reasoningEffort: 'high',
       thinkingEnabled: false,
@@ -127,6 +133,7 @@ describe('profile-settings-serializer', () => {
 
     applySettingsToLocal({
       customPromptPresets: presets,
+      favoritePromptPresetIds: ['builtin:translator', 'user:def'],
       selectedModel: 'gpt-oss-120b',
       reasoningEffort: 'low',
       thinkingEnabled: true,
@@ -139,6 +146,9 @@ describe('profile-settings-serializer', () => {
 
     expect(localStorage.getItem(USER_PREFS_CUSTOM_PROMPT_PRESETS)).toBe(
       JSON.stringify(presets),
+    )
+    expect(localStorage.getItem(USER_PREFS_FAVORITE_PROMPT_PRESETS)).toBe(
+      JSON.stringify(['builtin:translator', 'user:def']),
     )
     expect(localStorage.getItem(SETTINGS_SELECTED_MODEL)).toBe('gpt-oss-120b')
     expect(localStorage.getItem(SETTINGS_REASONING_EFFORT)).toBe('low')


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Pin up to 3 favorite prompt presets and show them on the home screen. Favorites persist locally and sync with your cloud profile, with a simple star toggle in the library.

- **New Features**
  - Pin/unpin favorites (built-in or custom) in the library via a star; limit 3; deleting a preset removes it from favorites.
  - Home “Prompt Suggestions” leads with favorites and backfills remaining slots with built-ins.
  - `usePromptLibrary` exposes `favoritePresetIds`, `favoritePresets`, `isFavorite`, `canAddFavorite`, `toggleFavorite`, and `MAX_FAVORITE_PRESETS`.
  - Persist favorites in `USER_PREFS_FAVORITE_PROMPT_PRESETS`; sync via profile `favoritePromptPresetIds`; schema and serializer updated with change events; tests added.

- **Bug Fixes**
  - Stale favorite IDs no longer block adding new favorites; the cap counts only favorites that resolve to existing presets.

<sup>Written for commit 6aec09aa7ca8d9b3ca83d41ff0838d8b913bd214. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/404?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

