### PR TITLE
Fix UI bugs and implement convenience features

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
         "tailwindcss-animate": "^1.0.7",
         "tinfoil": "^1.1.0",
         "uuid": "^11.1.1",
+        "yet-another-react-lightbox": "^3.32.0",
         "zod": "^3.25.76",
         "zod-to-json-schema": "^3.25.2"
       },
@@ -15015,6 +15016,32 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/yet-another-react-lightbox": {
+      "version": "3.32.0",
+      "resolved": "https://registry.npmjs.org/yet-another-react-lightbox/-/yet-another-react-lightbox-3.32.0.tgz",
+      "integrity": "sha512-FWODOMrE07i3O5MeWRcYlcnAUk518zkUYKAe307pVW5pkey3hKMcAIWn8yMIURzGvbd3m9eghWO9CocEZmQPIg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/igordanchenko"
+      },
+      "peerDependencies": {
+        "@types/react": "^16 || ^17 || ^18 || ^19",
+        "@types/react-dom": "^16 || ^17 || ^18 || ^19",
+        "react": "^16.8.0 || ^17 || ^18 || ^19",
+        "react-dom": "^16.8.0 || ^17 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "tailwindcss-animate": "^1.0.7",
     "tinfoil": "^1.1.0",
     "uuid": "^11.1.1",
+    "yet-another-react-lightbox": "^3.32.0",
     "zod": "^3.25.76",
     "zod-to-json-schema": "^3.25.2"
   },

--- a/src/components/chat/chat-input.tsx
+++ b/src/components/chat/chat-input.tsx
@@ -549,7 +549,7 @@ export function ChatInput({
                 }
               : undefined
             return (
-              <div className="pointer-events-none absolute right-8 top-px z-10 -translate-y-full">
+              <div className="pointer-events-none absolute right-8 top-px z-10 hidden -translate-y-full md:block">
                 <div
                   className={cn(
                     'pointer-events-auto inline-flex items-center gap-1.5 rounded-t-lg border border-b-0 px-2.5 py-1',

--- a/src/components/chat/chat-input.tsx
+++ b/src/components/chat/chat-input.tsx
@@ -1,6 +1,11 @@
 import { FiArrowUp } from '@/components/icons/lazy-icons'
 import { useProject } from '@/components/project'
 import { cn } from '@/components/ui/utils'
+import {
+  getProjectColor,
+  PROJECT_COLOR_LABEL_TINT_OPACITY,
+  projectColorRgba,
+} from '@/constants/project-colors'
 import { useToast } from '@/hooks/use-toast'
 import { getTinfoilClient } from '@/services/inference/tinfoil-client'
 import { logError } from '@/utils/error-handling'
@@ -537,16 +542,39 @@ export function ChatInput({
     <div className="flex flex-col gap-2">
       <div className="relative">
         {/* Project tab - manila folder style, absolutely positioned */}
-        {isProjectMode && activeProject && (
-          <div className="pointer-events-none absolute right-8 top-px z-10 -translate-y-full">
-            <div className="pointer-events-auto inline-flex items-center gap-1.5 rounded-t-lg border border-b-0 border-border-subtle bg-surface-chat px-2.5 py-1">
-              <FolderIcon className="h-3 w-3 text-content-secondary" />
-              <span className="text-xs font-medium text-content-secondary">
-                {activeProject.name}
-              </span>
-            </div>
-          </div>
-        )}
+        {isProjectMode &&
+          activeProject &&
+          (() => {
+            const projectColor = getProjectColor(activeProject.color)
+            const colorStyle = projectColor
+              ? {
+                  borderColor: projectColor.hex,
+                  backgroundColor: projectColorRgba(
+                    projectColor,
+                    PROJECT_COLOR_LABEL_TINT_OPACITY,
+                  ),
+                  color: projectColor.hex,
+                }
+              : undefined
+            return (
+              <div className="pointer-events-none absolute right-8 top-px z-10 -translate-y-full">
+                <div
+                  className={cn(
+                    'pointer-events-auto inline-flex items-center gap-1.5 rounded-t-lg border border-b-0 px-2.5 py-1',
+                    projectColor
+                      ? ''
+                      : 'border-border-subtle bg-surface-chat text-content-secondary',
+                  )}
+                  style={colorStyle}
+                >
+                  <FolderIcon className="h-3 w-3" />
+                  <span className="text-xs font-medium">
+                    {activeProject.name}
+                  </span>
+                </div>
+              </div>
+            )
+          })()}
         {/* Prompt preset tab - shows the active prompt for this chat */}
         {activePromptPreset &&
           (() => {

--- a/src/components/chat/chat-input.tsx
+++ b/src/components/chat/chat-input.tsx
@@ -1,11 +1,7 @@
 import { FiArrowUp } from '@/components/icons/lazy-icons'
 import { useProject } from '@/components/project'
 import { cn } from '@/components/ui/utils'
-import {
-  getProjectColor,
-  PROJECT_COLOR_LABEL_TINT_OPACITY,
-  projectColorRgba,
-} from '@/constants/project-colors'
+import { getProjectColor } from '@/constants/project-colors'
 import { useToast } from '@/hooks/use-toast'
 import { getTinfoilClient } from '@/services/inference/tinfoil-client'
 import { logError } from '@/utils/error-handling'
@@ -549,11 +545,7 @@ export function ChatInput({
             const colorStyle = projectColor
               ? {
                   borderColor: projectColor.hex,
-                  backgroundColor: projectColorRgba(
-                    projectColor,
-                    PROJECT_COLOR_LABEL_TINT_OPACITY,
-                  ),
-                  color: projectColor.hex,
+                  backgroundColor: projectColor.hex,
                 }
               : undefined
             return (
@@ -562,7 +554,7 @@ export function ChatInput({
                   className={cn(
                     'pointer-events-auto inline-flex items-center gap-1.5 rounded-t-lg border border-b-0 px-2.5 py-1',
                     projectColor
-                      ? ''
+                      ? 'text-gray-900'
                       : 'border-border-subtle bg-surface-chat text-content-secondary',
                   )}
                   style={colorStyle}

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -113,6 +113,7 @@ import {
   OPEN_ARTIFACT_PREVIEW_EVENT,
   type ArtifactPreviewSidebarDetail,
 } from './genui/widgets/ArtifactPreview'
+import { sortChats } from './hooks/chat-operations'
 import { useChatState } from './hooks/use-chat-state'
 import { useCustomSystemPrompt } from './hooks/use-custom-system-prompt'
 import { useMessageQueue } from './hooks/use-message-queue'
@@ -1626,7 +1627,7 @@ export function ChatInterface({
         }
         previousChatIdRef.current = null
         setCurrentChat(permanentChat)
-        setChats((prev) => [permanentChat, ...prev])
+        setChats((prev) => sortChats([permanentChat, ...prev]))
         const persist = (chat: Chat) => {
           if (storeHistory) {
             chatStorage.saveChatAndSync(chat).catch((err) => {

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -21,6 +21,7 @@ import {
   snapshotAndDecrementRemaining,
   type RateLimitInfo,
 } from '@/services/inference/tinfoil-client'
+import { generateTitle } from '@/services/inference/title'
 import { SignInButton, useAuth, useUser } from '@clerk/nextjs'
 import {
   ArrowDownIcon,
@@ -55,9 +56,11 @@ import { ENCRYPTION_KEY_CHANGED_EVENT } from '@/services/encryption/encryption-s
 
 import { cloudSync } from '@/services/cloud/cloud-sync'
 import { encryptionService } from '@/services/encryption/encryption-service'
+import { generateCodeExecutionAccessToken } from '@/services/exec-snapshot/access-token'
 import { isPrfSupported, PrfNotSupportedError } from '@/services/passkey'
 import { chatStorage } from '@/services/storage/chat-storage'
 import { indexedDBStorage } from '@/services/storage/indexed-db'
+import { sessionChatStorage } from '@/services/storage/session-storage'
 import {
   isCloudSyncEnabled,
   setCloudSyncEnabled,
@@ -68,6 +71,7 @@ import {
   getProjectUploadPreference,
   setProjectUploadPreference,
 } from '@/utils/project-upload-preference'
+import { generateReverseId } from '@/utils/reverse-id'
 import {
   estimateMessageTokens,
   estimateTokenCount,
@@ -1599,7 +1603,80 @@ export function ChatInterface({
   }, [createNewChat, exitProjectMode])
 
   const handleToggleTemporaryMode = useCallback(() => {
+    const hasMessages = (currentChat?.messages?.length ?? 0) > 0
+    const storeHistory = isSignedIn || !isCloudSyncEnabled()
+
     if (currentChat?.isTemporary) {
+      // Deselecting temporary mode on a started chat saves it permanently.
+      if (hasMessages) {
+        const { id: newId } = generateReverseId()
+        const permanentChat: Chat = {
+          ...currentChat,
+          id: newId,
+          isTemporary: false,
+          isBlankChat: false,
+          title:
+            currentChat.title === 'Temporary Chat'
+              ? 'Untitled'
+              : currentChat.title,
+          codeExecutionAccessToken:
+            currentChat.codeExecutionAccessToken ??
+            generateCodeExecutionAccessToken(),
+          createdAt: currentChat.createdAt ?? new Date(),
+        }
+        previousChatIdRef.current = null
+        setCurrentChat(permanentChat)
+        setChats((prev) => [permanentChat, ...prev])
+        const persist = (chat: Chat) => {
+          if (storeHistory) {
+            chatStorage.saveChatAndSync(chat).catch((err) => {
+              logError('Failed to save temporary chat as permanent', err, {
+                component: 'ChatInterface',
+                action: 'handleToggleTemporaryMode.save',
+                metadata: { chatId: chat.id },
+              })
+            })
+          } else {
+            sessionChatStorage.saveChat(chat)
+          }
+        }
+        persist(permanentChat)
+
+        // Temporary chats never get titles generated during streaming, so
+        // generate one now from the first user message (falling back to
+        // attachment text) to avoid a list full of "Untitled" entries.
+        if (permanentChat.title === 'Untitled') {
+          const firstUser = permanentChat.messages.find(
+            (m) => m.role === 'user',
+          )
+          const titleContent =
+            firstUser?.content?.trim() ||
+            (firstUser?.attachments
+              ?.map((a) => a.textContent || a.description || a.fileName)
+              .filter(Boolean)
+              .join('\n') ??
+              '')
+          if (titleContent) {
+            generateTitle([{ role: 'user', content: titleContent }])
+              .then((generated) => {
+                if (!generated || generated === 'Untitled') return
+                const titled: Chat = {
+                  ...permanentChat,
+                  title: generated,
+                  titleState: 'generated',
+                }
+                setCurrentChat((cur) => (cur?.id === titled.id ? titled : cur))
+                setChats((prev) =>
+                  prev.map((c) => (c.id === titled.id ? titled : c)),
+                )
+                persist(titled)
+              })
+              .catch(() => {})
+          }
+        }
+        return
+      }
+
       const previousId = previousChatIdRef.current
       previousChatIdRef.current = null
       const restored = previousId
@@ -1609,6 +1686,33 @@ export function ChatInterface({
         setCurrentChat(restored)
       } else {
         createNewChat(false, true)
+      }
+      return
+    }
+
+    // Selecting temporary mode on a started chat removes it from history and
+    // keeps the conversation in memory only.
+    if (hasMessages && currentChat) {
+      const chatId = currentChat.id
+      const tempChat: Chat = {
+        ...currentChat,
+        id: `temp-${Date.now()}`,
+        isTemporary: true,
+        isBlankChat: false,
+      }
+      previousChatIdRef.current = null
+      setCurrentChat(tempChat)
+      setChats((prev) => prev.filter((c) => c.id !== chatId))
+      if (storeHistory) {
+        chatStorage.deleteChat(chatId).catch((err) => {
+          logError('Failed to remove chat during temporary conversion', err, {
+            component: 'ChatInterface',
+            action: 'handleToggleTemporaryMode.remove',
+            metadata: { chatId },
+          })
+        })
+      } else {
+        sessionChatStorage.deleteChat(chatId)
       }
       return
     }
@@ -1625,14 +1729,7 @@ export function ChatInterface({
       presetId: currentChat?.presetId,
     }
     setCurrentChat(tempChat)
-  }, [
-    chats,
-    createNewChat,
-    currentChat?.id,
-    currentChat?.isTemporary,
-    currentChat?.presetId,
-    setCurrentChat,
-  ])
+  }, [chats, createNewChat, currentChat, isSignedIn, setChats, setCurrentChat])
 
   useEffect(() => {
     if (!isTemporaryMode && previousChatIdRef.current) {
@@ -2667,32 +2764,42 @@ export function ChatInterface({
               </button>
             )}
 
-          {/* Temporary chat toggle - hidden once a chat has started */}
-          {!(currentChat?.messages && currentChat.messages.length > 0) && (
-            <div className="group relative">
-              <button
-                type="button"
-                onClick={handleToggleTemporaryMode}
-                aria-label={
-                  isTemporaryMode
-                    ? 'Exit temporary chat'
-                    : 'Start temporary chat'
-                }
-                aria-pressed={isTemporaryMode}
-                className={cn(
-                  'flex items-center justify-center rounded-lg border p-2.5 transition-all duration-200',
-                  isTemporaryMode
-                    ? 'border-orange-500/40 bg-orange-500/15 text-orange-500 hover:bg-orange-500/25'
-                    : 'border-border-subtle bg-surface-chat-background text-content-secondary hover:bg-surface-chat hover:text-content-primary',
-                )}
-              >
-                <SlGhost className="h-4 w-4" />
-              </button>
-              <span className="pointer-events-none absolute -bottom-8 left-1/2 -translate-x-1/2 whitespace-nowrap rounded border border-border-subtle bg-surface-chat-background px-2 py-1 text-xs text-content-primary opacity-0 shadow-sm transition-opacity group-hover:opacity-100">
-                {isTemporaryMode ? 'Exit temporary chat' : 'Temporary chat'}
-              </span>
-            </div>
-          )}
+          {/* Temporary chat toggle. Remains available after a chat has
+              started so it can convert between temporary and permanent:
+              turning it off saves the conversation, turning it on removes
+              it from history again. */}
+          {(() => {
+            const hasMessages =
+              !!currentChat?.messages && currentChat.messages.length > 0
+            const label = hasMessages
+              ? isTemporaryMode
+                ? 'Save chat'
+                : 'Make temporary'
+              : isTemporaryMode
+                ? 'Exit temporary chat'
+                : 'Temporary chat'
+            return (
+              <div className="group relative">
+                <button
+                  type="button"
+                  onClick={handleToggleTemporaryMode}
+                  aria-label={label}
+                  aria-pressed={isTemporaryMode}
+                  className={cn(
+                    'flex items-center justify-center rounded-lg border p-2.5 transition-all duration-200',
+                    isTemporaryMode
+                      ? 'border-orange-500/40 bg-orange-500/15 text-orange-500 hover:bg-orange-500/25'
+                      : 'border-border-subtle bg-surface-chat-background text-content-secondary hover:bg-surface-chat hover:text-content-primary',
+                  )}
+                >
+                  <SlGhost className="h-4 w-4" />
+                </button>
+                <span className="pointer-events-none absolute -bottom-8 left-1/2 -translate-x-1/2 whitespace-nowrap rounded border border-border-subtle bg-surface-chat-background px-2 py-1 text-xs text-content-primary opacity-0 shadow-sm transition-opacity group-hover:opacity-100">
+                  {label}
+                </span>
+              </div>
+            )
+          })()}
 
           {/* Share button - only show when there are messages and chat is not temporary */}
           {!currentChat?.isTemporary &&

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -1841,8 +1841,21 @@ export function ChatInterface({
   // page refresh.
   const handleDeleteProjectChats = useCallback(
     async (projectId: string): Promise<void> => {
-      await chatStorage.deleteChatsByProject(projectId)
-      await reloadChats()
+      try {
+        await chatStorage.deleteChatsByProject(projectId)
+        await reloadChats()
+      } catch (error) {
+        logError('Failed to delete project chats', error, {
+          component: 'ChatInterface',
+          action: 'handleDeleteProjectChats',
+          metadata: { projectId },
+        })
+
+        // Rollback: reload chats to restore original state
+        await reloadChats()
+
+        throw error
+      }
     },
     [reloadChats],
   )

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -1818,6 +1818,17 @@ export function ChatInterface({
     [reloadChats, toast],
   )
 
+  // Handler for deleting every chat that belongs to a project. Reloads from
+  // storage afterwards so the deleted chats disappear locally without a
+  // page refresh.
+  const handleDeleteProjectChats = useCallback(
+    async (projectId: string): Promise<void> => {
+      await chatStorage.deleteChatsByProject(projectId)
+      await reloadChats()
+    },
+    [reloadChats],
+  )
+
   // Handler for converting a local-only chat to cloud chat via drag and drop
   const handleConvertChatToCloud = useCallback(
     async (chatId: string): Promise<void> => {
@@ -2902,6 +2913,7 @@ export function ChatInterface({
                     isSignedIn ? handleOpenEncryptionKeyModal : undefined
                   }
                   onRemoveChatFromProject={handleRemoveChatFromProject}
+                  onDeleteProjectChats={handleDeleteProjectChats}
                   onAddChatToProject={(chatId) =>
                     handleMoveChatToProject(chatId, activeProject.id)
                   }

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -768,6 +768,11 @@ export function ChatInterface({
 
   const isTemporaryMode = currentChat?.isTemporary === true
 
+  const currentChatRef = useRef<Chat | null>(null)
+  useEffect(() => {
+    currentChatRef.current = currentChat ?? null
+  }, [currentChat])
+
   useEffect(() => {
     setActivePresetId(currentChat?.presetId ?? null)
   }, [currentChat?.id, currentChat?.presetId])
@@ -1661,6 +1666,18 @@ export function ChatInterface({
             generateTitle([{ role: 'user', content: titleContent }])
               .then((generated) => {
                 if (!generated || generated === 'Untitled') return
+                // If the user re-converted this chat to temporary (or
+                // navigated away) while the title was generating, skip
+                // persistence so the async completion can't resurrect a
+                // chat the user just removed.
+                const active = currentChatRef.current
+                if (
+                  !active ||
+                  active.id !== permanentChat.id ||
+                  active.isTemporary
+                ) {
+                  return
+                }
                 const titled: Chat = {
                   ...permanentChat,
                   title: generated,

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -3201,6 +3201,7 @@ export function ChatInterface({
               <ProjectModeBanner
                 projectName={activeProject?.name || loadingProject?.name || ''}
                 isDarkMode={isDarkMode}
+                color={activeProject?.color}
               />
             ) : null}
 

--- a/src/components/chat/chat-messages.tsx
+++ b/src/components/chat/chat-messages.tsx
@@ -10,6 +10,7 @@ import { CONSTANTS } from './constants'
 import { ensureTimeline } from './ensure-timeline'
 import { CHAT_FONT_CLASSES, useChatFont } from './hooks/use-chat-font'
 import type { ReasoningEffort } from './hooks/use-reasoning-effort'
+import { ImageGalleryProvider } from './image-gallery-context'
 import { PrintableChat } from './PrintableChat'
 import type { PromptPreset } from './prompts/types'
 import { getRendererRegistry } from './renderers/client'
@@ -366,72 +367,74 @@ export function ChatMessages({
   const showLoadingPlaceholder = isWaitingForResponse && !hasAssistantThinking
 
   return (
-    <div
-      role="log"
-      aria-label="Conversation"
-      aria-live="polite"
-      className={`mx-auto w-full min-w-0 px-0 pb-6 pt-24 md:px-4 ${CHAT_FONT_CLASSES[chatFont]}`}
-    >
-      {/* Archived Messages - only shown if there are more than the max prompt messages */}
-      {archivedMessages.length > 0 && (
-        <>
-          <div className={`opacity-70`}>
-            {archivedMessages.map((message, i) => (
-              <ChatMessage
-                key={getMessageKey(`${chatId}-archived`, message, i)}
-                message={message}
-                messageIndex={i}
-                model={currentModel}
-                isDarkMode={isDarkMode}
-                isLastMessage={false}
-                isStreaming={false}
-                onEditMessage={onEditMessage}
-                onRegenerateMessage={onRegenerateMessage}
-              />
-            ))}
-          </div>
+    <ImageGalleryProvider messages={messages}>
+      <div
+        role="log"
+        aria-label="Conversation"
+        aria-live="polite"
+        className={`mx-auto w-full min-w-0 px-0 pb-6 pt-24 md:px-4 ${CHAT_FONT_CLASSES[chatFont]}`}
+      >
+        {/* Archived Messages - only shown if there are more than the max prompt messages */}
+        {archivedMessages.length > 0 && (
+          <>
+            <div className={`opacity-70`}>
+              {archivedMessages.map((message, i) => (
+                <ChatMessage
+                  key={getMessageKey(`${chatId}-archived`, message, i)}
+                  message={message}
+                  messageIndex={i}
+                  model={currentModel}
+                  isDarkMode={isDarkMode}
+                  isLastMessage={false}
+                  isStreaming={false}
+                  onEditMessage={onEditMessage}
+                  onRegenerateMessage={onRegenerateMessage}
+                />
+              ))}
+            </div>
 
-          {/* Separator */}
-          <MessagesSeparator isDarkMode={isDarkMode} />
-        </>
-      )}
+            {/* Separator */}
+            <MessagesSeparator isDarkMode={isDarkMode} />
+          </>
+        )}
 
-      {/* Live Messages - the last messages up to max prompt limit */}
-      {liveMessages.map((message, i) => (
-        <ChatMessage
-          key={getMessageKey(`${chatId}-live`, message, i)}
-          message={message}
-          messageIndex={archivedMessages.length + i}
-          model={currentModel}
-          isDarkMode={isDarkMode}
-          isLastMessage={i === liveMessages.length - 1}
-          isStreaming={i === liveMessages.length - 1 && isStreamingResponse}
-          onEditMessage={onEditMessage}
-          onRegenerateMessage={onRegenerateMessage}
-        />
-      ))}
-      {showLoadingPlaceholder && (
-        <LoadingMessage
-          isDarkMode={isDarkMode}
-          isRetrying={loadingState === 'retrying'}
-          retryInfo={retryInfo}
-        />
-      )}
-      {/* Spacer allows scrollIntoView to bring user message to top of viewport.
+        {/* Live Messages - the last messages up to max prompt limit */}
+        {liveMessages.map((message, i) => (
+          <ChatMessage
+            key={getMessageKey(`${chatId}-live`, message, i)}
+            message={message}
+            messageIndex={archivedMessages.length + i}
+            model={currentModel}
+            isDarkMode={isDarkMode}
+            isLastMessage={i === liveMessages.length - 1}
+            isStreaming={i === liveMessages.length - 1 && isStreamingResponse}
+            onEditMessage={onEditMessage}
+            onRegenerateMessage={onRegenerateMessage}
+          />
+        ))}
+        {showLoadingPlaceholder && (
+          <LoadingMessage
+            isDarkMode={isDarkMode}
+            isRetrying={loadingState === 'retrying'}
+            retryInfo={retryInfo}
+          />
+        )}
+        {/* Spacer allows scrollIntoView to bring user message to top of viewport.
           Subtracts the composer height (set on the scroll container as
           --input-area-height) so the total over-scroll is just enough for the
           fade above the input area, not a full 70dvh of empty space. */}
-      {showSpacer && (
-        <div
-          data-spacer
-          className="flex-shrink-0"
-          style={{
-            height: `max(0px, calc(70dvh - var(--input-area-height, 0px) - ${CONSTANTS.CHAT_INPUT_BOTTOM_GAP_PX}px))`,
-          }}
-          aria-hidden="true"
-        />
-      )}
-      <PrintableChat messages={messages} printRef={printRef} />
-    </div>
+        {showSpacer && (
+          <div
+            data-spacer
+            className="flex-shrink-0"
+            style={{
+              height: `max(0px, calc(70dvh - var(--input-area-height, 0px) - ${CONSTANTS.CHAT_INPUT_BOTTOM_GAP_PX}px))`,
+            }}
+            aria-hidden="true"
+          />
+        )}
+        <PrintableChat messages={messages} printRef={printRef} />
+      </div>
+    </ImageGalleryProvider>
   )
 }

--- a/src/components/chat/chat-sidebar.tsx
+++ b/src/components/chat/chat-sidebar.tsx
@@ -676,147 +676,166 @@ export function ChatSidebar({
 
   return (
     <>
-      {/* Collapsed sidebar rail - always visible on desktop when sidebar is closed */}
-      {!isMobile && !isOpen && (
-        <nav
-          aria-label="Chat history"
-          className={cn(
-            'fixed left-0 top-0 z-40 flex h-dvh flex-col border-r',
-            'border-border-subtle bg-surface-sidebar text-content-primary',
-          )}
-          style={{ width: `${CONSTANTS.CHAT_SIDEBAR_COLLAPSED_WIDTH_PX}px` }}
-        >
-          {/* Logo icon - shows expand icon on hover */}
-          <div className="flex h-16 flex-none items-center justify-center">
-            <button
-              onClick={() => setIsOpen(true)}
-              className="group/logo relative rounded p-2"
-              aria-label="Expand sidebar"
-            >
-              <img
-                src={isDarkMode ? '/icon-dark.png' : '/icon-light.png'}
-                alt=""
-                className="h-6 w-6 transition-opacity group-hover/logo:opacity-0"
-              />
-              <GoSidebarCollapse className="absolute inset-0 m-auto h-5 w-5 text-content-secondary opacity-0 transition-opacity group-hover/logo:opacity-100" />
-            </button>
-          </div>
-
-          {/* Action buttons */}
-          <div className="flex flex-col items-center gap-1 px-2">
-            {/* New chat button */}
-            <div className="group relative">
-              <Link
-                href="/newchat"
-                onClick={(e) => {
-                  if (
-                    e.metaKey ||
-                    e.ctrlKey ||
-                    e.shiftKey ||
-                    e.altKey ||
-                    e.button !== 0
-                  )
-                    return
-                  e.preventDefault()
-                  createNewChat(activeTab === 'local', true)
-                }}
-                onAuxClick={(e) => {
-                  if (e.button !== 1) return
-                  e.preventDefault()
-                  window.open('/newchat', '_blank', 'noopener,noreferrer')
-                }}
-                className={cn(
-                  'flex h-10 w-10 items-center justify-center rounded-lg transition-colors',
-                  'text-content-secondary hover:bg-surface-chat hover:text-content-primary',
-                )}
-                aria-label="New chat"
+      {/* Collapsed sidebar rail - shown on desktop when sidebar is closed.
+          Fades in only after the expanded sidebar has slid away so the two
+          appear to swap rather than the rail sitting statically underneath. */}
+      <AnimatePresence>
+        {!isMobile && !isOpen && (
+          <motion.nav
+            key="collapsed-rail"
+            aria-label="Chat history"
+            initial={{ opacity: 0 }}
+            animate={{
+              opacity: 1,
+              transition: {
+                duration: CONSTANTS.CHAT_SIDEBAR_RAIL_FADE_IN_DURATION_S,
+                delay: CONSTANTS.CHAT_SIDEBAR_SLIDE_DURATION_S,
+              },
+            }}
+            exit={{
+              opacity: 0,
+              transition: {
+                duration: CONSTANTS.CHAT_SIDEBAR_RAIL_FADE_OUT_DURATION_S,
+              },
+            }}
+            className={cn(
+              'fixed left-0 top-0 z-40 flex h-dvh flex-col border-r',
+              'border-border-subtle bg-surface-sidebar text-content-primary',
+            )}
+            style={{ width: `${CONSTANTS.CHAT_SIDEBAR_COLLAPSED_WIDTH_PX}px` }}
+          >
+            {/* Logo icon - shows expand icon on hover */}
+            <div className="flex h-16 flex-none items-center justify-center">
+              <button
+                onClick={() => setIsOpen(true)}
+                className="group/logo relative rounded p-2"
+                aria-label="Expand sidebar"
               >
-                <PiNotePencilLight className="h-5 w-5" />
-              </Link>
-              <span className="pointer-events-none absolute left-full top-1/2 z-50 ml-2 -translate-y-1/2 whitespace-nowrap rounded border border-border-subtle bg-surface-chat-background px-2 py-1 text-xs text-content-primary opacity-0 shadow-sm transition-opacity group-hover:opacity-100">
-                New chat{' '}
-                <span className="text-content-muted">
-                  {modKey}
-                  {isMac ? '⇧' : 'Shift+'}O
-                </span>
-              </span>
+                <img
+                  src={isDarkMode ? '/icon-dark.png' : '/icon-light.png'}
+                  alt=""
+                  className="h-6 w-6 transition-opacity group-hover/logo:opacity-0"
+                />
+                <GoSidebarCollapse className="absolute inset-0 m-auto h-5 w-5 text-content-secondary opacity-0 transition-opacity group-hover/logo:opacity-100" />
+              </button>
             </div>
 
-            {/* Projects button - only for premium users */}
-            {isSignedIn && isPremium && (
+            {/* Action buttons */}
+            <div className="flex flex-col items-center gap-1 px-2">
+              {/* New chat button */}
+              <div className="group relative">
+                <Link
+                  href="/newchat"
+                  onClick={(e) => {
+                    if (
+                      e.metaKey ||
+                      e.ctrlKey ||
+                      e.shiftKey ||
+                      e.altKey ||
+                      e.button !== 0
+                    )
+                      return
+                    e.preventDefault()
+                    createNewChat(activeTab === 'local', true)
+                  }}
+                  onAuxClick={(e) => {
+                    if (e.button !== 1) return
+                    e.preventDefault()
+                    window.open('/newchat', '_blank', 'noopener,noreferrer')
+                  }}
+                  className={cn(
+                    'flex h-10 w-10 items-center justify-center rounded-lg transition-colors',
+                    'text-content-secondary hover:bg-surface-chat hover:text-content-primary',
+                  )}
+                  aria-label="New chat"
+                >
+                  <PiNotePencilLight className="h-5 w-5" />
+                </Link>
+                <span className="pointer-events-none absolute left-full top-1/2 z-50 ml-2 -translate-y-1/2 whitespace-nowrap rounded border border-border-subtle bg-surface-chat-background px-2 py-1 text-xs text-content-primary opacity-0 shadow-sm transition-opacity group-hover:opacity-100">
+                  New chat{' '}
+                  <span className="text-content-muted">
+                    {modKey}
+                    {isMac ? '⇧' : 'Shift+'}O
+                  </span>
+                </span>
+              </div>
+
+              {/* Projects button - only for premium users */}
+              {isSignedIn && isPremium && (
+                <div className="group relative">
+                  <button
+                    onClick={() => {
+                      sessionStorage.setItem(
+                        UI_SIDEBAR_EXPAND_SECTION,
+                        'projects',
+                      )
+                      setIsProjectsExpanded(true)
+                      setIsChatHistoryExpanded(false)
+                      setIsOpen(true)
+                    }}
+                    className={cn(
+                      'flex h-10 w-10 items-center justify-center rounded-lg transition-colors',
+                      'text-content-secondary hover:bg-surface-chat hover:text-content-primary',
+                    )}
+                    aria-label="Projects"
+                  >
+                    <FolderIcon className="h-5 w-5" />
+                  </button>
+                  <span className="pointer-events-none absolute left-full top-1/2 z-50 ml-2 -translate-y-1/2 whitespace-nowrap rounded border border-border-subtle bg-surface-chat-background px-2 py-1 text-xs text-content-primary opacity-0 shadow-sm transition-opacity group-hover:opacity-100">
+                    Projects
+                  </span>
+                </div>
+              )}
+
+              {/* Chats button */}
               <div className="group relative">
                 <button
                   onClick={() => {
-                    sessionStorage.setItem(
-                      UI_SIDEBAR_EXPAND_SECTION,
-                      'projects',
-                    )
-                    setIsProjectsExpanded(true)
-                    setIsChatHistoryExpanded(false)
+                    sessionStorage.setItem(UI_SIDEBAR_EXPAND_SECTION, 'chats')
+                    setIsChatHistoryExpanded(true)
+                    setIsProjectsExpanded(false)
                     setIsOpen(true)
                   }}
                   className={cn(
                     'flex h-10 w-10 items-center justify-center rounded-lg transition-colors',
                     'text-content-secondary hover:bg-surface-chat hover:text-content-primary',
                   )}
-                  aria-label="Projects"
+                  aria-label="Chats"
                 >
-                  <FolderIcon className="h-5 w-5" />
+                  <IoChatbubblesOutline className="h-5 w-5" />
                 </button>
                 <span className="pointer-events-none absolute left-full top-1/2 z-50 ml-2 -translate-y-1/2 whitespace-nowrap rounded border border-border-subtle bg-surface-chat-background px-2 py-1 text-xs text-content-primary opacity-0 shadow-sm transition-opacity group-hover:opacity-100">
-                  Projects
+                  Chats <span className="text-content-muted">{modKey}.</span>
                 </span>
               </div>
-            )}
 
-            {/* Chats button */}
-            <div className="group relative">
-              <button
-                onClick={() => {
-                  sessionStorage.setItem(UI_SIDEBAR_EXPAND_SECTION, 'chats')
-                  setIsChatHistoryExpanded(true)
-                  setIsProjectsExpanded(false)
-                  setIsOpen(true)
-                }}
-                className={cn(
-                  'flex h-10 w-10 items-center justify-center rounded-lg transition-colors',
-                  'text-content-secondary hover:bg-surface-chat hover:text-content-primary',
-                )}
-                aria-label="Chats"
-              >
-                <IoChatbubblesOutline className="h-5 w-5" />
-              </button>
-              <span className="pointer-events-none absolute left-full top-1/2 z-50 ml-2 -translate-y-1/2 whitespace-nowrap rounded border border-border-subtle bg-surface-chat-background px-2 py-1 text-xs text-content-primary opacity-0 shadow-sm transition-opacity group-hover:opacity-100">
-                Chats <span className="text-content-muted">{modKey}.</span>
-              </span>
+              {/* Settings button */}
+              <div className="group relative">
+                <button
+                  onClick={onSettingsClick}
+                  className={cn(
+                    'flex h-10 w-10 items-center justify-center rounded-lg transition-colors',
+                    'text-content-secondary hover:bg-surface-chat hover:text-content-primary',
+                  )}
+                  aria-label="Settings"
+                >
+                  <Cog6ToothIcon className="h-5 w-5" />
+                  {syncNeedsAttention && (
+                    <span
+                      className="absolute right-1.5 top-1.5 h-2 w-2 rounded-full bg-orange-500"
+                      title="Cloud sync needs attention"
+                      aria-hidden="true"
+                    />
+                  )}
+                </button>
+                <span className="pointer-events-none absolute left-full top-1/2 z-50 ml-2 -translate-y-1/2 whitespace-nowrap rounded border border-border-subtle bg-surface-chat-background px-2 py-1 text-xs text-content-primary opacity-0 shadow-sm transition-opacity group-hover:opacity-100">
+                  Settings
+                </span>
+              </div>
             </div>
-
-            {/* Settings button */}
-            <div className="group relative">
-              <button
-                onClick={onSettingsClick}
-                className={cn(
-                  'flex h-10 w-10 items-center justify-center rounded-lg transition-colors',
-                  'text-content-secondary hover:bg-surface-chat hover:text-content-primary',
-                )}
-                aria-label="Settings"
-              >
-                <Cog6ToothIcon className="h-5 w-5" />
-                {syncNeedsAttention && (
-                  <span
-                    className="absolute right-1.5 top-1.5 h-2 w-2 rounded-full bg-orange-500"
-                    title="Cloud sync needs attention"
-                    aria-hidden="true"
-                  />
-                )}
-              </button>
-              <span className="pointer-events-none absolute left-full top-1/2 z-50 ml-2 -translate-y-1/2 whitespace-nowrap rounded border border-border-subtle bg-surface-chat-background px-2 py-1 text-xs text-content-primary opacity-0 shadow-sm transition-opacity group-hover:opacity-100">
-                Settings
-              </span>
-            </div>
-          </div>
-        </nav>
-      )}
+          </motion.nav>
+        )}
+      </AnimatePresence>
 
       {/* Expanded sidebar wrapper */}
       <nav

--- a/src/components/chat/chat-sidebar.tsx
+++ b/src/components/chat/chat-sidebar.tsx
@@ -706,8 +706,20 @@ export function ChatSidebar({
           <div className="flex flex-col items-center gap-1 px-2">
             {/* New chat button */}
             <div className="group relative">
-              <button
-                onClick={() => createNewChat(activeTab === 'local', true)}
+              <Link
+                href="/newchat"
+                onClick={(e) => {
+                  if (
+                    e.metaKey ||
+                    e.ctrlKey ||
+                    e.shiftKey ||
+                    e.altKey ||
+                    e.button !== 0
+                  )
+                    return
+                  e.preventDefault()
+                  createNewChat(activeTab === 'local', true)
+                }}
                 className={cn(
                   'flex h-10 w-10 items-center justify-center rounded-lg transition-colors',
                   'text-content-secondary hover:bg-surface-chat hover:text-content-primary',
@@ -715,7 +727,7 @@ export function ChatSidebar({
                 aria-label="New chat"
               >
                 <PiNotePencilLight className="h-5 w-5" />
-              </button>
+              </Link>
               <span className="pointer-events-none absolute left-full top-1/2 z-50 ml-2 -translate-y-1/2 whitespace-nowrap rounded border border-border-subtle bg-surface-chat-background px-2 py-1 text-xs text-content-primary opacity-0 shadow-sm transition-opacity group-hover:opacity-100">
                 New chat{' '}
                 <span className="text-content-muted">
@@ -829,15 +841,9 @@ export function ChatSidebar({
         {/* Header */}
         <div className="flex h-16 flex-none items-center justify-between p-4">
           <div className="flex items-center gap-3">
-            <button
-              onClick={() => {
-                window.location.href = window.location.origin
-              }}
-              title="Home"
-              className="flex items-center"
-            >
+            <Link href="/" title="Home" className="flex items-center">
               <Logo className="h-6 w-auto" dark={isDarkMode} />
-            </button>
+            </Link>
             {/* Settings button */}
             <div className="group relative flex items-center">
               <button
@@ -1025,9 +1031,22 @@ export function ChatSidebar({
 
           {/* New Chat button */}
           <div className="relative z-10 flex-none px-2 py-2">
-            <button
-              onClick={() => createNewChat(activeTab === 'local', true)}
-              disabled={currentChat?.isBlankChat}
+            <Link
+              href="/newchat"
+              aria-disabled={currentChat?.isBlankChat}
+              onClick={(e) => {
+                if (
+                  e.metaKey ||
+                  e.ctrlKey ||
+                  e.shiftKey ||
+                  e.altKey ||
+                  e.button !== 0
+                )
+                  return
+                e.preventDefault()
+                if (currentChat?.isBlankChat) return
+                createNewChat(activeTab === 'local', true)
+              }}
               className={cn(
                 'flex w-full items-center justify-between rounded-lg border px-2 py-2 text-sm transition-colors',
                 currentChat?.isBlankChat
@@ -1045,7 +1064,7 @@ export function ChatSidebar({
                 {modKey}
                 {isMac ? '⇧' : 'Shift+'}O
               </span>
-            </button>
+            </Link>
           </div>
 
           {/* Projects dropdown - show for premium users */}

--- a/src/components/chat/chat-sidebar.tsx
+++ b/src/components/chat/chat-sidebar.tsx
@@ -720,6 +720,11 @@ export function ChatSidebar({
                   e.preventDefault()
                   createNewChat(activeTab === 'local', true)
                 }}
+                onAuxClick={(e) => {
+                  if (e.button !== 1) return
+                  e.preventDefault()
+                  window.open('/newchat', '_blank', 'noopener,noreferrer')
+                }}
                 className={cn(
                   'flex h-10 w-10 items-center justify-center rounded-lg transition-colors',
                   'text-content-secondary hover:bg-surface-chat hover:text-content-primary',
@@ -1046,6 +1051,11 @@ export function ChatSidebar({
                 e.preventDefault()
                 if (currentChat?.isBlankChat) return
                 createNewChat(activeTab === 'local', true)
+              }}
+              onAuxClick={(e) => {
+                if (e.button !== 1) return
+                e.preventDefault()
+                window.open('/newchat', '_blank', 'noopener,noreferrer')
               }}
               className={cn(
                 'flex w-full items-center justify-between rounded-lg border px-2 py-2 text-sm transition-colors',

--- a/src/components/chat/chat-sidebar.tsx
+++ b/src/components/chat/chat-sidebar.tsx
@@ -52,6 +52,11 @@ import { useDrag } from './drag-context'
 
 import { useProject } from '@/components/project/project-context'
 import { cn } from '@/components/ui/utils'
+import {
+  getProjectColor,
+  PROJECT_COLOR_SIDEBAR_TINT_OPACITY,
+  projectColorTintLayer,
+} from '@/constants/project-colors'
 import { useCloudPagination } from '@/hooks/use-cloud-pagination'
 
 import { logError } from '@/utils/error-handling'
@@ -280,7 +285,17 @@ export function ChatSidebar({
     refresh: refreshProjects,
   } = useProjects({ autoLoad: isSignedIn && cloudSyncEnabled && isPremium })
 
-  const { deleteProject } = useProject()
+  const { deleteProject, activeProject } = useProject()
+
+  const sidebarTintColor = getProjectColor(activeProject?.color)
+  const sidebarTintStyle = sidebarTintColor
+    ? {
+        backgroundImage: projectColorTintLayer(
+          sidebarTintColor,
+          PROJECT_COLOR_SIDEBAR_TINT_OPACITY,
+        ),
+      }
+    : undefined
   const [deletingProjectId, setDeletingProjectId] = useState<string | null>(
     null,
   )
@@ -702,7 +717,10 @@ export function ChatSidebar({
               'fixed left-0 top-0 z-40 flex h-dvh flex-col border-r',
               'border-border-subtle bg-surface-sidebar text-content-primary',
             )}
-            style={{ width: `${CONSTANTS.CHAT_SIDEBAR_COLLAPSED_WIDTH_PX}px` }}
+            style={{
+              width: `${CONSTANTS.CHAT_SIDEBAR_COLLAPSED_WIDTH_PX}px`,
+              ...sidebarTintStyle,
+            }}
           >
             {/* Logo icon - shows expand icon on hover */}
             <div className="flex h-16 flex-none items-center justify-center">
@@ -860,6 +878,7 @@ export function ChatSidebar({
             !isMobile && !isOpen
               ? `-${CONSTANTS.CHAT_SIDEBAR_WIDTH_PX}px`
               : '0',
+          ...sidebarTintStyle,
         }}
       >
         {/* Header */}

--- a/src/components/chat/chat-sidebar.tsx
+++ b/src/components/chat/chat-sidebar.tsx
@@ -296,6 +296,11 @@ export function ChatSidebar({
         ),
       }
     : undefined
+
+  // Subtle background applied to expanded section panels so they read as
+  // distinct drawers against the sidebar surface.
+  const expandedPanelClass = isDarkMode ? 'bg-white/5' : 'bg-black/5'
+
   const [deletingProjectId, setDeletingProjectId] = useState<string | null>(
     null,
   )
@@ -1221,7 +1226,12 @@ export function ChatSidebar({
                     transition={{ duration: 0.2, ease: 'easeInOut' }}
                     className="overflow-hidden"
                   >
-                    <div className="min-h-0 flex-1 space-y-1 overflow-y-auto px-2 py-2">
+                    <div
+                      className={cn(
+                        'min-h-0 flex-1 space-y-1 overflow-y-auto px-2 py-2',
+                        expandedPanelClass,
+                      )}
+                    >
                       {/* Cloud sync disabled message */}
                       {!cloudSyncEnabled ? (
                         <div className="px-3 py-2">
@@ -1424,7 +1434,22 @@ export function ChatSidebar({
                                   {project.decryptionFailed ? (
                                     <FaLock className="mt-0.5 h-4 w-4 shrink-0 self-start text-orange-500" />
                                   ) : (
-                                    <FolderIcon className="mt-0.5 h-4 w-4 shrink-0 self-start text-content-muted" />
+                                    <FolderIcon
+                                      className={cn(
+                                        'mt-0.5 h-4 w-4 shrink-0 self-start',
+                                        !getProjectColor(project.color) &&
+                                          'text-content-muted',
+                                      )}
+                                      style={
+                                        getProjectColor(project.color)
+                                          ? {
+                                              color: getProjectColor(
+                                                project.color,
+                                              )!.hex,
+                                            }
+                                          : undefined
+                                      }
+                                    />
                                   )}
                                   <div className="flex min-w-0 flex-1 flex-col text-left">
                                     <span
@@ -1626,7 +1651,7 @@ export function ChatSidebar({
                   animate={{ height: 'auto', opacity: 1 }}
                   exit={{ height: 0, opacity: 0 }}
                   transition={{ duration: 0.2, ease: 'easeInOut' }}
-                  className="overflow-hidden"
+                  className={cn('overflow-hidden', expandedPanelClass)}
                 >
                   {/* Tabs for Cloud/Local chats - show when signed in, cloud sync enabled, and local-only mode enabled */}
                   {isSignedIn && cloudSyncEnabled && localOnlyModeEnabled && (
@@ -1838,7 +1863,7 @@ export function ChatSidebar({
                 animate={{ height: 'auto', opacity: 1 }}
                 exit={{ height: 0, opacity: 0 }}
                 transition={{ duration: 0.2, ease: 'easeInOut' }}
-                className="flex-1 overflow-hidden"
+                className={cn('flex-1 overflow-hidden', expandedPanelClass)}
               >
                 <div
                   id="chat-storage-panel"

--- a/src/components/chat/chat-sidebar.tsx
+++ b/src/components/chat/chat-sidebar.tsx
@@ -846,7 +846,16 @@ export function ChatSidebar({
         {/* Header */}
         <div className="flex h-16 flex-none items-center justify-between p-4">
           <div className="flex items-center gap-3">
-            <Link href="/" title="Home" className="flex items-center">
+            <Link
+              href="/"
+              title="Home"
+              className="flex items-center"
+              onAuxClick={(e) => {
+                if (e.button !== 1) return
+                e.preventDefault()
+                window.open('/', '_blank', 'noopener,noreferrer')
+              }}
+            >
               <Logo className="h-6 w-auto" dark={isDarkMode} />
             </Link>
             {/* Settings button */}

--- a/src/components/chat/components/context-usage-indicator.tsx
+++ b/src/components/chat/components/context-usage-indicator.tsx
@@ -80,7 +80,7 @@ export function ContextUsageIndicator({
         </svg>
         <span className="text-xs font-medium leading-none">{percentage}%</span>
       </span>
-      <span className="pointer-events-none absolute bottom-full right-0 z-20 mb-1 w-max max-w-64 whitespace-normal rounded border border-border-subtle bg-surface-chat-background px-2 py-1 text-center text-xs text-content-primary opacity-0 shadow-sm transition-opacity group-hover:opacity-100">
+      <span className="pointer-events-none absolute bottom-full right-0 z-20 mb-1 w-max max-w-xs whitespace-normal rounded border border-border-subtle bg-surface-chat-background px-2 py-1 text-center text-xs text-content-primary opacity-0 shadow-sm transition-opacity group-hover:opacity-100">
         {tooltip}
       </span>
     </div>

--- a/src/components/chat/components/context-usage-indicator.tsx
+++ b/src/components/chat/components/context-usage-indicator.tsx
@@ -80,7 +80,7 @@ export function ContextUsageIndicator({
         </svg>
         <span className="text-xs font-medium leading-none">{percentage}%</span>
       </span>
-      <span className="pointer-events-none absolute -top-9 right-0 z-20 max-w-64 whitespace-normal rounded border border-border-subtle bg-surface-chat-background px-2 py-1 text-center text-xs text-content-primary opacity-0 shadow-sm transition-opacity group-hover:opacity-100">
+      <span className="pointer-events-none absolute bottom-full right-0 z-20 mb-1 w-max max-w-64 whitespace-normal rounded border border-border-subtle bg-surface-chat-background px-2 py-1 text-center text-xs text-content-primary opacity-0 shadow-sm transition-opacity group-hover:opacity-100">
         {tooltip}
       </span>
     </div>

--- a/src/components/chat/constants.ts
+++ b/src/components/chat/constants.ts
@@ -37,6 +37,13 @@ export const CONSTANTS = {
   // Sidebar widths
   CHAT_SIDEBAR_WIDTH_PX: 300,
   CHAT_SIDEBAR_COLLAPSED_WIDTH_PX: 48,
+  // Duration of the expanded sidebar slide in/out (seconds)
+  CHAT_SIDEBAR_SLIDE_DURATION_S: 0.2,
+  // Collapsed rail fade timings (seconds). The fade-in waits for the expanded
+  // sidebar to finish sliding away so the two appear to swap rather than
+  // overlap.
+  CHAT_SIDEBAR_RAIL_FADE_IN_DURATION_S: 0.15,
+  CHAT_SIDEBAR_RAIL_FADE_OUT_DURATION_S: 0.1,
   SETTINGS_SIDEBAR_WIDTH_PX: 345,
   VERIFIER_SIDEBAR_WIDTH_PX: 345,
   ASK_SIDEBAR_WIDTH_PX: 420,

--- a/src/components/chat/hooks/use-chat-messaging.ts
+++ b/src/components/chat/hooks/use-chat-messaging.ts
@@ -572,8 +572,18 @@ export function useChatMessaging({
       // Fire title generation in parallel with streaming (based on user's message).
       // The promise is awaited after streaming completes, before the final save.
       if (isFirstMessage && userMessage) {
+        // When the user pastes long text it is captured as a document
+        // attachment rather than message text, leaving content empty. Fall
+        // back to attachment text/description so these chats still get a title.
+        const titleContent =
+          userMessage.content?.trim() ||
+          (userMessage.attachments
+            ?.map((a) => a.textContent || a.description || a.fileName)
+            .filter(Boolean)
+            .join('\n') ??
+            '')
         const titlePromise = generateTitle([
-          { role: 'user', content: userMessage.content || '' },
+          { role: 'user', content: titleContent },
         ])
         // Prevent unhandled rejection if streaming exits early and the
         // promise is never awaited (e.g. abort, navigation, empty response)

--- a/src/components/chat/hooks/use-chat-storage.ts
+++ b/src/components/chat/hooks/use-chat-storage.ts
@@ -1,6 +1,7 @@
 import { cloudStorage } from '@/services/cloud/cloud-storage'
 import { chatEvents } from '@/services/storage/chat-events'
 import { chatStorage } from '@/services/storage/chat-storage'
+import { deletedChatsTracker } from '@/services/storage/deleted-chats-tracker'
 import { logError, logInfo } from '@/utils/error-handling'
 import { useAuth } from '@clerk/nextjs'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
@@ -95,8 +96,14 @@ export function useChatStorage({
         const localBlank =
           getBlankChat(prevChats, true) || createBlankChat(true)
 
-        // Merge loaded chats with state (excluding blank chats)
-        const nonBlankChats = loadedChats.filter((c) => !c.isBlankChat)
+        // Merge loaded chats with state (excluding blank chats). Re-check the
+        // deleted tracker at apply-time: a chat can be deleted after this
+        // reload's loadChats() snapshot resolved but before this setChats runs.
+        // Without this re-filter, an in-flight reload would resurrect a chat
+        // the user just deleted until the next page refresh.
+        const nonBlankChats = loadedChats.filter(
+          (c) => !c.isBlankChat && !deletedChatsTracker.isDeleted(c.id),
+        )
 
         // Combine blank chats with loaded chats and sort
         const finalChats = sortChats([cloudBlank, localBlank, ...nonBlankChats])

--- a/src/components/chat/image-gallery-context.tsx
+++ b/src/components/chat/image-gallery-context.tsx
@@ -1,0 +1,124 @@
+'use client'
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react'
+import Lightbox from 'yet-another-react-lightbox'
+import 'yet-another-react-lightbox/styles.css'
+
+import { getMessageImages } from './attachment-helpers'
+import type { Attachment, Message } from './types'
+
+export type GalleryImage = {
+  key: string
+  src: string
+  alt: string
+}
+
+export function attachmentToImageSrc(attachment: Attachment): string | null {
+  const data = attachment.base64 || attachment.thumbnailBase64
+  if (!data) return null
+  return `data:${attachment.mimeType || 'image/jpeg'};base64,${data}`
+}
+
+/**
+ * Thin wrapper around the lightbox library so the provider and any local
+ * fallbacks share one configuration (and a single stylesheet import).
+ */
+export function ImageLightbox({
+  images,
+  index,
+  open,
+  onClose,
+  onIndexChange,
+}: {
+  images: GalleryImage[]
+  index: number
+  open: boolean
+  onClose: () => void
+  onIndexChange: (index: number) => void
+}) {
+  return (
+    <Lightbox
+      open={open}
+      close={onClose}
+      index={index}
+      slides={images.map((image) => ({ src: image.src, alt: image.alt }))}
+      controller={{ closeOnBackdropClick: true }}
+      on={{ view: ({ index: nextIndex }) => onIndexChange(nextIndex) }}
+    />
+  )
+}
+
+type ImageGalleryContextValue = {
+  openByKey: (key: string) => void
+}
+
+const ImageGalleryContext = createContext<ImageGalleryContextValue | null>(null)
+
+export function useImageGallery() {
+  return useContext(ImageGalleryContext)
+}
+
+/**
+ * Collects every image across the conversation so a click on any in-chat
+ * thumbnail opens a single gallery the user can page through end to end.
+ * Image keys are `${messageIndex}:${imageIndex}` because legacy attachment
+ * ids are only unique within a message, not across the whole conversation.
+ */
+export function ImageGalleryProvider({
+  messages,
+  children,
+}: {
+  messages: Message[]
+  children: ReactNode
+}) {
+  const images = useMemo<GalleryImage[]>(() => {
+    const collected: GalleryImage[] = []
+    messages.forEach((message, messageIndex) => {
+      getMessageImages(message).forEach((attachment, imageIndex) => {
+        const src = attachmentToImageSrc(attachment)
+        if (!src) return
+        collected.push({
+          key: `${messageIndex}:${imageIndex}`,
+          src,
+          alt: attachment.fileName || 'Image',
+        })
+      })
+    })
+    return collected
+  }, [messages])
+
+  const [open, setOpen] = useState(false)
+  const [index, setIndex] = useState(0)
+
+  const openByKey = useCallback(
+    (key: string) => {
+      const target = images.findIndex((image) => image.key === key)
+      if (target === -1) return
+      setIndex(target)
+      setOpen(true)
+    },
+    [images],
+  )
+
+  const value = useMemo(() => ({ openByKey }), [openByKey])
+
+  return (
+    <ImageGalleryContext.Provider value={value}>
+      {children}
+      <ImageLightbox
+        images={images}
+        index={index}
+        open={open}
+        onClose={() => setOpen(false)}
+        onIndexChange={setIndex}
+      />
+    </ImageGalleryContext.Provider>
+  )
+}

--- a/src/components/chat/model-selector.tsx
+++ b/src/components/chat/model-selector.tsx
@@ -263,7 +263,13 @@ export function ModelSelector({
             onClick={(e) => {
               e.preventDefault()
               e.stopPropagation()
-              setShowOtherModels(!showOtherModels)
+              setShowOtherModels((prev) => !prev)
+            }}
+            onTouchEnd={(e) => {
+              e.stopPropagation()
+              if (isScrollingRef.current) return
+              e.preventDefault()
+              setShowOtherModels((prev) => !prev)
             }}
             onMouseDown={(e) => e.stopPropagation()}
           >

--- a/src/components/chat/model-selector.tsx
+++ b/src/components/chat/model-selector.tsx
@@ -55,8 +55,14 @@ export function ModelSelector({
 
       const buttonRect = buttonElement.getBoundingClientRect()
 
+      // On mobile browsers (notably Firefox for Android) window.innerHeight
+      // does not account for the dynamic toolbar or on-screen keyboard, which
+      // can collapse the computed space and hide below-the-fold models. The
+      // visual viewport reflects the actually-visible area, so prefer it.
+      const viewportHeight = window.visualViewport?.height ?? window.innerHeight
+
       const spaceAbove = buttonRect.top - 20
-      const spaceBelow = window.innerHeight - buttonRect.bottom - 20
+      const spaceBelow = viewportHeight - buttonRect.bottom - 20
 
       let useAbove = preferredPosition === 'above'
 
@@ -75,7 +81,7 @@ export function ModelSelector({
       }
 
       const isMobile = window.innerWidth < 768
-      const maxHeightCap = isMobile ? 300 : window.innerHeight * 0.7
+      const maxHeightCap = isMobile ? 300 : viewportHeight * 0.7
 
       const menuWidth = 280
       const viewportWidth = window.innerWidth
@@ -127,6 +133,12 @@ export function ModelSelector({
 
     window.addEventListener('resize', throttledCalculatePosition)
     window.addEventListener('scroll', throttledCalculatePosition)
+    // The visual viewport changes when the mobile toolbar or keyboard shows
+    // or hides without firing window resize, so track it to keep the menu
+    // height and position in sync (e.g. Firefox for Android).
+    const visualViewport = window.visualViewport
+    visualViewport?.addEventListener('resize', throttledCalculatePosition)
+    visualViewport?.addEventListener('scroll', throttledCalculatePosition)
 
     return () => {
       if (animationFrameId !== null) {
@@ -134,6 +146,8 @@ export function ModelSelector({
       }
       window.removeEventListener('resize', throttledCalculatePosition)
       window.removeEventListener('scroll', throttledCalculatePosition)
+      visualViewport?.removeEventListener('resize', throttledCalculatePosition)
+      visualViewport?.removeEventListener('scroll', throttledCalculatePosition)
     }
   }, [preferredPosition])
 

--- a/src/components/chat/renderers/components/DocumentList.tsx
+++ b/src/components/chat/renderers/components/DocumentList.tsx
@@ -29,11 +29,26 @@ import {
   BsFiletypeXml,
 } from 'react-icons/bs'
 
+import { cn } from '@/components/ui/utils'
+
 import { getMessageAttachments } from '../../attachment-helpers'
+import {
+  attachmentToImageSrc,
+  ImageLightbox,
+  useImageGallery,
+  type GalleryImage,
+} from '../../image-gallery-context'
 import type { Attachment } from '../../types'
+
+// Number of thumbnails shown in the pile before collapsing the rest behind a
+// "+N" overlay on the last visible tile.
+const MAX_PILE_THUMBNAILS = 5
 
 interface DocumentListProps {
   attachments?: Attachment[]
+  // Index of the owning message within the conversation, used to key images
+  // into the shared gallery so the lightbox can span the whole conversation.
+  messageIndex?: number
   // Legacy props — used when attachments is not present
   documents?: Array<{ name: string }>
   documentContent?: string
@@ -135,15 +150,21 @@ function getPreviewForDocument(
 
 export const DocumentList = memo(function DocumentList({
   attachments,
+  messageIndex,
   documents,
   documentContent,
   imageData,
 }: DocumentListProps) {
+  const gallery = useImageGallery()
   const [modalOpen, setModalOpen] = useState(false)
   const [modalContent, setModalContent] = useState<{
     name: string
     content: string
   } | null>(null)
+  // Local fallback lightbox for render contexts without a gallery provider
+  // (e.g. shared/printable views); scoped to this message's images.
+  const [localLightboxOpen, setLocalLightboxOpen] = useState(false)
+  const [localLightboxIndex, setLocalLightboxIndex] = useState(0)
 
   useEffect(() => {
     if (!modalOpen) return
@@ -191,72 +212,126 @@ export const DocumentList = memo(function DocumentList({
     setModalOpen(true)
   }
 
+  const localImages: GalleryImage[] = imageAttachments
+    .map((attachment, i) => {
+      const src = attachmentToImageSrc(attachment)
+      return src
+        ? { key: String(i), src, alt: attachment.fileName || 'Image' }
+        : null
+    })
+    .filter((image): image is GalleryImage => image !== null)
+
+  const openImage = (imageIndex: number) => {
+    if (gallery && messageIndex !== undefined) {
+      gallery.openByKey(`${messageIndex}:${imageIndex}`)
+      return
+    }
+    setLocalLightboxIndex(imageIndex)
+    setLocalLightboxOpen(true)
+  }
+
+  const visibleImages = imageAttachments.slice(0, MAX_PILE_THUMBNAILS)
+  const hiddenImageCount = imageAttachments.length - visibleImages.length
+
   return (
     <>
-      <div className="mb-2 flex flex-wrap justify-end gap-2 px-4">
-        {imageAttachments.map((attachment) => {
-          const src = attachment.base64 || attachment.thumbnailBase64
-          return (
-            <div
-              key={attachment.id}
-              className="w-[300px] overflow-hidden rounded-lg"
-            >
-              {src ? (
-                <img
-                  src={`data:${attachment.mimeType || 'image/jpeg'};base64,${src}`}
-                  alt={attachment.fileName}
-                  className="h-auto w-full object-contain"
-                  loading="lazy"
-                />
-              ) : (
-                <div className="bg-surface-secondary flex h-[200px] w-full items-center justify-center">
-                  <div className="border-content-tertiary h-5 w-5 animate-spin rounded-full border-2 border-t-transparent" />
-                </div>
-              )}
-            </div>
-          )
-        })}
-        {docAttachments.map((attachment) => {
-          const preview = attachment.textContent
-            ? attachment.textContent
-                .split('\n')
-                .filter((l) => l.trim() && !l.trim().startsWith('# '))
-                .slice(0, 2)
-                .join('\n') || null
-            : getPreviewForDocument(documentContent, attachment.fileName)
+      {imageAttachments.length > 0 && (
+        <div className="group/pile mb-2 flex justify-end px-4">
+          <div className="flex items-center">
+            {visibleImages.map((attachment, i) => {
+              const thumb = attachment.thumbnailBase64 || attachment.base64
+              const isLastVisible = i === visibleImages.length - 1
+              const overflowBadge =
+                isLastVisible && hiddenImageCount > 0 ? hiddenImageCount : 0
+              return (
+                <button
+                  key={attachment.id}
+                  type="button"
+                  onClick={() => openImage(i)}
+                  aria-label={`View image ${attachment.fileName}`}
+                  style={{ zIndex: visibleImages.length - i }}
+                  className={cn(
+                    'bg-surface-secondary relative h-24 w-24 flex-none overflow-hidden rounded-lg border-2 border-surface-chat shadow-md transition-all duration-200 ease-out hover:z-10 hover:-translate-y-1',
+                    i > 0 && '-ml-14 group-hover/pile:ml-1',
+                  )}
+                >
+                  {thumb ? (
+                    <img
+                      src={`data:${attachment.mimeType || 'image/jpeg'};base64,${thumb}`}
+                      alt={attachment.fileName}
+                      className="h-full w-full object-cover"
+                      loading="lazy"
+                    />
+                  ) : (
+                    <div className="flex h-full w-full items-center justify-center">
+                      <div className="border-content-tertiary h-5 w-5 animate-spin rounded-full border-2 border-t-transparent" />
+                    </div>
+                  )}
+                  {overflowBadge > 0 && (
+                    <div className="absolute inset-0 flex items-center justify-center bg-black/55 text-lg font-semibold text-white">
+                      +{overflowBadge}
+                    </div>
+                  )}
+                </button>
+              )
+            })}
+          </div>
+        </div>
+      )}
+      {docAttachments.length > 0 && (
+        <div className="mb-2 flex flex-wrap justify-end gap-2 px-4">
+          {docAttachments.map((attachment) => {
+            const preview = attachment.textContent
+              ? attachment.textContent
+                  .split('\n')
+                  .filter((l) => l.trim() && !l.trim().startsWith('# '))
+                  .slice(0, 2)
+                  .join('\n') || null
+              : getPreviewForDocument(documentContent, attachment.fileName)
 
-          return (
-            <div
-              key={attachment.id}
-              role="button"
-              tabIndex={0}
-              onClick={() => openModal(attachment)}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter' || e.key === ' ') {
-                  e.preventDefault()
-                  openModal(attachment)
-                }
-              }}
-              className="flex min-w-[200px] max-w-[300px] cursor-pointer flex-col rounded-lg bg-surface-message-user/90 p-3 shadow-sm backdrop-blur-sm transition-colors hover:bg-surface-message-user"
-            >
-              <div className="flex items-center gap-2">
-                <div className="flex items-center justify-center p-1">
-                  {getFileIcon(attachment.fileName, 20)}
+            return (
+              <div
+                key={attachment.id}
+                role="button"
+                tabIndex={0}
+                onClick={() => openModal(attachment)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault()
+                    openModal(attachment)
+                  }
+                }}
+                className="flex min-w-[200px] max-w-[300px] cursor-pointer flex-col rounded-lg bg-surface-message-user/90 p-3 shadow-sm backdrop-blur-sm transition-colors hover:bg-surface-message-user"
+              >
+                <div className="flex items-center gap-2">
+                  <div className="flex items-center justify-center p-1">
+                    {getFileIcon(attachment.fileName, 20)}
+                  </div>
+                  <span className="truncate text-sm font-medium text-content-primary">
+                    {attachment.fileName}
+                  </span>
                 </div>
-                <span className="truncate text-sm font-medium text-content-primary">
-                  {attachment.fileName}
-                </span>
+
+                {preview && (
+                  <div className="mt-2 line-clamp-2 text-xs text-content-muted">
+                    {preview}
+                  </div>
+                )}
               </div>
+            )
+          })}
+        </div>
+      )}
 
-              {preview && (
-                <div className="mt-2 line-clamp-2 text-xs text-content-muted">
-                  {preview}
-                </div>
-              )}
-            </div>
-          )
-        })}
-      </div>
+      {!gallery && (
+        <ImageLightbox
+          images={localImages}
+          index={localLightboxIndex}
+          open={localLightboxOpen}
+          onClose={() => setLocalLightboxOpen(false)}
+          onIndexChange={setLocalLightboxIndex}
+        />
+      )}
 
       {modalOpen &&
         modalContent &&

--- a/src/components/chat/renderers/default/DefaultMessageRenderer.tsx
+++ b/src/components/chat/renderers/default/DefaultMessageRenderer.tsx
@@ -253,6 +253,7 @@ const DefaultMessageComponent = ({
       {/* Display documents and images for user messages */}
       {isUser && hasMessageAttachments(message) && (
         <DocumentList
+          messageIndex={messageIndex}
           attachments={message.attachments}
           documents={message.documents}
           documentContent={message.documentContent}

--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -2376,10 +2376,8 @@ ${encryptionKey.replace('key_', '')}
                       {/* Delete all saved chats */}
                       <div
                         className={cn(
-                          'rounded-lg border p-4',
-                          isDarkMode
-                            ? 'border-border-strong bg-surface-chat'
-                            : 'border-border-subtle bg-white',
+                          'rounded-lg border border-border-subtle p-4',
+                          isDarkMode ? 'bg-surface-sidebar' : 'bg-white',
                         )}
                       >
                         <div className="space-y-3">
@@ -2494,10 +2492,8 @@ ${encryptionKey.replace('key_', '')}
                       {isSignedIn && isPremium && (
                         <div
                           className={cn(
-                            'rounded-lg border p-4',
-                            isDarkMode
-                              ? 'border-border-strong bg-surface-chat'
-                              : 'border-border-subtle bg-white',
+                            'rounded-lg border border-border-subtle p-4',
+                            isDarkMode ? 'bg-surface-sidebar' : 'bg-white',
                           )}
                         >
                           <div className="space-y-3">

--- a/src/components/project/project-mode-banner.tsx
+++ b/src/components/project/project-mode-banner.tsx
@@ -24,7 +24,7 @@ export function ProjectModeBanner({
     : undefined
 
   return (
-    <div className="pointer-events-none relative z-10 hidden w-full flex-none justify-center md:flex">
+    <div className="pointer-events-none relative z-10 flex w-full flex-none justify-center md:hidden">
       <div
         className={cn(
           'pointer-events-auto flex items-center gap-2 rounded-b-xl border-x border-b px-4 py-1.5 transition-colors',

--- a/src/components/project/project-mode-banner.tsx
+++ b/src/components/project/project-mode-banner.tsx
@@ -1,26 +1,47 @@
 'use client'
 
 import { cn } from '@/components/ui/utils'
+import {
+  getProjectColor,
+  PROJECT_COLOR_LABEL_TINT_OPACITY,
+  projectColorRgba,
+} from '@/constants/project-colors'
 import { FolderIcon } from '@heroicons/react/24/outline'
 
 interface ProjectModeBannerProps {
   projectName: string
   isDarkMode: boolean
+  color?: string
 }
 
 export function ProjectModeBanner({
   projectName,
   isDarkMode,
+  color,
 }: ProjectModeBannerProps) {
+  const projectColor = getProjectColor(color)
+  const colorStyle = projectColor
+    ? {
+        borderColor: projectColor.hex,
+        backgroundColor: projectColorRgba(
+          projectColor,
+          PROJECT_COLOR_LABEL_TINT_OPACITY,
+        ),
+        color: projectColor.hex,
+      }
+    : undefined
+
   return (
     <div className="pointer-events-none relative z-10 hidden w-full flex-none justify-center md:flex">
       <div
         className={cn(
           'pointer-events-auto flex items-center gap-2 rounded-b-xl border-x border-b px-4 py-1.5 transition-colors',
-          isDarkMode
-            ? 'border-white/10 bg-white/5 text-white/60'
-            : 'border-gray-200 bg-gray-50 text-gray-500',
+          !projectColor &&
+            (isDarkMode
+              ? 'border-white/10 bg-white/5 text-white/60'
+              : 'border-gray-200 bg-gray-50 text-gray-500'),
         )}
+        style={colorStyle}
       >
         <FolderIcon className="h-3.5 w-3.5" />
         <span className="font-aeonik text-xs font-medium">

--- a/src/components/project/project-mode-banner.tsx
+++ b/src/components/project/project-mode-banner.tsx
@@ -1,11 +1,7 @@
 'use client'
 
 import { cn } from '@/components/ui/utils'
-import {
-  getProjectColor,
-  PROJECT_COLOR_LABEL_TINT_OPACITY,
-  projectColorRgba,
-} from '@/constants/project-colors'
+import { getProjectColor } from '@/constants/project-colors'
 import { FolderIcon } from '@heroicons/react/24/outline'
 
 interface ProjectModeBannerProps {
@@ -23,11 +19,7 @@ export function ProjectModeBanner({
   const colorStyle = projectColor
     ? {
         borderColor: projectColor.hex,
-        backgroundColor: projectColorRgba(
-          projectColor,
-          PROJECT_COLOR_LABEL_TINT_OPACITY,
-        ),
-        color: projectColor.hex,
+        backgroundColor: projectColor.hex,
       }
     : undefined
 
@@ -36,10 +28,11 @@ export function ProjectModeBanner({
       <div
         className={cn(
           'pointer-events-auto flex items-center gap-2 rounded-b-xl border-x border-b px-4 py-1.5 transition-colors',
-          !projectColor &&
-            (isDarkMode
+          projectColor
+            ? 'text-gray-900'
+            : isDarkMode
               ? 'border-white/10 bg-white/5 text-white/60'
-              : 'border-gray-200 bg-gray-50 text-gray-500'),
+              : 'border-gray-200 bg-gray-50 text-gray-500',
         )}
         style={colorStyle}
       >

--- a/src/components/project/project-provider.tsx
+++ b/src/components/project/project-provider.tsx
@@ -267,6 +267,7 @@ export function ProjectProvider({
                 description: data.description ?? prev.description,
                 systemInstructions:
                   data.systemInstructions ?? prev.systemInstructions,
+                color: data.color ?? prev.color,
                 memory: data.memory ?? prev.memory,
                 updatedAt: new Date().toISOString(),
               }

--- a/src/components/project/project-settings-content.tsx
+++ b/src/components/project/project-settings-content.tsx
@@ -2,7 +2,7 @@
 
 import { cn } from '@/components/ui/utils'
 import { PROJECT_COLORS } from '@/constants/project-colors'
-import { CheckIcon } from '@heroicons/react/24/outline'
+import { CheckIcon, NoSymbolIcon } from '@heroicons/react/24/outline'
 import { useCallback, useEffect, useState } from 'react'
 import { useProject } from './project-context'
 
@@ -71,21 +71,27 @@ export function ProjectSettingsContent({
   }, [activeProject, name, description, systemInstructions, updateProject])
 
   const handleColorSelect = useCallback(
-    async (nextColor: string) => {
+    async (nextColor: string | undefined) => {
       if (!activeProject) return
 
-      const selected = color === nextColor ? undefined : nextColor
-      setColor(selected)
+      setColor(nextColor)
       setSaveStatus('saving')
       try {
-        await updateProject(activeProject.id, { color: selected ?? '' })
+        await updateProject(activeProject.id, { color: nextColor ?? '' })
         setSaveStatus('saved')
         setTimeout(() => setSaveStatus('idle'), 2000)
       } catch {
         setSaveStatus('error')
       }
     },
-    [activeProject, color, updateProject],
+    [activeProject, updateProject],
+  )
+
+  const handleColorToggle = useCallback(
+    (nextColor: string) => {
+      handleColorSelect(color === nextColor ? undefined : nextColor)
+    },
+    [color, handleColorSelect],
   )
 
   if (!activeProject) return null
@@ -164,7 +170,7 @@ export function ProjectSettingsContent({
               <button
                 key={projectColor.id}
                 type="button"
-                onClick={() => handleColorSelect(projectColor.id)}
+                onClick={() => handleColorToggle(projectColor.id)}
                 title={projectColor.label}
                 aria-label={projectColor.label}
                 aria-pressed={isSelected}
@@ -181,6 +187,22 @@ export function ProjectSettingsContent({
               </button>
             )
           })}
+          <button
+            type="button"
+            onClick={() => handleColorSelect(undefined)}
+            title="No color"
+            aria-label="No color"
+            aria-pressed={!color}
+            className={cn(
+              'flex h-7 w-7 items-center justify-center rounded-full border border-border-strong text-content-muted ring-offset-2 transition-transform hover:scale-110 focus:outline-none focus:ring-2 focus:ring-emerald-500',
+              isDarkMode
+                ? 'ring-offset-surface-chat'
+                : 'ring-offset-surface-sidebar',
+              !color && 'ring-2 ring-content-primary',
+            )}
+          >
+            <NoSymbolIcon className="h-4 w-4" />
+          </button>
         </div>
       </div>
 

--- a/src/components/project/project-settings-content.tsx
+++ b/src/components/project/project-settings-content.tsx
@@ -1,6 +1,8 @@
 'use client'
 
 import { cn } from '@/components/ui/utils'
+import { PROJECT_COLORS } from '@/constants/project-colors'
+import { CheckIcon } from '@heroicons/react/24/outline'
 import { useCallback, useEffect, useState } from 'react'
 import { useProject } from './project-context'
 
@@ -29,6 +31,7 @@ export function ProjectSettingsContent({
   const [systemInstructions, setSystemInstructions] = useState(
     activeProject?.systemInstructions || '',
   )
+  const [color, setColor] = useState(activeProject?.color)
   const [saveStatus, setSaveStatus] = useState<
     'idle' | 'saving' | 'saved' | 'error'
   >('idle')
@@ -37,6 +40,7 @@ export function ProjectSettingsContent({
     setName(activeProject?.name || '')
     setDescription(activeProject?.description || '')
     setSystemInstructions(activeProject?.systemInstructions || '')
+    setColor(activeProject?.color)
     setSaveStatus('idle')
     // Only reset form when project ID changes, not when individual fields change
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -65,6 +69,24 @@ export function ProjectSettingsContent({
       setSaveStatus('error')
     }
   }, [activeProject, name, description, systemInstructions, updateProject])
+
+  const handleColorSelect = useCallback(
+    async (nextColor: string) => {
+      if (!activeProject) return
+
+      const selected = color === nextColor ? undefined : nextColor
+      setColor(selected)
+      setSaveStatus('saving')
+      try {
+        await updateProject(activeProject.id, { color: selected ?? '' })
+        setSaveStatus('saved')
+        setTimeout(() => setSaveStatus('idle'), 2000)
+      } catch {
+        setSaveStatus('error')
+      }
+    },
+    [activeProject, color, updateProject],
+  )
 
   if (!activeProject) return null
 
@@ -120,6 +142,46 @@ export function ProjectSettingsContent({
             'focus:outline-none focus:ring-2 focus:ring-emerald-500',
           )}
         />
+      </div>
+
+      {/* Project Color */}
+      <div>
+        <label
+          className={cn(
+            'mb-1 block font-aeonik text-sm font-medium',
+            'text-content-secondary',
+          )}
+        >
+          Color
+        </label>
+        <p className="mb-2 font-aeonik-fono text-xs text-content-muted">
+          Tints the project labels and sidebar
+        </p>
+        <div className="flex flex-wrap gap-2">
+          {PROJECT_COLORS.map((projectColor) => {
+            const isSelected = color === projectColor.id
+            return (
+              <button
+                key={projectColor.id}
+                type="button"
+                onClick={() => handleColorSelect(projectColor.id)}
+                title={projectColor.label}
+                aria-label={projectColor.label}
+                aria-pressed={isSelected}
+                className={cn(
+                  'flex h-7 w-7 items-center justify-center rounded-full ring-offset-2 transition-transform hover:scale-110 focus:outline-none focus:ring-2 focus:ring-emerald-500',
+                  isDarkMode
+                    ? 'ring-offset-surface-chat'
+                    : 'ring-offset-surface-sidebar',
+                  isSelected && 'ring-2 ring-content-primary',
+                )}
+                style={{ backgroundColor: projectColor.hex }}
+              >
+                {isSelected && <CheckIcon className="h-4 w-4 text-black/70" />}
+              </button>
+            )
+          })}
+        </div>
       </div>
 
       {/* System Instructions */}

--- a/src/components/project/project-sidebar.tsx
+++ b/src/components/project/project-sidebar.tsx
@@ -680,15 +680,18 @@ export function ProjectSidebar({
         {/* Header */}
         <div className="flex h-16 flex-none items-center justify-between border-b border-border-subtle p-4">
           <div className="flex items-center gap-3">
-            <button
-              onClick={() => {
-                window.location.href = window.location.origin
-              }}
+            <Link
+              href="/"
               title="Home"
               className="flex items-center"
+              onAuxClick={(e) => {
+                if (e.button !== 1) return
+                e.preventDefault()
+                window.open('/', '_blank', 'noopener,noreferrer')
+              }}
             >
               <Logo className="h-6 w-auto" dark={isDarkMode} />
-            </button>
+            </Link>
             {/* Settings button */}
             <div className="group relative flex items-center">
               <button

--- a/src/components/project/project-sidebar.tsx
+++ b/src/components/project/project-sidebar.tsx
@@ -11,7 +11,6 @@ import { Logo } from '@/components/logo'
 import { cn } from '@/components/ui/utils'
 import { UI_EXPAND_PROJECT_DOCUMENTS } from '@/constants/storage-keys'
 import { toast } from '@/hooks/use-toast'
-import { chatStorage } from '@/services/storage/chat-storage'
 import type { Fact } from '@/types/memory'
 import type { Project } from '@/types/project'
 import { useAuth } from '@clerk/nextjs'
@@ -94,6 +93,7 @@ interface ProjectSidebarProps {
   updateChatTitle?: (chatId: string, newTitle: string) => void
   onEncryptionKeyClick?: () => void
   onRemoveChatFromProject?: (chatId: string) => Promise<void>
+  onDeleteProjectChats?: (projectId: string) => Promise<void>
   onAddChatToProject?: (chatId: string) => Promise<void>
   onMoveChatToProject?: (chatId: string, projectId: string) => Promise<void>
   projects?: ProjectOption[]
@@ -194,6 +194,7 @@ export function ProjectSidebar({
   updateChatTitle,
   onEncryptionKeyClick,
   onRemoveChatFromProject,
+  onDeleteProjectChats,
   onAddChatToProject,
   onMoveChatToProject,
   projects = [],
@@ -430,10 +431,10 @@ export function ProjectSidebar({
   }, [project, deleteProject, onExitProject])
 
   const handleClearProjectChats = useCallback(async () => {
-    if (!project) return
+    if (!project || !onDeleteProjectChats) return
     setIsClearingChats(true)
     try {
-      await chatStorage.deleteChatsByProject(project.id)
+      await onDeleteProjectChats(project.id)
       // The currently open chat may have been one of the deleted chats, so
       // start a fresh blank chat in this project.
       onNewChat()
@@ -448,7 +449,7 @@ export function ProjectSidebar({
       setIsClearingChats(false)
       setShowClearChatsConfirm(false)
     }
-  }, [project, onNewChat])
+  }, [project, onDeleteProjectChats, onNewChat])
 
   const handleFileUpload = useCallback(
     async (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/components/project/project-sidebar.tsx
+++ b/src/components/project/project-sidebar.tsx
@@ -184,6 +184,73 @@ function getFileIcon(filename: string, className: string) {
   }
 }
 
+function DangerZoneAction({
+  isDarkMode,
+  triggerLabel,
+  confirmMessage,
+  confirmLabel,
+  pendingLabel,
+  isConfirmOpen,
+  isPending,
+  onOpenConfirm,
+  onCancel,
+  onConfirm,
+}: {
+  isDarkMode: boolean
+  triggerLabel: string
+  confirmMessage: string
+  confirmLabel: string
+  pendingLabel: string
+  isConfirmOpen: boolean
+  isPending: boolean
+  onOpenConfirm: () => void
+  onCancel: () => void
+  onConfirm: () => void
+}) {
+  if (isConfirmOpen) {
+    return (
+      <div className="rounded-lg bg-red-600 p-3">
+        <p role="alert" className="mb-3 font-aeonik-fono text-xs text-white">
+          {confirmMessage}
+        </p>
+        <div className="flex gap-2">
+          <button
+            onClick={onConfirm}
+            disabled={isPending}
+            className={cn(
+              'flex-1 rounded-lg bg-white px-3 py-1.5 text-xs font-semibold text-red-700 transition-colors hover:bg-red-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-red-600',
+              isPending && 'cursor-not-allowed opacity-50',
+            )}
+          >
+            {isPending ? pendingLabel : confirmLabel}
+          </button>
+          <button
+            onClick={onCancel}
+            className="flex-1 rounded-lg bg-red-800 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-red-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-red-600"
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <button
+      onClick={onOpenConfirm}
+      className={cn(
+        'flex w-full items-center justify-center gap-2 rounded-lg border px-3 py-2 text-xs font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-2 focus-visible:ring-offset-surface-sidebar',
+        isDarkMode
+          ? 'border-red-500/40 bg-red-950/30 text-red-300 hover:bg-red-950/50'
+          : 'border-red-300 bg-red-50 text-red-700 hover:bg-red-100',
+      )}
+    >
+      <TrashIcon className="h-3.5 w-3.5" aria-hidden="true" />
+      {triggerLabel}
+    </button>
+  )
+}
+
 export function ProjectSidebar({
   isOpen,
   setIsOpen,
@@ -1038,104 +1105,30 @@ export function ProjectSidebar({
 
                       {dangerZoneExpanded && (
                         <>
-                          {/* Delete all chats in this project */}
-                          {showClearChatsConfirm ? (
-                            <div className="rounded-lg bg-red-600 p-3">
-                              <p
-                                role="alert"
-                                className="mb-3 font-aeonik-fono text-xs text-white"
-                              >
-                                Delete all chats in this project? This cannot be
-                                undone. The project and its documents are kept.
-                              </p>
-                              <div className="flex gap-2">
-                                <button
-                                  onClick={handleClearProjectChats}
-                                  disabled={isClearingChats}
-                                  className={cn(
-                                    'flex-1 rounded-lg bg-white px-3 py-1.5 text-xs font-semibold text-red-700 transition-colors hover:bg-red-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-red-600',
-                                    isClearingChats &&
-                                      'cursor-not-allowed opacity-50',
-                                  )}
-                                >
-                                  {isClearingChats
-                                    ? 'Deleting...'
-                                    : 'Delete all'}
-                                </button>
-                                <button
-                                  onClick={() =>
-                                    setShowClearChatsConfirm(false)
-                                  }
-                                  className="flex-1 rounded-lg bg-red-800 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-red-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-red-600"
-                                >
-                                  Cancel
-                                </button>
-                              </div>
-                            </div>
-                          ) : (
-                            <button
-                              onClick={() => setShowClearChatsConfirm(true)}
-                              className={cn(
-                                'flex w-full items-center justify-center gap-2 rounded-lg border px-3 py-2 text-xs font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-2 focus-visible:ring-offset-surface-sidebar',
-                                isDarkMode
-                                  ? 'border-red-500/40 bg-red-950/30 text-red-300 hover:bg-red-950/50'
-                                  : 'border-red-300 bg-red-50 text-red-700 hover:bg-red-100',
-                              )}
-                            >
-                              <TrashIcon
-                                className="h-3.5 w-3.5"
-                                aria-hidden="true"
-                              />
-                              Delete all chats
-                            </button>
-                          )}
-
-                          {/* Delete Project */}
-                          {showDeleteConfirm ? (
-                            <div className="rounded-lg bg-red-600 p-3">
-                              <p
-                                role="alert"
-                                className="mb-3 font-aeonik-fono text-xs text-white"
-                              >
-                                Delete this project? This cannot be undone.
-                              </p>
-                              <div className="flex gap-2">
-                                <button
-                                  onClick={handleDeleteProject}
-                                  disabled={isDeleting}
-                                  className={cn(
-                                    'flex-1 rounded-lg bg-white px-3 py-1.5 text-xs font-semibold text-red-700 transition-colors hover:bg-red-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-red-600',
-                                    isDeleting &&
-                                      'cursor-not-allowed opacity-50',
-                                  )}
-                                >
-                                  {isDeleting ? 'Deleting...' : 'Delete'}
-                                </button>
-                                <button
-                                  onClick={() => setShowDeleteConfirm(false)}
-                                  className="flex-1 rounded-lg bg-red-800 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-red-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-red-600"
-                                >
-                                  Cancel
-                                </button>
-                              </div>
-                            </div>
-                          ) : (
-                            <button
-                              onClick={() => setShowDeleteConfirm(true)}
-                              className={cn(
-                                'flex w-full items-center justify-center gap-2 rounded-lg border px-3 py-2 text-xs font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-2 focus-visible:ring-offset-surface-sidebar',
-                                isDarkMode
-                                  ? 'border-red-500/40 bg-red-950/30 text-red-300 hover:bg-red-950/50'
-                                  : 'border-red-300 bg-red-50 text-red-700 hover:bg-red-100',
-                              )}
-                            >
-                              <TrashIcon
-                                className="h-3.5 w-3.5"
-                                aria-hidden="true"
-                              />
-                              Delete Project
-                            </button>
-                          )}
+                          <DangerZoneAction
+                            isDarkMode={isDarkMode}
+                            triggerLabel="Delete all chats"
+                            confirmMessage="Delete all chats in this project? This cannot be undone. The project and its documents are kept."
+                            confirmLabel="Delete all"
+                            pendingLabel="Deleting..."
+                            isConfirmOpen={showClearChatsConfirm}
+                            isPending={isClearingChats}
+                            onOpenConfirm={() => setShowClearChatsConfirm(true)}
+                            onCancel={() => setShowClearChatsConfirm(false)}
+                            onConfirm={handleClearProjectChats}
+                          />
+                          <DangerZoneAction
+                            isDarkMode={isDarkMode}
+                            triggerLabel="Delete Project"
+                            confirmMessage="Delete this project? This cannot be undone."
+                            confirmLabel="Delete"
+                            pendingLabel="Deleting..."
+                            isConfirmOpen={showDeleteConfirm}
+                            isPending={isDeleting}
+                            onOpenConfirm={() => setShowDeleteConfirm(true)}
+                            onCancel={() => setShowDeleteConfirm(false)}
+                            onConfirm={handleDeleteProject}
+                          />
                         </>
                       )}
                     </div>

--- a/src/components/project/project-sidebar.tsx
+++ b/src/components/project/project-sidebar.tsx
@@ -242,6 +242,7 @@ export function ProjectSidebar({
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
   const [isClearingChats, setIsClearingChats] = useState(false)
   const [showClearChatsConfirm, setShowClearChatsConfirm] = useState(false)
+  const [dangerZoneExpanded, setDangerZoneExpanded] = useState(false)
 
   const [isEditingProjectName, setIsEditingProjectName] = useState(false)
   const [editingProjectName, setEditingProjectName] = useState(
@@ -971,97 +972,116 @@ export function ProjectSidebar({
 
                       {/* Danger zone */}
                       <div className="mt-2 border-t border-border-subtle pt-3">
-                        <div className="mb-2 font-aeonik text-xs font-medium uppercase tracking-wide text-content-muted">
-                          Danger zone
-                        </div>
+                        <button
+                          type="button"
+                          onClick={() => setDangerZoneExpanded((prev) => !prev)}
+                          aria-expanded={dangerZoneExpanded}
+                          className="flex w-full items-center justify-between font-aeonik text-xs font-medium tracking-wide text-content-muted transition-colors hover:text-content-secondary"
+                        >
+                          <span>Danger Zone</span>
+                          {dangerZoneExpanded ? (
+                            <ChevronUpIcon className="h-4 w-4" />
+                          ) : (
+                            <ChevronDownIcon className="h-4 w-4" />
+                          )}
+                        </button>
                       </div>
 
-                      {/* Delete all chats in this project */}
-                      {showClearChatsConfirm ? (
-                        <div className="rounded-lg bg-red-600 p-3">
-                          <p className="mb-3 font-aeonik-fono text-xs text-white">
-                            Delete all chats in this project? This cannot be
-                            undone. The project and its documents are kept.
-                          </p>
-                          <div className="flex gap-2">
+                      {dangerZoneExpanded && (
+                        <>
+                          {/* Delete all chats in this project */}
+                          {showClearChatsConfirm ? (
+                            <div className="rounded-lg bg-red-600 p-3">
+                              <p className="mb-3 font-aeonik-fono text-xs text-white">
+                                Delete all chats in this project? This cannot be
+                                undone. The project and its documents are kept.
+                              </p>
+                              <div className="flex gap-2">
+                                <button
+                                  onClick={handleClearProjectChats}
+                                  disabled={isClearingChats}
+                                  className={cn(
+                                    'flex-1 rounded-lg px-3 py-1.5 text-xs font-medium transition-colors',
+                                    isDarkMode
+                                      ? 'bg-red-200 text-red-900 hover:bg-red-300'
+                                      : 'bg-white text-red-600 hover:bg-red-50',
+                                    isClearingChats &&
+                                      'cursor-not-allowed opacity-50',
+                                  )}
+                                >
+                                  {isClearingChats
+                                    ? 'Deleting...'
+                                    : 'Delete all'}
+                                </button>
+                                <button
+                                  onClick={() =>
+                                    setShowClearChatsConfirm(false)
+                                  }
+                                  className="flex-1 rounded-lg bg-red-700 px-3 py-1.5 text-xs font-medium text-white hover:bg-red-800"
+                                >
+                                  Cancel
+                                </button>
+                              </div>
+                            </div>
+                          ) : (
                             <button
-                              onClick={handleClearProjectChats}
-                              disabled={isClearingChats}
+                              onClick={() => setShowClearChatsConfirm(true)}
                               className={cn(
-                                'flex-1 rounded-lg px-3 py-1.5 text-xs font-medium transition-colors',
+                                'flex w-full items-center justify-center gap-2 rounded-lg border px-3 py-2 text-xs font-medium transition-colors',
                                 isDarkMode
-                                  ? 'bg-red-200 text-red-900 hover:bg-red-300'
-                                  : 'bg-white text-red-600 hover:bg-red-50',
-                                isClearingChats &&
-                                  'cursor-not-allowed opacity-50',
+                                  ? 'border-red-500/30 bg-red-950/20 text-red-400 hover:bg-red-950/40'
+                                  : 'border-red-300 bg-red-50 text-red-600 hover:bg-red-100',
                               )}
                             >
-                              {isClearingChats ? 'Deleting...' : 'Delete all'}
+                              <TrashIcon className="h-3.5 w-3.5" />
+                              Delete all chats
                             </button>
-                            <button
-                              onClick={() => setShowClearChatsConfirm(false)}
-                              className="flex-1 rounded-lg bg-red-700 px-3 py-1.5 text-xs font-medium text-white hover:bg-red-800"
-                            >
-                              Cancel
-                            </button>
-                          </div>
-                        </div>
-                      ) : (
-                        <button
-                          onClick={() => setShowClearChatsConfirm(true)}
-                          className={cn(
-                            'flex w-full items-center justify-center gap-2 rounded-lg border px-3 py-2 text-xs font-medium transition-colors',
-                            isDarkMode
-                              ? 'border-red-500/30 bg-red-950/20 text-red-400 hover:bg-red-950/40'
-                              : 'border-red-300 bg-red-50 text-red-600 hover:bg-red-100',
                           )}
-                        >
-                          <TrashIcon className="h-3.5 w-3.5" />
-                          Delete all chats
-                        </button>
-                      )}
 
-                      {/* Delete Project */}
-                      {showDeleteConfirm ? (
-                        <div className="rounded-lg bg-red-600 p-3">
-                          <p className="mb-3 font-aeonik-fono text-xs text-white">
-                            Delete this project? This cannot be undone.
-                          </p>
-                          <div className="flex gap-2">
+                          {/* Delete Project */}
+                          {showDeleteConfirm ? (
+                            <div className="rounded-lg bg-red-600 p-3">
+                              <p className="mb-3 font-aeonik-fono text-xs text-white">
+                                Delete this project? This cannot be undone.
+                              </p>
+                              <div className="flex gap-2">
+                                <button
+                                  onClick={handleDeleteProject}
+                                  disabled={isDeleting}
+                                  className={cn(
+                                    'flex-1 rounded-lg px-3 py-1.5 text-xs font-medium transition-colors',
+                                    isDarkMode
+                                      ? 'bg-red-200 text-red-900 hover:bg-red-300'
+                                      : 'bg-white text-red-600 hover:bg-red-50',
+                                    isDeleting &&
+                                      'cursor-not-allowed opacity-50',
+                                  )}
+                                >
+                                  {isDeleting ? 'Deleting...' : 'Delete'}
+                                </button>
+                                <button
+                                  onClick={() => setShowDeleteConfirm(false)}
+                                  className="flex-1 rounded-lg bg-red-700 px-3 py-1.5 text-xs font-medium text-white hover:bg-red-800"
+                                >
+                                  Cancel
+                                </button>
+                              </div>
+                            </div>
+                          ) : (
                             <button
-                              onClick={handleDeleteProject}
-                              disabled={isDeleting}
+                              onClick={() => setShowDeleteConfirm(true)}
                               className={cn(
-                                'flex-1 rounded-lg px-3 py-1.5 text-xs font-medium transition-colors',
+                                'flex w-full items-center justify-center gap-2 rounded-lg border px-3 py-2 text-xs font-medium transition-colors',
                                 isDarkMode
-                                  ? 'bg-red-200 text-red-900 hover:bg-red-300'
-                                  : 'bg-white text-red-600 hover:bg-red-50',
-                                isDeleting && 'cursor-not-allowed opacity-50',
+                                  ? 'border-red-500/30 bg-red-950/20 text-red-400 hover:bg-red-950/40'
+                                  : 'border-red-300 bg-red-50 text-red-600 hover:bg-red-100',
                               )}
                             >
-                              {isDeleting ? 'Deleting...' : 'Delete'}
+                              <TrashIcon className="h-3.5 w-3.5" />
+                              Delete Project
                             </button>
-                            <button
-                              onClick={() => setShowDeleteConfirm(false)}
-                              className="flex-1 rounded-lg bg-red-700 px-3 py-1.5 text-xs font-medium text-white hover:bg-red-800"
-                            >
-                              Cancel
-                            </button>
-                          </div>
-                        </div>
-                      ) : (
-                        <button
-                          onClick={() => setShowDeleteConfirm(true)}
-                          className={cn(
-                            'flex w-full items-center justify-center gap-2 rounded-lg border px-3 py-2 text-xs font-medium transition-colors',
-                            isDarkMode
-                              ? 'border-red-500/30 bg-red-950/20 text-red-400 hover:bg-red-950/40'
-                              : 'border-red-300 bg-red-50 text-red-600 hover:bg-red-100',
                           )}
-                        >
-                          <TrashIcon className="h-3.5 w-3.5" />
-                          Delete Project
-                        </button>
+                        </>
                       )}
                     </div>
                   </div>

--- a/src/components/project/project-sidebar.tsx
+++ b/src/components/project/project-sidebar.tsx
@@ -26,7 +26,13 @@ import {
   TrashIcon,
 } from '@heroicons/react/24/outline'
 import { AnimatePresence, motion } from 'framer-motion'
-import { useCallback, useEffect, useRef, useState } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type MouseEvent as ReactMouseEvent,
+} from 'react'
 import {
   BsFile,
   BsFiletypeCss,
@@ -523,6 +529,19 @@ export function ProjectSidebar({
     }
   }, [onNewChat, windowWidth, setIsOpen])
 
+  // Let modifier/middle clicks fall through so the New chat links open in a
+  // new tab; otherwise intercept the plain click for the in-app handler.
+  const handleNewChatLinkClick = useCallback(
+    (e: ReactMouseEvent<HTMLAnchorElement>, action: () => void) => {
+      if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) {
+        return
+      }
+      e.preventDefault()
+      action()
+    },
+    [],
+  )
+
   const handleRemoveDocument = useCallback(
     async (docId: string) => {
       try {
@@ -611,18 +630,7 @@ export function ProjectSidebar({
             <div className="group relative">
               <Link
                 href={projectId ? `/project/${projectId}` : '/newchat'}
-                onClick={(e) => {
-                  if (
-                    e.metaKey ||
-                    e.ctrlKey ||
-                    e.shiftKey ||
-                    e.altKey ||
-                    e.button !== 0
-                  )
-                    return
-                  e.preventDefault()
-                  onNewChat()
-                }}
+                onClick={(e) => handleNewChatLinkClick(e, onNewChat)}
                 className={cn(
                   'flex h-10 w-10 items-center justify-center rounded-lg transition-colors',
                   'text-content-secondary hover:bg-surface-chat hover:text-content-primary',
@@ -818,19 +826,12 @@ export function ProjectSidebar({
             <Link
               href={projectId ? `/project/${projectId}` : '/newchat'}
               aria-disabled={!currentChatId}
-              onClick={(e) => {
-                if (
-                  e.metaKey ||
-                  e.ctrlKey ||
-                  e.shiftKey ||
-                  e.altKey ||
-                  e.button !== 0
-                )
-                  return
-                e.preventDefault()
-                if (!currentChatId) return
-                handleNewChat()
-              }}
+              onClick={(e) =>
+                handleNewChatLinkClick(e, () => {
+                  if (!currentChatId) return
+                  handleNewChat()
+                })
+              }
               className={cn(
                 'flex w-full items-center justify-between rounded-lg border px-2 py-2 text-sm transition-colors',
                 !currentChatId

--- a/src/components/project/project-sidebar.tsx
+++ b/src/components/project/project-sidebar.tsx
@@ -542,6 +542,21 @@ export function ProjectSidebar({
     [],
   )
 
+  // onClick never fires for the middle button, so open the new tab
+  // explicitly to guarantee middle-click "open in new tab" works.
+  const handleNewChatAuxClick = useCallback(
+    (e: ReactMouseEvent<HTMLAnchorElement>) => {
+      if (e.button !== 1) return
+      e.preventDefault()
+      window.open(
+        projectId ? `/project/${projectId}` : '/newchat',
+        '_blank',
+        'noopener,noreferrer',
+      )
+    },
+    [projectId],
+  )
+
   const handleRemoveDocument = useCallback(
     async (docId: string) => {
       try {
@@ -631,6 +646,7 @@ export function ProjectSidebar({
               <Link
                 href={projectId ? `/project/${projectId}` : '/newchat'}
                 onClick={(e) => handleNewChatLinkClick(e, onNewChat)}
+                onAuxClick={handleNewChatAuxClick}
                 className={cn(
                   'flex h-10 w-10 items-center justify-center rounded-lg transition-colors',
                   'text-content-secondary hover:bg-surface-chat hover:text-content-primary',
@@ -832,6 +848,7 @@ export function ProjectSidebar({
                   handleNewChat()
                 })
               }
+              onAuxClick={handleNewChatAuxClick}
               className={cn(
                 'flex w-full items-center justify-between rounded-lg border px-2 py-2 text-sm transition-colors',
                 !currentChatId

--- a/src/components/project/project-sidebar.tsx
+++ b/src/components/project/project-sidebar.tsx
@@ -9,6 +9,7 @@ import { PiSpinnerThin } from '@/components/icons/lazy-icons'
 import { Link } from '@/components/link'
 import { Logo } from '@/components/logo'
 import { cn } from '@/components/ui/utils'
+import { PROJECT_COLORS } from '@/constants/project-colors'
 import { UI_EXPAND_PROJECT_DOCUMENTS } from '@/constants/storage-keys'
 import { toast } from '@/hooks/use-toast'
 import type { Fact } from '@/types/memory'
@@ -16,6 +17,7 @@ import type { Project } from '@/types/project'
 import { useAuth } from '@clerk/nextjs'
 import {
   ArrowLeftIcon,
+  CheckIcon,
   ChevronDownIcon,
   ChevronUpIcon,
   Cog6ToothIcon,
@@ -237,6 +239,7 @@ export function ProjectSidebar({
   const [editedInstructions, setEditedInstructions] = useState(
     project?.systemInstructions ?? '',
   )
+  const [editedColor, setEditedColor] = useState(project?.color)
   const [isSaving, setIsSaving] = useState(false)
   const [isDeleting, setIsDeleting] = useState(false)
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
@@ -275,6 +278,7 @@ export function ProjectSidebar({
       setEditedName(project.name)
       setEditedDescription(project.description)
       setEditedInstructions(project.systemInstructions)
+      setEditedColor(project.color)
       setEditingProjectName(project.name)
 
       const shouldAnimate =
@@ -365,6 +369,7 @@ export function ProjectSidebar({
         name: editedName,
         description: editedDescription,
         systemInstructions: editedInstructions,
+        color: editedColor ?? '',
       })
     } catch {
       toast({
@@ -381,6 +386,7 @@ export function ProjectSidebar({
     editedName,
     editedDescription,
     editedInstructions,
+    editedColor,
     updateProject,
   ])
 
@@ -585,7 +591,8 @@ export function ProjectSidebar({
   const hasUnsavedChanges = project
     ? editedName !== project.name ||
       editedDescription !== project.description ||
-      editedInstructions !== project.systemInstructions
+      editedInstructions !== project.systemInstructions ||
+      (editedColor ?? '') !== (project.color ?? '')
     : false
 
   const blankChat: ChatItemData = {
@@ -953,6 +960,42 @@ export function ProjectSidebar({
                             'focus:outline-none focus:ring-1 focus:ring-border-strong',
                           )}
                         />
+                      </div>
+
+                      {/* Color */}
+                      <div className="space-y-2">
+                        <div className="font-aeonik text-sm font-medium text-content-secondary">
+                          Color
+                        </div>
+                        <div className="flex flex-wrap gap-2">
+                          {PROJECT_COLORS.map((projectColor) => {
+                            const isSelected = editedColor === projectColor.id
+                            return (
+                              <button
+                                key={projectColor.id}
+                                type="button"
+                                onClick={() =>
+                                  setEditedColor(
+                                    isSelected ? undefined : projectColor.id,
+                                  )
+                                }
+                                title={projectColor.label}
+                                aria-label={projectColor.label}
+                                aria-pressed={isSelected}
+                                className={cn(
+                                  'flex h-7 w-7 items-center justify-center rounded-full transition-transform hover:scale-110 focus:outline-none focus:ring-1 focus:ring-border-strong',
+                                  isSelected &&
+                                    'ring-2 ring-content-primary ring-offset-2 ring-offset-surface-sidebar',
+                                )}
+                                style={{ backgroundColor: projectColor.hex }}
+                              >
+                                {isSelected && (
+                                  <CheckIcon className="h-4 w-4 text-black/70" />
+                                )}
+                              </button>
+                            )
+                          })}
+                        </div>
                       </div>
 
                       {/* Save button */}

--- a/src/components/project/project-sidebar.tsx
+++ b/src/components/project/project-sidebar.tsx
@@ -11,6 +11,7 @@ import { Logo } from '@/components/logo'
 import { cn } from '@/components/ui/utils'
 import { UI_EXPAND_PROJECT_DOCUMENTS } from '@/constants/storage-keys'
 import { toast } from '@/hooks/use-toast'
+import { chatStorage } from '@/services/storage/chat-storage'
 import type { Fact } from '@/types/memory'
 import type { Project } from '@/types/project'
 import { useAuth } from '@clerk/nextjs'
@@ -232,6 +233,8 @@ export function ProjectSidebar({
   const [isSaving, setIsSaving] = useState(false)
   const [isDeleting, setIsDeleting] = useState(false)
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
+  const [isClearingChats, setIsClearingChats] = useState(false)
+  const [showClearChatsConfirm, setShowClearChatsConfirm] = useState(false)
 
   const [isEditingProjectName, setIsEditingProjectName] = useState(false)
   const [editingProjectName, setEditingProjectName] = useState(
@@ -426,6 +429,27 @@ export function ProjectSidebar({
     }
   }, [project, deleteProject, onExitProject])
 
+  const handleClearProjectChats = useCallback(async () => {
+    if (!project) return
+    setIsClearingChats(true)
+    try {
+      await chatStorage.deleteChatsByProject(project.id)
+      // The currently open chat may have been one of the deleted chats, so
+      // start a fresh blank chat in this project.
+      onNewChat()
+    } catch {
+      toast({
+        title: 'Failed to delete project chats',
+        description:
+          'The chats in this project could not be deleted. Please try again.',
+        variant: 'destructive',
+      })
+    } finally {
+      setIsClearingChats(false)
+      setShowClearChatsConfirm(false)
+    }
+  }, [project, onNewChat])
+
   const handleFileUpload = useCallback(
     async (e: React.ChangeEvent<HTMLInputElement>) => {
       const files = e.target.files
@@ -584,8 +608,20 @@ export function ProjectSidebar({
           <div className="flex flex-col items-center gap-1 px-2">
             {/* New chat button */}
             <div className="group relative">
-              <button
-                onClick={onNewChat}
+              <Link
+                href={projectId ? `/project/${projectId}` : '/newchat'}
+                onClick={(e) => {
+                  if (
+                    e.metaKey ||
+                    e.ctrlKey ||
+                    e.shiftKey ||
+                    e.altKey ||
+                    e.button !== 0
+                  )
+                    return
+                  e.preventDefault()
+                  onNewChat()
+                }}
                 className={cn(
                   'flex h-10 w-10 items-center justify-center rounded-lg transition-colors',
                   'text-content-secondary hover:bg-surface-chat hover:text-content-primary',
@@ -593,7 +629,7 @@ export function ProjectSidebar({
                 aria-label="New chat"
               >
                 <PiNotePencilLight className="h-5 w-5" />
-              </button>
+              </Link>
               <span className="pointer-events-none absolute left-full top-1/2 z-50 ml-2 -translate-y-1/2 whitespace-nowrap rounded border border-border-subtle bg-surface-chat-background px-2 py-1 text-xs text-content-primary opacity-0 shadow-sm transition-opacity group-hover:opacity-100">
                 New chat{' '}
                 <span className="text-content-muted">
@@ -778,9 +814,22 @@ export function ProjectSidebar({
 
           {/* New Chat button */}
           <div className="relative z-10 mt-3 flex-none px-2 py-2">
-            <button
-              onClick={handleNewChat}
-              disabled={!currentChatId}
+            <Link
+              href={projectId ? `/project/${projectId}` : '/newchat'}
+              aria-disabled={!currentChatId}
+              onClick={(e) => {
+                if (
+                  e.metaKey ||
+                  e.ctrlKey ||
+                  e.shiftKey ||
+                  e.altKey ||
+                  e.button !== 0
+                )
+                  return
+                e.preventDefault()
+                if (!currentChatId) return
+                handleNewChat()
+              }}
               className={cn(
                 'flex w-full items-center justify-between rounded-lg border px-2 py-2 text-sm transition-colors',
                 !currentChatId
@@ -798,7 +847,7 @@ export function ProjectSidebar({
                 {modKey}
                 {isMac ? '⇧' : 'Shift+'}O
               </span>
-            </button>
+            </Link>
           </div>
 
           {/* Project Settings Dropdown */}
@@ -895,6 +944,58 @@ export function ProjectSidebar({
                           )}
                         >
                           {isSaving ? 'Saving...' : 'Save Changes'}
+                        </button>
+                      )}
+
+                      {/* Danger zone */}
+                      <div className="mt-2 border-t border-border-subtle pt-3">
+                        <div className="mb-2 font-aeonik text-xs font-medium uppercase tracking-wide text-content-muted">
+                          Danger zone
+                        </div>
+                      </div>
+
+                      {/* Delete all chats in this project */}
+                      {showClearChatsConfirm ? (
+                        <div className="rounded-lg bg-red-600 p-3">
+                          <p className="mb-3 font-aeonik-fono text-xs text-white">
+                            Delete all chats in this project? This cannot be
+                            undone. The project and its documents are kept.
+                          </p>
+                          <div className="flex gap-2">
+                            <button
+                              onClick={handleClearProjectChats}
+                              disabled={isClearingChats}
+                              className={cn(
+                                'flex-1 rounded-lg px-3 py-1.5 text-xs font-medium transition-colors',
+                                isDarkMode
+                                  ? 'bg-red-200 text-red-900 hover:bg-red-300'
+                                  : 'bg-white text-red-600 hover:bg-red-50',
+                                isClearingChats &&
+                                  'cursor-not-allowed opacity-50',
+                              )}
+                            >
+                              {isClearingChats ? 'Deleting...' : 'Delete all'}
+                            </button>
+                            <button
+                              onClick={() => setShowClearChatsConfirm(false)}
+                              className="flex-1 rounded-lg bg-red-700 px-3 py-1.5 text-xs font-medium text-white hover:bg-red-800"
+                            >
+                              Cancel
+                            </button>
+                          </div>
+                        </div>
+                      ) : (
+                        <button
+                          onClick={() => setShowClearChatsConfirm(true)}
+                          className={cn(
+                            'flex w-full items-center justify-center gap-2 rounded-lg border px-3 py-2 text-xs font-medium transition-colors',
+                            isDarkMode
+                              ? 'border-red-500/30 bg-red-950/20 text-red-400 hover:bg-red-950/40'
+                              : 'border-red-300 bg-red-50 text-red-600 hover:bg-red-100',
+                          )}
+                        >
+                          <TrashIcon className="h-3.5 w-3.5" />
+                          Delete all chats
                         </button>
                       )}
 

--- a/src/components/project/project-sidebar.tsx
+++ b/src/components/project/project-sidebar.tsx
@@ -980,9 +980,15 @@ export function ProjectSidebar({
                         >
                           <span>Danger Zone</span>
                           {dangerZoneExpanded ? (
-                            <ChevronUpIcon className="h-4 w-4" />
+                            <ChevronUpIcon
+                              className="h-4 w-4"
+                              aria-hidden="true"
+                            />
                           ) : (
-                            <ChevronDownIcon className="h-4 w-4" />
+                            <ChevronDownIcon
+                              className="h-4 w-4"
+                              aria-hidden="true"
+                            />
                           )}
                         </button>
                       </div>
@@ -992,7 +998,10 @@ export function ProjectSidebar({
                           {/* Delete all chats in this project */}
                           {showClearChatsConfirm ? (
                             <div className="rounded-lg bg-red-600 p-3">
-                              <p className="mb-3 font-aeonik-fono text-xs text-white">
+                              <p
+                                role="alert"
+                                className="mb-3 font-aeonik-fono text-xs text-white"
+                              >
                                 Delete all chats in this project? This cannot be
                                 undone. The project and its documents are kept.
                               </p>
@@ -1001,10 +1010,7 @@ export function ProjectSidebar({
                                   onClick={handleClearProjectChats}
                                   disabled={isClearingChats}
                                   className={cn(
-                                    'flex-1 rounded-lg px-3 py-1.5 text-xs font-medium transition-colors',
-                                    isDarkMode
-                                      ? 'bg-red-200 text-red-900 hover:bg-red-300'
-                                      : 'bg-white text-red-600 hover:bg-red-50',
+                                    'flex-1 rounded-lg bg-white px-3 py-1.5 text-xs font-semibold text-red-700 transition-colors hover:bg-red-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-red-600',
                                     isClearingChats &&
                                       'cursor-not-allowed opacity-50',
                                   )}
@@ -1017,7 +1023,7 @@ export function ProjectSidebar({
                                   onClick={() =>
                                     setShowClearChatsConfirm(false)
                                   }
-                                  className="flex-1 rounded-lg bg-red-700 px-3 py-1.5 text-xs font-medium text-white hover:bg-red-800"
+                                  className="flex-1 rounded-lg bg-red-800 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-red-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-red-600"
                                 >
                                   Cancel
                                 </button>
@@ -1027,13 +1033,16 @@ export function ProjectSidebar({
                             <button
                               onClick={() => setShowClearChatsConfirm(true)}
                               className={cn(
-                                'flex w-full items-center justify-center gap-2 rounded-lg border px-3 py-2 text-xs font-medium transition-colors',
+                                'flex w-full items-center justify-center gap-2 rounded-lg border px-3 py-2 text-xs font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-2 focus-visible:ring-offset-surface-sidebar',
                                 isDarkMode
-                                  ? 'border-red-500/30 bg-red-950/20 text-red-400 hover:bg-red-950/40'
-                                  : 'border-red-300 bg-red-50 text-red-600 hover:bg-red-100',
+                                  ? 'border-red-500/40 bg-red-950/30 text-red-300 hover:bg-red-950/50'
+                                  : 'border-red-300 bg-red-50 text-red-700 hover:bg-red-100',
                               )}
                             >
-                              <TrashIcon className="h-3.5 w-3.5" />
+                              <TrashIcon
+                                className="h-3.5 w-3.5"
+                                aria-hidden="true"
+                              />
                               Delete all chats
                             </button>
                           )}
@@ -1041,7 +1050,10 @@ export function ProjectSidebar({
                           {/* Delete Project */}
                           {showDeleteConfirm ? (
                             <div className="rounded-lg bg-red-600 p-3">
-                              <p className="mb-3 font-aeonik-fono text-xs text-white">
+                              <p
+                                role="alert"
+                                className="mb-3 font-aeonik-fono text-xs text-white"
+                              >
                                 Delete this project? This cannot be undone.
                               </p>
                               <div className="flex gap-2">
@@ -1049,10 +1061,7 @@ export function ProjectSidebar({
                                   onClick={handleDeleteProject}
                                   disabled={isDeleting}
                                   className={cn(
-                                    'flex-1 rounded-lg px-3 py-1.5 text-xs font-medium transition-colors',
-                                    isDarkMode
-                                      ? 'bg-red-200 text-red-900 hover:bg-red-300'
-                                      : 'bg-white text-red-600 hover:bg-red-50',
+                                    'flex-1 rounded-lg bg-white px-3 py-1.5 text-xs font-semibold text-red-700 transition-colors hover:bg-red-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-red-600',
                                     isDeleting &&
                                       'cursor-not-allowed opacity-50',
                                   )}
@@ -1061,7 +1070,7 @@ export function ProjectSidebar({
                                 </button>
                                 <button
                                   onClick={() => setShowDeleteConfirm(false)}
-                                  className="flex-1 rounded-lg bg-red-700 px-3 py-1.5 text-xs font-medium text-white hover:bg-red-800"
+                                  className="flex-1 rounded-lg bg-red-800 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-red-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-red-600"
                                 >
                                   Cancel
                                 </button>
@@ -1071,13 +1080,16 @@ export function ProjectSidebar({
                             <button
                               onClick={() => setShowDeleteConfirm(true)}
                               className={cn(
-                                'flex w-full items-center justify-center gap-2 rounded-lg border px-3 py-2 text-xs font-medium transition-colors',
+                                'flex w-full items-center justify-center gap-2 rounded-lg border px-3 py-2 text-xs font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-2 focus-visible:ring-offset-surface-sidebar',
                                 isDarkMode
-                                  ? 'border-red-500/30 bg-red-950/20 text-red-400 hover:bg-red-950/40'
-                                  : 'border-red-300 bg-red-50 text-red-600 hover:bg-red-100',
+                                  ? 'border-red-500/40 bg-red-950/30 text-red-300 hover:bg-red-950/50'
+                                  : 'border-red-300 bg-red-50 text-red-700 hover:bg-red-100',
                               )}
                             >
-                              <TrashIcon className="h-3.5 w-3.5" />
+                              <TrashIcon
+                                className="h-3.5 w-3.5"
+                                aria-hidden="true"
+                              />
                               Delete Project
                             </button>
                           )}

--- a/src/components/project/project-sidebar.tsx
+++ b/src/components/project/project-sidebar.tsx
@@ -29,6 +29,7 @@ import {
   DocumentIcon,
   DocumentPlusIcon,
   FolderIcon,
+  NoSymbolIcon,
   PencilSquareIcon,
   TrashIcon,
 } from '@heroicons/react/24/outline'
@@ -1087,6 +1088,20 @@ export function ProjectSidebar({
                               </button>
                             )
                           })}
+                          <button
+                            type="button"
+                            onClick={() => setEditedColor(undefined)}
+                            title="No color"
+                            aria-label="No color"
+                            aria-pressed={!editedColor}
+                            className={cn(
+                              'flex h-7 w-7 items-center justify-center rounded-full border border-border-strong text-content-muted transition-transform hover:scale-110 focus:outline-none focus:ring-1 focus:ring-border-strong',
+                              !editedColor &&
+                                'ring-2 ring-content-primary ring-offset-2 ring-offset-surface-sidebar',
+                            )}
+                          >
+                            <NoSymbolIcon className="h-4 w-4" />
+                          </button>
                         </div>
                       </div>
 

--- a/src/components/project/project-sidebar.tsx
+++ b/src/components/project/project-sidebar.tsx
@@ -9,7 +9,12 @@ import { PiSpinnerThin } from '@/components/icons/lazy-icons'
 import { Link } from '@/components/link'
 import { Logo } from '@/components/logo'
 import { cn } from '@/components/ui/utils'
-import { PROJECT_COLORS } from '@/constants/project-colors'
+import {
+  getProjectColor,
+  PROJECT_COLOR_SIDEBAR_TINT_OPACITY,
+  PROJECT_COLORS,
+  projectColorTintLayer,
+} from '@/constants/project-colors'
 import { UI_EXPAND_PROJECT_DOCUMENTS } from '@/constants/storage-keys'
 import { toast } from '@/hooks/use-toast'
 import type { Fact } from '@/types/memory'
@@ -691,6 +696,20 @@ export function ProjectSidebar({
 
   const isMobile = windowWidth < MOBILE_BREAKPOINT
 
+  const sidebarTintColor = getProjectColor(project?.color)
+  const sidebarTintStyle = sidebarTintColor
+    ? {
+        backgroundImage: projectColorTintLayer(
+          sidebarTintColor,
+          PROJECT_COLOR_SIDEBAR_TINT_OPACITY,
+        ),
+      }
+    : undefined
+
+  // Subtle background applied to expanded section panels so they read as
+  // distinct drawers against the sidebar surface.
+  const expandedPanelClass = isDarkMode ? 'bg-white/5' : 'bg-black/5'
+
   return (
     <>
       {/* Collapsed sidebar rail - always visible on desktop when sidebar is closed */}
@@ -700,7 +719,10 @@ export function ProjectSidebar({
             'fixed left-0 top-0 z-40 flex h-dvh flex-col border-r',
             'border-border-subtle bg-surface-sidebar text-content-primary',
           )}
-          style={{ width: `${CONSTANTS.CHAT_SIDEBAR_COLLAPSED_WIDTH_PX}px` }}
+          style={{
+            width: `${CONSTANTS.CHAT_SIDEBAR_COLLAPSED_WIDTH_PX}px`,
+            ...sidebarTintStyle,
+          }}
         >
           {/* Folder icon - shows expand icon on hover */}
           <div className="flex h-16 flex-none items-center justify-center">
@@ -750,7 +772,10 @@ export function ProjectSidebar({
           'border-border-subtle bg-surface-sidebar text-content-primary',
           'transition-all duration-200 ease-in-out',
         )}
-        style={{ maxWidth: `${CONSTANTS.CHAT_SIDEBAR_WIDTH_PX}px` }}
+        style={{
+          maxWidth: `${CONSTANTS.CHAT_SIDEBAR_WIDTH_PX}px`,
+          ...sidebarTintStyle,
+        }}
       >
         {/* Header */}
         <div className="flex h-16 flex-none items-center justify-between border-b border-border-subtle p-4">
@@ -955,7 +980,7 @@ export function ProjectSidebar({
               }
               disabled={isLoading}
               className={cn(
-                'flex w-full items-center justify-between bg-surface-sidebar px-4 py-3 text-sm transition-colors',
+                'flex w-full items-center justify-between px-4 py-3 text-sm transition-colors',
                 isLoading
                   ? 'cursor-default opacity-50'
                   : isDarkMode
@@ -985,7 +1010,7 @@ export function ProjectSidebar({
                   transition={{ duration: 0.2, ease: 'easeInOut' }}
                   className="overflow-hidden"
                 >
-                  <div className="px-4 py-4">
+                  <div className={cn('px-4 py-4', expandedPanelClass)}>
                     <div className="space-y-3">
                       {/* Description */}
                       <div className="space-y-2">
@@ -1146,7 +1171,7 @@ export function ProjectSidebar({
               }
               disabled={isLoading}
               className={cn(
-                'flex w-full items-center justify-between bg-surface-sidebar px-4 py-3 text-sm transition-colors',
+                'flex w-full items-center justify-between px-4 py-3 text-sm transition-colors',
                 isLoading
                   ? 'cursor-default opacity-50'
                   : isDarkMode
@@ -1185,7 +1210,12 @@ export function ProjectSidebar({
                   transition={{ duration: 0.2, ease: 'easeInOut' }}
                   className="overflow-hidden"
                 >
-                  <div className="max-h-64 overflow-y-auto px-2 py-2">
+                  <div
+                    className={cn(
+                      'max-h-64 overflow-y-auto px-2 py-2',
+                      expandedPanelClass,
+                    )}
+                  >
                     {/* Drag and drop zone - at top */}
                     <div
                       onClick={() =>
@@ -1391,7 +1421,7 @@ export function ProjectSidebar({
           </div>
 
           {/* Terms and privacy policy */}
-          <div className="relative z-10 flex h-[56px] flex-none items-center justify-center border-t border-border-subtle bg-surface-sidebar p-3">
+          <div className="relative z-10 flex h-[56px] flex-none items-center justify-center border-t border-border-subtle p-3">
             <p className="text-center text-xs leading-relaxed text-content-secondary">
               By using this service, you agree to Tinfoil&apos;s{' '}
               <Link

--- a/src/constants/project-colors.ts
+++ b/src/constants/project-colors.ts
@@ -44,12 +44,6 @@ export const PROJECT_COLORS: ProjectColor[] = [
     hex: '#98A6B4',
     rgb: [152, 166, 180],
   },
-  {
-    id: 'cotton-candy',
-    label: 'Cotton Candy',
-    hex: '#FFA0AA',
-    rgb: [255, 160, 170],
-  },
 ]
 
 const PROJECT_COLOR_MAP: Record<string, ProjectColor> = PROJECT_COLORS.reduce(

--- a/src/constants/project-colors.ts
+++ b/src/constants/project-colors.ts
@@ -38,12 +38,6 @@ export const PROJECT_COLORS: ProjectColor[] = [
     rgb: [138, 223, 141],
   },
   { id: 'baby-pink', label: 'Baby Pink', hex: '#FF9EC3', rgb: [255, 158, 195] },
-  {
-    id: 'cool-steel',
-    label: 'Cool Steel',
-    hex: '#98A6B4',
-    rgb: [152, 166, 180],
-  },
 ]
 
 const PROJECT_COLOR_MAP: Record<string, ProjectColor> = PROJECT_COLORS.reduce(

--- a/src/constants/project-colors.ts
+++ b/src/constants/project-colors.ts
@@ -1,0 +1,87 @@
+// ---------------------------------------------------------------------------
+// Project color palette. A project can be associated with one of these colors,
+// which tints its labels and the sidebar background while in project mode.
+// ---------------------------------------------------------------------------
+
+export interface ProjectColor {
+  id: string
+  label: string
+  hex: string
+  rgb: [number, number, number]
+}
+
+export const PROJECT_COLORS: ProjectColor[] = [
+  { id: 'maya-blue', label: 'Maya Blue', hex: '#85C6FF', rgb: [133, 198, 255] },
+  {
+    id: 'electric-aqua',
+    label: 'Electric Aqua',
+    hex: '#62DCE9',
+    rgb: [98, 220, 233],
+  },
+  {
+    id: 'sandy-brown',
+    label: 'Sandy Brown',
+    hex: '#FFB57A',
+    rgb: [255, 181, 122],
+  },
+  { id: 'mauve', label: 'Mauve', hex: '#E9ABFF', rgb: [233, 171, 255] },
+  {
+    id: 'tuscan-sun',
+    label: 'Tuscan Sun',
+    hex: '#F5CB58',
+    rgb: [245, 203, 88],
+  },
+  {
+    id: 'light-green',
+    label: 'Light Green',
+    hex: '#8ADF8D',
+    rgb: [138, 223, 141],
+  },
+  { id: 'baby-pink', label: 'Baby Pink', hex: '#FF9EC3', rgb: [255, 158, 195] },
+  {
+    id: 'cool-steel',
+    label: 'Cool Steel',
+    hex: '#98A6B4',
+    rgb: [152, 166, 180],
+  },
+  {
+    id: 'cotton-candy',
+    label: 'Cotton Candy',
+    hex: '#FFA0AA',
+    rgb: [255, 160, 170],
+  },
+]
+
+const PROJECT_COLOR_MAP: Record<string, ProjectColor> = PROJECT_COLORS.reduce(
+  (acc, color) => {
+    acc[color.id] = color
+    return acc
+  },
+  {} as Record<string, ProjectColor>,
+)
+
+// Opacity applied when tinting the sidebar background with a project color.
+export const PROJECT_COLOR_SIDEBAR_TINT_OPACITY = 0.1
+
+// Opacity applied to the background of project labels (banner and input tab).
+export const PROJECT_COLOR_LABEL_TINT_OPACITY = 0.18
+
+export function getProjectColor(id?: string | null): ProjectColor | undefined {
+  if (!id) return undefined
+  return PROJECT_COLOR_MAP[id]
+}
+
+export function projectColorRgba(color: ProjectColor, opacity: number): string {
+  const [r, g, b] = color.rgb
+  return `rgba(${r}, ${g}, ${b}, ${opacity})`
+}
+
+// A flat translucent layer drawn over an element's existing background-color
+// via background-image, so the underlying surface color still shows through.
+export function projectColorTintLayer(
+  color: ProjectColor,
+  opacity: number,
+): string {
+  const rgba = projectColorRgba(color, opacity)
+  return `linear-gradient(${rgba}, ${rgba})`
+}

--- a/src/services/cloud/cloud-storage.ts
+++ b/src/services/cloud/cloud-storage.ts
@@ -636,6 +636,28 @@ export class CloudStorageService {
     return { deleted }
   }
 
+  async deleteChatsByProject(projectId: string): Promise<{
+    deleted: number
+    notificationSent?: boolean
+  }> {
+    // Single server-side bulk delete: the controlplane removes every chat
+    // in the project and writes one tombstone per row, so other devices
+    // converge on the next sync without a per-chat round trip from here.
+    const response = await fetch(
+      `${API_BASE_URL}/api/projects/${encodeURIComponent(projectId)}/chats`,
+      {
+        method: 'DELETE',
+        headers: await this.getHeaders(),
+      },
+    )
+
+    if (!response.ok) {
+      throw new Error(`Failed to delete project chats: ${response.statusText}`)
+    }
+
+    return response.json()
+  }
+
   async getChatSyncStatus(): Promise<ChatSyncStatus> {
     let count = 0
     let lastUpdated: string | null = null

--- a/src/services/cloud/project-storage.ts
+++ b/src/services/cloud/project-storage.ts
@@ -137,6 +137,7 @@ export class ProjectStorageService {
       name: data.name,
       description: data.description || '',
       systemInstructions: data.systemInstructions || '',
+      color: data.color,
       memory: [],
     }
 
@@ -182,6 +183,7 @@ export class ProjectStorageService {
       description: data.description ?? existing.description,
       systemInstructions:
         data.systemInstructions ?? existing.systemInstructions,
+      color: data.color ?? existing.color,
       memory: data.memory ?? existing.memory,
     }
 
@@ -239,6 +241,7 @@ export class ProjectStorageService {
         name: decoded.name,
         description: decoded.description,
         systemInstructions: decoded.systemInstructions,
+        color: decoded.color,
         memory: decoded.memory || [],
         createdAt: now,
         updatedAt: now,
@@ -297,6 +300,7 @@ export class ProjectStorageService {
             name: decoded.name,
             description: decoded.description,
             systemInstructions: decoded.systemInstructions,
+            color: decoded.color,
             memory: decoded.memory || [],
             createdAt: now,
             updatedAt: now,

--- a/src/services/cloud/schemas.ts
+++ b/src/services/cloud/schemas.ts
@@ -84,6 +84,7 @@ export const ProjectDataSchema = z
     name: z.string(),
     description: z.string().optional(),
     systemInstructions: z.string().optional(),
+    color: z.string().optional(),
     memory: z.array(FactSchema).optional(),
   })
   .passthrough()

--- a/src/services/storage/chat-storage.ts
+++ b/src/services/storage/chat-storage.ts
@@ -166,8 +166,24 @@ export class ChatStorageService {
   async deleteChatsByProject(projectId: string): Promise<number> {
     await this.initialize()
 
-    // Bulk-delete from the cloud first. If it fails, skip the local wipe and
-    // tracker update so the user can retry without partial-deletion state.
+    // Delete locally and tombstone the ids before touching the cloud. An
+    // in-flight backup re-reads the chat from local storage right before
+    // uploading, so removing the local row first stops a concurrent upload
+    // from resurrecting a chat in the cloud after the bulk delete. This
+    // mirrors the ordering used by the single-chat deleteChat path.
+    const deletedIds = await indexedDBStorage.deleteChatsByProject(projectId)
+
+    for (const id of deletedIds) {
+      deletedChatsTracker.markAsDeleted(id)
+    }
+
+    if (deletedIds.length > 0) {
+      chatEvents.emit({ reason: 'delete', ids: deletedIds })
+    }
+
+    // Bulk-delete from the cloud in a single request. Best-effort: a failure
+    // is logged but not fatal, matching deleteChat, and the ids stay
+    // tombstoned locally so they will not re-sync onto this device.
     if (await cloudStorage.isAuthenticated()) {
       try {
         await cloudStorage.deleteChatsByProject(projectId)
@@ -177,18 +193,7 @@ export class ChatStorageService {
           action: 'deleteChatsByProject',
           metadata: { projectId },
         })
-        throw error
       }
-    }
-
-    const deletedIds = await indexedDBStorage.deleteChatsByProject(projectId)
-
-    for (const id of deletedIds) {
-      deletedChatsTracker.markAsDeleted(id)
-    }
-
-    if (deletedIds.length > 0) {
-      chatEvents.emit({ reason: 'delete', ids: deletedIds })
     }
 
     logInfo(`Deleted ${deletedIds.length} chats for project`, {

--- a/src/services/storage/chat-storage.ts
+++ b/src/services/storage/chat-storage.ts
@@ -166,6 +166,21 @@ export class ChatStorageService {
   async deleteChatsByProject(projectId: string): Promise<number> {
     await this.initialize()
 
+    // Bulk-delete from the cloud first. If it fails, skip the local wipe and
+    // tracker update so the user can retry without partial-deletion state.
+    if (await cloudStorage.isAuthenticated()) {
+      try {
+        await cloudStorage.deleteChatsByProject(projectId)
+      } catch (error) {
+        logError('Failed to bulk-delete project chats from cloud', error, {
+          component: 'ChatStorageService',
+          action: 'deleteChatsByProject',
+          metadata: { projectId },
+        })
+        throw error
+      }
+    }
+
     const deletedIds = await indexedDBStorage.deleteChatsByProject(projectId)
 
     for (const id of deletedIds) {
@@ -174,17 +189,6 @@ export class ChatStorageService {
 
     if (deletedIds.length > 0) {
       chatEvents.emit({ reason: 'delete', ids: deletedIds })
-    }
-
-    // Remove each chat from cloud storage (non-blocking per chat).
-    for (const id of deletedIds) {
-      cloudSync.deleteFromCloud(id).catch((error: unknown) => {
-        logError('Failed to delete project chat from cloud', error, {
-          component: 'ChatStorageService',
-          action: 'deleteChatsByProject',
-          metadata: { chatId: id, projectId },
-        })
-      })
     }
 
     logInfo(`Deleted ${deletedIds.length} chats for project`, {

--- a/src/services/storage/chat-storage.ts
+++ b/src/services/storage/chat-storage.ts
@@ -163,6 +163,39 @@ export class ChatStorageService {
     })
   }
 
+  async deleteChatsByProject(projectId: string): Promise<number> {
+    await this.initialize()
+
+    const deletedIds = await indexedDBStorage.deleteChatsByProject(projectId)
+
+    for (const id of deletedIds) {
+      deletedChatsTracker.markAsDeleted(id)
+    }
+
+    if (deletedIds.length > 0) {
+      chatEvents.emit({ reason: 'delete', ids: deletedIds })
+    }
+
+    // Remove each chat from cloud storage (non-blocking per chat).
+    for (const id of deletedIds) {
+      cloudSync.deleteFromCloud(id).catch((error: unknown) => {
+        logError('Failed to delete project chat from cloud', error, {
+          component: 'ChatStorageService',
+          action: 'deleteChatsByProject',
+          metadata: { chatId: id, projectId },
+        })
+      })
+    }
+
+    logInfo(`Deleted ${deletedIds.length} chats for project`, {
+      component: 'ChatStorageService',
+      action: 'deleteChatsByProject',
+      metadata: { projectId, count: deletedIds.length },
+    })
+
+    return deletedIds.length
+  }
+
   async deleteAllNonLocalChats(): Promise<number> {
     await this.initialize()
 

--- a/src/services/storage/indexed-db.ts
+++ b/src/services/storage/indexed-db.ts
@@ -455,6 +455,38 @@ export class IndexedDBStorage {
     })
   }
 
+  async deleteChatsByProject(projectId: string): Promise<string[]> {
+    // Serialize through saveQueue so deletions can't race with an in-flight
+    // saveChatInternal that would resurrect a row after the delete.
+    return this.enqueueSave('deleteChatsByProject', async () => {
+      const db = await this.ensureDB()
+      return new Promise<string[]>((resolve, reject) => {
+        const transaction = db.transaction([CHATS_STORE], 'readwrite')
+        const store = transaction.objectStore(CHATS_STORE)
+        const request = store.openCursor()
+        const deletedIds: string[] = []
+
+        request.onsuccess = (event) => {
+          const cursor = (event.target as IDBRequest<IDBCursorWithValue>).result
+          if (cursor) {
+            const chat = cursor.value as StoredChat
+            if (chat.projectId === projectId) {
+              deletedIds.push(chat.id)
+              cursor.delete()
+            }
+            cursor.continue()
+          }
+        }
+
+        transaction.oncomplete = () => resolve(deletedIds)
+        transaction.onerror = () =>
+          reject(new Error('Failed to delete project chats'))
+        request.onerror = () =>
+          reject(new Error('Failed to delete project chats'))
+      })
+    })
+  }
+
   async getAllChatIds(): Promise<string[]> {
     await this.saveQueue.catch(() => {})
     const db = await this.ensureDB()

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -10,6 +10,7 @@ export interface Project {
   name: string
   description: string
   systemInstructions: string
+  color?: string
   memory: Fact[]
   createdAt: string
   updatedAt: string
@@ -56,6 +57,7 @@ export interface ProjectData {
   name: string
   description: string
   systemInstructions: string
+  color?: string
   memory: Fact[]
 }
 
@@ -63,12 +65,14 @@ export interface CreateProjectData {
   name: string
   description?: string
   systemInstructions?: string
+  color?: string
 }
 
 export interface UpdateProjectData {
   name?: string
   description?: string
   systemInstructions?: string
+  color?: string
   memory?: Fact[]
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes chat UI bugs and adds convenience features. Adds an image gallery, temp/saved toggling, smarter auto-titles, a mobile-friendly model menu, project-wide bulk delete with instant refresh, middle/modified-click for New Chat/Home, smoother sidebar/rail transitions, and project color tints with a picker or no color, plus highlighted sections in the sidebar.

- New Features
  - Toggle temporary mode on started chats to convert between temporary and saved; saving assigns a new ID, adds a token if missing, generates a title when “Untitled,” and keeps the chat at the top of the list.
  - Delete all chats in a project from the sidebar’s danger zone; uses a single server-side bulk delete, refreshes the sidebar immediately, starts a fresh blank chat, and collapses behind a toggle with clearer, accessible styles.
  - New Chat and Home are Links that honor middle/modified-click to open in a new tab; left-click keeps current behavior; the collapsed rail and expanded sidebar now swap with a sequenced animation.
  - Browse image attachments in a lightbox gallery from a compact overlapping pile; spans the whole conversation and works in shared/print views, powered by `yet-another-react-lightbox`.
  - Pick a project color in Project Settings (and the project panel) to tint project labels and the sidebar, or opt out of color; stored with the project and applied to the chat input tab and project banner; distinguishes expanded sections in the sidebar.

- Bug Fixes
  - Prevent deleted chats from reappearing after background reloads or after renaming by re-checking the deletion tracker and serializing IndexedDB deletes; for project-wide deletes, remove locally and tombstone before the cloud bulk delete to avoid resurrection during backup/sync.
  - Generate titles for chats started by pasting long text (when content is empty) using attachment text/description/filename.
  - Keep the model selector usable on mobile by using the visual viewport and listening to its resize/scroll events; fix a touch bug where expanding “More models” could close the menu.
  - Show a single project mode banner per screen size to avoid duplicates.
  - Widen and reposition the context usage tooltip so it stays on one line; match Data settings cards to surrounding section backgrounds; improve contrast of project labels on solid color backgrounds.

<sup>Written for commit 3de4e88f81d0fabc649678df1c5c9977902ec402. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/409?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

