### PR TITLE
Concurrent chat streaming

### DIFF
--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -2887,7 +2887,6 @@ export function ChatInterface({
                 onSettingsClick={handleOpenSettingsModal}
                 windowWidth={windowWidth}
                 chatDecryptionProgress={decryptionProgress}
-                isStreaming={isStreaming}
               />
             </motion.div>
           )}

--- a/src/components/chat/chat-list-item.tsx
+++ b/src/components/chat/chat-list-item.tsx
@@ -348,13 +348,10 @@ export function ChatListItem({
               </div>
               {isStreaming ? (
                 <span
-                  className="flex flex-shrink-0 items-center"
+                  className="mx-2 flex w-[18px] flex-shrink-0 items-center justify-center"
                   title="Generating response"
                 >
-                  <span className="relative flex h-2 w-2">
-                    <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-500 opacity-75" />
-                    <span className="relative inline-flex h-2 w-2 rounded-full bg-emerald-500" />
-                  </span>
+                  <span className="stream-loader" />
                   <span className="sr-only">Generating response</span>
                 </span>
               ) : (

--- a/src/components/chat/chat-list-item.tsx
+++ b/src/components/chat/chat-list-item.tsx
@@ -65,8 +65,8 @@ interface ChatListItemProps {
   showSyncStatus?: boolean
   /**
    * True while this chat's assistant response is actively streaming.
-   * The cloud upload is deferred until the stream finishes, so the
-   * "Syncing with cloud" badge stays hidden until then.
+   * Drives the live "streaming" indicator and suppresses the "Syncing
+   * with cloud" badge (the upload is deferred until the stream finishes).
    */
   isStreaming?: boolean
   /**
@@ -346,12 +346,25 @@ export function ChatListItem({
                   displayTitle
                 )}
               </div>
-              {isNewChat && (
-                <div
-                  className="h-1.5 w-1.5 rounded-full bg-blue-500"
-                  title="New chat"
-                  aria-hidden="true"
-                />
+              {isStreaming ? (
+                <span
+                  className="flex flex-shrink-0 items-center"
+                  title="Generating response"
+                >
+                  <span className="relative flex h-2 w-2">
+                    <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-500 opacity-75" />
+                    <span className="relative inline-flex h-2 w-2 rounded-full bg-emerald-500" />
+                  </span>
+                  <span className="sr-only">Generating response</span>
+                </span>
+              ) : (
+                isNewChat && (
+                  <div
+                    className="h-1.5 w-1.5 rounded-full bg-blue-500"
+                    title="New chat"
+                    aria-hidden="true"
+                  />
+                )
               )}
             </div>
             {(chat.decryptionFailed ||

--- a/src/components/chat/chat-list.tsx
+++ b/src/components/chat/chat-list.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useStreamingChats } from '@/hooks/use-streaming-chats'
 import { useSyncFailedChats } from '@/hooks/use-sync-health'
 import { Fragment, useEffect, useState } from 'react'
 import { cn } from '../ui/utils'
@@ -29,12 +30,6 @@ interface ChatListProps {
   isLoading?: boolean
   showEncryptionStatus?: boolean
   showSyncStatus?: boolean
-  /**
-   * ID of the chat whose assistant response is currently streaming, if
-   * any. Used to suppress the "Syncing with cloud" badge until the
-   * stream finishes and the real upload happens.
-   */
-  streamingChatId?: string
   enableTitleAnimation?: boolean
   animatedDeleteConfirmation?: boolean
   isDraggable?: boolean
@@ -70,7 +65,6 @@ export function ChatList({
   isLoading = false,
   showEncryptionStatus = false,
   showSyncStatus = false,
-  streamingChatId,
   enableTitleAnimation = false,
   animatedDeleteConfirmation = true,
   isDraggable = false,
@@ -95,6 +89,9 @@ export function ChatList({
   const [editingTitle, setEditingTitle] = useState('')
   const [deletingChatId, setDeletingChatId] = useState<string | null>(null)
   const syncFailedChats = useSyncFailedChats()
+  // App-wide source of truth for which chats are streaming, so the
+  // indicator covers background streams in any chat, not just the active one.
+  const streamingChats = useStreamingChats()
   // Track chat IDs that were manually edited - skip animation for these
   const [manuallyEditedChatId, setManuallyEditedChatId] = useState<
     string | null
@@ -212,7 +209,7 @@ export function ChatList({
                 isDarkMode={isDarkMode}
                 showEncryptionStatus={showEncryptionStatus}
                 showSyncStatus={showSyncStatus}
-                isStreaming={!chat.isBlankChat && chat.id === streamingChatId}
+                isStreaming={!chat.isBlankChat && streamingChats.has(chat.id)}
                 syncFailed={Boolean(syncFailedChats[chat.id])}
                 enableTitleAnimation={
                   enableTitleAnimation && manuallyEditedChatId !== chat.id

--- a/src/components/chat/chat-sidebar.tsx
+++ b/src/components/chat/chat-sidebar.tsx
@@ -124,12 +124,6 @@ type ChatSidebarProps = {
     current: number
     total: number
   } | null
-  /**
-   * True while the active chat's assistant response is streaming. Used
-   * to defer the sidebar "Syncing with cloud" badge until the stream
-   * finishes and the real upload runs.
-   */
-  isStreaming?: boolean
 }
 
 const MOBILE_BREAKPOINT = 1024 // Same as in chat-interface.tsx
@@ -186,7 +180,6 @@ export function ChatSidebar({
   onSettingsClick,
   windowWidth,
   chatDecryptionProgress,
-  isStreaming,
 }: ChatSidebarProps) {
   const syncNeedsAttention = useSyncHealthAttention()
   const [isInitialLoad, setIsInitialLoad] = useState(true)
@@ -1852,9 +1845,6 @@ export function ChatSidebar({
                       isDarkMode={isDarkMode}
                       showEncryptionStatus={true}
                       showSyncStatus={true}
-                      streamingChatId={
-                        isStreaming ? currentChat?.id : undefined
-                      }
                       enableTitleAnimation={true}
                       isDraggable={
                         isSignedIn &&

--- a/src/components/chat/hooks/chat-persistence.ts
+++ b/src/components/chat/hooks/chat-persistence.ts
@@ -1,3 +1,4 @@
+import { streamingTracker } from '@/services/cloud/streaming-tracker'
 import { chatStorage } from '@/services/storage/chat-storage'
 import { sessionChatStorage } from '@/services/storage/session-storage'
 import { logError, logInfo } from '@/utils/error-handling'
@@ -16,14 +17,15 @@ import type { Chat, Message } from '../types'
 
 interface CreateUpdateChatWithHistoryCheckParams {
   storeHistory: boolean
-  isStreamingRef: React.MutableRefObject<boolean>
-  currentChatIdRef: React.MutableRefObject<string>
+  // Mirrors the id of the chat currently on screen. Used to decide whether
+  // a streamed update should also be reflected into `currentChat`. With
+  // concurrent streams this is independent of which chat is streaming.
+  viewedChatIdRef: React.MutableRefObject<string>
 }
 
 export function createUpdateChatWithHistoryCheck({
   storeHistory,
-  isStreamingRef,
-  currentChatIdRef,
+  viewedChatIdRef,
 }: CreateUpdateChatWithHistoryCheckParams) {
   return function updateChatWithHistoryCheck(
     setChats: React.Dispatch<React.SetStateAction<Chat[]>>,
@@ -34,7 +36,7 @@ export function createUpdateChatWithHistoryCheck({
     skipCloudSync = false,
     skipIndexedDBSave = false,
   ) {
-    const isCurrentChat = currentChatIdRef.current === chatId
+    const isCurrentChat = viewedChatIdRef.current === chatId
 
     // Only update messages and set isBlankChat based on message count
     // Keep all other properties from chatSnapshot (including title, isLocalOnly, etc.)
@@ -73,7 +75,9 @@ export function createUpdateChatWithHistoryCheck({
 
     if (storeHistory) {
       const shouldSkipCloudSync =
-        skipCloudSync || updatedChat.isLocalOnly || isStreamingRef.current
+        skipCloudSync ||
+        updatedChat.isLocalOnly ||
+        streamingTracker.isStreaming(chatId)
 
       // Skip IndexedDB save if explicitly requested (during streaming chunks)
       if (skipIndexedDBSave) {
@@ -87,7 +91,7 @@ export function createUpdateChatWithHistoryCheck({
           chatId,
           isLocalOnly: updatedChat.isLocalOnly,
           shouldSkipCloudSync,
-          isStreaming: isStreamingRef.current,
+          isStreaming: streamingTracker.isStreaming(chatId),
           messageCount: newMessages.length,
           title: updatedChat.title,
         },
@@ -106,18 +110,15 @@ export function createUpdateChatWithHistoryCheck({
             },
           })
           if (savedChat.id !== updatedChat.id) {
-            // ID changed (server assigned new ID)
-            if (isCurrentChat && currentChatIdRef.current === updatedChat.id) {
-              // If we're streaming, transfer the streaming state to the new ID
-              if (isStreamingRef.current) {
-                import('@/services/cloud/streaming-tracker').then(
-                  ({ streamingTracker }) => {
-                    streamingTracker.endStreaming(updatedChat.id)
-                    streamingTracker.startStreaming(savedChat.id)
-                  },
-                )
-              }
-              currentChatIdRef.current = savedChat.id
+            // ID changed (server assigned new ID).
+            // Carry the streaming marker across so cloud-sync gating and
+            // the sidebar indicator keep tracking the same conversation.
+            if (streamingTracker.isStreaming(updatedChat.id)) {
+              streamingTracker.endStreaming(updatedChat.id)
+              streamingTracker.startStreaming(savedChat.id)
+            }
+            if (isCurrentChat && viewedChatIdRef.current === updatedChat.id) {
+              viewedChatIdRef.current = savedChat.id
               setCurrentChat(savedChat)
             }
             setChats((prevChats) =>

--- a/src/components/chat/hooks/streaming/process-stream.ts
+++ b/src/components/chat/hooks/streaming/process-stream.ts
@@ -43,9 +43,7 @@ export async function processStreamingResponse(
   const streamLogger: StreamLogger | undefined = IS_DEV
     ? createStreamLogger()
     : undefined
-  const startingChatId = ctx.startingChatId
   const streamingChatId = ctx.updatedChat.id
-  const isSameChat = () => ctx.currentChatIdRef.current === startingChatId
 
   const preprocessor = createContentPreprocessor()
   const normalizer = createEventNormalizer()
@@ -55,16 +53,19 @@ export async function processStreamingResponse(
   let dirty = false
   let firstEventSeen = false
 
+  // Always write to the chat this stream owns, regardless of which chat is
+  // on screen. `updateChatWithHistoryCheck` mirrors the update into
+  // `currentChat` only when the streamed chat is the one being viewed, so a
+  // background stream updates the list entry without disturbing the view.
   const flushToUI = () => {
-    if (!isSameChat()) return
     dirty = false
     const message = assembler.toMessage(timeline.snapshot())
     const newMessages = [...ctx.updatedMessages, message]
     ctx.updateChatWithHistoryCheck(
       ctx.setChats,
-      { ...ctx.updatedChat, id: ctx.currentChatIdRef.current },
+      { ...ctx.updatedChat, id: ctx.streamChatIdRef.current },
       ctx.setCurrentChat,
-      ctx.currentChatIdRef.current,
+      ctx.streamChatIdRef.current,
       newMessages,
       false,
       true, // skip IndexedDB during streaming
@@ -216,12 +217,9 @@ export async function processStreamingResponse(
   }
 
   try {
-    ctx.isStreamingRef.current = true
     if (streamingChatId) streamingTracker.startStreaming(streamingChatId)
 
     for await (const sseJson of readSSEStream(response, streamLogger)) {
-      if (!isSameChat()) break
-
       const events = normalizer.processChunk(
         sseJson,
         preprocessor,
@@ -259,14 +257,14 @@ export async function processStreamingResponse(
     return assembler.toMessage(timeline.snapshot())
   } finally {
     ctx.setLoadingState('idle')
-    ctx.isStreamingRef.current = false
     ctx.setIsStreaming(false)
     if (streamingChatId) streamingTracker.endStreaming(streamingChatId)
+    // The backend may have swapped the id mid-stream; clear that too.
     if (
-      ctx.currentChatIdRef.current &&
-      ctx.currentChatIdRef.current !== streamingChatId
+      ctx.streamChatIdRef.current &&
+      ctx.streamChatIdRef.current !== streamingChatId
     ) {
-      streamingTracker.endStreaming(ctx.currentChatIdRef.current)
+      streamingTracker.endStreaming(ctx.streamChatIdRef.current)
     }
     ctx.setIsThinking(false)
     ctx.thinkingStartTimeRef.current = null

--- a/src/components/chat/hooks/streaming/types.ts
+++ b/src/components/chat/hooks/streaming/types.ts
@@ -104,8 +104,10 @@ export interface StreamingContext {
   updatedMessages: Message[]
   isFirstMessage: boolean
   modelsLength: number
-  currentChatIdRef: React.MutableRefObject<string>
-  isStreamingRef: React.MutableRefObject<boolean>
+  // Tracks the id of the chat this specific stream writes to. Created per
+  // `handleQuery` call so concurrent streams never clobber each other, and
+  // updated in place if the backend swaps the id mid-flight.
+  streamChatIdRef: React.MutableRefObject<string>
   thinkingStartTimeRef: React.MutableRefObject<number | null>
   setIsThinking: (val: boolean) => void
   setIsWaitingForResponse: (val: boolean) => void

--- a/src/components/chat/hooks/use-chat-messaging.ts
+++ b/src/components/chat/hooks/use-chat-messaging.ts
@@ -9,12 +9,18 @@
  *   - streaming: hooks/streaming-processor.ts (SSE parsing and thinking mode)
  *
  * State invariants:
- * - currentChatIdRef always mirrors the canonical chat id (temporary → server id swaps)
- * - isStreamingRef is true only while processing an assistant response (used to defer cloud sync)
- * - thinkingStartTimeRef is set only while a model is in thinking/reasoning mode
+ * - Each `handleQuery` call owns a `streamChatIdRef` tracking the chat it
+ *   writes to (handles temporary → server id swaps) independently of other
+ *   concurrent streams
+ * - `viewedChatIdRef` always mirrors the chat on screen (never frozen during
+ *   streaming) so background streams update their list entry without
+ *   hijacking the active view
+ * - Per-chat stream status lives in `useChatStreams`; the values exposed by
+ *   this hook are derived for the currently-viewed chat
  */
 import { useProject } from '@/components/project'
 import { type BaseModel } from '@/config/models'
+import { streamingTracker } from '@/services/cloud/streaming-tracker'
 import { generateCodeExecutionAccessToken } from '@/services/exec-snapshot/access-token'
 import { getCodeExecutionContainerAuthTokenForChat } from '@/services/exec-snapshot/use-exec-snapshot'
 import { sendChatStream } from '@/services/inference/inference-client'
@@ -36,6 +42,11 @@ import type { Chat, LoadingState, Message } from '../types'
 import { createBlankChat, sortChats } from './chat-operations'
 import { createUpdateChatWithHistoryCheck } from './chat-persistence'
 import { processStreamingResponse } from './streaming'
+import {
+  IDLE_STREAM_STATUS,
+  useChatStreams,
+  type RetryInfo,
+} from './use-chat-streams'
 import type { ReasoningEffort } from './use-reasoning-effort'
 
 interface UseChatMessagingProps {
@@ -77,7 +88,7 @@ interface UseChatMessagingReturn {
     baseMessages?: Message[],
     quote?: string,
   ) => void
-  cancelGeneration: () => Promise<void>
+  cancelGeneration: (chatId?: string) => Promise<void>
   editMessage: (messageIndex: number, newContent: string) => void
   regenerateMessage: (messageIndex: number) => void
   retryLastMessage: () => void
@@ -111,124 +122,148 @@ export function useChatMessaging({
   const { isProjectMode, activeProject } = useProject()
 
   const [input, setInput] = useState('')
-  const [loadingState, setLoadingState] = useState<LoadingState>('idle')
-  const [retryInfo, setRetryInfo] = useState<{
-    attempt: number
-    maxRetries: number
-    error?: string
-  } | null>(null)
-  const [abortController, setAbortController] =
-    useState<AbortController | null>(null)
-  const [isThinking, setIsThinking] = useState(false)
-  const [isWaitingForResponse, setIsWaitingForResponse] = useState(false)
-  const [isStreaming, setIsStreaming] = useState(false)
-  const [streamError, setStreamError] = useState<string | null>(null)
 
-  const dismissStreamError = useCallback(() => {
-    setStreamError(null)
-  }, [])
+  // Per-chat stream status so several conversations can stream at once.
+  const {
+    statusByChat,
+    patchStatus,
+    resetStatus,
+    moveStatus,
+    registerController,
+    clearController,
+    abort,
+  } = useChatStreams()
+
+  // Live mirror for reads inside stable callbacks, so streamed status
+  // updates don't force handleQuery to be re-created on every chunk.
+  const statusByChatRef = useRef(statusByChat)
+  statusByChatRef.current = statusByChat
+
+  // Status for the chat on screen drives the input area, stop button,
+  // thinking indicator, and error banner.
+  const currentStatus =
+    statusByChat[currentChat?.id ?? ''] ?? IDLE_STREAM_STATUS
+  const {
+    loadingState,
+    retryInfo,
+    isThinking,
+    isWaitingForResponse,
+    isStreaming,
+    streamError,
+  } = currentStatus
 
   const inputRef = useRef<HTMLTextAreaElement>(null)
-  const currentChatIdRef = useRef<string>(currentChat?.id || '')
-  const isStreamingRef = useRef(false)
-  const thinkingStartTimeRef = useRef<number | null>(null)
-  const earlyTitlePromiseRef = useRef<Promise<string> | null>(null)
 
-  // Helper to calculate thinking duration and reset timer
-  const getThinkingDuration = () => {
-    const duration = thinkingStartTimeRef.current
-      ? (Date.now() - thinkingStartTimeRef.current) / 1000
-      : undefined
-    thinkingStartTimeRef.current = null
-    return duration
-  }
+  // Mirrors the id of the chat on screen. Always current (never frozen
+  // during streaming) so background streams write to their own list entry
+  // without taking over the active view.
+  const viewedChatIdRef = useRef<string>(currentChat?.id || '')
 
-  // A modified version of updateChat that respects the storeHistory flag
-  // During streaming, we persist to IndexedDB but defer cloud backup unless immediate=true
-  // When the backend assigns a new id, we atomically rewrite ids in both currentChat and chats
+  const dismissStreamError = useCallback(() => {
+    patchStatus(viewedChatIdRef.current, { streamError: null })
+  }, [patchStatus])
+
+  // A modified version of updateChat that respects the storeHistory flag.
+  // During streaming we persist to IndexedDB but defer cloud backup; the
+  // streamed update is mirrored into currentChat only when the streamed
+  // chat is the one being viewed.
   const updateChatWithHistoryCheck = useMemo(
     () =>
       createUpdateChatWithHistoryCheck({
         storeHistory,
-        isStreamingRef,
-        currentChatIdRef,
+        viewedChatIdRef,
       }),
     [storeHistory],
   )
 
-  // Cancel generation function
-  const cancelGeneration = useCallback(async () => {
-    if (abortController) {
-      abortController.abort()
-      setAbortController(null)
-    }
-    setLoadingState('idle')
-    setRetryInfo(null)
-    setIsThinking(false)
-    setIsWaitingForResponse(false)
-    thinkingStartTimeRef.current = null
+  // Cancel the stream for a specific chat (defaults to the chat on screen).
+  // Passing an explicit id lets callers stop a background stream without
+  // first switching to it.
+  const cancelGeneration = useCallback(
+    async (chatId?: string) => {
+      const targetId = chatId ?? viewedChatIdRef.current
 
-    // If we're in thinking mode, remove the last message if it's a thinking message
-    if (isStreamingRef.current) {
-      setChats((prevChats) => {
-        const newChats = prevChats.map((chat) => {
-          if (chat.id === currentChatIdRef.current) {
-            // Remove the last message if it's a thinking message
-            const messages = chat.messages.filter(
-              (msg, idx) =>
-                !(idx === chat.messages.length - 1 && msg.isThinking),
-            )
-            return { ...chat, messages, pendingSave: false }
-          }
-          return chat
-        })
-        // Find and save the updated chat
-        const updatedChat = newChats.find(
-          (c) => c.id === currentChatIdRef.current,
-        )
-        if (updatedChat && !updatedChat.isTemporary) {
-          if (storeHistory) {
-            chatStorage
-              .saveChatAndSync(updatedChat)
-              .then((savedChat) => {
-                // Only update if the ID actually changed
-                if (savedChat.id !== updatedChat.id) {
-                  currentChatIdRef.current = savedChat.id
-                  setCurrentChat(savedChat)
-                  setChats((prevChats) =>
-                    prevChats.map((c) =>
-                      c.id === updatedChat.id ? savedChat : c,
-                    ),
-                  )
+      abort(targetId)
+      patchStatus(targetId, {
+        loadingState: 'idle',
+        retryInfo: null,
+        isThinking: false,
+        isWaitingForResponse: false,
+        isStreaming: false,
+      })
+
+      // If a stream was mid-flight, drop a dangling "thinking" placeholder
+      // and persist the truncated transcript for the affected chat.
+      if (streamingTracker.isStreaming(targetId)) {
+        const stripThinking = (messages: Message[]): Message[] =>
+          messages.filter(
+            (msg, idx) => !(idx === messages.length - 1 && msg.isThinking),
+          )
+
+        setChats((prevChats) => {
+          const newChats = prevChats.map((chat) =>
+            chat.id === targetId
+              ? {
+                  ...chat,
+                  messages: stripThinking(chat.messages),
+                  pendingSave: false,
                 }
-              })
-              .catch((error) => {
-                logError('Failed to save chat after cancellation', error, {
-                  component: 'useChatMessaging',
+              : chat,
+          )
+          const updatedChat = newChats.find((c) => c.id === targetId)
+          if (updatedChat && !updatedChat.isTemporary) {
+            if (storeHistory) {
+              chatStorage
+                .saveChatAndSync(updatedChat)
+                .then((savedChat) => {
+                  // Only update if the ID actually changed
+                  if (savedChat.id !== updatedChat.id) {
+                    moveStatus(updatedChat.id, savedChat.id)
+                    if (viewedChatIdRef.current === updatedChat.id) {
+                      viewedChatIdRef.current = savedChat.id
+                      setCurrentChat(savedChat)
+                    }
+                    setChats((prev) =>
+                      prev.map((c) =>
+                        c.id === updatedChat.id ? savedChat : c,
+                      ),
+                    )
+                  }
                 })
-              })
-          } else {
-            // Save to session storage for non-signed-in users
-            sessionChatStorage.saveChat(updatedChat)
+                .catch((error) => {
+                  logError('Failed to save chat after cancellation', error, {
+                    component: 'useChatMessaging',
+                  })
+                })
+            } else {
+              // Save to session storage for non-signed-in users
+              sessionChatStorage.saveChat(updatedChat)
+            }
           }
-        }
-        return newChats
-      })
+          return newChats
+        })
 
-      // Also update current chat
-      setCurrentChat((prev) => {
-        const messages = prev.messages.filter(
-          (msg, idx) => !(idx === prev.messages.length - 1 && msg.isThinking),
+        // Mirror the truncation into the active view if it's the same chat
+        setCurrentChat((prev) =>
+          prev.id === targetId
+            ? {
+                ...prev,
+                messages: stripThinking(prev.messages),
+                pendingSave: false,
+              }
+            : prev,
         )
-        return { ...prev, messages, pendingSave: false }
-      })
-    }
 
-    // Wait for any pending state updates
-    await new Promise((resolve) =>
-      setTimeout(resolve, CONSTANTS.ASYNC_STATE_DELAY_MS),
-    )
-  }, [abortController, storeHistory, setChats, setCurrentChat])
+        streamingTracker.endStreaming(targetId)
+      }
+
+      // Wait for any pending state updates
+      await new Promise((resolve) =>
+        setTimeout(resolve, CONSTANTS.ASYNC_STATE_DELAY_MS),
+      )
+    },
+    [abort, patchStatus, moveStatus, storeHistory, setChats, setCurrentChat],
+  )
 
   // Handle chat query
   // Lifecycle overview:
@@ -246,13 +281,18 @@ export function useChatMessaging({
       baseMessages?: Message[],
       quote?: string,
     ) => {
+      // Gate on the target chat's own status so a busy background stream
+      // never blocks sending in a different chat.
+      const targetChatStatus =
+        statusByChatRef.current[currentChat?.id ?? ''] ?? IDLE_STREAM_STATUS
+
       // Allow empty query if systemPromptOverride, attachments, or a quote are provided
       if (
         (!query.trim() &&
           !systemPromptOverride &&
           !attachments?.length &&
           !quote) ||
-        loadingState !== 'idle'
+        targetChatStatus.loadingState !== 'idle'
       )
         return
 
@@ -273,12 +313,35 @@ export function useChatMessaging({
         inputRef.current.style.height = CONSTANTS.INPUT_MIN_HEIGHT
       }
 
+      // This stream owns its own id tracker, thinking timer, and title
+      // promise so it never collides with other in-flight streams. Scoped
+      // setters always target the (possibly swapped) id of this stream.
+      const streamChatIdRef = { current: currentChat.id }
+      const thinkingStartTimeRef: { current: number | null } = {
+        current: null,
+      }
+      let earlyTitlePromise: Promise<string> | null = null
+
+      const setLoadingStateFor = (s: LoadingState) =>
+        patchStatus(streamChatIdRef.current, { loadingState: s })
+      const setRetryInfoFor = (r: RetryInfo | null) =>
+        patchStatus(streamChatIdRef.current, { retryInfo: r })
+      const setIsThinkingFor = (v: boolean) =>
+        patchStatus(streamChatIdRef.current, { isThinking: v })
+      const setIsWaitingForResponseFor = (v: boolean) =>
+        patchStatus(streamChatIdRef.current, { isWaitingForResponse: v })
+      const setIsStreamingFor = (v: boolean) =>
+        patchStatus(streamChatIdRef.current, { isStreaming: v })
+      const setStreamErrorFor = (e: string | null) =>
+        patchStatus(streamChatIdRef.current, { streamError: e })
+
       const controller = new AbortController()
-      setAbortController(controller)
-      setLoadingState('loading')
-      setIsWaitingForResponse(true)
-      setIsStreaming(true)
-      setStreamError(null)
+      registerController(streamChatIdRef.current, controller)
+      resetStatus(streamChatIdRef.current, {
+        loadingState: 'loading',
+        isWaitingForResponse: true,
+        isStreaming: true,
+      })
 
       // Only create a user message if there's actual query content
       // When using system prompt override with empty query, skip user message
@@ -306,7 +369,7 @@ export function useChatMessaging({
 
       // Reset title generation for new chats
       if (isFirstMessage) {
-        earlyTitlePromiseRef.current = null
+        earlyTitlePromise = null
       }
 
       // Handle blank chat conversion: create chat immediately with server-valid ID
@@ -321,7 +384,8 @@ export function useChatMessaging({
           createdAt: new Date(),
         }
 
-        currentChatIdRef.current = updatedChat.id
+        moveStatus(streamChatIdRef.current, updatedChat.id)
+        streamChatIdRef.current = updatedChat.id
         setCurrentChat(updatedChat)
         setChats((prevChats) =>
           prevChats.map((c) => (c.id === updatedChat.id ? updatedChat : c)),
@@ -360,7 +424,8 @@ export function useChatMessaging({
         }
 
         // Update state immediately for instant UI feedback
-        currentChatIdRef.current = chatId
+        moveStatus(streamChatIdRef.current, chatId)
+        streamChatIdRef.current = chatId
         setCurrentChat(updatedChat)
 
         // Replace the blank chat with the new real chat
@@ -431,7 +496,8 @@ export function useChatMessaging({
           pendingSave: true,
         }
 
-        currentChatIdRef.current = updatedChat.id
+        moveStatus(streamChatIdRef.current, updatedChat.id)
+        streamChatIdRef.current = updatedChat.id
         setCurrentChat(updatedChat)
 
         // Replace blank chat with the new chat
@@ -500,7 +566,7 @@ export function useChatMessaging({
       }
 
       // Capture the starting chat ID before any async operations that might change it
-      const startingChatId = currentChatIdRef.current
+      const startingChatId = streamChatIdRef.current
 
       // Fire title generation in parallel with streaming (based on user's message).
       // The promise is awaited after streaming completes, before the final save.
@@ -511,7 +577,7 @@ export function useChatMessaging({
         // Prevent unhandled rejection if streaming exits early and the
         // promise is never awaited (e.g. abort, navigation, empty response)
         titlePromise.catch(() => {})
-        earlyTitlePromiseRef.current = titlePromise
+        earlyTitlePromise = titlePromise
       }
 
       // Project memory is currently disabled - uncomment to re-enable
@@ -536,7 +602,7 @@ export function useChatMessaging({
           action: 'handleQuery.startStreaming',
           metadata: {
             model: selectedModel,
-            chatId: currentChatIdRef.current,
+            chatId: streamChatIdRef.current,
             startingChatId,
             isLocalOnly: updatedChat.isLocalOnly,
             messageCount: updatedMessages.length,
@@ -551,13 +617,19 @@ export function useChatMessaging({
             )) ?? undefined)
           : undefined
 
+        // Mark the chat as streaming up front (after the initial creation
+        // save above) so the sidebar indicator and cloud-sync gating cover
+        // the whole request, including the wait for the first token. The
+        // stream processor's own startStreaming call is idempotent.
+        streamingTracker.startStreaming(streamChatIdRef.current)
+
         const response = await sendChatStream({
           model,
           systemPrompt: baseSystemPrompt,
           rules,
           onRetry: (attempt, maxRetries, error) => {
-            setLoadingState('retrying')
-            setRetryInfo({ attempt, maxRetries, error })
+            setLoadingStateFor('retrying')
+            setRetryInfoFor({ attempt, maxRetries, error })
           },
           updatedMessages,
           signal: controller.signal,
@@ -577,16 +649,15 @@ export function useChatMessaging({
           updatedMessages,
           isFirstMessage,
           modelsLength: models.length,
-          currentChatIdRef,
-          isStreamingRef,
+          streamChatIdRef,
           thinkingStartTimeRef,
-          setIsThinking,
-          setIsWaitingForResponse,
-          setIsStreaming,
+          setIsThinking: setIsThinkingFor,
+          setIsWaitingForResponse: setIsWaitingForResponseFor,
+          setIsStreaming: setIsStreamingFor,
           updateChatWithHistoryCheck,
           setChats,
           setCurrentChat,
-          setLoadingState,
+          setLoadingState: setLoadingStateFor,
           storeHistory,
           startingChatId,
         })
@@ -602,23 +673,10 @@ export function useChatMessaging({
             !!assistantMessage.timeline?.length)
 
         if (assistantMessage && hasAssistantMessageToSave) {
-          const chatId = currentChatIdRef.current
-
-          // If user navigated away during streaming, don't save to the new chat
-          if (chatId !== updatedChat.id) {
-            logInfo(
-              '[handleQuery] User navigated away during streaming, skipping save',
-              {
-                component: 'useChatMessaging',
-                action: 'handleQuery.navigationDuringStream',
-                metadata: {
-                  streamingChatId: updatedChat.id,
-                  currentChatId: chatId,
-                },
-              },
-            )
-            return
-          }
+          // Use this stream's own id (already reflects any server id swap).
+          // The response is always saved to that chat, even if the user has
+          // navigated to a different conversation while it streamed.
+          const chatId = streamChatIdRef.current
 
           logInfo('[handleQuery] Streaming completed, processing response', {
             component: 'useChatMessaging',
@@ -644,10 +702,10 @@ export function useChatMessaging({
           if (
             isFirstMessage &&
             updatedChat.title === 'Untitled' &&
-            earlyTitlePromiseRef.current
+            earlyTitlePromise
           ) {
             try {
-              const generated = await earlyTitlePromiseRef.current
+              const generated = await earlyTitlePromise
               if (generated && generated !== 'Untitled') {
                 resolvedTitle = generated
                 resolvedTitleState = 'generated'
@@ -732,11 +790,10 @@ export function useChatMessaging({
         }
       } catch (error) {
         // Ensure UI loading flags are reset on pre-stream errors
-        setIsWaitingForResponse(false)
-        setIsStreaming(false)
-        setLoadingState('idle')
-        setIsThinking(false)
-        isStreamingRef.current = false
+        setIsWaitingForResponseFor(false)
+        setIsStreamingFor(false)
+        setLoadingStateFor('idle')
+        setIsThinkingFor(false)
         thinkingStartTimeRef.current = null
         if (!(error instanceof DOMException && error.name === 'AbortError')) {
           logError('Chat query failed', error, {
@@ -766,8 +823,8 @@ export function useChatMessaging({
               isHourlyRateLimitError,
             }
 
-            // Use the current chat ID from ref which has the correct (possibly server) ID
-            const currentId = currentChatIdRef.current || updatedChat.id
+            // Use this stream's id which has the correct (possibly server) ID
+            const currentId = streamChatIdRef.current || updatedChat.id
             updateChatWithHistoryCheck(
               setChats,
               { ...updatedChat, id: currentId, pendingSave: false },
@@ -778,7 +835,7 @@ export function useChatMessaging({
             )
           } else {
             // Surface as a dismissable floating banner instead of a chat message
-            setStreamError(errorMsg)
+            setStreamErrorFor(errorMsg)
           }
         }
       } finally {
@@ -789,14 +846,22 @@ export function useChatMessaging({
           refreshRateLimit()
         }
 
-        // Ensure loading state is reset regardless of where failure occurs
-        setLoadingState('idle')
-        setRetryInfo(null)
-        setAbortController(null)
+        // Settle this stream's status (preserving any streamError so the
+        // banner can surface when the user returns to the chat).
+        patchStatus(streamChatIdRef.current, {
+          loadingState: 'idle',
+          retryInfo: null,
+          isWaitingForResponse: false,
+          isStreaming: false,
+          isThinking: false,
+        })
+        clearController(streamChatIdRef.current)
+        // Covers pre-stream failures where the processor (which normally
+        // ends streaming) never ran. Idempotent if already ended.
+        streamingTracker.endStreaming(streamChatIdRef.current)
       }
     },
     [
-      loadingState,
       currentChat,
       storeHistory,
       setChats,
@@ -815,6 +880,11 @@ export function useChatMessaging({
       codeExecutionEnabled,
       piiCheckEnabled,
       codeExecutionEncryptionKey,
+      patchStatus,
+      resetStatus,
+      moveStatus,
+      registerController,
+      clearController,
     ],
   )
 
@@ -945,7 +1015,7 @@ export function useChatMessaging({
         isStreaming ||
         isWaitingForResponse ||
         isThinking ||
-        isStreamingRef.current
+        streamingTracker.isStreaming(currentChat.id)
 
       if (isGenerationActive) {
         pendingRegenerateRef.current = {
@@ -1011,19 +1081,19 @@ export function useChatMessaging({
     if (!currentChat) return
     for (let i = currentChat.messages.length - 1; i >= 0; i--) {
       if (currentChat.messages[i].role === 'user') {
-        setStreamError(null)
+        patchStatus(currentChat.id, { streamError: null })
         regenerateMessage(i)
         return
       }
     }
-  }, [currentChat, regenerateMessage])
+  }, [currentChat, regenerateMessage, patchStatus])
 
-  // Update currentChatIdRef when currentChat changes
-  // But don't overwrite during streaming to preserve ID swaps
+  // Keep the viewed-chat id in sync. Unlike the old single-stream design
+  // this is never frozen during streaming, so switching to another chat
+  // mid-stream lets the background stream keep updating its own entry while
+  // the active view follows the user.
   useEffect(() => {
-    if (!isStreamingRef.current) {
-      currentChatIdRef.current = currentChat?.id || ''
-    }
+    viewedChatIdRef.current = currentChat?.id || ''
   }, [currentChat])
 
   return {

--- a/src/components/chat/hooks/use-chat-messaging.ts
+++ b/src/components/chat/hooks/use-chat-messaging.ts
@@ -158,6 +158,7 @@ export function useChatMessaging({
   // during streaming) so background streams write to their own list entry
   // without taking over the active view.
   const viewedChatIdRef = useRef<string>(currentChat?.id || '')
+  viewedChatIdRef.current = currentChat?.id || ''
 
   const dismissStreamError = useCallback(() => {
     patchStatus(viewedChatIdRef.current, { streamError: null })
@@ -1087,14 +1088,6 @@ export function useChatMessaging({
       }
     }
   }, [currentChat, regenerateMessage, patchStatus])
-
-  // Keep the viewed-chat id in sync. Unlike the old single-stream design
-  // this is never frozen during streaming, so switching to another chat
-  // mid-stream lets the background stream keep updating its own entry while
-  // the active view follows the user.
-  useEffect(() => {
-    viewedChatIdRef.current = currentChat?.id || ''
-  }, [currentChat])
 
   return {
     input,

--- a/src/components/chat/hooks/use-chat-state.ts
+++ b/src/components/chat/hooks/use-chat-state.ts
@@ -66,7 +66,7 @@ interface UseChatStateReturn {
     action: () => void,
   ) => void
   handleModelSelect: (modelName: AIModel) => void
-  cancelGeneration: () => Promise<void>
+  cancelGeneration: (chatId?: string) => Promise<void>
   updateChatTitle: (chatId: string, newTitle: string) => void
   reloadChats: () => Promise<void>
   editMessage: (messageIndex: number, newContent: string) => void
@@ -150,18 +150,9 @@ export function useChatState({
   } = useChatStorage({
     storeHistory,
     scrollToBottom,
-    beforeSwitchChat: async () => {
-      // Cancel generation will be defined after useChatMessaging hook
-      if (cancelGenerationRef.current) {
-        await cancelGenerationRef.current()
-      }
-    },
     initialChatId,
     isLocalChatUrl,
   })
-
-  // Create ref to store cancelGeneration function
-  const cancelGenerationRef = useRef<(() => Promise<void>) | null>(null)
 
   // Model Management
   const {
@@ -224,9 +215,6 @@ export function useChatState({
     piiCheckEnabled,
     codeExecutionEncryptionKey,
   })
-
-  // Update ref with cancelGeneration function
-  cancelGenerationRef.current = cancelGeneration
 
   // Add effect to handle dismissing the model/reasoning selectors
   useEffect(() => {

--- a/src/components/chat/hooks/use-chat-storage.ts
+++ b/src/components/chat/hooks/use-chat-storage.ts
@@ -19,7 +19,6 @@ import { ChatPersistenceManager } from './chat-persistence-manager'
 interface UseChatStorageProps {
   storeHistory: boolean
   scrollToBottom?: () => void
-  beforeSwitchChat?: () => Promise<void>
   initialChatId?: string | null
   isLocalChatUrl?: boolean
 }
@@ -44,7 +43,6 @@ interface UseChatStorageReturn {
 
 export function useChatStorage({
   storeHistory,
-  beforeSwitchChat,
   initialChatId,
   isLocalChatUrl = false,
 }: UseChatStorageProps): UseChatStorageReturn {
@@ -311,32 +309,25 @@ export function useChatStorage({
     }
   }, [])
 
-  // Switch to a different chat
-  const switchChat = useCallback(
-    async (chat: Chat) => {
-      // Cancel any ongoing stream before switching
-      if (beforeSwitchChat) {
-        await beforeSwitchChat()
-      }
+  // Switch to a different chat. Streams keep running in the background, so
+  // switching never cancels an in-flight generation.
+  const switchChat = useCallback(async (chat: Chat) => {
+    // Clear any pending timer from a previous switch
+    if (switchChatTimerRef.current) {
+      clearTimeout(switchChatTimerRef.current)
+    }
 
-      // Clear any pending timer from a previous switch
-      if (switchChatTimerRef.current) {
-        clearTimeout(switchChatTimerRef.current)
-      }
+    isSwitchingChatRef.current = true
+    setCurrentChat(chat)
+    setIsInitialLoad(true)
 
-      isSwitchingChatRef.current = true
-      setCurrentChat(chat)
-      setIsInitialLoad(true)
-
-      // Brief delay to show loading state
-      switchChatTimerRef.current = setTimeout(() => {
-        setIsInitialLoad(false)
-        isSwitchingChatRef.current = false
-        switchChatTimerRef.current = null
-      }, CONSTANTS.CHAT_INIT_DELAY_MS)
-    },
-    [beforeSwitchChat],
-  )
+    // Brief delay to show loading state
+    switchChatTimerRef.current = setTimeout(() => {
+      setIsInitialLoad(false)
+      isSwitchingChatRef.current = false
+      switchChatTimerRef.current = null
+    }, CONSTANTS.CHAT_INIT_DELAY_MS)
+  }, [])
 
   // Handle chat selection
   const handleChatSelect = useCallback(

--- a/src/components/chat/hooks/use-chat-streams.ts
+++ b/src/components/chat/hooks/use-chat-streams.ts
@@ -1,0 +1,131 @@
+import { useCallback, useRef, useState } from 'react'
+import type { LoadingState } from '../types'
+
+export interface RetryInfo {
+  attempt: number
+  maxRetries: number
+  error?: string
+}
+
+/**
+ * UI-facing state for a single chat's in-flight stream. One entry exists
+ * per actively-streaming chat; the absence of an entry means the chat is
+ * idle (see `IDLE_STREAM_STATUS`).
+ *
+ * `streamError` outlives the stream itself: it is preserved when the
+ * stream settles so the floating error banner can surface when the user
+ * navigates back to the chat that failed.
+ */
+export interface ChatStreamStatus {
+  loadingState: LoadingState
+  retryInfo: RetryInfo | null
+  isThinking: boolean
+  isWaitingForResponse: boolean
+  isStreaming: boolean
+  streamError: string | null
+}
+
+export const IDLE_STREAM_STATUS: ChatStreamStatus = {
+  loadingState: 'idle',
+  retryInfo: null,
+  isThinking: false,
+  isWaitingForResponse: false,
+  isStreaming: false,
+  streamError: null,
+}
+
+export interface UseChatStreamsReturn {
+  statusByChat: Record<string, ChatStreamStatus>
+  /** Merge a partial status into the chat's existing (or idle) status. */
+  patchStatus: (chatId: string, partial: Partial<ChatStreamStatus>) => void
+  /** Reset to idle, optionally overriding specific fields. */
+  resetStatus: (chatId: string, partial?: Partial<ChatStreamStatus>) => void
+  /** Re-key a chat's status and abort controller after a server id swap. */
+  moveStatus: (fromId: string, toId: string) => void
+  registerController: (chatId: string, controller: AbortController) => void
+  clearController: (chatId: string) => void
+  /** Abort the stream for a chat. Returns true if a controller existed. */
+  abort: (chatId: string) => boolean
+}
+
+/**
+ * Owns per-chat stream status so multiple chats can stream concurrently.
+ *
+ * Status flags live in React state (they drive the input area, stop
+ * button, and thinking indicators for whichever chat is on screen). Abort
+ * controllers live in a ref since aborting never needs to trigger a
+ * render.
+ */
+export function useChatStreams(): UseChatStreamsReturn {
+  const [statusByChat, setStatusByChat] = useState<
+    Record<string, ChatStreamStatus>
+  >({})
+  const abortControllersRef = useRef<Map<string, AbortController>>(new Map())
+
+  const patchStatus = useCallback(
+    (chatId: string, partial: Partial<ChatStreamStatus>) => {
+      setStatusByChat((prev) => {
+        const current = prev[chatId] ?? IDLE_STREAM_STATUS
+        return { ...prev, [chatId]: { ...current, ...partial } }
+      })
+    },
+    [],
+  )
+
+  const resetStatus = useCallback(
+    (chatId: string, partial?: Partial<ChatStreamStatus>) => {
+      setStatusByChat((prev) => ({
+        ...prev,
+        [chatId]: { ...IDLE_STREAM_STATUS, ...partial },
+      }))
+    },
+    [],
+  )
+
+  const moveStatus = useCallback((fromId: string, toId: string) => {
+    if (fromId === toId) return
+
+    setStatusByChat((prev) => {
+      if (!(fromId in prev)) return prev
+      const next = { ...prev }
+      next[toId] = prev[fromId]
+      delete next[fromId]
+      return next
+    })
+
+    const controller = abortControllersRef.current.get(fromId)
+    if (controller) {
+      abortControllersRef.current.delete(fromId)
+      abortControllersRef.current.set(toId, controller)
+    }
+  }, [])
+
+  const registerController = useCallback(
+    (chatId: string, controller: AbortController) => {
+      abortControllersRef.current.set(chatId, controller)
+    },
+    [],
+  )
+
+  const clearController = useCallback((chatId: string) => {
+    abortControllersRef.current.delete(chatId)
+  }, [])
+
+  const abort = useCallback((chatId: string): boolean => {
+    const controller = abortControllersRef.current.get(chatId)
+    if (!controller) return false
+    controller.abort()
+    abortControllersRef.current.delete(chatId)
+    return true
+  }, [])
+
+  return {
+    statusByChat,
+    patchStatus,
+    resetStatus,
+    moveStatus,
+    registerController,
+    clearController,
+    abort,
+  }
+}

--- a/src/components/chat/hooks/use-message-queue.ts
+++ b/src/components/chat/hooks/use-message-queue.ts
@@ -1,5 +1,5 @@
 import { MESSAGE_QUEUE_PREFIX } from '@/constants/storage-keys'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import type { Attachment, LoadingState, Message, QueuedMessage } from '../types'
 
 type HandleQuery = (
@@ -69,18 +69,17 @@ function writeToStorage(key: string | null, queue: QueuedMessage[]): void {
   }
 }
 
-function removeFromStorage(key: string | null): void {
-  if (!key || !isBrowser) return
-  try {
-    window.sessionStorage.removeItem(key)
-  } catch {
-    /* noop */
-  }
-}
-
 /**
  * Holds user messages submitted while the assistant is busy and dispatches
- * them one-at-a-time through a single async pump.
+ * them one-at-a-time per chat.
+ *
+ * Concurrency model:
+ *
+ *   Each chat owns its own queue and its own single-flight pump, so a
+ *   conversation that is streaming never blocks a different conversation
+ *   from sending. `handleQuery` always targets the chat on screen, so a
+ *   pump only dispatches while its chat is the active one; a backgrounded
+ *   chat keeps its queued messages and resumes draining when reopened.
  *
  * Why a pump instead of an effect-per-tick:
  *
@@ -107,43 +106,35 @@ export function useMessageQueue({
   onBeforeDispatch,
   onRateLimited,
 }: UseMessageQueueArgs): UseMessageQueueReturn {
-  const initialKey = useMemo(() => storageKeyFor(chatId), [chatId])
+  // Per-chat queues so several conversations can hold pending messages at
+  // once. Hydrated lazily from sessionStorage on first access.
+  const queuesRef = useRef<Map<string, QueuedMessage[]>>(new Map())
 
-  const [queue, setQueue] = useState<QueuedMessage[]>(() =>
-    loadFromStorage(initialKey),
-  )
-  const queueRef = useRef<QueuedMessage[]>(queue)
-  const currentKeyRef = useRef<string | null>(initialKey)
-
-  const writeQueue = useCallback(
-    (updater: (prev: QueuedMessage[]) => QueuedMessage[]) => {
-      const next = updater(queueRef.current)
-      queueRef.current = next
-      setQueue(next)
-      writeToStorage(currentKeyRef.current, next)
+  const getQueue = useCallback(
+    (id: string | null | undefined): QueuedMessage[] => {
+      if (!id) return []
+      let q = queuesRef.current.get(id)
+      if (!q) {
+        q = loadFromStorage(storageKeyFor(id))
+        queuesRef.current.set(id, q)
+      }
+      return q
     },
     [],
   )
 
-  // Handle chat-id changes: migrate pending items to the new key, or load
-  // the new chat's stored queue if we have nothing pending.
-  useEffect(() => {
-    const nextKey = storageKeyFor(chatId)
-    if (nextKey === currentKeyRef.current) return
+  // Mirror of the active chat id for reads inside stable callbacks.
+  const currentChatIdRef = useRef<string | null | undefined>(chatId)
+  currentChatIdRef.current = chatId
 
-    const previousKey = currentKeyRef.current
-    currentKeyRef.current = nextKey
+  // Rendered queue tracks the chat on screen.
+  const [queue, setQueue] = useState<QueuedMessage[]>(() => getQueue(chatId))
 
-    if (queueRef.current.length > 0) {
-      removeFromStorage(previousKey)
-      writeToStorage(nextKey, queueRef.current)
-      return
-    }
-
-    const loaded = loadFromStorage(nextKey)
-    queueRef.current = loaded
-    setQueue(loaded)
-  }, [chatId])
+  const setQueueFor = useCallback((id: string, next: QueuedMessage[]) => {
+    queuesRef.current.set(id, next)
+    writeToStorage(storageKeyFor(id), next)
+    if (id === currentChatIdRef.current) setQueue(next)
+  }, [])
 
   const handleQueryRef = useRef(handleQuery)
   const isRateLimitedRef = useRef(isRateLimited)
@@ -156,10 +147,10 @@ export function useMessageQueue({
     onRateLimitedRef.current = onRateLimited
   })
 
-  // Live mirror of `loadingState`, used by the pump to gate the next
-  // dispatch on the chat actually being idle.
+  // Live mirror of the active chat's `loadingState`, used by the pump to
+  // gate the next dispatch on that chat actually being idle.
   const loadingStateRef = useRef<LoadingState>(loadingState)
-  // Pending resolvers for `waitForIdle`. Resolved whenever the chat
+  // Pending resolvers for `waitForIdle`. Resolved whenever the active chat
   // transitions to `'idle'`.
   const idleWaitersRef = useRef<Array<() => void>>([])
   useEffect(() => {
@@ -186,66 +177,74 @@ export function useMessageQueue({
     }
   })
 
-  // Single-flight pump. While running, it owns the dispatch lifecycle and
-  // drains the queue one message at a time. Awaiting `handleQuery`'s
-  // promise is the only serialization signal we trust — it resolves
-  // exactly once, when the stream we kicked off completes (success,
-  // error, or abort).
-  const pumpRunningRef = useRef(false)
+  // One single-flight pump per chat. Dispatch always targets the chat on
+  // screen (handleQuery is bound to it), so the pump only proceeds while
+  // its chat is active and stops otherwise, leaving the queue to resume
+  // when the chat is reopened.
+  const pumpRunningRef = useRef<Set<string>>(new Set())
 
-  const runPump = useCallback(async (): Promise<void> => {
-    if (pumpRunningRef.current) return
-    pumpRunningRef.current = true
-    try {
-      while (queueRef.current.length > 0) {
-        await waitForIdle()
+  const runPump = useCallback(
+    async (id: string): Promise<void> => {
+      if (!id) return
+      if (pumpRunningRef.current.has(id)) return
+      pumpRunningRef.current.add(id)
+      try {
+        while (getQueue(id).length > 0) {
+          // Only the chat on screen can dispatch; pause otherwise.
+          if (id !== currentChatIdRef.current) return
+          await waitForIdle()
+          if (id !== currentChatIdRef.current) return
 
-        if (isRateLimitedRef.current()) {
-          if (!rateLimitPromptShownRef.current) {
-            rateLimitPromptShownRef.current = true
-            onRateLimitedRef.current?.()
+          if (isRateLimitedRef.current()) {
+            if (!rateLimitPromptShownRef.current) {
+              rateLimitPromptShownRef.current = true
+              onRateLimitedRef.current?.()
+            }
+            return
           }
-          return
+          rateLimitPromptShownRef.current = false
+
+          const [next, ...rest] = getQueue(id)
+          if (!next) break
+          setQueueFor(id, rest)
+          onBeforeDispatchRef.current?.()
+
+          try {
+            const result = handleQueryRef.current(
+              next.text,
+              next.attachments,
+              undefined,
+              undefined,
+              next.quote,
+            )
+            if (
+              result &&
+              typeof (result as Promise<unknown>).then === 'function'
+            ) {
+              await (result as Promise<unknown>)
+            }
+          } catch {
+            /* errors are surfaced by the chat itself; keep draining */
+          }
         }
-        rateLimitPromptShownRef.current = false
-
-        const [next, ...rest] = queueRef.current
-        if (!next) break
-        writeQueue(() => rest)
-        onBeforeDispatchRef.current?.()
-
-        try {
-          const result = handleQueryRef.current(
-            next.text,
-            next.attachments,
-            undefined,
-            undefined,
-            next.quote,
-          )
-          if (
-            result &&
-            typeof (result as Promise<unknown>).then === 'function'
-          ) {
-            await (result as Promise<unknown>)
-          }
-        } catch {
-          /* errors are surfaced by the chat itself; keep draining */
+      } finally {
+        pumpRunningRef.current.delete(id)
+        // If something was enqueued while the pump was tearing down and the
+        // chat is still active, restart it on the next tick.
+        if (id === currentChatIdRef.current && getQueue(id).length > 0) {
+          queueMicrotask(() => {
+            void runPump(id)
+          })
         }
       }
-    } finally {
-      pumpRunningRef.current = false
-      // If something was enqueued while the pump was tearing down,
-      // restart it on the next tick.
-      if (queueRef.current.length > 0) {
-        queueMicrotask(() => {
-          void runPump()
-        })
-      }
-    }
-  }, [waitForIdle, writeQueue])
+    },
+    [getQueue, setQueueFor, waitForIdle],
+  )
 
   const submit = useCallback(
     (input: QueueSubmitInput): void => {
+      const id = currentChatIdRef.current
+      if (!id) return
       const item: QueuedMessage = {
         id: generateQueuedId(),
         text: input.text,
@@ -255,26 +254,32 @@ export function useMessageQueue({
             : undefined,
         quote: input.quote ?? undefined,
       }
-      writeQueue((prev) => [...prev, item])
-      void runPump()
+      setQueueFor(id, [...getQueue(id), item])
+      void runPump(id)
     },
-    [writeQueue, runPump],
+    [getQueue, setQueueFor, runPump],
   )
 
-  // Restart the pump if there's something queued (e.g. left over in
-  // sessionStorage from a previous session) and we're idle on mount or
-  // after a chat switch.
+  // Sync the rendered queue to the active chat and resume draining it (e.g.
+  // messages left in sessionStorage, or queued while the chat was in the
+  // background). Runs on mount and on every chat switch.
   useEffect(() => {
-    if (queue.length > 0 && !pumpRunningRef.current) {
-      void runPump()
+    setQueue(getQueue(chatId))
+    if (chatId && getQueue(chatId).length > 0) {
+      void runPump(chatId)
     }
-  }, [queue, runPump])
+  }, [chatId, getQueue, runPump])
 
   const removeQueuedMessage = useCallback(
-    (id: string): void => {
-      writeQueue((prev) => prev.filter((item) => item.id !== id))
+    (queuedId: string): void => {
+      const id = currentChatIdRef.current
+      if (!id) return
+      setQueueFor(
+        id,
+        getQueue(id).filter((item) => item.id !== queuedId),
+      )
     },
-    [writeQueue],
+    [getQueue, setQueueFor],
   )
 
   return { queuedMessages: queue, submit, removeQueuedMessage }

--- a/src/components/chat/hooks/use-message-queue.ts
+++ b/src/components/chat/hooks/use-message-queue.ts
@@ -139,16 +139,19 @@ export function useMessageQueue({
     if (id === currentChatIdRef.current) setQueue(next)
   }, [])
 
+  // Latest-value mirrors so the async pump always calls the current
+  // handlers (in particular handleQuery, which is bound to the chat on
+  // screen) without being re-created on every render. Assigned during
+  // render so they can never be stale relative to currentChatIdRef when the
+  // pump dispatches in a microtask (an effect would lag a paint behind).
   const handleQueryRef = useRef(handleQuery)
   const isRateLimitedRef = useRef(isRateLimited)
   const onBeforeDispatchRef = useRef(onBeforeDispatch)
   const onRateLimitedRef = useRef(onRateLimited)
-  useEffect(() => {
-    handleQueryRef.current = handleQuery
-    isRateLimitedRef.current = isRateLimited
-    onBeforeDispatchRef.current = onBeforeDispatch
-    onRateLimitedRef.current = onRateLimited
-  })
+  handleQueryRef.current = handleQuery
+  isRateLimitedRef.current = isRateLimited
+  onBeforeDispatchRef.current = onBeforeDispatch
+  onRateLimitedRef.current = onRateLimited
 
   // Live mirror of the active chat's `loadingState`, used by the pump to
   // gate the next dispatch on that chat actually being idle.
@@ -174,11 +177,6 @@ export function useMessageQueue({
 
   // Rate-limit prompt latch: show at most once per exhaustion window.
   const rateLimitPromptShownRef = useRef(false)
-  useEffect(() => {
-    if (!isRateLimited()) {
-      rateLimitPromptShownRef.current = false
-    }
-  })
 
   // One single-flight pump per chat. Dispatch always targets the chat on
   // screen (handleQuery is bound to it), so the pump only proceeds while
@@ -240,10 +238,13 @@ export function useMessageQueue({
           pumpsRef.current.delete(pump.id)
         }
         // If something was enqueued while the pump was tearing down and the
-        // chat is still active, restart it on the next tick.
+        // chat is still active, restart it on the next tick. Skip while
+        // rate-limited so we don't busy-spin; the rate-limit effect resumes
+        // the queue once the limit clears.
         if (
           pump.id === currentChatIdRef.current &&
-          getQueue(pump.id).length > 0
+          getQueue(pump.id).length > 0 &&
+          !isRateLimitedRef.current()
         ) {
           queueMicrotask(() => {
             void runPump(pump.id)
@@ -253,6 +254,19 @@ export function useMessageQueue({
     },
     [getQueue, setQueueFor, waitForIdle],
   )
+
+  // When the rate limit clears, reset the one-shot prompt latch and resume
+  // the active chat's queue (the pump bails out while rate-limited rather
+  // than busy-waiting). Runs whenever the rate-limit predicate changes.
+  useEffect(() => {
+    if (!isRateLimited()) {
+      rateLimitPromptShownRef.current = false
+      const id = currentChatIdRef.current
+      if (id != null && getQueue(id).length > 0) {
+        void runPump(id)
+      }
+    }
+  }, [isRateLimited, getQueue, runPump])
 
   const submit = useCallback(
     (input: QueueSubmitInput): void => {

--- a/src/components/chat/hooks/use-message-queue.ts
+++ b/src/components/chat/hooks/use-message-queue.ts
@@ -112,7 +112,10 @@ export function useMessageQueue({
 
   const getQueue = useCallback(
     (id: string | null | undefined): QueuedMessage[] => {
-      if (!id) return []
+      // Only null/undefined means "no chat". A blank chat has an empty
+      // string id (see createBlankChat) and is a valid, queueable target;
+      // its messages live in memory only since storageKeyFor('') is null.
+      if (id == null) return []
       let q = queuesRef.current.get(id)
       if (!q) {
         q = loadFromStorage(storageKeyFor(id))
@@ -185,7 +188,7 @@ export function useMessageQueue({
 
   const runPump = useCallback(
     async (id: string): Promise<void> => {
-      if (!id) return
+      if (id == null) return
       if (pumpRunningRef.current.has(id)) return
       pumpRunningRef.current.add(id)
       try {
@@ -244,7 +247,7 @@ export function useMessageQueue({
   const submit = useCallback(
     (input: QueueSubmitInput): void => {
       const id = currentChatIdRef.current
-      if (!id) return
+      if (id == null) return
       const item: QueuedMessage = {
         id: generateQueuedId(),
         text: input.text,
@@ -265,7 +268,7 @@ export function useMessageQueue({
   // background). Runs on mount and on every chat switch.
   useEffect(() => {
     setQueue(getQueue(chatId))
-    if (chatId && getQueue(chatId).length > 0) {
+    if (chatId != null && getQueue(chatId).length > 0) {
       void runPump(chatId)
     }
   }, [chatId, getQueue, runPump])
@@ -273,7 +276,7 @@ export function useMessageQueue({
   const removeQueuedMessage = useCallback(
     (queuedId: string): void => {
       const id = currentChatIdRef.current
-      if (!id) return
+      if (id == null) return
       setQueueFor(
         id,
         getQueue(id).filter((item) => item.id !== queuedId),

--- a/src/components/chat/hooks/use-message-queue.ts
+++ b/src/components/chat/hooks/use-message-queue.ts
@@ -184,19 +184,24 @@ export function useMessageQueue({
   // screen (handleQuery is bound to it), so the pump only proceeds while
   // its chat is active and stops otherwise, leaving the queue to resume
   // when the chat is reopened.
-  const pumpRunningRef = useRef<Set<string>>(new Set())
+  // Active pumps keyed by their current chat id. Each holds a mutable `id`
+  // so a blank chat's pump can follow the conversion to a real id (see the
+  // re-key in the chat-sync effect) instead of staying parked on the shared
+  // blank id ('') and blocking the next new chat.
+  const pumpsRef = useRef<Map<string, { id: string }>>(new Map())
 
   const runPump = useCallback(
-    async (id: string): Promise<void> => {
-      if (id == null) return
-      if (pumpRunningRef.current.has(id)) return
-      pumpRunningRef.current.add(id)
+    async (startId: string): Promise<void> => {
+      if (startId == null) return
+      if (pumpsRef.current.has(startId)) return
+      const pump = { id: startId }
+      pumpsRef.current.set(startId, pump)
       try {
-        while (getQueue(id).length > 0) {
+        while (getQueue(pump.id).length > 0) {
           // Only the chat on screen can dispatch; pause otherwise.
-          if (id !== currentChatIdRef.current) return
+          if (pump.id !== currentChatIdRef.current) return
           await waitForIdle()
-          if (id !== currentChatIdRef.current) return
+          if (pump.id !== currentChatIdRef.current) return
 
           if (isRateLimitedRef.current()) {
             if (!rateLimitPromptShownRef.current) {
@@ -207,9 +212,9 @@ export function useMessageQueue({
           }
           rateLimitPromptShownRef.current = false
 
-          const [next, ...rest] = getQueue(id)
+          const [next, ...rest] = getQueue(pump.id)
           if (!next) break
-          setQueueFor(id, rest)
+          setQueueFor(pump.id, rest)
           onBeforeDispatchRef.current?.()
 
           try {
@@ -231,12 +236,17 @@ export function useMessageQueue({
           }
         }
       } finally {
-        pumpRunningRef.current.delete(id)
+        if (pumpsRef.current.get(pump.id) === pump) {
+          pumpsRef.current.delete(pump.id)
+        }
         // If something was enqueued while the pump was tearing down and the
         // chat is still active, restart it on the next tick.
-        if (id === currentChatIdRef.current && getQueue(id).length > 0) {
+        if (
+          pump.id === currentChatIdRef.current &&
+          getQueue(pump.id).length > 0
+        ) {
           queueMicrotask(() => {
-            void runPump(id)
+            void runPump(pump.id)
           })
         }
       }
@@ -263,10 +273,46 @@ export function useMessageQueue({
     [getQueue, setQueueFor, runPump],
   )
 
+  // Tracks the previously-rendered chat id so we can detect a blank chat
+  // being converted to a real id (a brand-new conversation getting its
+  // server/local id on its first message).
+  const prevChatIdRef = useRef<string | null | undefined>(chatId)
+
   // Sync the rendered queue to the active chat and resume draining it (e.g.
   // messages left in sessionStorage, or queued while the chat was in the
   // background). Runs on mount and on every chat switch.
   useEffect(() => {
+    const prev = prevChatIdRef.current
+    prevChatIdRef.current = chatId
+
+    // Blank chats all share the empty-string id. When one converts to a
+    // real id, re-key its in-flight pump and queue so the freed blank id is
+    // immediately available to the next new chat. Only blank ('') ids are
+    // transient and reused this way, so this never fires on a plain switch
+    // between existing chats.
+    if (
+      prev === '' &&
+      chatId != null &&
+      chatId !== '' &&
+      pumpsRef.current.has('')
+    ) {
+      const pump = pumpsRef.current.get('')
+      const pending = queuesRef.current.get('')
+      if (pending && pending.length > 0) {
+        queuesRef.current.set(chatId, [
+          ...(queuesRef.current.get(chatId) ?? []),
+          ...pending,
+        ])
+        writeToStorage(storageKeyFor(chatId), queuesRef.current.get(chatId)!)
+      }
+      queuesRef.current.delete('')
+      if (pump) {
+        pump.id = chatId
+        pumpsRef.current.delete('')
+        pumpsRef.current.set(chatId, pump)
+      }
+    }
+
     setQueue(getQueue(chatId))
     if (chatId != null && getQueue(chatId).length > 0) {
       void runPump(chatId)

--- a/src/components/chat/hooks/use-sidebar-chat.ts
+++ b/src/components/chat/hooks/use-sidebar-chat.ts
@@ -98,9 +98,8 @@ export function useSidebarChat({
 
   // Refs kept in sync with state so the streaming processor (which captures
   // them once) can read the latest values.
-  const isStreamingRef = useRef(false)
   const thinkingStartTimeRef = useRef<number | null>(null)
-  const currentChatIdRef = useRef<string>(EPHEMERAL_CHAT_ID)
+  const streamChatIdRef = useRef<string>(EPHEMERAL_CHAT_ID)
   const abortControllerRef = useRef<AbortController | null>(null)
 
   const cancel = useCallback(() => {
@@ -108,7 +107,6 @@ export function useSidebarChat({
       abortControllerRef.current.abort()
       abortControllerRef.current = null
     }
-    isStreamingRef.current = false
     thinkingStartTimeRef.current = null
     setLoadingState('idle')
     setRetryInfo(null)
@@ -217,14 +215,12 @@ export function useSidebarChat({
             piiCheckEnabled,
           })
 
-          isStreamingRef.current = true
           const assistantMessage = await processStreamingResponse(response, {
             updatedChat: ephemeralChat as never,
             updatedMessages: apiMessages,
             isFirstMessage: true,
             modelsLength: models.length,
-            currentChatIdRef,
-            isStreamingRef,
+            streamChatIdRef,
             thinkingStartTimeRef,
             setIsThinking,
             setIsWaitingForResponse,
@@ -273,7 +269,6 @@ export function useSidebarChat({
             setRetryInfo(null)
             setIsWaitingForResponse(false)
             setIsStreaming(false)
-            isStreamingRef.current = false
             thinkingStartTimeRef.current = null
             abortControllerRef.current = null
           }

--- a/src/hooks/use-streaming-chats.ts
+++ b/src/hooks/use-streaming-chats.ts
@@ -1,0 +1,17 @@
+import { streamingTracker } from '@/services/cloud/streaming-tracker'
+import { useSyncExternalStore } from 'react'
+
+/**
+ * Subscribe to the set of chat ids that currently have an in-flight
+ * assistant stream. Re-renders only when a stream starts or ends.
+ *
+ * Backed by the app-wide `streamingTracker`, so any component can show a
+ * live "streaming" indicator without threading props through the tree.
+ */
+export function useStreamingChats(): ReadonlySet<string> {
+  return useSyncExternalStore(
+    streamingTracker.subscribe,
+    streamingTracker.getSnapshot,
+    streamingTracker.getSnapshot,
+  )
+}

--- a/src/services/cloud/streaming-tracker.ts
+++ b/src/services/cloud/streaming-tracker.ts
@@ -1,15 +1,34 @@
 import { logError } from '@/utils/error-handling'
 
+/**
+ * Tracks which chats currently have an in-flight assistant stream.
+ *
+ * This is the single, app-wide source of truth for "is chat X streaming".
+ * It is consumed in three independent places:
+ *   1. Persistence/cloud-sync gating (defer uploads until a stream ends).
+ *   2. The streaming pipeline (start/end markers per chat).
+ *   3. The sidebar streaming indicator, via `useStreamingChats` which
+ *      subscribes through the observer API below.
+ *
+ * Because multiple chats can stream concurrently, callers must always key
+ * off a specific `chatId` rather than a global boolean.
+ */
 class StreamingTracker {
   private streamingChats = new Set<string>()
   private streamEndCallbacks = new Map<string, (() => void)[]>()
+  private listeners = new Set<() => void>()
+  // Immutable snapshot handed to React via useSyncExternalStore. A fresh
+  // Set is published on every change so referential identity tracks state.
+  private snapshot: ReadonlySet<string> = new Set()
 
   startStreaming(chatId: string): void {
+    if (this.streamingChats.has(chatId)) return
     this.streamingChats.add(chatId)
+    this.publish()
   }
 
   endStreaming(chatId: string): void {
-    this.streamingChats.delete(chatId)
+    const wasStreaming = this.streamingChats.delete(chatId)
 
     // Execute any callbacks waiting for this chat to finish streaming
     const callbacks = this.streamEndCallbacks.get(chatId)
@@ -29,6 +48,8 @@ class StreamingTracker {
       // Always clean up callbacks, even if some failed
       this.streamEndCallbacks.delete(chatId)
     }
+
+    if (wasStreaming) this.publish()
   }
 
   isStreaming(chatId: string): boolean {
@@ -50,6 +71,33 @@ class StreamingTracker {
     const callbacks = this.streamEndCallbacks.get(chatId) || []
     callbacks.push(callback)
     this.streamEndCallbacks.set(chatId, callbacks)
+  }
+
+  /**
+   * Observer API for React. Arrow-bound so they can be passed directly to
+   * `useSyncExternalStore` without re-binding on every render.
+   */
+  subscribe = (listener: () => void): (() => void) => {
+    this.listeners.add(listener)
+    return () => {
+      this.listeners.delete(listener)
+    }
+  }
+
+  getSnapshot = (): ReadonlySet<string> => this.snapshot
+
+  private publish(): void {
+    this.snapshot = new Set(this.streamingChats)
+    this.listeners.forEach((listener) => {
+      try {
+        listener()
+      } catch (error) {
+        logError('Error notifying streaming listener', error, {
+          component: 'StreamingTracker',
+          action: 'publish',
+        })
+      }
+    })
   }
 }
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -48,6 +48,41 @@
   }
 }
 
+/* Three-dot streaming indicator shown next to a chat title in the sidebar */
+.stream-loader {
+  width: 4px;
+  aspect-ratio: 1;
+  border-radius: 50%;
+  color: #10b981; /* emerald-500 */
+  animation: stream-loader 1s infinite linear alternate;
+}
+@keyframes stream-loader {
+  0% {
+    box-shadow:
+      7px 0 currentColor,
+      -7px 0 rgba(16, 185, 129, 0.2);
+    background: currentColor;
+  }
+  33% {
+    box-shadow:
+      7px 0 currentColor,
+      -7px 0 rgba(16, 185, 129, 0.2);
+    background: rgba(16, 185, 129, 0.2);
+  }
+  66% {
+    box-shadow:
+      7px 0 rgba(16, 185, 129, 0.2),
+      -7px 0 currentColor;
+    background: rgba(16, 185, 129, 0.2);
+  }
+  100% {
+    box-shadow:
+      7px 0 rgba(16, 185, 129, 0.2),
+      -7px 0 currentColor;
+    background: currentColor;
+  }
+}
+
 /* Prevent vertical scrollbars in message content */
 .katex-display {
   overflow-x: auto !important;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -48,36 +48,36 @@
   }
 }
 
-/* Three-dot streaming indicator shown next to a chat title in the sidebar */
+/* Three-dot streaming indicator shown next to a chat title in the sidebar.
+   Inherits the chat title color via currentColor. */
 .stream-loader {
   width: 4px;
   aspect-ratio: 1;
   border-radius: 50%;
-  color: #10b981; /* emerald-500 */
   animation: stream-loader 1s infinite linear alternate;
 }
 @keyframes stream-loader {
   0% {
     box-shadow:
       7px 0 currentColor,
-      -7px 0 rgba(16, 185, 129, 0.2);
+      -7px 0 color-mix(in srgb, currentColor 20%, transparent);
     background: currentColor;
   }
   33% {
     box-shadow:
       7px 0 currentColor,
-      -7px 0 rgba(16, 185, 129, 0.2);
-    background: rgba(16, 185, 129, 0.2);
+      -7px 0 color-mix(in srgb, currentColor 20%, transparent);
+    background: color-mix(in srgb, currentColor 20%, transparent);
   }
   66% {
     box-shadow:
-      7px 0 rgba(16, 185, 129, 0.2),
+      7px 0 color-mix(in srgb, currentColor 20%, transparent),
       -7px 0 currentColor;
-    background: rgba(16, 185, 129, 0.2);
+    background: color-mix(in srgb, currentColor 20%, transparent);
   }
   100% {
     box-shadow:
-      7px 0 rgba(16, 185, 129, 0.2),
+      7px 0 color-mix(in srgb, currentColor 20%, transparent),
       -7px 0 currentColor;
     background: currentColor;
   }

--- a/tests/components/chat/use-chat-messaging.cancel-generation.test.tsx
+++ b/tests/components/chat/use-chat-messaging.cancel-generation.test.tsx
@@ -1,0 +1,139 @@
+import { useChatMessaging } from '@/components/chat/hooks/use-chat-messaging'
+import type { Chat } from '@/components/chat/types'
+import { act, renderHook } from '@testing-library/react'
+import {
+  type Dispatch,
+  type RefObject,
+  type SetStateAction,
+  useLayoutEffect,
+} from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const abortMock = vi.fn()
+const patchStatusMock = vi.fn()
+const resetStatusMock = vi.fn()
+const moveStatusMock = vi.fn()
+const registerControllerMock = vi.fn()
+const clearControllerMock = vi.fn()
+
+vi.mock('@clerk/nextjs', () => ({
+  useAuth: () => ({
+    isSignedIn: false,
+  }),
+}))
+
+vi.mock('@/components/project', () => ({
+  useProject: () => ({
+    isProjectMode: false,
+    activeProject: null,
+  }),
+}))
+
+vi.mock('@/services/cloud/streaming-tracker', () => ({
+  streamingTracker: {
+    isStreaming: vi.fn(() => false),
+    endStreaming: vi.fn(),
+  },
+}))
+
+vi.mock('@/components/chat/hooks/use-chat-streams', async () => {
+  const actual = await vi.importActual<
+    typeof import('@/components/chat/hooks/use-chat-streams')
+  >('@/components/chat/hooks/use-chat-streams')
+
+  return {
+    ...actual,
+    useChatStreams: () => ({
+      statusByChat: {},
+      patchStatus: patchStatusMock,
+      resetStatus: resetStatusMock,
+      moveStatus: moveStatusMock,
+      registerController: registerControllerMock,
+      clearController: clearControllerMock,
+      abort: abortMock,
+    }),
+  }
+})
+
+function createChat(id: string): Chat {
+  return {
+    id,
+    title: `Chat ${id}`,
+    messages: [],
+    createdAt: new Date(),
+    isBlankChat: false,
+  }
+}
+
+const noopSetChats: Dispatch<SetStateAction<Chat[]>> = (_value) => undefined
+const noopSetCurrentChat: Dispatch<SetStateAction<Chat>> = (_value) => undefined
+const messagesEndRef = { current: null } as RefObject<HTMLDivElement | null>
+
+type HookProps = {
+  currentChat: Chat
+  triggerCancelOnLayout: boolean
+}
+
+function useChatMessagingHarness({
+  currentChat,
+  triggerCancelOnLayout,
+}: HookProps) {
+  const messaging = useChatMessaging({
+    systemPrompt: '',
+    rules: '',
+    storeHistory: false,
+    models: [],
+    selectedModel: 'test-model',
+    chats: [currentChat],
+    currentChat,
+    setChats: noopSetChats,
+    setCurrentChat: noopSetCurrentChat,
+    messagesEndRef,
+  })
+  const { cancelGeneration } = messaging
+
+  useLayoutEffect(() => {
+    if (triggerCancelOnLayout) {
+      void cancelGeneration()
+    }
+  }, [triggerCancelOnLayout, cancelGeneration])
+
+  return messaging
+}
+
+describe('useChatMessaging cancelGeneration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('targets the latest rendered chat during a chat switch', () => {
+    const firstChat = createChat('chat-a')
+    const secondChat = createChat('chat-b')
+
+    const { rerender } = renderHook(useChatMessagingHarness, {
+      initialProps: {
+        currentChat: firstChat,
+        triggerCancelOnLayout: false,
+      },
+    })
+
+    act(() => {
+      rerender({
+        currentChat: secondChat,
+        triggerCancelOnLayout: true,
+      })
+    })
+
+    expect(abortMock).toHaveBeenCalledWith('chat-b')
+    expect(patchStatusMock).toHaveBeenCalledWith(
+      'chat-b',
+      expect.objectContaining({
+        loadingState: 'idle',
+        retryInfo: null,
+        isThinking: false,
+        isWaitingForResponse: false,
+        isStreaming: false,
+      }),
+    )
+  })
+})

--- a/tests/components/chat/use-message-queue.concurrency.test.tsx
+++ b/tests/components/chat/use-message-queue.concurrency.test.tsx
@@ -105,6 +105,65 @@ describe('useMessageQueue concurrency', () => {
     )
   })
 
+  it('frees the blank chat id after conversion so the next new chat can send', async () => {
+    let resolveA: (() => void) | undefined
+    const handleQuery = vi.fn((text: string) => {
+      if (text === 'A') {
+        return new Promise<void>((resolve) => {
+          resolveA = resolve
+        })
+      }
+      return Promise.resolve()
+    })
+
+    const { result, rerender } = renderHook(
+      ({ chatId, loadingState }) =>
+        useMessageQueue({
+          chatId,
+          loadingState,
+          handleQuery,
+          isRateLimited: () => false,
+        }),
+      {
+        initialProps: {
+          chatId: '',
+          loadingState: 'idle' as LoadingState,
+        },
+      },
+    )
+
+    // First message in a brand-new blank chat; its stream stays in-flight.
+    act(() => {
+      result.current.submit({ text: 'A' })
+    })
+    await flushMicrotasks()
+    expect(handleQuery).toHaveBeenCalledTimes(1)
+
+    // The blank chat converts to a real id and keeps streaming.
+    rerender({ chatId: 'real-1', loadingState: 'loading' as LoadingState })
+    await flushMicrotasks()
+
+    // User opens a fresh blank chat (the empty id is reused) and sends; it
+    // must dispatch immediately even though the first chat is still
+    // streaming.
+    rerender({ chatId: '', loadingState: 'idle' as LoadingState })
+    act(() => {
+      result.current.submit({ text: 'B' })
+    })
+    await flushMicrotasks()
+
+    expect(handleQuery).toHaveBeenCalledTimes(2)
+    expect(handleQuery).toHaveBeenLastCalledWith(
+      'B',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+    )
+
+    resolveA?.()
+  })
+
   it('serializes multiple messages within the same chat', async () => {
     const resolvers: Array<() => void> = []
     const handleQuery = vi.fn(

--- a/tests/components/chat/use-message-queue.concurrency.test.tsx
+++ b/tests/components/chat/use-message-queue.concurrency.test.tsx
@@ -78,6 +78,33 @@ describe('useMessageQueue concurrency', () => {
     resolveA?.()
   })
 
+  it('dispatches the first message of a blank chat (empty string id)', async () => {
+    const handleQuery = vi.fn(() => Promise.resolve())
+
+    const { result } = renderHook(() =>
+      useMessageQueue({
+        chatId: '',
+        loadingState: 'idle' as LoadingState,
+        handleQuery,
+        isRateLimited: () => false,
+      }),
+    )
+
+    act(() => {
+      result.current.submit({ text: 'hello' })
+    })
+    await flushMicrotasks()
+
+    expect(handleQuery).toHaveBeenCalledTimes(1)
+    expect(handleQuery).toHaveBeenLastCalledWith(
+      'hello',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+    )
+  })
+
   it('serializes multiple messages within the same chat', async () => {
     const resolvers: Array<() => void> = []
     const handleQuery = vi.fn(

--- a/tests/components/chat/use-message-queue.concurrency.test.tsx
+++ b/tests/components/chat/use-message-queue.concurrency.test.tsx
@@ -1,0 +1,131 @@
+import { useMessageQueue } from '@/components/chat/hooks/use-message-queue'
+import type { LoadingState } from '@/components/chat/types'
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+async function flushMicrotasks(): Promise<void> {
+  await act(async () => {
+    for (let i = 0; i < 5; i++) await Promise.resolve()
+  })
+}
+
+describe('useMessageQueue concurrency', () => {
+  beforeEach(() => {
+    window.sessionStorage.clear()
+  })
+
+  it('dispatches in a newly active chat while another chat is still streaming', async () => {
+    let resolveA: (() => void) | undefined
+    const handleQuery = vi.fn((text: string) => {
+      if (text === 'A') {
+        return new Promise<void>((resolve) => {
+          resolveA = resolve
+        })
+      }
+      return Promise.resolve()
+    })
+
+    const { result, rerender } = renderHook(
+      ({ chatId, loadingState }) =>
+        useMessageQueue({
+          chatId,
+          loadingState,
+          handleQuery,
+          isRateLimited: () => false,
+        }),
+      {
+        initialProps: {
+          chatId: 'chat-a',
+          loadingState: 'idle' as LoadingState,
+        },
+      },
+    )
+
+    // Send in chat A; its stream stays in-flight (promise never resolves).
+    act(() => {
+      result.current.submit({ text: 'A' })
+    })
+    await flushMicrotasks()
+    expect(handleQuery).toHaveBeenCalledTimes(1)
+    expect(handleQuery).toHaveBeenLastCalledWith(
+      'A',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+    )
+
+    // Chat A is now streaming; switch to a different, idle chat B.
+    rerender({ chatId: 'chat-a', loadingState: 'loading' as LoadingState })
+    rerender({ chatId: 'chat-b', loadingState: 'idle' as LoadingState })
+
+    // Send in chat B; it must dispatch immediately even though chat A's
+    // stream has not finished.
+    act(() => {
+      result.current.submit({ text: 'B' })
+    })
+    await flushMicrotasks()
+
+    expect(handleQuery).toHaveBeenCalledTimes(2)
+    expect(handleQuery).toHaveBeenLastCalledWith(
+      'B',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+    )
+
+    resolveA?.()
+  })
+
+  it('serializes multiple messages within the same chat', async () => {
+    const resolvers: Array<() => void> = []
+    const handleQuery = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolvers.push(resolve)
+        }),
+    )
+
+    const { result } = renderHook(() =>
+      useMessageQueue({
+        chatId: 'chat-a',
+        loadingState: 'idle' as LoadingState,
+        handleQuery,
+        isRateLimited: () => false,
+      }),
+    )
+
+    act(() => {
+      result.current.submit({ text: 'first' })
+      result.current.submit({ text: 'second' })
+    })
+    await flushMicrotasks()
+
+    // Only the first message dispatches until its stream resolves.
+    expect(handleQuery).toHaveBeenCalledTimes(1)
+    expect(handleQuery).toHaveBeenLastCalledWith(
+      'first',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+    )
+
+    act(() => {
+      resolvers[0]?.()
+    })
+    await flushMicrotasks()
+
+    expect(handleQuery).toHaveBeenCalledTimes(2)
+    expect(handleQuery).toHaveBeenLastCalledWith(
+      'second',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+    )
+
+    resolvers[1]?.()
+  })
+})

--- a/tests/components/chat/use-message-queue.concurrency.test.tsx
+++ b/tests/components/chat/use-message-queue.concurrency.test.tsx
@@ -214,4 +214,171 @@ describe('useMessageQueue concurrency', () => {
 
     resolvers[1]?.()
   })
+
+  it('parks a queued message when switching away and resumes on return', async () => {
+    const handleQuery = vi.fn(() => Promise.resolve())
+
+    const { result, rerender } = renderHook(
+      ({ chatId, loadingState }) =>
+        useMessageQueue({
+          chatId,
+          loadingState,
+          handleQuery,
+          isRateLimited: () => false,
+        }),
+      {
+        initialProps: {
+          chatId: 'A',
+          loadingState: 'loading' as LoadingState,
+        },
+      },
+    )
+
+    // Chat A is mid-stream; the queued message must not dispatch yet.
+    act(() => {
+      result.current.submit({ text: 'q1' })
+    })
+    await flushMicrotasks()
+    expect(handleQuery).not.toHaveBeenCalled()
+
+    // Switch to an idle chat B; q1 stays parked on A (not dispatched to B).
+    rerender({ chatId: 'B', loadingState: 'idle' as LoadingState })
+    await flushMicrotasks()
+    expect(handleQuery).not.toHaveBeenCalled()
+
+    // Return to A, now finished streaming; the parked message dispatches.
+    rerender({ chatId: 'A', loadingState: 'idle' as LoadingState })
+    await flushMicrotasks()
+    expect(handleQuery).toHaveBeenCalledTimes(1)
+    expect(handleQuery).toHaveBeenLastCalledWith(
+      'q1',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+    )
+  })
+
+  it('holds a message while rate-limited and resumes when the limit clears', async () => {
+    const handleQuery = vi.fn(() => Promise.resolve())
+    const onRateLimited = vi.fn()
+
+    const { result, rerender } = renderHook(
+      ({ isRateLimited }) =>
+        useMessageQueue({
+          chatId: 'A',
+          loadingState: 'idle' as LoadingState,
+          handleQuery,
+          isRateLimited,
+          onRateLimited,
+        }),
+      { initialProps: { isRateLimited: () => true } },
+    )
+
+    act(() => {
+      result.current.submit({ text: 'q1' })
+    })
+    await flushMicrotasks()
+
+    // Held: prompt shown once, nothing dispatched, no busy-spin.
+    expect(handleQuery).not.toHaveBeenCalled()
+    expect(onRateLimited).toHaveBeenCalledTimes(1)
+
+    // The limit clears (new predicate identity drives the resume effect).
+    rerender({ isRateLimited: () => false })
+    await flushMicrotasks()
+
+    expect(handleQuery).toHaveBeenCalledTimes(1)
+    expect(handleQuery).toHaveBeenLastCalledWith(
+      'q1',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+    )
+  })
+
+  it('removes a specific queued message from the active chat', async () => {
+    const handleQuery = vi.fn(() => new Promise<void>(() => {}))
+
+    const { result } = renderHook(() =>
+      useMessageQueue({
+        chatId: 'A',
+        loadingState: 'loading' as LoadingState,
+        handleQuery,
+        isRateLimited: () => false,
+      }),
+    )
+
+    act(() => {
+      result.current.submit({ text: 'q1' })
+      result.current.submit({ text: 'q2' })
+    })
+    await flushMicrotasks()
+
+    expect(result.current.queuedMessages.map((m) => m.text)).toEqual([
+      'q1',
+      'q2',
+    ])
+    expect(handleQuery).not.toHaveBeenCalled()
+
+    const firstId = result.current.queuedMessages[0].id
+    act(() => {
+      result.current.removeQueuedMessage(firstId)
+    })
+
+    expect(result.current.queuedMessages.map((m) => m.text)).toEqual(['q2'])
+  })
+
+  it('keeps each chat queue isolated and renders the active one', async () => {
+    const handleQuery = vi.fn(() => new Promise<void>(() => {}))
+
+    const { result, rerender } = renderHook(
+      ({ chatId }) =>
+        useMessageQueue({
+          chatId,
+          loadingState: 'loading' as LoadingState,
+          handleQuery,
+          isRateLimited: () => false,
+        }),
+      { initialProps: { chatId: 'A' } },
+    )
+
+    act(() => {
+      result.current.submit({ text: 'a-msg' })
+    })
+    await flushMicrotasks()
+    expect(result.current.queuedMessages.map((m) => m.text)).toEqual(['a-msg'])
+
+    // Switching to B shows B's (empty) queue without losing A's.
+    rerender({ chatId: 'B' })
+    expect(result.current.queuedMessages).toEqual([])
+
+    rerender({ chatId: 'A' })
+    expect(result.current.queuedMessages.map((m) => m.text)).toEqual(['a-msg'])
+  })
+
+  it('drains multiple messages when handleQuery is synchronous (void)', async () => {
+    const calls: string[] = []
+    const handleQuery = vi.fn((text: string) => {
+      calls.push(text)
+    })
+
+    const { result } = renderHook(() =>
+      useMessageQueue({
+        chatId: 'A',
+        loadingState: 'idle' as LoadingState,
+        handleQuery,
+        isRateLimited: () => false,
+      }),
+    )
+
+    act(() => {
+      result.current.submit({ text: 'q1' })
+      result.current.submit({ text: 'q2' })
+    })
+    await flushMicrotasks()
+
+    expect(calls).toEqual(['q1', 'q2'])
+  })
 })


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enables multiple chats to stream concurrently with a live sidebar indicator (three‑dot, matches chat title color). Defers per‑chat cloud sync until the stream ends, fixes cancel targeting on chat switches, and lets you start a new chat while another is streaming (including the first message).

- **New Features**
  - Stream multiple chats; per‑chat status via `useChatStreams`. Cancel a specific stream with `cancelGeneration(chatId?)`.
  - Sidebar shows a live “Generating response” three‑dot loader that matches the chat title color; “Syncing with cloud” stays hidden until the stream ends. Backed by app‑wide `streamingTracker` and `useStreamingChats`.
  - Streams continue in the background and save to their own conversation; early title generation runs per stream.

- **Refactors**
  - Streaming pipeline tracks its own chat id via `streamChatIdRef`; UI state derives from `useChatStreams` (replaces global refs).
  - Cloud sync gating uses `streamingTracker.isStreaming(chatId)` and preserves streaming markers across server id swaps; sidebar/list streaming state comes from `useStreamingChats`.
  - Message queue is per‑chat with single‑flight pumps; re‑keys the blank chat id on conversion so a new blank chat can send while another is still streaming; hardened against stale handler captures and busy‑spin, and auto‑resumes after rate limits clear.

<sup>Written for commit 45940971b7655bb123acc5929cfd24322e2d453d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/408?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

