### PR TITLE
Personalization and genui toggles

### DIFF
--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -5,6 +5,7 @@ import {
 } from '@/config/models'
 import {
   SETTINGS_CODE_EXECUTION_ENABLED,
+  SETTINGS_GENUI_ENABLED,
   SETTINGS_HAS_SEEN_WEB_SEARCH_INTRO,
   SETTINGS_PII_CHECK_ENABLED,
   SETTINGS_WEB_SEARCH_ENABLED,
@@ -494,6 +495,13 @@ export function ChatInterface({
     return saved === null ? true : saved === 'true'
   })
 
+  // Generative UI setting (controlled from settings modal, defaults to on)
+  const [genUIEnabled, setGenUIEnabled] = useState(() => {
+    if (typeof window === 'undefined') return true
+    const saved = localStorage.getItem(SETTINGS_GENUI_ENABLED)
+    return saved === null ? true : saved === 'true'
+  })
+
   // State for tracking processed documents
   const [processedDocuments, setProcessedDocuments] = useState<
     ProcessedDocument[]
@@ -764,6 +772,7 @@ export function ChatInterface({
     canUseCodeExecution,
     codeExecutionEnabled: canUseCodeExecution ? codeExecutionEnabled : false,
     piiCheckEnabled,
+    genUIEnabled,
   })
 
   const isTemporaryMode = currentChat?.isTemporary === true
@@ -1121,6 +1130,25 @@ export function ChatInterface({
       window.removeEventListener(
         'piiCheckEnabledChanged',
         handlePiiCheckChange as EventListener,
+      )
+    }
+  }, [])
+
+  // Listen for Generative UI setting changes from settings modal
+  useEffect(() => {
+    const handleGenUIChange = (event: CustomEvent<{ enabled: boolean }>) => {
+      setGenUIEnabled(event.detail.enabled)
+    }
+
+    window.addEventListener(
+      'genUIEnabledChanged',
+      handleGenUIChange as EventListener,
+    )
+
+    return () => {
+      window.removeEventListener(
+        'genUIEnabledChanged',
+        handleGenUIChange as EventListener,
       )
     }
   }, [])

--- a/src/components/chat/hooks/use-chat-messaging.ts
+++ b/src/components/chat/hooks/use-chat-messaging.ts
@@ -66,6 +66,7 @@ interface UseChatMessagingProps {
   webSearchEnabled?: boolean
   codeExecutionEnabled?: boolean
   piiCheckEnabled?: boolean
+  genUIEnabled?: boolean
   codeExecutionEncryptionKey?: string | null
 }
 
@@ -116,6 +117,7 @@ export function useChatMessaging({
   webSearchEnabled,
   codeExecutionEnabled,
   piiCheckEnabled,
+  genUIEnabled,
   codeExecutionEncryptionKey,
 }: UseChatMessagingProps): UseChatMessagingReturn {
   const { isSignedIn } = useAuth()
@@ -649,7 +651,7 @@ export function useChatMessaging({
           webSearchEnabled,
           codeExecutionEnabled,
           piiCheckEnabled,
-          genUIEnabled: true,
+          genUIEnabled: genUIEnabled ?? true,
           codeExecutionAccessToken: updatedChat.codeExecutionAccessToken,
           codeExecutionEncryptionKey: codeExecutionEncryptionKey ?? undefined,
           codeExecutionContainerAuthToken,
@@ -890,6 +892,7 @@ export function useChatMessaging({
       webSearchEnabled,
       codeExecutionEnabled,
       piiCheckEnabled,
+      genUIEnabled,
       codeExecutionEncryptionKey,
       patchStatus,
       resetStatus,

--- a/src/components/chat/hooks/use-chat-state.ts
+++ b/src/components/chat/hooks/use-chat-state.ts
@@ -96,6 +96,7 @@ export function useChatState({
   canUseCodeExecution = false,
   codeExecutionEnabled,
   piiCheckEnabled,
+  genUIEnabled,
 }: {
   systemPrompt: string
   rules?: string
@@ -113,6 +114,7 @@ export function useChatState({
   canUseCodeExecution?: boolean
   codeExecutionEnabled?: boolean
   piiCheckEnabled?: boolean
+  genUIEnabled?: boolean
 }): UseChatStateReturn {
   const hasCreatedInitialChatRef = useRef(false)
 
@@ -213,6 +215,7 @@ export function useChatState({
     codeExecutionEnabled:
       codeExecutionEnabled && codeExecutionEncryptionKey != null,
     piiCheckEnabled,
+    genUIEnabled,
     codeExecutionEncryptionKey,
   })
 

--- a/src/components/chat/hooks/use-custom-system-prompt.ts
+++ b/src/components/chat/hooks/use-custom-system-prompt.ts
@@ -25,6 +25,18 @@ type UseCustomSystemPromptReturn = {
   isUsingPersonalization: boolean
 }
 
+const stripSystemTags = (prompt: string): string =>
+  prompt
+    .replace(/^<system>\s*\n?/, '')
+    .replace(/\n?<\/system>\s*$/, '')
+    .trim()
+
+const hasSystemPromptContent = (prompt: string): boolean =>
+  stripSystemTags(prompt).length > 0
+
+const normalizeSystemPrompt = (prompt: string): string =>
+  hasSystemPromptContent(prompt) ? prompt : ''
+
 export const useCustomSystemPrompt = (
   defaultSystemPrompt: string,
   rules: string = '',
@@ -84,7 +96,11 @@ export const useCustomSystemPrompt = (
       )
 
       setIsUsingCustomPrompt(savedUsingCustomPrompt === 'true')
-      setCustomPrompt(savedCustomPrompt || defaultSystemPrompt || '')
+      if (savedCustomPrompt !== null) {
+        setCustomPrompt(normalizeSystemPrompt(savedCustomPrompt))
+      } else {
+        setCustomPrompt(defaultSystemPrompt || '')
+      }
     }
   }, [defaultSystemPrompt])
 
@@ -120,7 +136,7 @@ export const useCustomSystemPrompt = (
     const handleCustomPromptChange = (event: CustomEvent) => {
       const { isEnabled, customPrompt } = event.detail
       setIsUsingCustomPrompt(isEnabled || false)
-      setCustomPrompt(customPrompt || defaultSystemPrompt || '')
+      setCustomPrompt(normalizeSystemPrompt(customPrompt ?? ''))
     }
 
     window.addEventListener(
@@ -234,7 +250,7 @@ export const useCustomSystemPrompt = (
     let basePrompt: string
     if (activePresetPrompt && activePresetPrompt.trim()) {
       basePrompt = activePresetPrompt
-    } else if (isUsingCustomPrompt && customPrompt) {
+    } else if (isUsingCustomPrompt) {
       basePrompt = customPrompt
     } else {
       basePrompt = defaultSystemPrompt
@@ -247,6 +263,13 @@ export const useCustomSystemPrompt = (
   // Apply the same replacements to rules
   const processRules = (): string => {
     if (!rules) return ''
+    if (
+      isUsingCustomPrompt &&
+      !hasSystemPromptContent(customPrompt) &&
+      !(activePresetPrompt && activePresetPrompt.trim())
+    ) {
+      return ''
+    }
     return replacePlaceholders(rules)
   }
 

--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -5,6 +5,7 @@ import { API_BASE_URL } from '@/config'
 import {
   SETTINGS_CHAT_FONT,
   SETTINGS_CLOUD_SYNC_EXPLICITLY_DISABLED,
+  SETTINGS_GENUI_ENABLED,
   SETTINGS_PII_CHECK_ENABLED,
   USER_PREFS_ADDITIONAL_CONTEXT,
   USER_PREFS_CUSTOM_PROMPT_ENABLED,
@@ -423,6 +424,9 @@ export function SettingsModal({
   // Web Search PII check setting (defaults to on)
   const [piiCheckEnabled, setPiiCheckEnabled] = useState<boolean>(true)
 
+  // Generative UI setting (defaults to on)
+  const [genUIEnabled, setGenUIEnabled] = useState<boolean>(true)
+
   // Chat font setting
   const [chatFont, setChatFont] = useState<ChatFont>('system')
 
@@ -654,6 +658,10 @@ export function SettingsModal({
     // Load PII check setting (defaults to true if not set)
     const savedPiiCheck = localStorage.getItem(SETTINGS_PII_CHECK_ENABLED)
     setPiiCheckEnabled(savedPiiCheck === null ? true : savedPiiCheck === 'true')
+
+    // Load Generative UI setting (defaults to true if not set)
+    const savedGenUI = localStorage.getItem(SETTINGS_GENUI_ENABLED)
+    setGenUIEnabled(savedGenUI === null ? true : savedGenUI === 'true')
 
     // Load chat font setting
     const savedChatFont = localStorage.getItem(SETTINGS_CHAT_FONT)
@@ -2043,14 +2051,16 @@ ${encryptionKey.replace('key_', '')}
               {navItems.find((item) => item.id === activeTab)?.label}
             </h2>
             <div className="flex items-center gap-2">
-              {activeTab === 'personalization' && hasUnsavedPersonalization && (
-                <button
-                  onClick={handleSavePersonalization}
-                  className="rounded-lg bg-brand-accent-dark px-3 py-1 text-sm font-medium text-white transition-colors hover:bg-brand-accent-dark/90"
-                >
-                  Save
-                </button>
-              )}
+              {activeTab === 'personalization' &&
+                isUsingPersonalization &&
+                hasUnsavedPersonalization && (
+                  <button
+                    onClick={handleSavePersonalization}
+                    className="rounded-lg bg-brand-accent-dark px-3 py-1 text-sm font-medium text-white transition-colors hover:bg-brand-accent-dark/90"
+                  >
+                    Save
+                  </button>
+                )}
               <button
                 onClick={() => setIsOpen(false)}
                 className="rounded-lg p-1.5 text-content-secondary transition-colors hover:bg-surface-chat"
@@ -2127,14 +2137,16 @@ ${encryptionKey.replace('key_', '')}
             <h2 className="font-aeonik text-lg font-semibold text-content-primary">
               {navItems.find((item) => item.id === activeTab)?.label}
             </h2>
-            {activeTab === 'personalization' && hasUnsavedPersonalization && (
-              <button
-                onClick={handleSavePersonalization}
-                className="rounded-lg bg-brand-accent-dark px-4 py-1.5 text-sm font-medium text-white transition-colors hover:bg-brand-accent-dark/90"
-              >
-                Save
-              </button>
-            )}
+            {activeTab === 'personalization' &&
+              isUsingPersonalization &&
+              hasUnsavedPersonalization && (
+                <button
+                  onClick={handleSavePersonalization}
+                  className="rounded-lg bg-brand-accent-dark px-4 py-1.5 text-sm font-medium text-white transition-colors hover:bg-brand-accent-dark/90"
+                >
+                  Save
+                </button>
+              )}
           </div>
 
           {/* Content */}
@@ -2349,6 +2361,50 @@ ${encryptionKey.replace('key_', '')}
                                   )
                                   window.dispatchEvent(
                                     new CustomEvent('piiCheckEnabledChanged', {
+                                      detail: { enabled: newValue },
+                                    }),
+                                  )
+                                }
+                              }}
+                              className="peer sr-only"
+                            />
+                            <div className="peer h-5 w-9 rounded-full border border-border-subtle bg-content-muted/40 after:absolute after:left-[2px] after:top-[2px] after:h-4 after:w-4 after:rounded-full after:bg-content-muted/70 after:shadow-sm after:transition-all after:content-[''] peer-checked:bg-brand-accent-light peer-checked:after:translate-x-full peer-checked:after:bg-white peer-focus:outline-none" />
+                          </label>
+                        </div>
+                      </div>
+
+                      {/* Generative UI */}
+                      <div
+                        className={cn(
+                          'rounded-lg border border-border-subtle p-4',
+                          isDarkMode ? 'bg-surface-sidebar' : 'bg-white',
+                        )}
+                      >
+                        <div className="flex items-start justify-between">
+                          <div className="mr-3 flex-1">
+                            <div className="font-aeonik text-sm font-medium text-content-primary">
+                              Generative UI
+                            </div>
+                            <div className="font-aeonik-fono text-xs text-content-muted">
+                              Let Tin render interactive widgets like charts and
+                              timelines. When off, no tool capabilities are sent
+                              to the model.
+                            </div>
+                          </div>
+                          <label className="relative inline-flex cursor-pointer items-center">
+                            <input
+                              type="checkbox"
+                              checked={genUIEnabled}
+                              onChange={(e) => {
+                                const newValue = e.target.checked
+                                setGenUIEnabled(newValue)
+                                if (isClient) {
+                                  localStorage.setItem(
+                                    SETTINGS_GENUI_ENABLED,
+                                    newValue.toString(),
+                                  )
+                                  window.dispatchEvent(
+                                    new CustomEvent('genUIEnabledChanged', {
                                       detail: { enabled: newValue },
                                     }),
                                   )
@@ -2616,162 +2672,203 @@ ${encryptionKey.replace('key_', '')}
               {/* Personalization Tab */}
               {activeTab === 'personalization' && (
                 <>
-                  {/* Nickname */}
+                  {/* Enable Personalization */}
                   <div
                     className={cn(
                       'rounded-lg border border-border-subtle p-4',
                       isDarkMode ? 'bg-surface-sidebar' : 'bg-white',
                     )}
                   >
-                    <div className="space-y-3">
-                      <div>
+                    <div className="flex items-start justify-between">
+                      <div className="mr-3 flex-1">
                         <div className="font-aeonik text-sm font-medium text-content-primary">
-                          Name
+                          Personalize responses
                         </div>
                         <div className="font-aeonik-fono text-xs text-content-muted">
-                          How should Tin call you?
+                          Tailor Tin&apos;s replies using the details below.
+                          When off, none of these are sent to the model.
                         </div>
                       </div>
-                      <input
-                        type="text"
-                        value={nickname}
-                        onChange={(e) => handleNicknameChange(e.target.value)}
-                        placeholder="Nickname"
-                        className={cn(
-                          'w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500',
-                          isDarkMode
-                            ? 'border-border-strong bg-surface-chat text-content-secondary placeholder:text-content-muted'
-                            : 'border-border-subtle bg-surface-sidebar text-content-primary placeholder:text-content-muted',
-                        )}
-                      />
-                    </div>
-                  </div>
-
-                  {/* Profession */}
-                  <div
-                    className={cn(
-                      'rounded-lg border border-border-subtle p-4',
-                      isDarkMode ? 'bg-surface-sidebar' : 'bg-white',
-                    )}
-                  >
-                    <div className="space-y-3">
-                      <div>
-                        <div className="font-aeonik text-sm font-medium text-content-primary">
-                          Occupation
-                        </div>
-                        <div className="font-aeonik-fono text-xs text-content-muted">
-                          What do you do?
-                        </div>
-                      </div>
-                      <div className="relative">
+                      <label className="relative inline-flex cursor-pointer items-center">
                         <input
-                          type="text"
-                          value={profession}
+                          type="checkbox"
+                          checked={isUsingPersonalization}
                           onChange={(e) =>
-                            handleProfessionChange(e.target.value)
+                            handleTogglePersonalization(e.target.checked)
                           }
-                          className={cn(
-                            'w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500',
-                            isDarkMode
-                              ? 'border-border-strong bg-surface-chat text-content-secondary'
-                              : 'border-border-subtle bg-surface-sidebar text-content-primary',
-                          )}
+                          className="peer sr-only"
                         />
-                        {!profession && (
-                          <span
-                            className={cn(
-                              'pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-sm text-content-muted transition-opacity duration-150',
-                              placeholderVisible ? 'opacity-100' : 'opacity-0',
-                            )}
-                          >
-                            {getCurrentPlaceholder()}
-                          </span>
-                        )}
-                      </div>
+                        <div className="peer h-5 w-9 rounded-full border border-border-subtle bg-content-muted/40 after:absolute after:left-[2px] after:top-[2px] after:h-4 after:w-4 after:rounded-full after:bg-content-muted/70 after:shadow-sm after:transition-all after:content-[''] peer-checked:bg-brand-accent-light peer-checked:after:translate-x-full peer-checked:after:bg-white peer-focus:outline-none" />
+                      </label>
                     </div>
                   </div>
 
-                  {/* Traits */}
-                  <div
-                    className={cn(
-                      'rounded-lg border border-border-subtle p-4',
-                      isDarkMode ? 'bg-surface-sidebar' : 'bg-white',
-                    )}
-                  >
-                    <div className="space-y-3">
-                      <div>
-                        <div className="font-aeonik text-sm font-medium text-content-primary">
-                          Conversational Traits
-                        </div>
-                        <div className="font-aeonik-fono text-xs text-content-muted">
-                          What traits should Tin have?
-                        </div>
-                      </div>
-                      <div className="flex flex-wrap gap-1.5">
-                        {availableTraits.map((trait) => (
-                          <button
-                            key={trait}
-                            onClick={() => handleTraitToggle(trait)}
-                            className={cn(
-                              'rounded-full px-3 py-1.5 text-sm transition-colors',
-                              selectedTraits.includes(trait)
-                                ? 'bg-brand-accent-light text-brand-accent-dark'
-                                : isDarkMode
-                                  ? 'bg-surface-chat text-content-secondary hover:bg-surface-chat'
-                                  : 'border border-border-subtle bg-surface-sidebar text-content-secondary hover:bg-surface-chat',
-                            )}
-                          >
-                            {selectedTraits.includes(trait) ? '✓ ' : '+ '}
-                            {trait}
-                          </button>
-                        ))}
-                      </div>
-                    </div>
-                  </div>
-
-                  {/* Additional Context */}
-                  <div
-                    className={cn(
-                      'rounded-lg border border-border-subtle p-4',
-                      isDarkMode ? 'bg-surface-sidebar' : 'bg-white',
-                    )}
-                  >
-                    <div className="space-y-3">
-                      <div>
-                        <div className="font-aeonik text-sm font-medium text-content-primary">
-                          Additional Context
-                        </div>
-                        <div className="font-aeonik-fono text-xs text-content-muted">
-                          Anything else Tin should know about you?
-                        </div>
-                      </div>
-                      <textarea
-                        value={additionalContext}
-                        onChange={(e) => handleContextChange(e.target.value)}
-                        placeholder="Interests and other preferences you'd like Tin to know about you."
-                        rows={3}
+                  {isUsingPersonalization && (
+                    <>
+                      {/* Nickname */}
+                      <div
                         className={cn(
-                          'w-full resize-none rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500',
-                          isDarkMode
-                            ? 'border-border-strong bg-surface-chat text-content-secondary placeholder:text-content-muted'
-                            : 'border-border-subtle bg-surface-sidebar text-content-primary placeholder:text-content-muted',
+                          'rounded-lg border border-border-subtle p-4',
+                          isDarkMode ? 'bg-surface-sidebar' : 'bg-white',
                         )}
-                      />
-                    </div>
-                  </div>
+                      >
+                        <div className="space-y-3">
+                          <div>
+                            <div className="font-aeonik text-sm font-medium text-content-primary">
+                              Name
+                            </div>
+                            <div className="font-aeonik-fono text-xs text-content-muted">
+                              How should Tin call you?
+                            </div>
+                          </div>
+                          <input
+                            type="text"
+                            value={nickname}
+                            onChange={(e) =>
+                              handleNicknameChange(e.target.value)
+                            }
+                            placeholder="Nickname"
+                            className={cn(
+                              'w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500',
+                              isDarkMode
+                                ? 'border-border-strong bg-surface-chat text-content-secondary placeholder:text-content-muted'
+                                : 'border-border-subtle bg-surface-sidebar text-content-primary placeholder:text-content-muted',
+                            )}
+                          />
+                        </div>
+                      </div>
 
-                  {/* Reset Button */}
-                  <button
-                    onClick={handleResetPersonalization}
-                    className={cn(
-                      'w-full rounded-lg border px-3 py-1.5 text-sm font-medium transition-colors',
-                      isDarkMode
-                        ? 'border-red-500/30 bg-red-950/20 text-red-400 hover:bg-red-950/40'
-                        : 'border-red-300 bg-red-50 text-red-600 hover:bg-red-100',
-                    )}
-                  >
-                    Reset all fields
-                  </button>
+                      {/* Profession */}
+                      <div
+                        className={cn(
+                          'rounded-lg border border-border-subtle p-4',
+                          isDarkMode ? 'bg-surface-sidebar' : 'bg-white',
+                        )}
+                      >
+                        <div className="space-y-3">
+                          <div>
+                            <div className="font-aeonik text-sm font-medium text-content-primary">
+                              Occupation
+                            </div>
+                            <div className="font-aeonik-fono text-xs text-content-muted">
+                              What do you do?
+                            </div>
+                          </div>
+                          <div className="relative">
+                            <input
+                              type="text"
+                              value={profession}
+                              onChange={(e) =>
+                                handleProfessionChange(e.target.value)
+                              }
+                              className={cn(
+                                'w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500',
+                                isDarkMode
+                                  ? 'border-border-strong bg-surface-chat text-content-secondary'
+                                  : 'border-border-subtle bg-surface-sidebar text-content-primary',
+                              )}
+                            />
+                            {!profession && (
+                              <span
+                                className={cn(
+                                  'pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-sm text-content-muted transition-opacity duration-150',
+                                  placeholderVisible
+                                    ? 'opacity-100'
+                                    : 'opacity-0',
+                                )}
+                              >
+                                {getCurrentPlaceholder()}
+                              </span>
+                            )}
+                          </div>
+                        </div>
+                      </div>
+
+                      {/* Traits */}
+                      <div
+                        className={cn(
+                          'rounded-lg border border-border-subtle p-4',
+                          isDarkMode ? 'bg-surface-sidebar' : 'bg-white',
+                        )}
+                      >
+                        <div className="space-y-3">
+                          <div>
+                            <div className="font-aeonik text-sm font-medium text-content-primary">
+                              Conversational Traits
+                            </div>
+                            <div className="font-aeonik-fono text-xs text-content-muted">
+                              What traits should Tin have?
+                            </div>
+                          </div>
+                          <div className="flex flex-wrap gap-1.5">
+                            {availableTraits.map((trait) => (
+                              <button
+                                key={trait}
+                                onClick={() => handleTraitToggle(trait)}
+                                className={cn(
+                                  'rounded-full px-3 py-1.5 text-sm transition-colors',
+                                  selectedTraits.includes(trait)
+                                    ? 'bg-brand-accent-light text-brand-accent-dark'
+                                    : isDarkMode
+                                      ? 'bg-surface-chat text-content-secondary hover:bg-surface-chat'
+                                      : 'border border-border-subtle bg-surface-sidebar text-content-secondary hover:bg-surface-chat',
+                                )}
+                              >
+                                {selectedTraits.includes(trait) ? '✓ ' : '+ '}
+                                {trait}
+                              </button>
+                            ))}
+                          </div>
+                        </div>
+                      </div>
+
+                      {/* Additional Context */}
+                      <div
+                        className={cn(
+                          'rounded-lg border border-border-subtle p-4',
+                          isDarkMode ? 'bg-surface-sidebar' : 'bg-white',
+                        )}
+                      >
+                        <div className="space-y-3">
+                          <div>
+                            <div className="font-aeonik text-sm font-medium text-content-primary">
+                              Additional Context
+                            </div>
+                            <div className="font-aeonik-fono text-xs text-content-muted">
+                              Anything else Tin should know about you?
+                            </div>
+                          </div>
+                          <textarea
+                            value={additionalContext}
+                            onChange={(e) =>
+                              handleContextChange(e.target.value)
+                            }
+                            placeholder="Interests and other preferences you'd like Tin to know about you."
+                            rows={3}
+                            className={cn(
+                              'w-full resize-none rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500',
+                              isDarkMode
+                                ? 'border-border-strong bg-surface-chat text-content-secondary placeholder:text-content-muted'
+                                : 'border-border-subtle bg-surface-sidebar text-content-primary placeholder:text-content-muted',
+                            )}
+                          />
+                        </div>
+                      </div>
+
+                      {/* Reset Button */}
+                      <button
+                        onClick={handleResetPersonalization}
+                        className={cn(
+                          'w-full rounded-lg border px-3 py-1.5 text-sm font-medium transition-colors',
+                          isDarkMode
+                            ? 'border-red-500/30 bg-red-950/20 text-red-400 hover:bg-red-950/40'
+                            : 'border-red-300 bg-red-50 text-red-600 hover:bg-red-100',
+                        )}
+                      >
+                        Reset all fields
+                      </button>
+                    </>
+                  )}
                 </>
               )}
 

--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -945,6 +945,7 @@ export function SettingsModal({
   // Helper to add <system> tags if not present
   const ensureSystemTags = (prompt: string): string => {
     const trimmed = prompt.trim()
+    if (!trimmed) return ''
     if (!trimmed.startsWith('<system>')) {
       return `<system>\n${trimmed}\n</system>`
     }

--- a/src/constants/storage-keys.ts
+++ b/src/constants/storage-keys.ts
@@ -38,6 +38,7 @@ export const SETTINGS_WEB_SEARCH_ENABLED = 'tinfoil-settings-web-search-enabled'
 export const SETTINGS_CODE_EXECUTION_ENABLED =
   'tinfoil-settings-code-execution-enabled'
 export const SETTINGS_PII_CHECK_ENABLED = 'tinfoil-settings-pii-check-enabled'
+export const SETTINGS_GENUI_ENABLED = 'tinfoil-settings-genui-enabled'
 export const SETTINGS_THEME_MODE = 'tinfoil-settings-theme-mode'
 export const SETTINGS_THEME = 'tinfoil-settings-theme'
 export const SETTINGS_CHAT_FONT = 'tinfoil-settings-chat-font'

--- a/src/services/cloud/profile-settings-serializer.ts
+++ b/src/services/cloud/profile-settings-serializer.ts
@@ -1,6 +1,7 @@
 import {
   SETTINGS_CHAT_FONT,
   SETTINGS_CODE_EXECUTION_ENABLED,
+  SETTINGS_GENUI_ENABLED,
   SETTINGS_PII_CHECK_ENABLED,
   SETTINGS_REASONING_EFFORT,
   SETTINGS_SELECTED_MODEL,
@@ -91,6 +92,7 @@ export function hasProfileChanged(
     profile1.webSearchEnabled !== profile2.webSearchEnabled ||
     profile1.codeExecutionEnabled !== profile2.codeExecutionEnabled ||
     profile1.piiCheckEnabled !== profile2.piiCheckEnabled ||
+    profile1.genUIEnabled !== profile2.genUIEnabled ||
     profile1.chatFont !== profile2.chatFont ||
     profile1.projectUploadPreference !== profile2.projectUploadPreference
   )
@@ -214,6 +216,11 @@ export function loadLocalSettings(): ProfileData {
     settings.piiCheckEnabled = piiCheckEnabled === 'true'
   }
 
+  const genUIEnabled = localStorage.getItem(SETTINGS_GENUI_ENABLED)
+  if (genUIEnabled !== null) {
+    settings.genUIEnabled = genUIEnabled === 'true'
+  }
+
   const chatFont = localStorage.getItem(SETTINGS_CHAT_FONT)
   if (
     chatFont === 'system' ||
@@ -255,6 +262,7 @@ export function resetSettingsToLocalDefaults(): ProfileData {
     webSearchEnabled: true,
     codeExecutionEnabled: false,
     piiCheckEnabled: true,
+    genUIEnabled: true,
     chatFont: 'system',
   }
 
@@ -455,6 +463,15 @@ export function applySettingsToLocal(settings: ProfileData): void {
     window.dispatchEvent(
       new CustomEvent('piiCheckEnabledChanged', {
         detail: { enabled: settings.piiCheckEnabled },
+      }),
+    )
+  }
+
+  if (settings.genUIEnabled !== undefined) {
+    localStorage.setItem(SETTINGS_GENUI_ENABLED, String(settings.genUIEnabled))
+    window.dispatchEvent(
+      new CustomEvent('genUIEnabledChanged', {
+        detail: { enabled: settings.genUIEnabled },
       }),
     )
   }

--- a/src/services/cloud/profile-sync.ts
+++ b/src/services/cloud/profile-sync.ts
@@ -75,6 +75,7 @@ export interface ProfileData {
   webSearchEnabled?: boolean
   codeExecutionEnabled?: boolean
   piiCheckEnabled?: boolean
+  genUIEnabled?: boolean
   chatFont?: 'system' | 'serif' | 'mono' | 'dyslexic'
   projectUploadPreference?: 'project' | 'chat'
 

--- a/src/services/cloud/schemas.ts
+++ b/src/services/cloud/schemas.ts
@@ -66,6 +66,7 @@ export const ProfileDataSchema = z
     webSearchEnabled: z.boolean().optional(),
     codeExecutionEnabled: z.boolean().optional(),
     piiCheckEnabled: z.boolean().optional(),
+    genUIEnabled: z.boolean().optional(),
     chatFont: z.enum(['system', 'serif', 'mono', 'dyslexic']).optional(),
     projectUploadPreference: z.enum(['project', 'chat']).optional(),
     version: z.number().optional(),

--- a/src/services/inference/chat-query-builder.ts
+++ b/src/services/inference/chat-query-builder.ts
@@ -106,10 +106,12 @@ export class ChatQueryBuilder {
           const withHint = genUIHint
             ? `${rawInstructions}\n\n${genUIHint}`
             : rawInstructions
-          result.push({
-            role: 'user',
-            content: `<system>\n${withHint}\n</system>`,
-          } as ChatCompletionUserMessageParam)
+          if (withHint.trim()) {
+            result.push({
+              role: 'user',
+              content: `<system>\n${withHint}\n</system>`,
+            } as ChatCompletionUserMessageParam)
+          }
           addedSystemInstructions = true
         }
 
@@ -180,7 +182,8 @@ export class ChatQueryBuilder {
     genUIHint: string | null,
   ): string | null {
     const base = rules ? `${systemPrompt}\n${rules}` : systemPrompt
-    return genUIHint ? `${base}\n\n${genUIHint}` : base
+    const content = genUIHint ? `${base}\n\n${genUIHint}` : base
+    return content.trim() ? content : null
   }
 
   /**

--- a/tests/services/inference/chat-query-builder.test.ts
+++ b/tests/services/inference/chat-query-builder.test.ts
@@ -1,0 +1,46 @@
+import type { Message } from '@/components/chat/types'
+import type { BaseModel } from '@/config/models'
+import { ChatQueryBuilder } from '@/services/inference/chat-query-builder'
+import { describe, expect, it } from 'vitest'
+
+const model: BaseModel = {
+  modelName: 'gpt-oss-120b',
+  image: '',
+  name: 'GPT-OSS 120B',
+  nameShort: 'GPT-OSS',
+  description: '',
+  type: 'chat',
+  chat: true,
+}
+
+const userMessage: Message = {
+  role: 'user',
+  content: 'hello',
+  timestamp: new Date('2026-01-01T00:00:00Z'),
+}
+
+describe('ChatQueryBuilder', () => {
+  it('omits system messages when there is no prompt content', () => {
+    const messages = ChatQueryBuilder.buildMessages({
+      model,
+      systemPrompt: '',
+      rules: '',
+      messages: [userMessage],
+      includeGenUIHint: false,
+    })
+
+    expect(messages).toEqual([{ role: 'user', content: 'hello' }])
+  })
+
+  it('omits synthetic system wrappers when there is no prompt content', () => {
+    const messages = ChatQueryBuilder.buildMessages({
+      model: { ...model, modelName: 'deepseek-r1' },
+      systemPrompt: '',
+      rules: '',
+      messages: [userMessage],
+      includeGenUIHint: false,
+    })
+
+    expect(messages).toEqual([{ role: 'user', content: 'hello' }])
+  })
+})


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds user-facing toggles for Personalization and Generative UI, and hardens prompt building to avoid sending empty system instructions. When off, we stop sending personal details and tool capability hints to the model.

- **New Features**
  - Generative UI toggle in Settings. Persists in `tinfoil-settings-genui-enabled`, syncs via profile settings, broadcasts changes, and chat requests now respect it (no tool capability hints when off).
  - Personalization master toggle. Gates nickname/occupation/traits/context; when off, none of this data is included. Save button shows only when personalization is enabled and there are unsaved changes.

- **Bug Fixes**
  - Prevent empty prompt steering: strip `<system>` tags, normalize empty custom prompts, skip rules when there’s no prompt content, and only add system messages when non-empty. Added tests for omitting empty system messages.

<sup>Written for commit d79348644162887f1452393358a051930c6d6fd9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/412?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

