### PR TITLE
A11y screen reader fixes

### DIFF
--- a/src/components/chat/chat-messages.tsx
+++ b/src/components/chat/chat-messages.tsx
@@ -372,6 +372,7 @@ export function ChatMessages({
         role="log"
         aria-label="Conversation"
         aria-live="polite"
+        aria-busy={isStreamingResponse}
         className={`mx-auto w-full min-w-0 px-0 pb-6 pt-24 md:px-4 ${CHAT_FONT_CLASSES[chatFont]}`}
       >
         {/* Archived Messages - only shown if there are more than the max prompt messages */}

--- a/src/components/chat/chat-sidebar.tsx
+++ b/src/components/chat/chat-sidebar.tsx
@@ -747,18 +747,13 @@ export function ChatSidebar({
             <div className="flex flex-col items-center gap-1 px-2">
               {/* New chat button */}
               <div className="group relative">
-                <Link
-                  href="/newchat"
+                <button
+                  type="button"
                   onClick={(e) => {
-                    if (
-                      e.metaKey ||
-                      e.ctrlKey ||
-                      e.shiftKey ||
-                      e.altKey ||
-                      e.button !== 0
-                    )
+                    if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) {
+                      window.open('/newchat', '_blank', 'noopener,noreferrer')
                       return
-                    e.preventDefault()
+                    }
                     createNewChat(activeTab === 'local', true)
                   }}
                   onAuxClick={(e) => {
@@ -773,7 +768,7 @@ export function ChatSidebar({
                   aria-label="New chat"
                 >
                   <PiNotePencilLight className="h-5 w-5" />
-                </Link>
+                </button>
                 <span className="pointer-events-none absolute left-full top-1/2 z-50 ml-2 -translate-y-1/2 whitespace-nowrap rounded border border-border-subtle bg-surface-chat-background px-2 py-1 text-xs text-content-primary opacity-0 shadow-sm transition-opacity group-hover:opacity-100">
                   New chat{' '}
                   <span className="text-content-muted">
@@ -1088,19 +1083,14 @@ export function ChatSidebar({
 
           {/* New Chat button */}
           <div className="relative z-10 flex-none px-2 py-2">
-            <Link
-              href="/newchat"
+            <button
+              type="button"
               aria-disabled={currentChat?.isBlankChat}
               onClick={(e) => {
-                if (
-                  e.metaKey ||
-                  e.ctrlKey ||
-                  e.shiftKey ||
-                  e.altKey ||
-                  e.button !== 0
-                )
+                if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) {
+                  window.open('/newchat', '_blank', 'noopener,noreferrer')
                   return
-                e.preventDefault()
+                }
                 if (currentChat?.isBlankChat) return
                 createNewChat(activeTab === 'local', true)
               }}
@@ -1126,7 +1116,7 @@ export function ChatSidebar({
                 {modKey}
                 {isMac ? '⇧' : 'Shift+'}O
               </span>
-            </Link>
+            </button>
           </div>
 
           {/* Projects dropdown - show for premium users */}

--- a/src/components/chat/components/context-usage-indicator.tsx
+++ b/src/components/chat/components/context-usage-indicator.tsx
@@ -46,7 +46,7 @@ export function ContextUsageIndicator({
   return (
     <div className={cn('group relative flex items-center', className)}>
       <span
-        role="status"
+        role="img"
         aria-label={tooltip}
         className={cn(
           'flex h-7 items-center gap-1 rounded-lg px-1.5',

--- a/src/components/project/project-sidebar.tsx
+++ b/src/components/project/project-sidebar.tsx
@@ -609,32 +609,35 @@ export function ProjectSidebar({
     }
   }, [onNewChat, windowWidth, setIsOpen])
 
-  // Let modifier/middle clicks fall through so the New chat links open in a
-  // new tab; otherwise intercept the plain click for the in-app handler.
-  const handleNewChatLinkClick = useCallback(
-    (e: ReactMouseEvent<HTMLAnchorElement>, action: () => void) => {
-      if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) {
+  const newChatHref = projectId ? `/project/${projectId}` : '/newchat'
+
+  const openNewChatInNewTab = useCallback(() => {
+    window.open(newChatHref, '_blank', 'noopener,noreferrer')
+  }, [newChatHref])
+
+  // The New chat control is a button for parity with the other sidebar
+  // actions; modifier clicks still open a new tab so the link affordance is
+  // preserved, otherwise the plain click runs the in-app handler.
+  const handleNewChatButtonClick = useCallback(
+    (e: ReactMouseEvent<HTMLButtonElement>, action: () => void) => {
+      if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) {
+        openNewChatInNewTab()
         return
       }
-      e.preventDefault()
       action()
     },
-    [],
+    [openNewChatInNewTab],
   )
 
   // onClick never fires for the middle button, so open the new tab
   // explicitly to guarantee middle-click "open in new tab" works.
   const handleNewChatAuxClick = useCallback(
-    (e: ReactMouseEvent<HTMLAnchorElement>) => {
+    (e: ReactMouseEvent<HTMLButtonElement>) => {
       if (e.button !== 1) return
       e.preventDefault()
-      window.open(
-        projectId ? `/project/${projectId}` : '/newchat',
-        '_blank',
-        'noopener,noreferrer',
-      )
+      openNewChatInNewTab()
     },
-    [projectId],
+    [openNewChatInNewTab],
   )
 
   const handleRemoveDocument = useCallback(
@@ -741,9 +744,9 @@ export function ProjectSidebar({
           <div className="flex flex-col items-center gap-1 px-2">
             {/* New chat button */}
             <div className="group relative">
-              <Link
-                href={projectId ? `/project/${projectId}` : '/newchat'}
-                onClick={(e) => handleNewChatLinkClick(e, onNewChat)}
+              <button
+                type="button"
+                onClick={(e) => handleNewChatButtonClick(e, onNewChat)}
                 onAuxClick={handleNewChatAuxClick}
                 className={cn(
                   'flex h-10 w-10 items-center justify-center rounded-lg transition-colors',
@@ -752,7 +755,7 @@ export function ProjectSidebar({
                 aria-label="New chat"
               >
                 <PiNotePencilLight className="h-5 w-5" />
-              </Link>
+              </button>
               <span className="pointer-events-none absolute left-full top-1/2 z-50 ml-2 -translate-y-1/2 whitespace-nowrap rounded border border-border-subtle bg-surface-chat-background px-2 py-1 text-xs text-content-primary opacity-0 shadow-sm transition-opacity group-hover:opacity-100">
                 New chat{' '}
                 <span className="text-content-muted">
@@ -943,11 +946,11 @@ export function ProjectSidebar({
 
           {/* New Chat button */}
           <div className="relative z-10 mt-3 flex-none px-2 py-2">
-            <Link
-              href={projectId ? `/project/${projectId}` : '/newchat'}
+            <button
+              type="button"
               aria-disabled={!currentChatId}
               onClick={(e) =>
-                handleNewChatLinkClick(e, () => {
+                handleNewChatButtonClick(e, () => {
                   if (!currentChatId) return
                   handleNewChat()
                 })
@@ -970,7 +973,7 @@ export function ProjectSidebar({
                 {modKey}
                 {isMac ? '⇧' : 'Shift+'}O
               </span>
-            </Link>
+            </button>
           </div>
 
           {/* Project Settings Dropdown */}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Improve screen reader behavior by reducing chat update chatter and making the “New chat” control correctly announced and consistent across sidebars. The context usage indicator no longer speaks as a live status.

- **Bug Fixes**
  - Chat: set aria-busy on the conversation log while streaming; change the context usage indicator to role="img" to avoid status announcements.
  - Sidebars: convert “New chat” from Link to button in chat and project sidebars for proper control semantics; preserve Cmd/Ctrl/Shift-click and middle-click to open a new tab.

<sup>Written for commit 487b46c20916486ed5dc7cda01719f039bfdd466. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/411?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

