### PR TITLE
Keep settings from other clients during profile sync

### DIFF
--- a/src/services/cloud/profile-sync.ts
+++ b/src/services/cloud/profile-sync.ts
@@ -27,6 +27,25 @@ function isStaleBlobConflict(error: unknown): boolean {
   )
 }
 
+// Top-level keys this client models. The profile is a single
+// full-replace blob shared across clients, so anything else in a
+// fetched profile belongs to a newer or other-platform client (e.g. an
+// iOS-only setting) and must survive our next push rather than being
+// dropped when we re-serialize only the keys we know about.
+const KNOWN_PROFILE_KEYS = new Set<string>(Object.keys(ProfileDataSchema.shape))
+
+function extractUnknownProfileFields(
+  source: Record<string, unknown>,
+): Record<string, unknown> {
+  const extra: Record<string, unknown> = {}
+  for (const key of Object.keys(source)) {
+    if (!KNOWN_PROFILE_KEYS.has(key)) {
+      extra[key] = source[key]
+    }
+  }
+  return extra
+}
+
 export interface ProfileData {
   // Theme settings
   isDarkMode?: boolean
@@ -76,6 +95,10 @@ export interface ProfilePromptPreset {
 export class ProfileSyncService {
   private cachedProfile: ProfileData | null = null
   private failedDecryptionData: string | null = null
+  // Fields from the last fetched profile that this client does not
+  // model, carried forward on every push so we never wipe settings
+  // owned by another client.
+  private unknownRemoteFields: Record<string, unknown> = {}
 
   async isAuthenticated(): Promise<boolean> {
     return authTokenManager.isAuthenticated()
@@ -104,7 +127,10 @@ export class ProfileSyncService {
       })
       const item = resp.items[0]
       if (!item || !item.ok) {
-        if (item && item.code === 'NOT_FOUND') return null
+        if (item && item.code === 'NOT_FOUND') {
+          this.unknownRemoteFields = {}
+          return null
+        }
         throw new Error(
           item?.code || 'Failed to pull profile from sync enclave',
         )
@@ -124,6 +150,9 @@ export class ProfileSyncService {
         return null
       }
       const decoded = validation.data as ProfileData
+      this.unknownRemoteFields = extractUnknownProfileFields(
+        validation.data as Record<string, unknown>,
+      )
       const etagVersion = item.etag ? parseInt(item.etag, 10) : NaN
       if (Number.isFinite(etagVersion)) {
         decoded.version = etagVersion
@@ -167,9 +196,7 @@ export class ProfileSyncService {
   }
 
   // Save profile to cloud
-  async saveProfile(
-    profile: ProfileData,
-  ): Promise<{
+  async saveProfile(profile: ProfileData): Promise<{
     success: boolean
     version?: number
     remoteProfile?: ProfileData
@@ -207,9 +234,11 @@ export class ProfileSyncService {
           version: baseVersion + 1,
         }
 
-        const plaintext = new TextEncoder().encode(
-          JSON.stringify(profileWithMetadata),
-        )
+        // Carry forward fields we do not model under our own known
+        // fields, so a push never drops settings owned by another
+        // client. Known fields always win the merge.
+        const payload = { ...this.unknownRemoteFields, ...profileWithMetadata }
+        const plaintext = new TextEncoder().encode(JSON.stringify(payload))
         const ifMatch = baseVersion > 0 ? String(baseVersion) : null
 
         const pushResp = await enclavePush({
@@ -335,6 +364,7 @@ export class ProfileSyncService {
   clearCache(): void {
     this.cachedProfile = null
     this.failedDecryptionData = null
+    this.unknownRemoteFields = {}
   }
 
   // Get sync status to check if profile changed without fetching full data

--- a/tests/services/cloud/profile-sync.test.ts
+++ b/tests/services/cloud/profile-sync.test.ts
@@ -118,6 +118,78 @@ describe('ProfileSyncService', () => {
     expect(service.getCachedProfile()).toMatchObject({ nickname: 'Remote' })
   })
 
+  it('preserves unknown profile fields across a fetch and re-push', async () => {
+    mockPull.mockResolvedValue({
+      items: [
+        {
+          ok: true,
+          etag: '7',
+          plaintext: btoa(
+            JSON.stringify({
+              nickname: 'Remote',
+              experimentalSetting: { foo: 1 },
+              updatedAt: '2026-06-16T09:00:00.000Z',
+            }),
+          ),
+        },
+      ],
+    })
+
+    const service = new ProfileSyncService()
+    await service.fetchProfile()
+    const result = await service.saveProfile({ nickname: 'Sacha', version: 7 })
+
+    expect(result.success).toBe(true)
+    const pushed = JSON.parse(
+      new TextDecoder().decode(mockPush.mock.calls[0][0].plaintext),
+    )
+    // The field we do not model survives the round-trip, and our own
+    // known field still wins.
+    expect(pushed.experimentalSetting).toEqual({ foo: 1 })
+    expect(pushed.nickname).toBe('Sacha')
+  })
+
+  it('carries unknown remote fields onto the rebased push when local wins', async () => {
+    mockPush
+      .mockRejectedValueOnce(
+        new SyncEnclaveError('STALE_BLOB', 412, 'STALE_BLOB'),
+      )
+      .mockResolvedValueOnce({
+        ok: true,
+        etag: '10',
+        key_id: 'aa'.repeat(16),
+      })
+    mockPull.mockResolvedValue({
+      items: [
+        {
+          ok: true,
+          etag: '9',
+          plaintext: btoa(
+            JSON.stringify({
+              nickname: 'Remote',
+              experimentalSetting: 'keep-me',
+              updatedAt: '2026-06-16T09:00:00.000Z',
+            }),
+          ),
+        },
+      ],
+    })
+
+    const service = new ProfileSyncService()
+    const result = await service.saveProfile({
+      nickname: 'Sacha',
+      version: 0,
+      updatedAt: '2026-06-16T10:00:00.000Z',
+    })
+
+    expect(result.success).toBe(true)
+    const rebased = JSON.parse(
+      new TextDecoder().decode(mockPush.mock.calls[1][0].plaintext),
+    )
+    expect(rebased.experimentalSetting).toBe('keep-me')
+    expect(rebased.nickname).toBe('Sacha')
+  })
+
   it('saves profile updates with the caller last-synced etag', async () => {
     const service = new ProfileSyncService()
     const result = await service.saveProfile({ nickname: 'Sacha', version: 7 })


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Preserves unknown profile fields from other clients during sync so we don’t wipe their settings. We merge remote unknown fields into our push while keeping our known fields authoritative.

- **Bug Fixes**
  - Track unknown remote keys using `KNOWN_PROFILE_KEYS` and store them in `unknownRemoteFields`.
  - On push, send `{ ...unknownRemoteFields, ...profileWithMetadata }` so known fields win and unknown ones survive.
  - Reset `unknownRemoteFields` on NOT_FOUND responses and in `clearCache()`.
  - Add tests to confirm preservation across fetch/re-push and during a rebase after a stale conflict.

<sup>Written for commit 2c877884bf52c442431491384b6726bd2e7bdea4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/405?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

