### PR TITLE
Chat inport and export with attachments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@clerk/nextjs": "^7.3.4",
         "@headlessui/react": "^2.1.1",
         "@heroicons/react": "^2.1.4",
+        "@noble/hashes": "^2.2.0",
         "@radix-ui/react-alert-dialog": "^1.1.4",
         "@radix-ui/react-dialog": "^1.1.4",
         "@radix-ui/react-progress": "^1.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "boring-avatars": "^2.0.4",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "fflate": "^0.8.3",
         "framer-motion": "^11.18.2",
         "html2pdf.js": "^0.14.0",
         "isomorphic-dompurify": "^2.35.0",
@@ -7424,9 +7425,9 @@
       }
     },
     "node_modules/fflate": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
-      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
       "license": "MIT"
     },
     "node_modules/file-entry-cache": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@clerk/nextjs": "^7.3.4",
     "@headlessui/react": "^2.1.1",
     "@heroicons/react": "^2.1.4",
+    "@noble/hashes": "^2.2.0",
     "@radix-ui/react-alert-dialog": "^1.1.4",
     "@radix-ui/react-dialog": "^1.1.4",
     "@radix-ui/react-progress": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "boring-avatars": "^2.0.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "fflate": "^0.8.3",
     "framer-motion": "^11.18.2",
     "html2pdf.js": "^0.14.0",
     "isomorphic-dompurify": "^2.35.0",

--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -1781,6 +1781,7 @@ export function SettingsModal({
               title: storedChat.title,
               messages: storedChat.messages,
               createdAt: new Date(storedChat.createdAt),
+              updatedAt: storedChat.updatedAt,
               isLocalOnly: storedChat.isLocalOnly,
               isBlankChat: storedChat.isBlankChat,
               syncedAt: storedChat.syncedAt,
@@ -3785,7 +3786,9 @@ ${encryptionKey.replace('key_', '')}
                           3
                         </div>
                         <div className="font-aeonik-fono text-sm text-content-muted">
-                          Download and unzip the file you receive by email.
+                          {shouldImportOffDevice()
+                            ? 'Download the ZIP file you receive by email.'
+                            : 'Download and unzip the file you receive by email.'}
                         </div>
                       </div>
                       <div className="flex items-start gap-3">
@@ -3800,11 +3803,23 @@ ${encryptionKey.replace('key_', '')}
                           4
                         </div>
                         <div className="font-aeonik-fono text-sm text-content-muted">
-                          Select{' '}
-                          <code className="rounded bg-surface-chat px-1.5 py-0.5 font-mono text-xs">
-                            conversations.json
-                          </code>{' '}
-                          from the unzipped folder.
+                          {shouldImportOffDevice() ? (
+                            <>
+                              Select the ZIP export to include attachments, or{' '}
+                              <code className="rounded bg-surface-chat px-1.5 py-0.5 font-mono text-xs">
+                                conversations.json
+                              </code>{' '}
+                              for chat text only.
+                            </>
+                          ) : (
+                            <>
+                              Select{' '}
+                              <code className="rounded bg-surface-chat px-1.5 py-0.5 font-mono text-xs">
+                                conversations.json
+                              </code>{' '}
+                              from the unzipped folder.
+                            </>
+                          )}
                         </div>
                       </div>
                       <input
@@ -3903,7 +3918,9 @@ ${encryptionKey.replace('key_', '')}
                           3
                         </div>
                         <div className="font-aeonik-fono text-sm text-content-muted">
-                          Download and unzip the file you receive by email.
+                          {shouldImportOffDevice()
+                            ? 'Download the ZIP file you receive by email.'
+                            : 'Download and unzip the file you receive by email.'}
                         </div>
                       </div>
                       <div className="flex items-start gap-3">
@@ -3918,15 +3935,28 @@ ${encryptionKey.replace('key_', '')}
                           4
                         </div>
                         <div className="font-aeonik-fono text-sm text-content-muted">
-                          Select{' '}
-                          <code className="rounded bg-surface-chat px-1.5 py-0.5 font-mono text-xs">
-                            conversations.json
-                          </code>{' '}
-                          or{' '}
-                          <code className="rounded bg-surface-chat px-1.5 py-0.5 font-mono text-xs">
-                            projects.json
-                          </code>{' '}
-                          from the unzipped folder.
+                          {shouldImportOffDevice() ? (
+                            <>
+                              Select the ZIP export with the Conversations
+                              button to include attachments. Use{' '}
+                              <code className="rounded bg-surface-chat px-1.5 py-0.5 font-mono text-xs">
+                                projects.json
+                              </code>{' '}
+                              only for project imports.
+                            </>
+                          ) : (
+                            <>
+                              Select{' '}
+                              <code className="rounded bg-surface-chat px-1.5 py-0.5 font-mono text-xs">
+                                conversations.json
+                              </code>{' '}
+                              or{' '}
+                              <code className="rounded bg-surface-chat px-1.5 py-0.5 font-mono text-xs">
+                                projects.json
+                              </code>{' '}
+                              from the unzipped folder.
+                            </>
+                          )}
                         </div>
                       </div>
                       <input

--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -18,6 +18,7 @@ import {
 import { useProjects } from '@/hooks/use-projects'
 import { useToast } from '@/hooks/use-toast'
 import { authTokenManager } from '@/services/auth'
+import { buildChatExport } from '@/services/chat-export/export-archive'
 import { validateCurrentPrimaryKey } from '@/services/cloud/cloud-key-preflight'
 import { cloudStorage } from '@/services/cloud/cloud-storage'
 import { cloudSync } from '@/services/cloud/cloud-sync'
@@ -32,7 +33,9 @@ import {
 } from '@/services/passkey'
 import { chatStorage } from '@/services/storage/chat-storage'
 import { sessionChatStorage } from '@/services/storage/session-storage'
+import { attachmentGet } from '@/services/sync-enclave/sync-api'
 import { TINFOIL_COLORS } from '@/theme/colors'
+import { base64ToUint8Array } from '@/utils/binary-codec'
 import {
   parseChatGPTConversations,
   parseClaudeConversations,
@@ -44,7 +47,7 @@ import {
   setCloudSyncEnabled,
   setLocalOnlyModeEnabled,
 } from '@/utils/cloud-sync-settings'
-import { logError, logInfo } from '@/utils/error-handling'
+import { logError, logInfo, logWarning } from '@/utils/error-handling'
 import { generateReverseId } from '@/utils/reverse-id'
 import { SignInButton, useAuth, useUser } from '@clerk/nextjs'
 import {
@@ -89,7 +92,7 @@ import {
   type PresetEditorState,
 } from './prompts/preset-editor'
 import type { PromptPreset } from './prompts/types'
-import type { Chat } from './types'
+import type { Attachment, Chat } from './types'
 
 const CHARS = '0123456789ABCDEF!@#$%^&*()_+<>?/'
 
@@ -1578,37 +1581,42 @@ export function SettingsModal({
     setExportType('chats')
 
     try {
-      // Convert chats to Claude-compatible format
-      const conversations = chatsToExport.map((chat) => ({
-        uuid: chat.id,
-        name: chat.title,
-        created_at: new Date(chat.createdAt).toISOString(),
-        updated_at: new Date(chat.createdAt).toISOString(),
-        chat_messages: chat.messages.map((message, index) => ({
-          uuid: `${chat.id}_msg_${index}`,
-          text: message.content,
-          sender: message.role === 'user' ? 'human' : 'assistant',
-          created_at: new Date(message.timestamp).toISOString(),
-          ...(message.thoughts
-            ? {
-                content: [
-                  {
-                    type: 'thinking',
-                    thinking: message.thoughts,
-                  },
-                ],
-              }
-            : {}),
-        })),
-      }))
+      // Fetch one binary attachment at a time so the browser never
+      // holds every attachment's bytes in memory at once.
+      const fetchAttachmentBytes = async (
+        att: Attachment,
+      ): Promise<Uint8Array | null> => {
+        try {
+          if (att.base64) {
+            return base64ToUint8Array(att.base64)
+          }
+          if (att.encryptionKey) {
+            return await attachmentGet({
+              id: att.id,
+              attKeyB64: att.encryptionKey,
+            })
+          }
+        } catch {
+          logWarning('Failed to fetch attachment for export', {
+            component: 'SettingsModal',
+            action: 'downloadChats',
+            metadata: { attachmentId: att.id },
+          })
+        }
+        return null
+      }
 
-      // Create and download JSON file
-      const jsonContent = JSON.stringify(conversations, null, 2)
-      const blob = new Blob([jsonContent], { type: 'application/json' })
+      const archive = await buildChatExport(chatsToExport, fetchAttachmentBytes)
+      const blob =
+        typeof archive.data === 'string'
+          ? new Blob([archive.data], { type: archive.mimeType })
+          : new Blob([new Uint8Array(archive.data)], {
+              type: archive.mimeType,
+            })
       const url = window.URL.createObjectURL(blob)
       const a = document.createElement('a')
       a.href = url
-      a.download = 'conversations.json'
+      a.download = archive.filename
       document.body.appendChild(a)
       a.click()
       document.body.removeChild(a)

--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -488,9 +488,9 @@ export function SettingsModal({
   const [upgradeError, setUpgradeError] = useState<string | null>(null)
 
   // Import state
-  const [importSource, setImportSource] = useState<'chatgpt' | 'claude' | null>(
-    null,
-  )
+  const [importSource, setImportSource] = useState<
+    'chatgpt' | 'claude' | 'tinfoil' | null
+  >(null)
   const [isImporting, setIsImporting] = useState(false)
   const [importProgress, setImportProgress] = useState<{
     current: number
@@ -502,10 +502,13 @@ export function SettingsModal({
     chatsImported: number
     projectsImported: number
     errors: string[]
+    pending?: boolean
+    message?: string
   } | null>(null)
   const chatGptFileInputRef = useRef<HTMLInputElement>(null)
   const claudeConversationsFileInputRef = useRef<HTMLInputElement>(null)
   const claudeProjectsFileInputRef = useRef<HTMLInputElement>(null)
+  const tinfoilFileInputRef = useRef<HTMLInputElement>(null)
 
   // Export state
   const [isExporting, setIsExporting] = useState(false)
@@ -1262,7 +1265,7 @@ export function SettingsModal({
     Boolean(isSignedIn) && isCloudSyncEnabled() && hasPrimaryKey()
 
   const importOffDevice = async (
-    source: 'chatgpt' | 'claude',
+    source: 'chatgpt' | 'claude' | 'tinfoil',
     file: File,
     sourceLabel: string,
   ) => {
@@ -1272,17 +1275,22 @@ export function SettingsModal({
     try {
       const { status } = await runOffDeviceImport(source, file)
       const errors = status.errors ?? []
+      const pending = status.status === 'staging' || status.status === 'running'
       setImportResult({
         success: status.status !== 'failed',
         chatsImported: status.imported,
         projectsImported: 0,
         errors,
+        pending,
+        message: pending
+          ? `Your ${sourceLabel} export is being imported securely. We'll email you when it's done.`
+          : undefined,
       })
       toast({
         title: 'Import started',
         description: `Your ${sourceLabel} export is being imported securely. We'll email you when it's done.`,
       })
-      if (onChatsUpdated) {
+      if (!pending && onChatsUpdated) {
         onChatsUpdated()
       }
     } catch (err) {
@@ -1412,6 +1420,36 @@ export function SettingsModal({
       setImportProgress(null)
       e.target.value = ''
     }
+  }
+
+  const handleImportTinfoil = async (
+    e: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+
+    if (shouldImportOffDevice()) {
+      await importOffDevice('tinfoil', file, 'Tinfoil')
+      e.target.value = ''
+      return
+    }
+
+    setImportSource('tinfoil')
+    setImportResult({
+      success: false,
+      chatsImported: 0,
+      projectsImported: 0,
+      errors: [
+        'Tinfoil exports with attachments can be re-imported when cloud sync is enabled.',
+      ],
+    })
+    toast({
+      title: 'Cloud sync required',
+      description:
+        'Turn on cloud sync to re-import Tinfoil exports securely through the enclave.',
+      variant: 'destructive',
+    })
+    e.target.value = ''
   }
 
   const handleImportClaudeConversations = async (
@@ -3639,10 +3677,17 @@ ${encryptionKey.replace('key_', '')}
                                   : 'text-red-500',
                               )}
                             >
-                              {importResult.success
-                                ? 'Import complete'
-                                : 'Import completed with errors'}
+                              {importResult.pending
+                                ? 'Import in progress'
+                                : importResult.success
+                                  ? 'Import complete'
+                                  : 'Import completed with errors'}
                             </div>
+                            {importResult.message && (
+                              <div className="font-aeonik-fono text-xs text-content-muted">
+                                {importResult.message}
+                              </div>
+                            )}
                             <div className="font-aeonik-fono text-xs text-content-muted">
                               {importResult.chatsImported > 0 &&
                                 `${importResult.chatsImported} chat${importResult.chatsImported !== 1 ? 's' : ''} imported`}
@@ -3941,6 +3986,49 @@ ${encryptionKey.replace('key_', '')}
                           )}
                         </button>
                       </div>
+                    </div>
+                  </div>
+
+                  {/* Tinfoil Import */}
+                  <div className="space-y-3">
+                    <h3 className="font-aeonik text-sm font-medium text-content-secondary">
+                      Import from Tinfoil
+                    </h3>
+                    <div
+                      className={cn(
+                        'space-y-3 rounded-lg border border-border-subtle p-4',
+                        isDarkMode ? 'bg-surface-sidebar' : 'bg-white',
+                      )}
+                    >
+                      <div className="font-aeonik-fono text-xs text-content-muted">
+                        Re-import a Tinfoil conversations export through the
+                        sync enclave. We&apos;ll email you when the import is
+                        done.
+                      </div>
+                      <input
+                        ref={tinfoilFileInputRef}
+                        type="file"
+                        accept=".json,.zip"
+                        onChange={handleImportTinfoil}
+                        className="hidden"
+                        disabled={isImporting}
+                      />
+                      <button
+                        onClick={() => tinfoilFileInputRef.current?.click()}
+                        disabled={isImporting}
+                        className={cn(
+                          'flex w-full items-center justify-center gap-2 rounded-lg border border-border-subtle px-4 py-2.5 text-sm font-medium transition-colors',
+                          isImporting
+                            ? 'cursor-not-allowed opacity-50'
+                            : 'hover:bg-surface-chat',
+                          isDarkMode
+                            ? 'bg-surface-chat text-content-primary'
+                            : 'bg-surface-sidebar text-content-primary',
+                        )}
+                      >
+                        <ArrowUpTrayIcon className="h-4 w-4" />
+                        Select Tinfoil Export
+                      </button>
                     </div>
                   </div>
 

--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -3810,7 +3810,9 @@ ${encryptionKey.replace('key_', '')}
                       <input
                         ref={chatGptFileInputRef}
                         type="file"
-                        accept=".json,.zip"
+                        accept={
+                          shouldImportOffDevice() ? '.json,.zip' : '.json'
+                        }
                         onChange={handleImportChatGPT}
                         className="hidden"
                         disabled={isImporting}
@@ -3930,7 +3932,9 @@ ${encryptionKey.replace('key_', '')}
                       <input
                         ref={claudeConversationsFileInputRef}
                         type="file"
-                        accept=".json,.zip"
+                        accept={
+                          shouldImportOffDevice() ? '.json,.zip' : '.json'
+                        }
                         onChange={handleImportClaudeConversations}
                         className="hidden"
                         disabled={isImporting}

--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -19,6 +19,8 @@ import { useProjects } from '@/hooks/use-projects'
 import { useToast } from '@/hooks/use-toast'
 import { authTokenManager } from '@/services/auth'
 import { buildChatExport } from '@/services/chat-export/export-archive'
+import { runOffDeviceImport } from '@/services/chat-import/off-device-import'
+import { hasPrimaryKey } from '@/services/cloud/cek-encoding'
 import { validateCurrentPrimaryKey } from '@/services/cloud/cloud-key-preflight'
 import { cloudStorage } from '@/services/cloud/cloud-storage'
 import { cloudSync } from '@/services/cloud/cloud-sync'
@@ -1253,11 +1255,67 @@ export function SettingsModal({
     isCloudSyncEnabled: isCloudSyncEnabled(),
   })
 
+  // Cloud-sync users import off-device: the raw export is uploaded to
+  // the enclave, which parses, seals, and stores everything without the
+  // plaintext touching app servers, then emails the user on completion.
+  const shouldImportOffDevice = () =>
+    Boolean(isSignedIn) && isCloudSyncEnabled() && hasPrimaryKey()
+
+  const importOffDevice = async (
+    source: 'chatgpt' | 'claude',
+    file: File,
+    sourceLabel: string,
+  ) => {
+    setImportSource(source)
+    setIsImporting(true)
+    setImportResult(null)
+    try {
+      const { status } = await runOffDeviceImport(source, file)
+      const errors = status.errors ?? []
+      setImportResult({
+        success: status.status !== 'failed',
+        chatsImported: status.imported,
+        projectsImported: 0,
+        errors,
+      })
+      toast({
+        title: 'Import started',
+        description: `Your ${sourceLabel} export is being imported securely. We'll email you when it's done.`,
+      })
+      if (onChatsUpdated) {
+        onChatsUpdated()
+      }
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : 'Failed to start import'
+      setImportResult({
+        success: false,
+        chatsImported: 0,
+        projectsImported: 0,
+        errors: [message],
+      })
+      toast({
+        title: 'Import failed',
+        description: `Could not start the ${sourceLabel} import`,
+        variant: 'destructive',
+      })
+    } finally {
+      setIsImporting(false)
+      setImportProgress(null)
+    }
+  }
+
   const handleImportChatGPT = async (
     e: React.ChangeEvent<HTMLInputElement>,
   ) => {
     const file = e.target.files?.[0]
     if (!file) return
+
+    if (shouldImportOffDevice()) {
+      await importOffDevice('chatgpt', file, 'ChatGPT')
+      e.target.value = ''
+      return
+    }
 
     setImportSource('chatgpt')
     setIsImporting(true)
@@ -1361,6 +1419,12 @@ export function SettingsModal({
   ) => {
     const file = e.target.files?.[0]
     if (!file) return
+
+    if (shouldImportOffDevice()) {
+      await importOffDevice('claude', file, 'Claude')
+      e.target.value = ''
+      return
+    }
 
     setImportSource('claude')
     setIsImporting(true)
@@ -3701,7 +3765,7 @@ ${encryptionKey.replace('key_', '')}
                       <input
                         ref={chatGptFileInputRef}
                         type="file"
-                        accept=".json"
+                        accept=".json,.zip"
                         onChange={handleImportChatGPT}
                         className="hidden"
                         disabled={isImporting}
@@ -3821,7 +3885,7 @@ ${encryptionKey.replace('key_', '')}
                       <input
                         ref={claudeConversationsFileInputRef}
                         type="file"
-                        accept=".json"
+                        accept=".json,.zip"
                         onChange={handleImportClaudeConversations}
                         className="hidden"
                         disabled={isImporting}

--- a/src/services/chat-export/export-archive.ts
+++ b/src/services/chat-export/export-archive.ts
@@ -76,8 +76,8 @@ function cleanFilename(name: string): string {
 }
 
 /**
- * Strip path separators and control characters so an attachment file
- * name can be written as a ZIP entry without escaping its directory.
+ * Returns a safe ZIP path segment from name, then sanitized fallback,
+ * then a static final fallback.
  */
 export function sanitizeFilename(name: string, fallback: string): string {
   return cleanFilename(name) || cleanFilename(fallback) || 'file'

--- a/src/services/chat-export/export-archive.ts
+++ b/src/services/chat-export/export-archive.ts
@@ -179,7 +179,7 @@ export async function buildChatExport(
       uuid: chat.id,
       name: chat.title,
       created_at: new Date(chat.createdAt).toISOString(),
-      updated_at: new Date(chat.createdAt).toISOString(),
+      updated_at: new Date(chat.updatedAt ?? chat.createdAt).toISOString(),
       ...(chat.projectId ? { projectId: chat.projectId } : {}),
       chat_messages: chatMessages,
     })

--- a/src/services/chat-export/export-archive.ts
+++ b/src/services/chat-export/export-archive.ts
@@ -66,18 +66,21 @@ function chatsHaveBinaryAttachments(chats: Chat[]): boolean {
   )
 }
 
+function cleanFilename(name: string): string {
+  const base = (name || '').split(/[\\/]/).pop() ?? ''
+  return base
+    .replace(/[\u0000-\u001f\u007f]/g, '')
+    .replace(/[^a-zA-Z0-9._ ()+-]/g, '_')
+    .replace(/^\.+/, '')
+    .trim()
+}
+
 /**
  * Strip path separators and control characters so an attachment file
  * name can be written as a ZIP entry without escaping its directory.
  */
 export function sanitizeFilename(name: string, fallback: string): string {
-  const base = (name || '').split(/[\\/]/).pop() ?? ''
-  const cleaned = base
-    .replace(/[\u0000-\u001f\u007f]/g, '')
-    .replace(/[^a-zA-Z0-9._ ()+-]/g, '_')
-    .replace(/^\.+/, '')
-    .trim()
-  return cleaned.length > 0 ? cleaned : fallback
+  return cleanFilename(name) || cleanFilename(fallback) || 'file'
 }
 
 async function sha256Hex(bytes: Uint8Array): Promise<string> {
@@ -122,8 +125,9 @@ export async function buildChatExport(
       for (const att of message.attachments ?? []) {
         if (isBinaryImage(att)) {
           attachmentCount++
-          const safeName = sanitizeFilename(att.fileName, `${att.id}.bin`)
-          const exportPath = `${ATTACHMENTS_DIR}/${att.id}/${safeName}`
+          const safeId = sanitizeFilename(att.id, 'attachment')
+          const safeName = sanitizeFilename(att.fileName, `${safeId}.bin`)
+          const exportPath = `${ATTACHMENTS_DIR}/${safeId}/${safeName}`
           const exported: ExportedAttachment = {
             id: att.id,
             type: 'image',

--- a/src/services/chat-export/export-archive.ts
+++ b/src/services/chat-export/export-archive.ts
@@ -1,0 +1,232 @@
+import { strToU8, zipSync } from 'fflate'
+
+import type { Attachment, Chat } from '@/components/chat/types'
+
+/**
+ * Off-device-import-compatible chat export. When any exported chat has
+ * a binary (image) attachment, the export is a ZIP containing:
+ *
+ *   - conversations.json: Claude-compatible conversation JSON enriched
+ *     with Tinfoil attachment metadata (the sync enclave's Tinfoil
+ *     importer reads exactly this shape).
+ *   - attachments/<attachment-id>/<safe-filename>: raw attachment bytes.
+ *   - manifest.json: export version, counts, and per-file SHA-256.
+ *
+ * conversations.json never carries `encryptionKey` or inline binary
+ * base64 — keys stay client-side and binaries live as ZIP entries.
+ *
+ * When there are no binary attachments the export stays a plain
+ * conversations.json string, preserving the previous behavior.
+ */
+
+export const EXPORT_VERSION = 1
+const ATTACHMENTS_DIR = 'attachments'
+const CONVERSATIONS_FILE = 'conversations.json'
+const MANIFEST_FILE = 'manifest.json'
+
+/** Fetches the raw bytes for one binary attachment, or null when unavailable. */
+export type AttachmentBytesFetcher = (
+  attachment: Attachment,
+) => Promise<Uint8Array | null>
+
+export interface ExportArchive {
+  /** ZIP bytes when `isZip`, otherwise the conversations.json string. */
+  data: Uint8Array | string
+  filename: string
+  mimeType: string
+  isZip: boolean
+  chatCount: number
+  attachmentCount: number
+  warnings: string[]
+}
+
+interface ExportedAttachment {
+  id: string
+  type: 'image' | 'document'
+  fileName: string
+  mimeType?: string
+  fileSize?: number
+  exportPath?: string
+  textContent?: string
+}
+
+interface ManifestEntry {
+  exportPath: string
+  sha256: string
+  fileSize: number
+}
+
+function isBinaryImage(att: Attachment): boolean {
+  return att.type === 'image'
+}
+
+function chatsHaveBinaryAttachments(chats: Chat[]): boolean {
+  return chats.some((chat) =>
+    chat.messages.some((msg) => (msg.attachments ?? []).some(isBinaryImage)),
+  )
+}
+
+/**
+ * Strip path separators and control characters so an attachment file
+ * name can be written as a ZIP entry without escaping its directory.
+ */
+export function sanitizeFilename(name: string, fallback: string): string {
+  const base = (name || '').split(/[\\/]/).pop() ?? ''
+  const cleaned = base
+    .replace(/[\u0000-\u001f\u007f]/g, '')
+    .replace(/[^a-zA-Z0-9._ ()+-]/g, '_')
+    .replace(/^\.+/, '')
+    .trim()
+  return cleaned.length > 0 ? cleaned : fallback
+}
+
+async function sha256Hex(bytes: Uint8Array): Promise<string> {
+  const view = new Uint8Array(bytes.byteLength)
+  view.set(bytes)
+  const digest = new Uint8Array(await crypto.subtle.digest('SHA-256', view))
+  let out = ''
+  for (let i = 0; i < digest.length; i++) {
+    out += digest[i].toString(16).padStart(2, '0')
+  }
+  return out
+}
+
+function toClaudeContent(thoughts?: string) {
+  if (!thoughts) return undefined
+  return [{ type: 'thinking', thinking: thoughts }]
+}
+
+/**
+ * Build the export. `fetchAttachmentBytes` is called for one binary
+ * attachment at a time so the browser never holds every attachment's
+ * bytes in memory at once. Failed fetches keep the attachment's
+ * metadata and add a manifest warning instead of aborting the export.
+ */
+export async function buildChatExport(
+  chats: Chat[],
+  fetchAttachmentBytes: AttachmentBytesFetcher,
+): Promise<ExportArchive> {
+  const needsZip = chatsHaveBinaryAttachments(chats)
+  const warnings: string[] = []
+  const zipFiles: Record<string, Uint8Array> = {}
+  const manifestEntries: ManifestEntry[] = []
+  let attachmentCount = 0
+
+  const conversations = []
+  for (const chat of chats) {
+    const chatMessages = []
+    for (let index = 0; index < chat.messages.length; index++) {
+      const message = chat.messages[index]
+      const exportedAttachments: ExportedAttachment[] = []
+
+      for (const att of message.attachments ?? []) {
+        if (isBinaryImage(att)) {
+          attachmentCount++
+          const safeName = sanitizeFilename(att.fileName, `${att.id}.bin`)
+          const exportPath = `${ATTACHMENTS_DIR}/${att.id}/${safeName}`
+          const exported: ExportedAttachment = {
+            id: att.id,
+            type: 'image',
+            fileName: safeName,
+            mimeType: att.mimeType,
+            fileSize: att.fileSize,
+          }
+
+          if (needsZip) {
+            const bytes = await fetchAttachmentBytes(att)
+            if (bytes) {
+              zipFiles[exportPath] = bytes
+              exported.exportPath = exportPath
+              exported.fileSize = bytes.byteLength
+              manifestEntries.push({
+                exportPath,
+                sha256: await sha256Hex(bytes),
+                fileSize: bytes.byteLength,
+              })
+            } else {
+              warnings.push(`Could not fetch attachment ${att.id}`)
+            }
+          }
+          exportedAttachments.push(exported)
+        } else {
+          attachmentCount++
+          exportedAttachments.push({
+            id: att.id,
+            type: 'document',
+            fileName: att.fileName,
+            mimeType: att.mimeType,
+            fileSize: att.fileSize,
+            textContent: att.textContent,
+          })
+        }
+      }
+
+      chatMessages.push({
+        uuid: `${chat.id}_msg_${index}`,
+        text: message.content,
+        sender: message.role === 'user' ? 'human' : 'assistant',
+        created_at: new Date(message.timestamp).toISOString(),
+        ...(toClaudeContent(message.thoughts)
+          ? { content: toClaudeContent(message.thoughts) }
+          : {}),
+        ...(exportedAttachments.length > 0
+          ? { attachments: exportedAttachments }
+          : {}),
+      })
+    }
+
+    conversations.push({
+      uuid: chat.id,
+      name: chat.title,
+      created_at: new Date(chat.createdAt).toISOString(),
+      updated_at: new Date(chat.createdAt).toISOString(),
+      ...(chat.projectId ? { projectId: chat.projectId } : {}),
+      chat_messages: chatMessages,
+    })
+  }
+
+  const conversationsJson = JSON.stringify(conversations, null, 2)
+
+  if (!needsZip) {
+    return {
+      data: conversationsJson,
+      filename: CONVERSATIONS_FILE,
+      mimeType: 'application/json',
+      isZip: false,
+      chatCount: chats.length,
+      attachmentCount,
+      warnings,
+    }
+  }
+
+  zipFiles[CONVERSATIONS_FILE] = strToU8(conversationsJson)
+  zipFiles[MANIFEST_FILE] = strToU8(
+    JSON.stringify(
+      {
+        version: EXPORT_VERSION,
+        created_at: new Date().toISOString(),
+        chat_count: chats.length,
+        attachment_count: attachmentEntriesWritten(manifestEntries),
+        attachments: manifestEntries,
+        warnings,
+      },
+      null,
+      2,
+    ),
+  )
+
+  const zipped = zipSync(zipFiles)
+  return {
+    data: zipped,
+    filename: 'tinfoil-chats.zip',
+    mimeType: 'application/zip',
+    isZip: true,
+    chatCount: chats.length,
+    attachmentCount,
+    warnings,
+  }
+}
+
+function attachmentEntriesWritten(entries: ManifestEntry[]): number {
+  return entries.length
+}

--- a/src/services/chat-export/export-archive.ts
+++ b/src/services/chat-export/export-archive.ts
@@ -23,6 +23,7 @@ export const EXPORT_VERSION = 1
 const ATTACHMENTS_DIR = 'attachments'
 const CONVERSATIONS_FILE = 'conversations.json'
 const MANIFEST_FILE = 'manifest.json'
+const FIRST_COLLISION_SUFFIX = 2
 
 /** Fetches the raw bytes for one binary attachment, or null when unavailable. */
 export type AttachmentBytesFetcher = (
@@ -94,6 +95,31 @@ async function sha256Hex(bytes: Uint8Array): Promise<string> {
   return out
 }
 
+function uniqueAttachmentExportPath(
+  safeId: string,
+  safeName: string,
+  usedPaths: Set<string>,
+): string {
+  const basePath = `${ATTACHMENTS_DIR}/${safeId}/${safeName}`
+  if (!usedPaths.has(basePath)) {
+    usedPaths.add(basePath)
+    return basePath
+  }
+
+  const dotIndex = safeName.lastIndexOf('.')
+  const hasExtension = dotIndex > 0
+  const nameRoot = hasExtension ? safeName.slice(0, dotIndex) : safeName
+  const extension = hasExtension ? safeName.slice(dotIndex) : ''
+
+  for (let suffix = FIRST_COLLISION_SUFFIX; ; suffix++) {
+    const candidate = `${ATTACHMENTS_DIR}/${safeId}/${nameRoot}-${suffix}${extension}`
+    if (!usedPaths.has(candidate)) {
+      usedPaths.add(candidate)
+      return candidate
+    }
+  }
+}
+
 function toClaudeContent(thoughts?: string) {
   if (!thoughts) return undefined
   return [{ type: 'thinking', thinking: thoughts }]
@@ -113,6 +139,7 @@ export async function buildChatExport(
   const warnings: string[] = []
   const zipFiles: Record<string, Uint8Array> = {}
   const manifestEntries: ManifestEntry[] = []
+  const usedAttachmentPaths = new Set<string>()
   let attachmentCount = 0
 
   const conversations = []
@@ -127,7 +154,11 @@ export async function buildChatExport(
           attachmentCount++
           const safeId = sanitizeFilename(att.id, 'attachment')
           const safeName = sanitizeFilename(att.fileName, `${safeId}.bin`)
-          const exportPath = `${ATTACHMENTS_DIR}/${safeId}/${safeName}`
+          const exportPath = uniqueAttachmentExportPath(
+            safeId,
+            safeName,
+            usedAttachmentPaths,
+          )
           const exported: ExportedAttachment = {
             id: att.id,
             type: 'image',

--- a/src/services/chat-import/off-device-import.ts
+++ b/src/services/chat-import/off-device-import.ts
@@ -1,0 +1,76 @@
+import { requirePrimaryKeyB64 } from '@/services/cloud/cek-encoding'
+import {
+  importCreate,
+  importStart,
+  importUploadChunk,
+  type ImportSource,
+  type ImportStatusResponse,
+} from '@/services/sync-enclave/sync-api'
+
+/**
+ * Off-device chat import: upload a raw ChatGPT/Claude/Tinfoil export to
+ * the sync enclave in fixed-size chunks, then hand the enclave the CEK
+ * so it parses, seals, and stores every chat + attachment without the
+ * plaintext ever touching application servers. The enclave emails the
+ * user when the detached job finishes; the browser only needs to stay
+ * open through the upload and the kickoff.
+ */
+
+// Mirrors the enclave's MaxImportChunkBytes; both sides must agree on
+// the fixed chunk size so chunk offsets line up during reassembly.
+export const IMPORT_CHUNK_BYTES = 8 * 1024 * 1024
+
+export interface OffDeviceImportResult {
+  jobId: string
+  status: ImportStatusResponse
+}
+
+async function sha256Hex(bytes: Uint8Array): Promise<string> {
+  const view = new Uint8Array(bytes.byteLength)
+  view.set(bytes)
+  const digest = new Uint8Array(await crypto.subtle.digest('SHA-256', view))
+  let out = ''
+  for (let i = 0; i < digest.length; i++) {
+    out += digest[i].toString(16).padStart(2, '0')
+  }
+  return out
+}
+
+export async function runOffDeviceImport(
+  source: ImportSource,
+  file: File,
+): Promise<OffDeviceImportResult> {
+  const archive = new Uint8Array(await file.arrayBuffer())
+  if (archive.length === 0) {
+    throw new Error('The export file is empty')
+  }
+
+  const totalChunks = Math.ceil(archive.length / IMPORT_CHUNK_BYTES)
+  const archiveSha256 = await sha256Hex(archive)
+
+  const { job_id, upload_id } = await importCreate({
+    source,
+    totalBytes: archive.length,
+    totalChunks,
+    archiveSha256,
+  })
+
+  for (let index = 0; index < totalChunks; index++) {
+    const start = index * IMPORT_CHUNK_BYTES
+    const end = Math.min(start + IMPORT_CHUNK_BYTES, archive.length)
+    const chunk = archive.subarray(start, end)
+    await importUploadChunk({
+      uploadId: upload_id,
+      chunkIndex: index,
+      chunkSha256: await sha256Hex(chunk),
+      data: chunk,
+    })
+  }
+
+  const status = await importStart({
+    jobId: job_id,
+    keyB64: requirePrimaryKeyB64(),
+  })
+
+  return { jobId: job_id, status }
+}

--- a/src/services/chat-import/off-device-import.ts
+++ b/src/services/chat-import/off-device-import.ts
@@ -6,6 +6,7 @@ import {
   type ImportSource,
   type ImportStatusResponse,
 } from '@/services/sync-enclave/sync-api'
+import { sha256 } from '@noble/hashes/sha2.js'
 
 /**
  * Off-device chat import: upload a raw ChatGPT/Claude/Tinfoil export to
@@ -19,50 +20,74 @@ import {
 // Mirrors the enclave's MaxImportChunkBytes; both sides must agree on
 // the fixed chunk size so chunk offsets line up during reassembly.
 export const IMPORT_CHUNK_BYTES = 8 * 1024 * 1024
+export const IMPORT_MAX_ARCHIVE_BYTES = 512 * 1024 * 1024
 
 export interface OffDeviceImportResult {
   jobId: string
   status: ImportStatusResponse
 }
 
-async function sha256Hex(bytes: Uint8Array): Promise<string> {
-  const view = new Uint8Array(bytes.byteLength)
-  view.set(bytes)
-  const digest = new Uint8Array(await crypto.subtle.digest('SHA-256', view))
+function bytesToHex(bytes: Uint8Array): string {
   let out = ''
-  for (let i = 0; i < digest.length; i++) {
-    out += digest[i].toString(16).padStart(2, '0')
+  for (let i = 0; i < bytes.length; i++) {
+    out += bytes[i].toString(16).padStart(2, '0')
   }
   return out
+}
+
+async function readChunk(file: File, index: number): Promise<Uint8Array> {
+  const start = index * IMPORT_CHUNK_BYTES
+  const end = Math.min(start + IMPORT_CHUNK_BYTES, file.size)
+  return new Uint8Array(await file.slice(start, end).arrayBuffer())
+}
+
+async function hashFileByChunk(file: File): Promise<{
+  archiveSha256: string
+  chunkSha256s: string[]
+}> {
+  const totalChunks = Math.ceil(file.size / IMPORT_CHUNK_BYTES)
+  const archiveHash = sha256.create()
+  const chunkSha256s: string[] = []
+
+  for (let index = 0; index < totalChunks; index++) {
+    const chunk = await readChunk(file, index)
+    archiveHash.update(chunk)
+    chunkSha256s.push(bytesToHex(sha256(chunk)))
+  }
+
+  return {
+    archiveSha256: bytesToHex(archiveHash.digest()),
+    chunkSha256s,
+  }
 }
 
 export async function runOffDeviceImport(
   source: ImportSource,
   file: File,
 ): Promise<OffDeviceImportResult> {
-  const archive = new Uint8Array(await file.arrayBuffer())
-  if (archive.length === 0) {
+  if (file.size === 0) {
     throw new Error('The export file is empty')
   }
+  if (file.size > IMPORT_MAX_ARCHIVE_BYTES) {
+    throw new Error('The export file is too large')
+  }
 
-  const totalChunks = Math.ceil(archive.length / IMPORT_CHUNK_BYTES)
-  const archiveSha256 = await sha256Hex(archive)
+  const totalChunks = Math.ceil(file.size / IMPORT_CHUNK_BYTES)
+  const { archiveSha256, chunkSha256s } = await hashFileByChunk(file)
 
   const { job_id, upload_id } = await importCreate({
     source,
-    totalBytes: archive.length,
+    totalBytes: file.size,
     totalChunks,
     archiveSha256,
   })
 
   for (let index = 0; index < totalChunks; index++) {
-    const start = index * IMPORT_CHUNK_BYTES
-    const end = Math.min(start + IMPORT_CHUNK_BYTES, archive.length)
-    const chunk = archive.subarray(start, end)
+    const chunk = await readChunk(file, index)
     await importUploadChunk({
       uploadId: upload_id,
       chunkIndex: index,
-      chunkSha256: await sha256Hex(chunk),
+      chunkSha256: chunkSha256s[index],
       data: chunk,
     })
   }

--- a/src/services/sync-enclave/sync-api.ts
+++ b/src/services/sync-enclave/sync-api.ts
@@ -292,6 +292,115 @@ export interface MigrateAllResponse {
 }
 
 /* -------------------------------------------------------------------------- */
+/*  Off-device chat import                                                    */
+/* -------------------------------------------------------------------------- */
+
+export type ImportSource = 'chatgpt' | 'claude' | 'tinfoil'
+
+export type ImportJobStatus =
+  | 'idle'
+  | 'staging'
+  | 'running'
+  | 'completed'
+  | 'failed'
+
+export interface ImportCreateRequest {
+  source: ImportSource
+  /** Total size of the raw archive in bytes. */
+  totalBytes: number
+  /** Number of chunks the client will upload. */
+  totalChunks: number
+  /** Hex SHA-256 of the full archive, verified before parsing. */
+  archiveSha256: string
+}
+
+export interface ImportCreateResponse {
+  job_id: string
+  upload_id: string
+}
+
+export interface ImportUploadChunkRequest {
+  uploadId: string
+  chunkIndex: number
+  /** Hex SHA-256 of this chunk's raw bytes. */
+  chunkSha256: string
+  /** Raw chunk bytes; the client base64-encodes them on the wire. */
+  data: Uint8Array
+}
+
+export interface ImportStartRequest {
+  jobId: string
+  /** User's CEK, base64 raw 32 bytes. Held in enclave memory for the job. */
+  keyB64: string
+}
+
+export interface ImportStatusResponse {
+  status: ImportJobStatus
+  imported: number
+  failed: number
+  total: number
+  errors?: string[]
+  job_id?: string
+}
+
+/**
+ * Create an off-device import job. The enclave allocates a job id and
+ * an upload id and prepares an encrypted staging area for the archive
+ * chunks. The browser must stay open through the chunk upload and
+ * import/start; once import/start returns the tab can close.
+ */
+export async function importCreate(
+  req: ImportCreateRequest,
+): Promise<ImportCreateResponse> {
+  const client = await getSyncEnclaveClient()
+  return client.post<ImportCreateResponse>('/v1/import/create', {
+    source: req.source,
+    total_bytes: req.totalBytes,
+    total_chunks: req.totalChunks,
+    archive_sha256: req.archiveSha256,
+  })
+}
+
+/** Stage one archive chunk. Replaying the same index+hash is idempotent. */
+export async function importUploadChunk(
+  req: ImportUploadChunkRequest,
+): Promise<OKResponse> {
+  const client = await getSyncEnclaveClient()
+  return client.post<OKResponse>('/v1/import/upload', {
+    upload_id: req.uploadId,
+    chunk_index: req.chunkIndex,
+    chunk_sha256: req.chunkSha256,
+    data: bytesToB64(req.data),
+  })
+}
+
+/**
+ * Kick off the detached import job. The enclave validates the staged
+ * archive, parses it, seals every chat + attachment under the supplied
+ * CEK, and emails the user on completion.
+ */
+export async function importStart(
+  req: ImportStartRequest,
+): Promise<ImportStatusResponse> {
+  const client = await getSyncEnclaveClient()
+  return client.post<ImportStatusResponse>('/v1/import/start', {
+    job_id: req.jobId,
+    key: req.keyB64,
+  })
+}
+
+/** Poll an import job's progress while the tab stays open. */
+export async function importStatus(
+  jobId: string,
+): Promise<ImportStatusResponse> {
+  const client = await getSyncEnclaveClient()
+  const resp = await client.post<ImportStatusResponse>('/v1/import/status', {
+    job_id: jobId,
+  })
+  return { ...resp, errors: resp.errors ?? [] }
+}
+
+/* -------------------------------------------------------------------------- */
 /*  Health                                                                    */
 /* -------------------------------------------------------------------------- */
 

--- a/tests/services/chat-export/export-archive.test.ts
+++ b/tests/services/chat-export/export-archive.test.ts
@@ -183,6 +183,50 @@ describe('buildChatExport', () => {
     const manifest = JSON.parse(strFromU8(entries['manifest.json']))
     expect(manifest.attachments[0].exportPath).toBe('attachments/id/id.bin')
   })
+
+  it('keeps colliding sanitized attachment paths distinct', async () => {
+    const firstBytes = new Uint8Array([1, 2, 3])
+    const secondBytes = new Uint8Array([4, 5, 6])
+    const chats = [
+      chat({
+        messages: [
+          {
+            role: 'user',
+            content: 'see pics',
+            timestamp: new Date('2023-11-14T22:13:21.000Z'),
+            attachments: [
+              {
+                id: '../same/id',
+                type: 'image',
+                fileName: 'pic.png',
+              },
+              {
+                id: 'id',
+                type: 'image',
+                fileName: 'pic.png',
+              },
+            ],
+          },
+        ],
+      }),
+    ]
+
+    const result = await buildChatExport(chats, async (att) =>
+      att.id === '../same/id' ? firstBytes : secondBytes,
+    )
+    const entries = unzipSync(result.data as Uint8Array)
+
+    expect(entries['attachments/id/pic.png']).toEqual(firstBytes)
+    expect(entries['attachments/id/pic-2.png']).toEqual(secondBytes)
+
+    const conversations = JSON.parse(strFromU8(entries['conversations.json']))
+    expect(conversations[0].chat_messages[0].attachments[0].exportPath).toBe(
+      'attachments/id/pic.png',
+    )
+    expect(conversations[0].chat_messages[0].attachments[1].exportPath).toBe(
+      'attachments/id/pic-2.png',
+    )
+  })
 })
 
 describe('sanitizeFilename', () => {

--- a/tests/services/chat-export/export-archive.test.ts
+++ b/tests/services/chat-export/export-archive.test.ts
@@ -21,6 +21,7 @@ describe('buildChatExport', () => {
   it('returns plain conversations.json when there are no binary attachments', async () => {
     const chats = [
       chat({
+        updatedAt: '2023-11-15T22:13:20.000Z',
         messages: [
           {
             role: 'user',
@@ -37,6 +38,7 @@ describe('buildChatExport', () => {
     expect(result.filename).toBe('conversations.json')
     const parsed = JSON.parse(result.data as string)
     expect(parsed[0].uuid).toBe('chat-1')
+    expect(parsed[0].updated_at).toBe('2023-11-15T22:13:20.000Z')
     expect(parsed[0].chat_messages[0].sender).toBe('human')
   })
 

--- a/tests/services/chat-export/export-archive.test.ts
+++ b/tests/services/chat-export/export-archive.test.ts
@@ -147,6 +147,42 @@ describe('buildChatExport', () => {
     const att = conversations[0].chat_messages[0].attachments[0]
     expect(att.exportPath).toBeUndefined()
   })
+
+  it('sanitizes attachment IDs before using them in zip paths', async () => {
+    const imageBytes = new Uint8Array([1, 2, 3])
+    const chats = [
+      chat({
+        messages: [
+          {
+            role: 'user',
+            content: 'see pic',
+            timestamp: new Date('2023-11-14T22:13:21.000Z'),
+            attachments: [
+              {
+                id: '../evil/id',
+                type: 'image',
+                fileName: '',
+              },
+            ],
+          },
+        ],
+      }),
+    ]
+
+    const result = await buildChatExport(chats, async () => imageBytes)
+    const entries = unzipSync(result.data as Uint8Array)
+
+    expect(Object.keys(entries)).toContain('attachments/id/id.bin')
+    expect(Object.keys(entries)).not.toContain('attachments/../evil/id/id.bin')
+
+    const conversations = JSON.parse(strFromU8(entries['conversations.json']))
+    const att = conversations[0].chat_messages[0].attachments[0]
+    expect(att.id).toBe('../evil/id')
+    expect(att.exportPath).toBe('attachments/id/id.bin')
+
+    const manifest = JSON.parse(strFromU8(entries['manifest.json']))
+    expect(manifest.attachments[0].exportPath).toBe('attachments/id/id.bin')
+  })
 })
 
 describe('sanitizeFilename', () => {
@@ -154,5 +190,6 @@ describe('sanitizeFilename', () => {
     expect(sanitizeFilename('../../etc/passwd', 'fallback')).toBe('passwd')
     expect(sanitizeFilename('a/b/c.png', 'fallback')).toBe('c.png')
     expect(sanitizeFilename('', 'fallback.bin')).toBe('fallback.bin')
+    expect(sanitizeFilename('', '../fallback.bin')).toBe('fallback.bin')
   })
 })

--- a/tests/services/chat-export/export-archive.test.ts
+++ b/tests/services/chat-export/export-archive.test.ts
@@ -1,0 +1,156 @@
+import { strFromU8, unzipSync } from 'fflate'
+import { describe, expect, it } from 'vitest'
+
+import type { Chat } from '@/components/chat/types'
+import {
+  buildChatExport,
+  sanitizeFilename,
+} from '@/services/chat-export/export-archive'
+
+function chat(overrides: Partial<Chat>): Chat {
+  return {
+    id: 'chat-1',
+    title: 'Test',
+    messages: [],
+    createdAt: new Date('2023-11-14T22:13:20.000Z'),
+    ...overrides,
+  }
+}
+
+describe('buildChatExport', () => {
+  it('returns plain conversations.json when there are no binary attachments', async () => {
+    const chats = [
+      chat({
+        messages: [
+          {
+            role: 'user',
+            content: 'hello',
+            timestamp: new Date('2023-11-14T22:13:21.000Z'),
+          },
+        ],
+      }),
+    ]
+
+    const result = await buildChatExport(chats, async () => null)
+
+    expect(result.isZip).toBe(false)
+    expect(result.filename).toBe('conversations.json')
+    const parsed = JSON.parse(result.data as string)
+    expect(parsed[0].uuid).toBe('chat-1')
+    expect(parsed[0].chat_messages[0].sender).toBe('human')
+  })
+
+  it('keeps document text inline without forcing a zip', async () => {
+    const chats = [
+      chat({
+        messages: [
+          {
+            role: 'user',
+            content: 'read this',
+            timestamp: new Date('2023-11-14T22:13:21.000Z'),
+            attachments: [
+              {
+                id: 'doc-1',
+                type: 'document',
+                fileName: 'spec.txt',
+                textContent: 'the contents',
+              },
+            ],
+          },
+        ],
+      }),
+    ]
+
+    const result = await buildChatExport(chats, async () => null)
+
+    expect(result.isZip).toBe(false)
+    const parsed = JSON.parse(result.data as string)
+    const att = parsed[0].chat_messages[0].attachments[0]
+    expect(att.type).toBe('document')
+    expect(att.textContent).toBe('the contents')
+  })
+
+  it('produces a zip with attachments, manifest, and no key leakage', async () => {
+    const imageBytes = new Uint8Array([1, 2, 3, 4, 5])
+    const chats = [
+      chat({
+        messages: [
+          {
+            role: 'user',
+            content: 'see pic',
+            timestamp: new Date('2023-11-14T22:13:21.000Z'),
+            attachments: [
+              {
+                id: 'img-1',
+                type: 'image',
+                fileName: 'pic.png',
+                mimeType: 'image/png',
+                encryptionKey: 'SECRET_KEY_MATERIAL',
+                base64: 'AAAA',
+              },
+            ],
+          },
+        ],
+      }),
+    ]
+
+    const result = await buildChatExport(chats, async () => imageBytes)
+
+    expect(result.isZip).toBe(true)
+    expect(result.filename).toBe('tinfoil-chats.zip')
+
+    const entries = unzipSync(result.data as Uint8Array)
+    expect(Object.keys(entries)).toContain('conversations.json')
+    expect(Object.keys(entries)).toContain('manifest.json')
+    expect(Object.keys(entries)).toContain('attachments/img-1/pic.png')
+    expect(entries['attachments/img-1/pic.png']).toEqual(imageBytes)
+
+    const conversationsText = strFromU8(entries['conversations.json'])
+    expect(conversationsText).not.toContain('SECRET_KEY_MATERIAL')
+    expect(conversationsText).not.toContain('encryptionKey')
+    expect(conversationsText).not.toContain('"base64"')
+
+    const conversations = JSON.parse(conversationsText)
+    const att = conversations[0].chat_messages[0].attachments[0]
+    expect(att.exportPath).toBe('attachments/img-1/pic.png')
+    expect(att.type).toBe('image')
+
+    const manifest = JSON.parse(strFromU8(entries['manifest.json']))
+    expect(manifest.attachment_count).toBe(1)
+    expect(manifest.attachments[0].exportPath).toBe('attachments/img-1/pic.png')
+    expect(manifest.attachments[0].fileSize).toBe(5)
+  })
+
+  it('records a warning and continues when an attachment cannot be fetched', async () => {
+    const chats = [
+      chat({
+        messages: [
+          {
+            role: 'user',
+            content: 'see pic',
+            timestamp: new Date('2023-11-14T22:13:21.000Z'),
+            attachments: [{ id: 'img-1', type: 'image', fileName: 'pic.png' }],
+          },
+        ],
+      }),
+    ]
+
+    const result = await buildChatExport(chats, async () => null)
+
+    expect(result.isZip).toBe(true)
+    expect(result.warnings.length).toBe(1)
+    const entries = unzipSync(result.data as Uint8Array)
+    expect(Object.keys(entries)).not.toContain('attachments/img-1/pic.png')
+    const conversations = JSON.parse(strFromU8(entries['conversations.json']))
+    const att = conversations[0].chat_messages[0].attachments[0]
+    expect(att.exportPath).toBeUndefined()
+  })
+})
+
+describe('sanitizeFilename', () => {
+  it('strips path separators and control characters', () => {
+    expect(sanitizeFilename('../../etc/passwd', 'fallback')).toBe('passwd')
+    expect(sanitizeFilename('a/b/c.png', 'fallback')).toBe('c.png')
+    expect(sanitizeFilename('', 'fallback.bin')).toBe('fallback.bin')
+  })
+})

--- a/tests/services/chat-import/off-device-import.test.ts
+++ b/tests/services/chat-import/off-device-import.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const importCreate = vi.fn()
+const importUploadChunk = vi.fn()
+const importStart = vi.fn()
+
+vi.mock('@/services/sync-enclave/sync-api', () => ({
+  importCreate: (...args: unknown[]) => importCreate(...args),
+  importUploadChunk: (...args: unknown[]) => importUploadChunk(...args),
+  importStart: (...args: unknown[]) => importStart(...args),
+}))
+
+vi.mock('@/services/cloud/cek-encoding', () => ({
+  requirePrimaryKeyB64: () => 'cek-base64',
+}))
+
+import {
+  IMPORT_CHUNK_BYTES,
+  runOffDeviceImport,
+} from '@/services/chat-import/off-device-import'
+
+function fileOf(bytes: Uint8Array): File {
+  return new File([bytes], 'export.zip', { type: 'application/zip' })
+}
+
+describe('runOffDeviceImport', () => {
+  beforeEach(() => {
+    importCreate.mockReset()
+    importUploadChunk.mockReset()
+    importStart.mockReset()
+    importCreate.mockResolvedValue({ job_id: 'job-1', upload_id: 'up-1' })
+    importUploadChunk.mockResolvedValue({ ok: true })
+    importStart.mockResolvedValue({
+      status: 'running',
+      imported: 0,
+      failed: 0,
+      total: 0,
+      errors: [],
+    })
+  })
+
+  it('rejects an empty file before any upload', async () => {
+    await expect(
+      runOffDeviceImport('chatgpt', fileOf(new Uint8Array())),
+    ).rejects.toThrow()
+    expect(importCreate).not.toHaveBeenCalled()
+  })
+
+  it('splits a large archive into fixed-size chunks and hands the CEK to start', async () => {
+    const size = IMPORT_CHUNK_BYTES + 1234
+    const archive = new Uint8Array(size)
+    for (let i = 0; i < size; i++) archive[i] = i % 251
+
+    const result = await runOffDeviceImport('claude', fileOf(archive))
+
+    expect(importCreate).toHaveBeenCalledTimes(1)
+    const createArg = importCreate.mock.calls[0][0]
+    expect(createArg.source).toBe('claude')
+    expect(createArg.totalBytes).toBe(size)
+    expect(createArg.totalChunks).toBe(2)
+    expect(createArg.archiveSha256).toMatch(/^[0-9a-f]{64}$/)
+
+    expect(importUploadChunk).toHaveBeenCalledTimes(2)
+    const first = importUploadChunk.mock.calls[0][0]
+    const second = importUploadChunk.mock.calls[1][0]
+    expect(first.uploadId).toBe('up-1')
+    expect(first.chunkIndex).toBe(0)
+    expect(first.data.byteLength).toBe(IMPORT_CHUNK_BYTES)
+    expect(second.chunkIndex).toBe(1)
+    expect(second.data.byteLength).toBe(1234)
+
+    expect(importStart).toHaveBeenCalledWith({
+      jobId: 'job-1',
+      keyB64: 'cek-base64',
+    })
+    expect(result.jobId).toBe('job-1')
+  })
+})


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds chat export with attachments and secure off-device import via the sync enclave. Exports become a ZIP when attachments are present; imports support ChatGPT, Claude, and Tinfoil with chunked upload and background processing.

- **New Features**
  - Export chats with attachments: builds Claude-compatible `conversations.json`; when images exist, creates `tinfoil-chats.zip` with `attachments/` and a `manifest.json` (per-file SHA-256 and exact sizes). No encryption keys or inline base64; downloads one attachment at a time.
  - Off-device import (cloud sync users): upload `.json` or `.zip` exports for ChatGPT, Claude, or Tinfoil; files are chunked (8MB) and verified, then the enclave parses and seals data. UI adds a Tinfoil import option, accepts `.zip` where relevant, shows in-progress state, and emails on completion.

- **Bug Fixes**
  - Accurate export metadata: correct `updated_at`, manifest counts only written attachments, and exact file sizes and SHA-256 hashes.
  - Safer paths and imports: sanitize attachment IDs/filenames with fallbacks (e.g., `id.bin`) and ensure unique ZIP paths; record warnings when attachments can’t be fetched; require a primary key for off-device import and cap archives at 512MB.

<sup>Written for commit 01214ff0c1129590e2431181806bf92e34e4f6bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/410?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

