### PR TITLE
Minor UI nits

### DIFF
--- a/src/components/chat/chat-list-item.tsx
+++ b/src/components/chat/chat-list-item.tsx
@@ -315,7 +315,7 @@ export function ChatListItem({
           type="button"
           onClick={onSelect}
           aria-current={isSelected ? 'true' : undefined}
-          className="min-w-0 flex-1 cursor-pointer rounded-md pr-2 text-left focus:outline-none focus:ring-2 focus:ring-brand-accent-dark dark:focus:ring-brand-accent-light"
+          className="min-w-0 flex-1 cursor-pointer rounded-md pr-2 text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-accent-dark dark:focus-visible:ring-brand-accent-light"
         >
           <>
             <div className="flex items-center gap-1.5">

--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -2378,8 +2378,8 @@ ${encryptionKey.replace('key_', '')}
                         className={cn(
                           'rounded-lg border p-4',
                           isDarkMode
-                            ? 'border-red-500/30 bg-red-950/10'
-                            : 'border-red-200 bg-red-50/50',
+                            ? 'border-border-strong bg-surface-chat'
+                            : 'border-border-subtle bg-white',
                         )}
                       >
                         <div className="space-y-3">
@@ -2496,8 +2496,8 @@ ${encryptionKey.replace('key_', '')}
                           className={cn(
                             'rounded-lg border p-4',
                             isDarkMode
-                              ? 'border-red-500/30 bg-red-950/10'
-                              : 'border-red-200 bg-red-50/50',
+                              ? 'border-border-strong bg-surface-chat'
+                              : 'border-border-subtle bg-white',
                           )}
                         >
                           <div className="space-y-3">

--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -2916,12 +2916,7 @@ ${encryptionKey.replace('key_', '')}
                           <button
                             type="button"
                             onClick={startCreatePreset}
-                            className={cn(
-                              'flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium transition-colors',
-                              isDarkMode
-                                ? 'text-content-secondary hover:bg-surface-chat hover:text-content-primary'
-                                : 'text-content-secondary hover:bg-surface-chat hover:text-content-primary',
-                            )}
+                            className="flex items-center gap-1 rounded-md bg-brand-accent-dark px-2 py-1 text-xs font-medium text-white transition-colors hover:bg-brand-accent-dark/90"
                           >
                             <PlusIcon className="h-3.5 w-3.5" />
                             New


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Minor UI polish to improve accessibility and visual consistency across chat and settings.

- **Bug Fixes**
  - Chat list: use focus-visible rings to avoid showing focus outlines on mouse clicks while keeping keyboard focus visible.
  - Settings modal: change data deletion cards to neutral surfaces (dark: `bg-surface-chat`, light: `bg-white`) with standard borders.
  - Presets: make the “New” button solid `bg-brand-accent-dark` with white text and a subtle hover state for better contrast.

<sup>Written for commit a4b4a879d879094031050b560dd97d64e2e50e03. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/407?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

