### PR TITLE
Bulletproof sync clocks

### DIFF
--- a/src/constants/storage-keys.ts
+++ b/src/constants/storage-keys.ts
@@ -112,11 +112,6 @@ export const SYNC_PROJECT_CHAT_STATUS_PREFIX =
   'tinfoil-sync-project-chat-status-'
 export const SYNC_PROFILE_STATUS = 'tinfoil-sync-profile-status'
 export const SYNC_PROFILE_DIRTY = 'tinfoil-sync-profile-dirty'
-// Per-field dirty set (JSON array of field names) for the profile. A
-// field is listed only while it holds a local edit not yet pushed, so
-// conflict resolution can merge field-by-field instead of treating the
-// whole profile as one dirty blob.
-export const SYNC_PROFILE_DIRTY_FIELDS = 'tinfoil-sync-profile-dirty-fields'
 // Content modification time of the pending local profile edit, used to
 // arbitrate last-write-wins against a concurrently-updated remote.
 export const SYNC_PROFILE_CHANGED_AT = 'tinfoil-sync-profile-changed-at'

--- a/src/constants/storage-keys.ts
+++ b/src/constants/storage-keys.ts
@@ -112,9 +112,21 @@ export const SYNC_PROJECT_CHAT_STATUS_PREFIX =
   'tinfoil-sync-project-chat-status-'
 export const SYNC_PROFILE_STATUS = 'tinfoil-sync-profile-status'
 export const SYNC_PROFILE_DIRTY = 'tinfoil-sync-profile-dirty'
+// Per-field dirty set (JSON array of field names) for the profile. A
+// field is listed only while it holds a local edit not yet pushed, so
+// conflict resolution can merge field-by-field instead of treating the
+// whole profile as one dirty blob.
+export const SYNC_PROFILE_DIRTY_FIELDS = 'tinfoil-sync-profile-dirty-fields'
 // Content modification time of the pending local profile edit, used to
 // arbitrate last-write-wins against a concurrently-updated remote.
 export const SYNC_PROFILE_CHANGED_AT = 'tinfoil-sync-profile-changed-at'
+// Stable per-device id used as the deterministic tiebreak in the edit
+// clock that arbitrates sync conflicts. Generated once per browser
+// profile and never changes.
+export const SYNC_DEVICE_ID = 'tinfoil-sync-device-id'
+// Persisted Lamport counter backing the edit clock. Monotonic per
+// device; advanced past any remote clock value the client observes.
+export const SYNC_EDIT_CLOCK = 'tinfoil-sync-edit-clock'
 
 // --- localStorage: Migration flags -----------------------------------------
 // Set the first time a build evicts locally-cached cloud chats that the

--- a/src/hooks/use-profile-sync.ts
+++ b/src/hooks/use-profile-sync.ts
@@ -201,6 +201,14 @@ export function useProfileSync() {
                 action: 'smartSyncFromCloud',
               })
               lastSyncedVersion.current = 0
+              // Invalidate the change-detection baseline so syncToCloud
+              // sees the populated local profile as a change and actually
+              // re-pushes it. Without this, its hasProfileChanged guard
+              // compares local against the still-populated baseline,
+              // finds no diff, clears the dirty flag, and no-ops, leaving
+              // the remote tombstoned and local data unrecovered.
+              lastSyncedProfile.current = null
+              lastFieldClocks.current = {}
               profileSync.clearCache()
               profileSyncCache.current.save(remoteStatus)
               // Flag the local edit; the sync interval then pushes it as

--- a/src/hooks/use-profile-sync.ts
+++ b/src/hooks/use-profile-sync.ts
@@ -6,6 +6,11 @@ import {
 } from '@/constants/storage-keys'
 import { getCurrentCloudKeyAuthorizationMode } from '@/services/cloud/cloud-key-authorization'
 import type { ProfileSyncStatus } from '@/services/cloud/cloud-storage'
+import { nextClock, type EditClock } from '@/services/cloud/edit-clock'
+import {
+  changedProfileFields,
+  isProfilePopulated,
+} from '@/services/cloud/profile-merge'
 import {
   applySettingsToLocal,
   hasProfileChanged,
@@ -29,6 +34,9 @@ export function useProfileSync() {
   const hasPendingChanges = useRef(false)
   const isApplyingRemoteProfile = useRef(false)
   const lastSyncedProfile = useRef<ProfileData | null>(null)
+  // Field clocks last seen/pushed, carried forward so unchanged fields
+  // keep their clock across cycles when the fetched cache is empty.
+  const lastFieldClocks = useRef<Record<string, EditClock>>({})
   const profileSyncCache = useRef(
     new SyncStatusCache<ProfileSyncStatus>(PROFILE_SYNC_STATUS_KEY),
   )
@@ -137,6 +145,7 @@ export function useProfileSync() {
           // and wedge every future pull behind a never-clearing dirty
           // flag while looping STALE_BLOB pushes.
           lastSyncedProfile.current = loadLocalSettings()
+          lastFieldClocks.current = cloudProfile.fieldClocks ?? {}
 
           logInfo('Profile synced from cloud', {
             component: 'ProfileSync',
@@ -182,16 +191,35 @@ export function useProfileSync() {
             cached.lastUpdated !== remoteStatus.lastUpdated
 
           if (needsReset && !hasLocalProfileChanges()) {
-            isApplyingRemoteProfile.current = true
-            try {
-              const defaults = resetSettingsToLocalDefaults()
-              clearLocalProfileChanged()
+            const localSettings = loadLocalSettings()
+            if (isProfilePopulated(localSettings)) {
+              // A profile tombstone must never silently wipe a populated
+              // local profile. Resurrect it by re-pushing local as a
+              // fresh create instead of resetting to defaults.
+              logInfo('Profile tombstone ignored; resurrecting local profile', {
+                component: 'ProfileSync',
+                action: 'smartSyncFromCloud',
+              })
               lastSyncedVersion.current = 0
-              lastSyncedProfile.current = defaults
               profileSync.clearCache()
               profileSyncCache.current.save(remoteStatus)
-            } finally {
-              isApplyingRemoteProfile.current = false
+              // Flag the local edit; the sync interval then pushes it as
+              // a create on the next tick.
+              markLocalProfileChanged()
+            } else {
+              // No user content to lose; accept the reset to defaults.
+              isApplyingRemoteProfile.current = true
+              try {
+                const defaults = resetSettingsToLocalDefaults()
+                clearLocalProfileChanged()
+                lastSyncedVersion.current = 0
+                lastSyncedProfile.current = defaults
+                lastFieldClocks.current = {}
+                profileSync.clearCache()
+                profileSyncCache.current.save(remoteStatus)
+              } finally {
+                isApplyingRemoteProfile.current = false
+              }
             }
           }
         }
@@ -256,6 +284,7 @@ export function useProfileSync() {
           // and wedge every future pull behind a never-clearing dirty
           // flag while looping STALE_BLOB pushes.
           lastSyncedProfile.current = loadLocalSettings()
+          lastFieldClocks.current = cloudProfile.fieldClocks ?? {}
         }
 
         // Update cached sync status only after successful processing
@@ -267,7 +296,12 @@ export function useProfileSync() {
         action: 'smartSyncFromCloud',
       })
     }
-  }, [clearLocalProfileChanged, hasLocalProfileChanges, isSignedIn])
+  }, [
+    clearLocalProfileChanged,
+    hasLocalProfileChanges,
+    markLocalProfileChanged,
+    isSignedIn,
+  ])
 
   // Sync profile from local to cloud (debounced)
   const syncToCloud = useCallback(async () => {
@@ -308,13 +342,33 @@ export function useProfileSync() {
         // Mark that we have pending changes only when we're actually going to sync
         hasPendingChanges.current = true
 
+        // Stamp a fresh edit clock on every field that changed since the
+        // last sync, carrying forward the existing clocks for the rest.
+        // One tick covers this push because it is a single local write
+        // event; the deviceId tiebreak keeps it ordered against peers.
+        const baseClocks =
+          profileSync.getCachedProfile()?.fieldClocks ?? lastFieldClocks.current
+        const changedFields = changedProfileFields(
+          localSettings,
+          lastSyncedProfile.current,
+        )
+        const fieldClocks: Record<string, EditClock> = { ...baseClocks }
+        if (changedFields.length > 0) {
+          const tick = nextClock()
+          for (const field of changedFields) {
+            fieldClocks[field] = tick
+          }
+        }
+        lastFieldClocks.current = fieldClocks
+
         // Include the last synced version so the service can increment
         // it, plus the edit time so conflict resolution can arbitrate
-        // last-write-wins against the remote.
+        // last-write-wins against the remote when a clock is absent.
         const profileWithVersion = {
           ...localSettings,
           version: lastSyncedVersion.current,
           updatedAt: getLocalProfileChangedAt(),
+          fieldClocks,
         }
 
         const result = await profileSync.saveProfile(profileWithVersion)
@@ -339,6 +393,7 @@ export function useProfileSync() {
             // remote, so fields we derive but the peer omits don't read
             // back as a phantom change and re-trigger the push loop.
             lastSyncedProfile.current = loadLocalSettings()
+            lastFieldClocks.current = result.remoteProfile.fieldClocks ?? {}
           } else {
             lastSyncedProfile.current = localSettings
           }

--- a/src/services/cloud/chat-codec.ts
+++ b/src/services/cloud/chat-codec.ts
@@ -10,6 +10,7 @@
 import { ensureValidISODate } from '@/utils/chat-timestamps'
 import { logInfo } from '@/utils/error-handling'
 import type { StoredChat } from '../storage/indexed-db'
+import { observe } from './edit-clock'
 import { RemoteChatPlaintextSchema } from './schemas'
 
 export interface RemoteChatData {
@@ -93,6 +94,10 @@ export async function processRemoteChat(
     throw new Error(`v2_plaintext_invalid: ${validation.error.message}`)
   }
   const decrypted = validation.data
+
+  // Advance the local logical clock past any remote edit clock so a
+  // later local edit is guaranteed to outrank what we just observed.
+  observe(typeof decrypted.clock === 'number' ? decrypted.clock : null)
 
   const chat: StoredChat = {
     ...decrypted,

--- a/src/services/cloud/cloud-storage.ts
+++ b/src/services/cloud/cloud-storage.ts
@@ -254,9 +254,14 @@ export class CloudStorageService {
       chat.id,
       idempotencyKey,
     )
+    // Stamp the clock version this push will create so a remote reader
+    // can tell the clock is current (etag === clockVersion) versus a
+    // later clock-unaware write that would force the updatedAt fallback.
+    const baseVersion = options.restoreDeleted ? 0 : (chat.syncVersion ?? 0)
     const strippedChat = {
       ...chat,
       messages: stripBase64FromMessages(messages),
+      clockVersion: baseVersion + 1,
     }
     const plaintext = new TextEncoder().encode(JSON.stringify(strippedChat))
 

--- a/src/services/cloud/cloud-sync.ts
+++ b/src/services/cloud/cloud-sync.ts
@@ -26,6 +26,7 @@ import {
   type ChatSyncStatus,
   type UploadChatOptions,
 } from './cloud-storage'
+import type { EditClock } from './edit-clock'
 import { adoptLocalKeyForMigration } from './ensure-current-key'
 import {
   runLegacyBlobMigrationAndFinalize,
@@ -41,7 +42,7 @@ import {
   reportSyncPaused,
   reportSyncSuccess,
 } from './sync-health'
-import { isUploadableChat, remoteWinsLastWrite } from './sync-predicates'
+import { isUploadableChat, remoteWins } from './sync-predicates'
 import { SyncStatusCache } from './sync-status-cache'
 import { UploadCoalescer } from './upload-coalescer'
 
@@ -860,12 +861,32 @@ export class CloudSyncService {
         return
       }
 
-      const remoteWins = remoteWinsLastWrite(
-        localChat?.updatedAt,
-        remoteChat.updatedAt,
-      )
+      // A chat's edit clock is trusted only when it was maintained at
+      // the row's current synced version; otherwise a clock-unaware
+      // write intervened and we fall back to updatedAt arbitration.
+      const trustedClock = (
+        c: typeof localChat | typeof remoteChat,
+      ): EditClock | undefined => {
+        if (
+          !c ||
+          typeof c.clock !== 'number' ||
+          typeof c.writer !== 'string' ||
+          c.clockVersion == null ||
+          c.clockVersion !== (c.syncVersion ?? -1)
+        ) {
+          return undefined
+        }
+        return { v: c.clock, w: c.writer }
+      }
 
-      if (!remoteWins) {
+      const remoteIsWinner = remoteWins({
+        localClock: trustedClock(localChat),
+        remoteClock: trustedClock(remoteChat),
+        localUpdatedAt: localChat?.updatedAt,
+        remoteUpdatedAt: remoteChat.updatedAt,
+      })
+
+      if (!remoteIsWinner) {
         await indexedDBStorage.rebaseSyncVersion(
           chatId,
           remoteChat.syncVersion ?? 0,

--- a/src/services/cloud/edit-clock.ts
+++ b/src/services/cloud/edit-clock.ts
@@ -10,9 +10,11 @@
  *   - `v` is a per-device monotonic counter, advanced past any remote
  *     value the device observes so a later edit always outranks the
  *     state it was based on.
- *   - `w` is a stable per-device id used only as a deterministic
- *     tiebreak when two devices land the same counter value, so every
- *     device picks the same winner.
+ *   - `w` is a per-writer id used only as a deterministic tiebreak when
+ *     two writers land the same counter value, so every replica picks
+ *     the same winner. It combines a persisted per-installation id with
+ *     a per-runtime nonce, so two browser tabs sharing one installation
+ *     never mint the same `(v, w)` for distinct concurrent edits.
  */
 
 import { SYNC_DEVICE_ID, SYNC_EDIT_CLOCK } from '@/constants/storage-keys'
@@ -31,6 +33,16 @@ const MAX_COUNTER = Number.MAX_SAFE_INTEGER
 
 let deviceIdCache: string | null = null
 let counterCache: number | null = null
+let writerNonce: string | null = null
+
+// Coerce an arbitrary value (often untrusted remote input) to a usable
+// counter: a non-negative safe integer within the ceiling, or 0. This
+// rejects fractional, negative, non-finite, and oversized values so they
+// can neither make a later tick fractional nor poison it toward overflow.
+function safeCounter(value?: number | null): number {
+  if (value == null || !Number.isSafeInteger(value) || value <= 0) return 0
+  return Math.min(value, MAX_COUNTER)
+}
 
 function randomId(): string {
   if (
@@ -44,48 +56,57 @@ function randomId(): string {
   return `dev-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`
 }
 
-/**
- * Stable id for this device/installation. Generated once and persisted;
- * reused for the life of the browser profile.
- */
-export function deviceId(): string {
-  if (deviceIdCache !== null) return deviceIdCache
-  if (typeof window === 'undefined') {
-    deviceIdCache = randomId()
-    return deviceIdCache
-  }
+// Persisted per-installation id, reused for the life of the browser
+// profile. Shared by every tab of the same profile.
+function installationId(): string {
+  if (typeof window === 'undefined') return randomId()
   try {
     const stored = localStorage.getItem(SYNC_DEVICE_ID)
-    if (stored) {
-      deviceIdCache = stored
-      return stored
-    }
+    if (stored) return stored
     const next = randomId()
     localStorage.setItem(SYNC_DEVICE_ID, next)
-    deviceIdCache = next
     return next
   } catch {
-    deviceIdCache = randomId()
-    return deviceIdCache
+    return randomId()
   }
 }
 
+/**
+ * Writer id stamped on every clock this runtime mints. Stable for the
+ * life of the runtime, but unique per runtime instance: the persisted
+ * installation id is combined with a per-runtime nonce so two tabs of
+ * the same browser profile, which share localStorage and so cannot
+ * coordinate their counters atomically, still never produce the same
+ * `(v, w)` for two distinct concurrent edits.
+ */
+export function deviceId(): string {
+  if (deviceIdCache !== null) return deviceIdCache
+  if (writerNonce === null) writerNonce = randomId()
+  deviceIdCache = `${installationId()}.${writerNonce}`
+  return deviceIdCache
+}
+
 function loadCounter(): number {
-  if (counterCache !== null) return counterCache
   if (typeof window === 'undefined') {
-    counterCache = 0
-    return 0
+    counterCache = counterCache ?? 0
+    return counterCache
   }
+  let stored = 0
   try {
     const raw = localStorage.getItem(SYNC_EDIT_CLOCK)
-    const parsed = raw ? parseInt(raw, 10) : 0
-    // Clamp a previously-persisted value too, so a counter poisoned
-    // before this bound existed self-heals instead of staying stuck.
-    counterCache =
-      Number.isFinite(parsed) && parsed > 0 ? Math.min(parsed, MAX_COUNTER) : 0
+    // safeCounter also clamps a previously-persisted value, so a counter
+    // poisoned before this bound existed self-heals instead of staying
+    // stuck.
+    stored = safeCounter(raw ? parseInt(raw, 10) : 0)
   } catch {
-    counterCache = 0
+    stored = 0
   }
+  // Reconcile with the persisted value on every read rather than trusting
+  // the in-memory cache. Tabs share localStorage but each have their own
+  // cache, so a stale cache would hand out a value another tab already
+  // used, minting duplicate clocks. The cache only guards against a failed
+  // write regressing us below a value we already handed out.
+  counterCache = Math.max(counterCache ?? 0, stored)
   return counterCache
 }
 
@@ -107,15 +128,14 @@ function persistCounter(value: number): void {
  * later local edit is guaranteed to outrank it.
  */
 export function observe(remoteV?: number | null): void {
-  // Remote values are untrusted input (decrypted blob); a value above
-  // the ceiling is treated as malformed and ignored rather than allowed
-  // to poison the counter to a point where it can no longer advance.
-  if (remoteV == null || !Number.isFinite(remoteV) || remoteV > MAX_COUNTER) {
-    return
-  }
-  const current = loadCounter()
-  if (remoteV > current) {
-    persistCounter(remoteV)
+  // Remote values are untrusted input (decrypted blob); safeCounter
+  // collapses anything malformed (fractional, negative, non-finite,
+  // oversized) to 0 so it can neither poison the counter toward overflow
+  // nor make a later tick fractional or non-monotonic.
+  const value = safeCounter(remoteV)
+  if (value === 0) return
+  if (value > loadCounter()) {
+    persistCounter(value)
   }
 }
 
@@ -126,10 +146,7 @@ export function observe(remoteV?: number | null): void {
  */
 export function nextClock(observedMax?: number | null): EditClock {
   const base = Math.min(
-    Math.max(
-      loadCounter(),
-      observedMax != null && Number.isFinite(observedMax) ? observedMax : 0,
-    ),
+    Math.max(loadCounter(), safeCounter(observedMax)),
     MAX_COUNTER,
   )
   const next = Math.min(base + 1, MAX_COUNTER)
@@ -144,4 +161,5 @@ export function nextClock(observedMax?: number | null): EditClock {
 export function resetEditClockCache(): void {
   deviceIdCache = null
   counterCache = null
+  writerNonce = null
 }

--- a/src/services/cloud/edit-clock.ts
+++ b/src/services/cloud/edit-clock.ts
@@ -22,6 +22,13 @@ export interface EditClock {
   w: string
 }
 
+// Upper bound for the logical counter. Far above any value a legitimate
+// edit history could reach, yet capped at the JS safe-integer ceiling so
+// the counter never loses precision and an observed remote value can
+// never push it past where `+ 1` stops advancing. Matches the iOS
+// ceiling so both platforms clamp identically.
+const MAX_COUNTER = Number.MAX_SAFE_INTEGER
+
 let deviceIdCache: string | null = null
 let counterCache: number | null = null
 
@@ -72,7 +79,10 @@ function loadCounter(): number {
   try {
     const raw = localStorage.getItem(SYNC_EDIT_CLOCK)
     const parsed = raw ? parseInt(raw, 10) : 0
-    counterCache = Number.isFinite(parsed) && parsed > 0 ? parsed : 0
+    // Clamp a previously-persisted value too, so a counter poisoned
+    // before this bound existed self-heals instead of staying stuck.
+    counterCache =
+      Number.isFinite(parsed) && parsed > 0 ? Math.min(parsed, MAX_COUNTER) : 0
   } catch {
     counterCache = 0
   }
@@ -97,7 +107,12 @@ function persistCounter(value: number): void {
  * later local edit is guaranteed to outrank it.
  */
 export function observe(remoteV?: number | null): void {
-  if (remoteV == null || !Number.isFinite(remoteV)) return
+  // Remote values are untrusted input (decrypted blob); a value above
+  // the ceiling is treated as malformed and ignored rather than allowed
+  // to poison the counter to a point where it can no longer advance.
+  if (remoteV == null || !Number.isFinite(remoteV) || remoteV > MAX_COUNTER) {
+    return
+  }
   const current = loadCounter()
   if (remoteV > current) {
     persistCounter(remoteV)
@@ -110,11 +125,14 @@ export function observe(remoteV?: number | null): void {
  * still moves forward.
  */
 export function nextClock(observedMax?: number | null): EditClock {
-  const base = Math.max(
-    loadCounter(),
-    observedMax != null && Number.isFinite(observedMax) ? observedMax : 0,
+  const base = Math.min(
+    Math.max(
+      loadCounter(),
+      observedMax != null && Number.isFinite(observedMax) ? observedMax : 0,
+    ),
+    MAX_COUNTER,
   )
-  const next = base + 1
+  const next = Math.min(base + 1, MAX_COUNTER)
   persistCounter(next)
   return { v: next, w: deviceId() }
 }

--- a/src/services/cloud/edit-clock.ts
+++ b/src/services/cloud/edit-clock.ts
@@ -1,0 +1,129 @@
+/**
+ * Edit Clock
+ *
+ * A Lamport-style logical clock shared by every mergeable sync unit
+ * (each chat row, each profile field). Arbitration by this clock is a
+ * total order on `(v, w)`, which makes conflict resolution a CRDT
+ * LWW-register: order-independent and convergent across devices, and
+ * immune to wall-clock skew between devices.
+ *
+ *   - `v` is a per-device monotonic counter, advanced past any remote
+ *     value the device observes so a later edit always outranks the
+ *     state it was based on.
+ *   - `w` is a stable per-device id used only as a deterministic
+ *     tiebreak when two devices land the same counter value, so every
+ *     device picks the same winner.
+ */
+
+import { SYNC_DEVICE_ID, SYNC_EDIT_CLOCK } from '@/constants/storage-keys'
+
+export interface EditClock {
+  v: number
+  w: string
+}
+
+let deviceIdCache: string | null = null
+let counterCache: number | null = null
+
+function randomId(): string {
+  if (
+    typeof crypto !== 'undefined' &&
+    typeof crypto.randomUUID === 'function'
+  ) {
+    return crypto.randomUUID()
+  }
+  // Non-crypto fallback for environments without randomUUID. The id is
+  // only a tiebreak label, never a security boundary.
+  return `dev-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`
+}
+
+/**
+ * Stable id for this device/installation. Generated once and persisted;
+ * reused for the life of the browser profile.
+ */
+export function deviceId(): string {
+  if (deviceIdCache !== null) return deviceIdCache
+  if (typeof window === 'undefined') {
+    deviceIdCache = randomId()
+    return deviceIdCache
+  }
+  try {
+    const stored = localStorage.getItem(SYNC_DEVICE_ID)
+    if (stored) {
+      deviceIdCache = stored
+      return stored
+    }
+    const next = randomId()
+    localStorage.setItem(SYNC_DEVICE_ID, next)
+    deviceIdCache = next
+    return next
+  } catch {
+    deviceIdCache = randomId()
+    return deviceIdCache
+  }
+}
+
+function loadCounter(): number {
+  if (counterCache !== null) return counterCache
+  if (typeof window === 'undefined') {
+    counterCache = 0
+    return 0
+  }
+  try {
+    const raw = localStorage.getItem(SYNC_EDIT_CLOCK)
+    const parsed = raw ? parseInt(raw, 10) : 0
+    counterCache = Number.isFinite(parsed) && parsed > 0 ? parsed : 0
+  } catch {
+    counterCache = 0
+  }
+  return counterCache
+}
+
+function persistCounter(value: number): void {
+  counterCache = value
+  if (typeof window === 'undefined') return
+  try {
+    localStorage.setItem(SYNC_EDIT_CLOCK, String(value))
+  } catch {
+    // A persistence failure only risks a counter that restarts lower
+    // after a reload; the deviceId tiebreak still keeps arbitration
+    // deterministic, and observe() re-advances past any remote value.
+  }
+}
+
+/**
+ * Advance the local counter past an observed remote value without
+ * producing a new tick. Called whenever a remote clock is seen so a
+ * later local edit is guaranteed to outrank it.
+ */
+export function observe(remoteV?: number | null): void {
+  if (remoteV == null || !Number.isFinite(remoteV)) return
+  const current = loadCounter()
+  if (remoteV > current) {
+    persistCounter(remoteV)
+  }
+}
+
+/**
+ * Produce the next clock for a local edit. Advances past `observedMax`
+ * (e.g. the unit's current clock) so a re-edit of an already-high unit
+ * still moves forward.
+ */
+export function nextClock(observedMax?: number | null): EditClock {
+  const base = Math.max(
+    loadCounter(),
+    observedMax != null && Number.isFinite(observedMax) ? observedMax : 0,
+  )
+  const next = base + 1
+  persistCounter(next)
+  return { v: next, w: deviceId() }
+}
+
+/**
+ * Reset in-memory caches. Used by sign-out cleanup so a new user does
+ * not inherit the previous user's device id or counter.
+ */
+export function resetEditClockCache(): void {
+  deviceIdCache = null
+  counterCache = null
+}

--- a/src/services/cloud/profile-merge.ts
+++ b/src/services/cloud/profile-merge.ts
@@ -131,9 +131,12 @@ export function mergeProfiles(args: {
   }
 
   const merged: ProfileData = { ...local }
-  const mergedClocks: Record<string, EditClock> = {
-    ...(local.fieldClocks ?? {}),
-  }
+  // Build the merged clocks from scratch, carrying only clocks we
+  // actually trust. Seeding from local.fieldClocks would smuggle
+  // untrusted/stale clocks into the output, which the next push
+  // re-stamps as trusted (clockVersion === version) and corrupts future
+  // conflict resolution.
+  const mergedClocks: Record<string, EditClock> = {}
   let adoptedRemote = false
 
   for (const field of PROFILE_MERGE_FIELDS) {
@@ -141,6 +144,9 @@ export function mergeProfiles(args: {
     const lc = fieldClock(local, field, localTrusted)
     const rc = fieldClock(remote, field, remoteTrusted)
     if (!remoteHasField) {
+      // Remote omits this field: keep the local value and its clock, but
+      // only when the local clock is trusted.
+      if (lc) mergedClocks[field] = lc
       continue
     }
     const takeRemote = remoteWins({
@@ -153,6 +159,9 @@ export function mergeProfiles(args: {
       ;(merged as Record<string, unknown>)[field] = (
         remote as Record<string, unknown>
       )[field]
+      // Record a clock for the adopted value only if the remote clock is
+      // trusted; otherwise leave it absent so future reads fall back to
+      // updatedAt for this field.
       if (rc) mergedClocks[field] = rc
       adoptedRemote = true
     } else if (lc) {

--- a/src/services/cloud/profile-merge.ts
+++ b/src/services/cloud/profile-merge.ts
@@ -1,0 +1,169 @@
+import type { EditClock } from './edit-clock'
+import type { ProfileData } from './profile-sync'
+import { remoteWins } from './sync-predicates'
+
+/**
+ * User-facing profile fields that participate in the field-level
+ * conflict merge. Metadata (version, updatedAt, clocks) is handled
+ * separately and intentionally excluded.
+ */
+export const PROFILE_MERGE_FIELDS = [
+  'isDarkMode',
+  'themeMode',
+  'language',
+  'nickname',
+  'profession',
+  'traits',
+  'additionalContext',
+  'isUsingPersonalization',
+  'isUsingCustomPrompt',
+  'customSystemPrompt',
+  'customPromptPresets',
+  'favoritePromptPresetIds',
+  'selectedModel',
+  'reasoningEffort',
+  'thinkingEnabled',
+  'webSearchEnabled',
+  'codeExecutionEnabled',
+  'piiCheckEnabled',
+  'genUIEnabled',
+  'chatFont',
+  'projectUploadPreference',
+] as const
+
+// A blob's field clocks are trustworthy only when they were maintained
+// at the row's current server version. If a clock-unaware client wrote
+// since, clockVersion lags the etag and we must not trust the clocks.
+function clocksTrusted(p: ProfileData | null | undefined): boolean {
+  return !!p && p.clockVersion != null && p.clockVersion === p.version
+}
+
+function fieldClock(
+  p: ProfileData | null | undefined,
+  field: string,
+  trusted: boolean,
+): EditClock | undefined {
+  if (!trusted || !p?.fieldClocks) return undefined
+  const c = p.fieldClocks[field]
+  return c && typeof c.v === 'number' && typeof c.w === 'string' ? c : undefined
+}
+
+/**
+ * Field names whose local value differs from the last-synced baseline.
+ * Derived by diffing values rather than tracking UI events, so a field
+ * can never be missed because its change event was not wired up.
+ */
+export function changedProfileFields(
+  local: ProfileData,
+  baseline: ProfileData | null | undefined,
+): string[] {
+  if (!baseline) return [...PROFILE_MERGE_FIELDS]
+  const changed: string[] = []
+  for (const field of PROFILE_MERGE_FIELDS) {
+    const a = (local as Record<string, unknown>)[field]
+    const b = (baseline as Record<string, unknown>)[field]
+    const differ =
+      typeof a === 'object' || typeof b === 'object'
+        ? JSON.stringify(a ?? null) !== JSON.stringify(b ?? null)
+        : a !== b
+    if (differ) changed.push(field)
+  }
+  return changed
+}
+
+function nonEmptyString(value: unknown): boolean {
+  return typeof value === 'string' && value.trim().length > 0
+}
+
+function nonEmptyArray(value: unknown): boolean {
+  return Array.isArray(value) && value.length > 0
+}
+
+/**
+ * True when the profile carries user content worth protecting (a name,
+ * prompts, traits, etc.). Used to refuse letting an empty/default blob
+ * silently wipe a populated profile on the fallback arbitration path.
+ */
+export function isProfilePopulated(p: ProfileData | null | undefined): boolean {
+  if (!p) return false
+  return (
+    nonEmptyString(p.nickname) ||
+    nonEmptyString(p.profession) ||
+    nonEmptyString(p.additionalContext) ||
+    nonEmptyString(p.customSystemPrompt) ||
+    nonEmptyArray(p.traits) ||
+    nonEmptyArray(p.customPromptPresets) ||
+    nonEmptyArray(p.favoritePromptPresetIds)
+  )
+}
+
+function laterTimestamp(a?: string, b?: string): string | undefined {
+  const ta = a ? new Date(a).getTime() : NaN
+  const tb = b ? new Date(b).getTime() : NaN
+  if (Number.isNaN(ta)) return b
+  if (Number.isNaN(tb)) return a
+  return ta >= tb ? a : b
+}
+
+/**
+ * Merge a remote profile into the local one field by field. Each field
+ * is arbitrated by its edit clock when both sides are trusted (a
+ * convergent CRDT LWW-register, immune to clock skew), falling back to
+ * whole-blob updatedAt when a clock is absent or untrusted.
+ *
+ * Returns the merged profile plus whether any field was adopted from
+ * the remote (so the caller knows it must apply the result locally).
+ */
+export function mergeProfiles(args: {
+  local: ProfileData
+  remote: ProfileData
+}): { merged: ProfileData; adoptedRemote: boolean } {
+  const { local, remote } = args
+  const localTrusted = clocksTrusted(local)
+  const remoteTrusted = clocksTrusted(remote)
+  const fallback = !(localTrusted && remoteTrusted)
+
+  // On the fallback path there is no per-field signal to trust, so a
+  // single empty/default remote could clobber every populated local
+  // field at once (the data-loss incident). Refuse it outright.
+  if (fallback && !isProfilePopulated(remote) && isProfilePopulated(local)) {
+    return { merged: { ...local }, adoptedRemote: false }
+  }
+
+  const merged: ProfileData = { ...local }
+  const mergedClocks: Record<string, EditClock> = {
+    ...(local.fieldClocks ?? {}),
+  }
+  let adoptedRemote = false
+
+  for (const field of PROFILE_MERGE_FIELDS) {
+    const remoteHasField = Object.prototype.hasOwnProperty.call(remote, field)
+    const lc = fieldClock(local, field, localTrusted)
+    const rc = fieldClock(remote, field, remoteTrusted)
+    if (!remoteHasField) {
+      continue
+    }
+    const takeRemote = remoteWins({
+      localClock: lc,
+      remoteClock: rc,
+      localUpdatedAt: local.updatedAt,
+      remoteUpdatedAt: remote.updatedAt,
+    })
+    if (takeRemote) {
+      ;(merged as Record<string, unknown>)[field] = (
+        remote as Record<string, unknown>
+      )[field]
+      if (rc) mergedClocks[field] = rc
+      adoptedRemote = true
+    } else if (lc) {
+      mergedClocks[field] = lc
+    }
+  }
+
+  merged.fieldClocks =
+    Object.keys(mergedClocks).length > 0 ? mergedClocks : undefined
+  merged.updatedAt =
+    laterTimestamp(local.updatedAt, remote.updatedAt) ??
+    new Date().toISOString()
+  return { merged, adoptedRemote }
+}

--- a/src/services/cloud/profile-sync.ts
+++ b/src/services/cloud/profile-sync.ts
@@ -11,8 +11,9 @@ import { SyncEnclaveError } from '../sync-enclave/sync-enclave-client'
 import { WIRE_CODES } from '../sync-enclave/wire-contract'
 import { pullKey, requirePrimaryKeyB64 } from './cek-encoding'
 import type { ProfileSyncStatus } from './cloud-storage'
+import { observe } from './edit-clock'
+import { mergeProfiles } from './profile-merge'
 import { ProfileDataSchema } from './schemas'
-import { remoteWinsLastWrite } from './sync-predicates'
 
 const PROFILE_SCOPE = 'profile'
 const PROFILE_ROW_ID = 'profile'
@@ -82,6 +83,14 @@ export interface ProfileData {
   // Metadata
   version?: number
   updatedAt?: string
+
+  // Per-field edit clocks and the row version they were last
+  // maintained at. fieldClocks is trusted for the field-level merge
+  // only when clockVersion equals the profile row's server etag
+  // (version); otherwise a clock-unaware write intervened and merge
+  // falls back to updatedAt arbitration.
+  fieldClocks?: Record<string, { v: number; w: string }>
+  clockVersion?: number
 }
 
 export interface ProfilePromptPreset {
@@ -159,6 +168,14 @@ export class ProfileSyncService {
         decoded.version = etagVersion
       }
 
+      // Advance the local logical clock past every remote field clock
+      // so a later local edit is guaranteed to outrank what we observed.
+      if (decoded.fieldClocks) {
+        for (const clock of Object.values(decoded.fieldClocks)) {
+          observe(typeof clock?.v === 'number' ? clock.v : null)
+        }
+      }
+
       this.cachedProfile = decoded
       this.failedDecryptionData = null
 
@@ -221,6 +238,10 @@ export class ProfileSyncService {
         },
       })
 
+      // The working copy that gets pushed. On a conflict it is replaced
+      // by the field-level merge of local and remote before re-push.
+      let working: ProfileData = profile
+
       // Push the local profile under a given base version. The
       // controlplane treats a missing/zero version as create-only and
       // any positive version as a CAS update gated on the row's etag.
@@ -228,11 +249,15 @@ export class ProfileSyncService {
         baseVersion: number,
       ): Promise<{ success: boolean; version?: number }> => {
         const profileWithMetadata: ProfileData = {
-          ...profile,
+          ...working,
           // Preserve the caller's edit time so other devices can
           // arbitrate last-write-wins; only stamp now when absent.
-          updatedAt: profile.updatedAt ?? new Date().toISOString(),
+          updatedAt: working.updatedAt ?? new Date().toISOString(),
           version: baseVersion + 1,
+          // The field clocks are current as of the version this push
+          // creates, so a remote reader trusts them (etag ===
+          // clockVersion) instead of falling back to updatedAt.
+          clockVersion: baseVersion + 1,
         }
 
         // Carry forward fields we do not model under our own known
@@ -280,37 +305,43 @@ export class ProfileSyncService {
           throw pushError
         }
         // Optimistic-concurrency conflict: the server holds a version
-        // our push was not based on. Re-read it and arbitrate
-        // last-write-wins by content modification time.
-        logInfo('Profile push conflicted; arbitrating last-write-wins', {
+        // our push was not based on. Re-read it and merge field by
+        // field so neither device's edits are lost, then re-push the
+        // merged result onto the server's current version.
+        logInfo('Profile push conflicted; merging fields', {
           component: 'ProfileSync',
           action: 'saveProfile',
         })
         const remote = await this.fetchProfile()
 
-        if (
-          remote &&
-          remoteWinsLastWrite(profile.updatedAt, remote.updatedAt)
-        ) {
-          // The remote is the strictly newer write. Adopt it instead of
-          // clobbering, and hand it back so the caller can apply it
-          // locally; both devices then converge on the same settings.
-          logInfo('Profile conflict resolved by adopting newer remote', {
-            component: 'ProfileSync',
-            action: 'saveProfile',
-          })
-          this.cachedProfile = remote
-          return {
-            success: true,
-            version: remote.version,
-            remoteProfile: remote,
-          }
+        if (!remote) {
+          // The remote vanished between the conflict and our re-read;
+          // re-push local as a fresh create.
+          return await pushAtVersion(0)
         }
 
-        // Our local edit is the last write. Rebase onto the server's
-        // current version and re-push so local wins instead of looping
-        // on STALE_BLOB forever.
-        return await pushAtVersion(remote?.version ?? 0)
+        const { merged, adoptedRemote } = mergeProfiles({
+          local: profile,
+          remote,
+        })
+        working = merged
+
+        logInfo('Profile conflict resolved by field-level merge', {
+          component: 'ProfileSync',
+          action: 'saveProfile',
+          metadata: { adoptedRemote },
+        })
+
+        const pushed = await pushAtVersion(remote.version ?? 0)
+        // Hand the merged profile back so the caller applies any fields
+        // adopted from the remote and both devices converge.
+        return adoptedRemote
+          ? {
+              success: pushed.success,
+              version: pushed.version,
+              remoteProfile: this.cachedProfile ?? merged,
+            }
+          : pushed
       }
     } catch (error) {
       // Silently fail if no auth token

--- a/src/services/cloud/schemas.ts
+++ b/src/services/cloud/schemas.ts
@@ -19,6 +19,13 @@ const MessageSchema = z
   })
   .passthrough()
 
+// Per-unit logical edit clock: `v` is a Lamport counter, `w` the
+// writing device id used as a deterministic tiebreak.
+export const EditClockSchema = z.object({
+  v: z.number(),
+  w: z.string(),
+})
+
 export const RemoteChatPlaintextSchema = z
   .object({
     title: z.string().optional(),
@@ -30,6 +37,13 @@ export const RemoteChatPlaintextSchema = z
     isBlankChat: z.boolean().optional(),
     syncVersion: z.number().optional(),
     projectId: z.string().nullable().optional(),
+    // Per-row edit clock and the row version it was last maintained at.
+    // Trusted for conflict arbitration only when clockVersion equals the
+    // row's server etag; otherwise a clock-unaware write intervened and
+    // callers fall back to updatedAt.
+    clock: z.number().optional(),
+    writer: z.string().optional(),
+    clockVersion: z.number().optional(),
   })
   .passthrough()
 
@@ -71,6 +85,11 @@ export const ProfileDataSchema = z
     projectUploadPreference: z.enum(['project', 'chat']).optional(),
     version: z.number().optional(),
     updatedAt: z.string().optional(),
+    // Per-field edit clocks and the row version they were last
+    // maintained at. fieldClocks is trusted for the field-level merge
+    // only when clockVersion equals the profile row's server etag.
+    fieldClocks: z.record(z.string(), EditClockSchema).optional(),
+    clockVersion: z.number().optional(),
   })
   .passthrough()
 

--- a/src/services/cloud/schemas.ts
+++ b/src/services/cloud/schemas.ts
@@ -20,11 +20,15 @@ const MessageSchema = z
   .passthrough()
 
 // Per-unit logical edit clock: `v` is a Lamport counter, `w` the
-// writing device id used as a deterministic tiebreak.
-export const EditClockSchema = z.object({
-  v: z.number(),
-  w: z.string(),
-})
+// writing device id used as a deterministic tiebreak. Passthrough keeps
+// any future clock fields written by a newer client intact on round-trip
+// instead of silently dropping them.
+export const EditClockSchema = z
+  .object({
+    v: z.number(),
+    w: z.string(),
+  })
+  .passthrough()
 
 export const RemoteChatPlaintextSchema = z
   .object({

--- a/src/services/cloud/sync-predicates.ts
+++ b/src/services/cloud/sync-predicates.ts
@@ -7,6 +7,7 @@
  */
 
 import type { StoredChat } from '@/services/storage/indexed-db'
+import type { EditClock } from './edit-clock'
 
 /**
  * Determines if a chat is eligible for upload to the cloud.
@@ -121,4 +122,39 @@ export function remoteWinsLastWrite(
     ? new Date(remoteUpdatedAt).getTime()
     : Number.NaN
   return !Number.isNaN(remoteTime) && remoteTime > localTime
+}
+
+/**
+ * Unified conflict arbitration for every sync scope (chat rows,
+ * profile fields). When both sides carry a trusted edit clock the
+ * winner is the higher `(v, w)` pair — a total order that makes the
+ * merge a convergent CRDT LWW-register and removes wall-clock skew
+ * from the decision. When either clock is absent (legacy rows, or a
+ * write by a client that predates clocks) it falls back to the
+ * timestamp arbitration so behavior matches the pre-clock client.
+ *
+ * Callers MUST pass clocks only when both are trusted (the row's
+ * server etag equals the `clockVersion` stamped in the blob);
+ * otherwise pass `undefined` so the timestamp fallback governs.
+ *
+ * Returns true when the remote copy should overwrite local.
+ */
+export function remoteWins(args: {
+  localClock?: EditClock | null
+  remoteClock?: EditClock | null
+  localUpdatedAt?: string | null
+  remoteUpdatedAt?: string | null
+}): boolean {
+  const { localClock, remoteClock, localUpdatedAt, remoteUpdatedAt } = args
+  if (localClock && remoteClock) {
+    if (remoteClock.v !== localClock.v) {
+      return remoteClock.v > localClock.v
+    }
+    if (remoteClock.w !== localClock.w) {
+      return remoteClock.w > localClock.w
+    }
+    // Identical clock: the same logical write. No overwrite.
+    return false
+  }
+  return remoteWinsLastWrite(localUpdatedAt, remoteUpdatedAt)
 }

--- a/src/services/storage/indexed-db.ts
+++ b/src/services/storage/indexed-db.ts
@@ -1,4 +1,5 @@
 import type { Chat as ChatType } from '@/components/chat/types'
+import { nextClock } from '@/services/cloud/edit-clock'
 import { logError, logWarning } from '@/utils/error-handling'
 
 export interface Chat extends Omit<ChatType, 'createdAt'> {
@@ -19,6 +20,13 @@ export interface StoredChat extends Chat {
   loadedAt?: number
   isLocalOnly?: boolean
   isBlankChat?: boolean
+  // Logical edit clock for conflict arbitration. `clock`/`writer` are
+  // bumped on each local content edit; `clockVersion` records the
+  // syncVersion the clock was last maintained at, so a reader can tell
+  // whether a clock-unaware client wrote since (see remoteWins).
+  clock?: number
+  writer?: string
+  clockVersion?: number
 }
 
 /**
@@ -330,11 +338,32 @@ export class IndexedDBStorage {
         const isFailedDecryption =
           (chat as StoredChat).decryptionFailed === true
 
+        // Bump the edit clock only on a genuine local content edit: a
+        // changed existing chat, or a brand-new locally-created one.
+        // Re-saves that don't touch content (and synced writes) keep the
+        // existing clock so they don't outrank a real concurrent edit.
+        const bumpClock =
+          !isFailedDecryption &&
+          options.markContentChangesAsLocal !== false &&
+          (hasContentChanges ||
+            (!existingChat && ((chat as StoredChat).locallyModified ?? true)))
+        const bumpedClock = bumpClock
+          ? nextClock(existingChat?.clock ?? (chat as StoredChat).clock)
+          : null
+
         const storedChat: StoredChat = {
           ...chat,
           messages: messagesForStorage as any,
           lastAccessedAt: Date.now(),
           syncedAt: existingChat?.syncedAt ?? (chat as StoredChat).syncedAt,
+          clock:
+            bumpedClock?.v ?? existingChat?.clock ?? (chat as StoredChat).clock,
+          writer:
+            bumpedClock?.w ??
+            existingChat?.writer ??
+            (chat as StoredChat).writer,
+          clockVersion:
+            existingChat?.clockVersion ?? (chat as StoredChat).clockVersion,
           // For existing chats: mark as modified if content changed, or preserve existing modified state
           // This ensures modified chats are always picked up for sync even if they were
           // loaded with locallyModified: false from a previous sync
@@ -671,6 +700,9 @@ export class IndexedDBStorage {
           chat.syncedAt = Date.now()
           chat.locallyModified = false
           chat.syncVersion = syncVersion
+          // The clock is now current as of this synced version, so a
+          // later reader trusts it for arbitration.
+          chat.clockVersion = syncVersion
 
           const request = store.put(chat)
 
@@ -761,6 +793,10 @@ export class IndexedDBStorage {
       if (!concurrentEdit) {
         chat.locallyModified = false
         chat.syncedAt = Date.now()
+        // Clock is current as of the uploaded version. On a concurrent
+        // edit the chat stays dirty and clockVersion intentionally lags
+        // so the next upload re-stamps it.
+        chat.clockVersion = opts.syncVersion
       }
 
       return new Promise<void>((resolve, reject) => {

--- a/src/utils/signout-cleanup.ts
+++ b/src/utils/signout-cleanup.ts
@@ -5,6 +5,7 @@ import {
   USER_ENCRYPTION_KEY,
 } from '@/constants/storage-keys'
 import { cloudSync } from '@/services/cloud/cloud-sync'
+import { resetEditClockCache } from '@/services/cloud/edit-clock'
 import { profileSync } from '@/services/cloud/profile-sync'
 import { resetSyncHealth } from '@/services/cloud/sync-health'
 import { encryptionService } from '@/services/encryption/encryption-service'
@@ -50,6 +51,10 @@ async function clearAllUserData(options: ClearUserDataOptions): Promise<void> {
   cloudSync.clearSyncStatus()
   deletedChatsTracker.clear()
   resetSyncHealth()
+
+  // Drop the in-memory edit-clock counter/device-id so the next user
+  // re-reads from cleared storage instead of inheriting this session's.
+  resetEditClockCache()
 
   // Clear project event handlers
   projectEvents.clear()

--- a/tests/services/cloud/edit-clock.test.ts
+++ b/tests/services/cloud/edit-clock.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Edit Clock Tests
+ *
+ * The Lamport-style clock must be strictly monotonic per device, must
+ * advance past any observed remote value, and must expose a stable
+ * device id for deterministic tiebreaking.
+ */
+
+import {
+  deviceId,
+  nextClock,
+  observe,
+  resetEditClockCache,
+} from '@/services/cloud/edit-clock'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+beforeEach(() => {
+  localStorage.clear()
+  resetEditClockCache()
+})
+
+describe('edit clock', () => {
+  it('produces strictly increasing counters', () => {
+    const a = nextClock()
+    const b = nextClock()
+    const c = nextClock()
+    expect(b.v).toBeGreaterThan(a.v)
+    expect(c.v).toBeGreaterThan(b.v)
+  })
+
+  it('advances past an observed remote value', () => {
+    nextClock() // local at 1
+    observe(50)
+    const next = nextClock()
+    expect(next.v).toBeGreaterThan(50)
+  })
+
+  it('ignores remote values lower than the local counter', () => {
+    const high = nextClock().v
+    observe(high - 1)
+    expect(nextClock().v).toBe(high + 1)
+  })
+
+  it('advances past an explicit observed maximum on the unit', () => {
+    expect(nextClock(99).v).toBe(100)
+  })
+
+  it('keeps a stable device id and stamps it as the writer', () => {
+    const id = deviceId()
+    expect(id).toBeTruthy()
+    expect(deviceId()).toBe(id)
+    expect(nextClock().w).toBe(id)
+  })
+
+  it('persists the counter across cache resets via storage', () => {
+    const v = nextClock().v
+    resetEditClockCache()
+    expect(nextClock().v).toBe(v + 1)
+  })
+})

--- a/tests/services/cloud/edit-clock.test.ts
+++ b/tests/services/cloud/edit-clock.test.ts
@@ -6,6 +6,7 @@
  * device id for deterministic tiebreaking.
  */
 
+import { SYNC_EDIT_CLOCK } from '@/constants/storage-keys'
 import {
   deviceId,
   nextClock,
@@ -56,6 +57,33 @@ describe('edit clock', () => {
     const v = nextClock().v
     resetEditClockCache()
     expect(nextClock().v).toBe(v + 1)
+  })
+
+  it('reconciles with storage so a value another tab advanced is not reused', () => {
+    expect(nextClock().v).toBe(1)
+    // Another tab sharing this localStorage advances the counter.
+    localStorage.setItem(SYNC_EDIT_CLOCK, '8')
+    // This tab must continue past the other tab's value rather than
+    // reuse 2 from its stale in-memory cache.
+    expect(nextClock().v).toBe(9)
+  })
+
+  it('mints a distinct writer id per runtime so concurrent tabs differ', () => {
+    const first = deviceId()
+    // A fresh runtime (another tab) keeps the persisted installation id
+    // but draws a new per-runtime nonce.
+    resetEditClockCache()
+    const second = deviceId()
+    expect(second).not.toBe(first)
+  })
+
+  it('ignores fractional, negative, and zero remote values', () => {
+    observe(2.5)
+    observe(-10)
+    observe(0)
+    const next = nextClock()
+    expect(next.v).toBe(1)
+    expect(Number.isInteger(next.v)).toBe(true)
   })
 
   it('ignores a remote value above the safe-integer ceiling', () => {

--- a/tests/services/cloud/edit-clock.test.ts
+++ b/tests/services/cloud/edit-clock.test.ts
@@ -57,4 +57,23 @@ describe('edit clock', () => {
     resetEditClockCache()
     expect(nextClock().v).toBe(v + 1)
   })
+
+  it('ignores a remote value above the safe-integer ceiling', () => {
+    // A crafted/corrupt remote clock must not poison the counter.
+    observe(Number.MAX_SAFE_INTEGER + 1)
+    observe(Number.POSITIVE_INFINITY)
+    // The counter is untouched, so it keeps advancing from the base.
+    expect(nextClock().v).toBe(1)
+    expect(nextClock().v).toBe(2)
+  })
+
+  it('caps the counter at the ceiling without overflowing or trapping', () => {
+    observe(Number.MAX_SAFE_INTEGER)
+    const next = nextClock()
+    expect(Number.isSafeInteger(next.v)).toBe(true)
+    expect(next.v).toBe(Number.MAX_SAFE_INTEGER)
+    // A subsequent tick stays pinned at the ceiling rather than losing
+    // precision or producing a non-finite value.
+    expect(nextClock().v).toBe(Number.MAX_SAFE_INTEGER)
+  })
 })

--- a/tests/services/cloud/profile-merge.test.ts
+++ b/tests/services/cloud/profile-merge.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Profile Merge Tests
+ *
+ * Field-level conflict resolution for profile sync. The merge must:
+ * - keep each side's freshest field by edit clock when both are trusted
+ * - fall back to whole-blob updatedAt when clocks are absent/untrusted
+ * - never let an empty/default blob wipe a populated profile on fallback
+ * - converge: merging in either direction yields the same field values
+ */
+
+import {
+  changedProfileFields,
+  isProfilePopulated,
+  mergeProfiles,
+} from '@/services/cloud/profile-merge'
+import type { ProfileData } from '@/services/cloud/profile-sync'
+import { describe, expect, it } from 'vitest'
+
+// A trusted blob has clockVersion === version, so its field clocks are
+// honored during the merge.
+function trusted(p: ProfileData): ProfileData {
+  return { ...p, version: 10, clockVersion: 10 }
+}
+
+describe('mergeProfiles', () => {
+  it('keeps each side’s field with the higher clock', () => {
+    const local = trusted({
+      nickname: 'local-name',
+      customSystemPrompt: 'old-prompt',
+      fieldClocks: {
+        nickname: { v: 5, w: 'A' },
+        customSystemPrompt: { v: 1, w: 'A' },
+      },
+      updatedAt: '2024-01-01T00:00:00.000Z',
+    })
+    const remote = trusted({
+      nickname: 'remote-name',
+      customSystemPrompt: 'new-prompt',
+      fieldClocks: {
+        nickname: { v: 2, w: 'B' },
+        customSystemPrompt: { v: 9, w: 'B' },
+      },
+      updatedAt: '2024-01-02T00:00:00.000Z',
+    })
+
+    const { merged, adoptedRemote } = mergeProfiles({ local, remote })
+
+    // local nickname (clock 5) beats remote (clock 2); remote prompt
+    // (clock 9) beats local (clock 1). Neither edit is lost.
+    expect(merged.nickname).toBe('local-name')
+    expect(merged.customSystemPrompt).toBe('new-prompt')
+    expect(adoptedRemote).toBe(true)
+  })
+
+  it('converges regardless of merge direction', () => {
+    const local = trusted({
+      nickname: 'local-name',
+      profession: 'old-job',
+      fieldClocks: {
+        nickname: { v: 5, w: 'A' },
+        profession: { v: 1, w: 'A' },
+      },
+    })
+    const remote = trusted({
+      nickname: 'remote-name',
+      profession: 'new-job',
+      fieldClocks: {
+        nickname: { v: 2, w: 'B' },
+        profession: { v: 9, w: 'B' },
+      },
+    })
+
+    const a = mergeProfiles({ local, remote }).merged
+    const b = mergeProfiles({ local: remote, remote: local }).merged
+
+    expect(a.nickname).toBe(b.nickname)
+    expect(a.profession).toBe(b.profession)
+    expect(a.nickname).toBe('local-name')
+    expect(a.profession).toBe('new-job')
+  })
+
+  it('refuses to let an empty remote wipe a populated local on fallback', () => {
+    // No trusted clocks -> fallback path. Remote is newer by wall clock
+    // but empty; the populated local profile must survive.
+    const local: ProfileData = {
+      nickname: 'real-user',
+      customSystemPrompt: 'my prompt',
+      traits: ['curious'],
+      updatedAt: '2024-01-01T00:00:00.000Z',
+    }
+    const remote: ProfileData = {
+      nickname: '',
+      customSystemPrompt: '',
+      traits: [],
+      updatedAt: '2024-01-02T00:00:00.000Z',
+    }
+
+    const { merged, adoptedRemote } = mergeProfiles({ local, remote })
+
+    expect(merged.nickname).toBe('real-user')
+    expect(merged.customSystemPrompt).toBe('my prompt')
+    expect(adoptedRemote).toBe(false)
+  })
+
+  it('falls back to updatedAt when clocks are untrusted', () => {
+    // clockVersion !== version means a clock-unaware client wrote since,
+    // so the field clocks are ignored and the newer blob wins wholesale.
+    const local: ProfileData = {
+      nickname: 'local',
+      selectedModel: 'gpt-oss-120b',
+      version: 4,
+      clockVersion: 2,
+      fieldClocks: { nickname: { v: 99, w: 'A' } },
+      updatedAt: '2024-01-01T00:00:00.000Z',
+    }
+    const remote: ProfileData = {
+      nickname: 'remote',
+      selectedModel: 'gpt-oss-120b',
+      version: 5,
+      clockVersion: 2,
+      fieldClocks: { nickname: { v: 1, w: 'B' } },
+      updatedAt: '2024-01-02T00:00:00.000Z',
+    }
+
+    const { merged } = mergeProfiles({ local, remote })
+
+    // Despite local's huge clock, it is untrusted; newer remote wins.
+    expect(merged.nickname).toBe('remote')
+  })
+})
+
+describe('isProfilePopulated', () => {
+  it('is true when any user content is present', () => {
+    expect(isProfilePopulated({ nickname: 'x' })).toBe(true)
+    expect(isProfilePopulated({ traits: ['a'] })).toBe(true)
+    expect(isProfilePopulated({ customSystemPrompt: 'hi' })).toBe(true)
+  })
+
+  it('is false for empty or default-only profiles', () => {
+    expect(isProfilePopulated(null)).toBe(false)
+    expect(
+      isProfilePopulated({
+        nickname: '',
+        traits: [],
+        themeMode: 'system',
+        thinkingEnabled: true,
+      }),
+    ).toBe(false)
+  })
+})
+
+describe('changedProfileFields', () => {
+  it('lists every field when there is no baseline', () => {
+    const fields = changedProfileFields({ nickname: 'a' }, null)
+    expect(fields).toContain('nickname')
+    expect(fields.length).toBeGreaterThan(1)
+  })
+
+  it('detects primitive and array changes only', () => {
+    const baseline: ProfileData = {
+      nickname: 'a',
+      traits: ['x'],
+      thinkingEnabled: true,
+    }
+    const local: ProfileData = {
+      nickname: 'b',
+      traits: ['x', 'y'],
+      thinkingEnabled: true,
+    }
+    const fields = changedProfileFields(local, baseline)
+    expect(fields.sort()).toEqual(['nickname', 'traits'])
+  })
+})

--- a/tests/services/cloud/profile-merge.test.ts
+++ b/tests/services/cloud/profile-merge.test.ts
@@ -102,6 +102,38 @@ describe('mergeProfiles', () => {
     expect(adoptedRemote).toBe(false)
   })
 
+  it('does not carry untrusted local clocks into the merged output', () => {
+    // Local clocks are untrusted (clockVersion !== version). They must
+    // not survive into the merge, or the next push would re-stamp them
+    // as trusted and corrupt future conflict resolution.
+    const local: ProfileData = {
+      nickname: 'local',
+      profession: 'local-job',
+      version: 4,
+      clockVersion: 2,
+      fieldClocks: {
+        nickname: { v: 99, w: 'A' },
+        profession: { v: 99, w: 'A' },
+      },
+      updatedAt: '2024-01-02T00:00:00.000Z',
+    }
+    // Remote omits profession, and local wins nickname by updatedAt.
+    const remote: ProfileData = {
+      nickname: 'remote',
+      version: 5,
+      clockVersion: 2,
+      fieldClocks: { nickname: { v: 1, w: 'B' } },
+      updatedAt: '2024-01-01T00:00:00.000Z',
+    }
+
+    const { merged } = mergeProfiles({ local, remote })
+
+    expect(merged.nickname).toBe('local')
+    expect(merged.profession).toBe('local-job')
+    // No trusted clock existed for either field, so none is carried.
+    expect(merged.fieldClocks).toBeUndefined()
+  })
+
   it('falls back to updatedAt when clocks are untrusted', () => {
     // clockVersion !== version means a clock-unaware client wrote since,
     // so the field clocks are ignored and the newer blob wins wholesale.

--- a/tests/services/cloud/profile-sync.test.ts
+++ b/tests/services/cloud/profile-sync.test.ts
@@ -84,10 +84,16 @@ describe('ProfileSyncService', () => {
     expect(mockPush.mock.calls[1][0]).toMatchObject({ ifMatch: '9' })
   })
 
-  it('adopts the newer remote profile on a stale-blob conflict', async () => {
-    mockPush.mockRejectedValueOnce(
-      new SyncEnclaveError('STALE_BLOB', 412, 'STALE_BLOB'),
-    )
+  it('adopts the newer remote field and re-pushes the merge on conflict', async () => {
+    mockPush
+      .mockRejectedValueOnce(
+        new SyncEnclaveError('STALE_BLOB', 412, 'STALE_BLOB'),
+      )
+      .mockResolvedValueOnce({
+        ok: true,
+        etag: '10',
+        key_id: 'aa'.repeat(16),
+      })
     mockPull.mockResolvedValue({
       items: [
         {
@@ -111,10 +117,12 @@ describe('ProfileSyncService', () => {
     })
 
     expect(result.success).toBe(true)
-    expect(result.version).toBe(9)
+    expect(result.version).toBe(10)
     expect(result.remoteProfile).toMatchObject({ nickname: 'Remote' })
-    // The remote write wins, so the local copy is not re-uploaded.
-    expect(mockPush).toHaveBeenCalledTimes(1)
+    // The merge re-pushes the resolved profile onto the server's
+    // current version so both devices converge.
+    expect(mockPush).toHaveBeenCalledTimes(2)
+    expect(mockPush.mock.calls[1][0]).toMatchObject({ ifMatch: '9' })
     expect(service.getCachedProfile()).toMatchObject({ nickname: 'Remote' })
   })
 

--- a/tests/services/cloud/sync-predicates.test.ts
+++ b/tests/services/cloud/sync-predicates.test.ts
@@ -12,6 +12,7 @@
 
 import {
   isUploadableChat,
+  remoteWins,
   remoteWinsLastWrite,
   shouldIngestRemoteChat,
 } from '@/services/cloud/sync-predicates'
@@ -241,6 +242,76 @@ describe('Sync Predicates', () => {
     it('lets local win when remote has no usable timestamp', () => {
       expect(remoteWinsLastWrite(older, undefined)).toBe(false)
       expect(remoteWinsLastWrite(older, 'not-a-date')).toBe(false)
+    })
+  })
+
+  describe('remoteWins', () => {
+    const older = '2024-01-01T00:00:00.000Z'
+    const newer = '2024-01-02T00:00:00.000Z'
+
+    it('prefers the higher clock counter over wall-clock time', () => {
+      // Remote has an older timestamp but a higher logical clock; the
+      // clock must win so wall-clock skew cannot decide the outcome.
+      expect(
+        remoteWins({
+          localClock: { v: 1, w: 'a' },
+          remoteClock: { v: 2, w: 'a' },
+          localUpdatedAt: newer,
+          remoteUpdatedAt: older,
+        }),
+      ).toBe(true)
+    })
+
+    it('lets local win when its clock counter is higher', () => {
+      expect(
+        remoteWins({
+          localClock: { v: 5, w: 'a' },
+          remoteClock: { v: 4, w: 'b' },
+        }),
+      ).toBe(false)
+    })
+
+    it('breaks an equal counter by writer id deterministically', () => {
+      expect(
+        remoteWins({
+          localClock: { v: 3, w: 'aaa' },
+          remoteClock: { v: 3, w: 'bbb' },
+        }),
+      ).toBe(true)
+      expect(
+        remoteWins({
+          localClock: { v: 3, w: 'bbb' },
+          remoteClock: { v: 3, w: 'aaa' },
+        }),
+      ).toBe(false)
+    })
+
+    it('treats an identical clock as the same write (no overwrite)', () => {
+      expect(
+        remoteWins({
+          localClock: { v: 7, w: 'a' },
+          remoteClock: { v: 7, w: 'a' },
+        }),
+      ).toBe(false)
+    })
+
+    it('falls back to updatedAt when a clock is missing', () => {
+      expect(
+        remoteWins({
+          localClock: { v: 9, w: 'a' },
+          remoteClock: undefined,
+          localUpdatedAt: older,
+          remoteUpdatedAt: newer,
+        }),
+      ).toBe(true)
+      expect(
+        remoteWins({
+          localClock: undefined,
+          remoteClock: { v: 9, w: 'a' },
+          localUpdatedAt: newer,
+          remoteUpdatedAt: older,
+        }),
+      ).toBe(false)
     })
   })
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Introduce a per-device Lamport edit clock and field‑level profile merge to make sync conflict resolution deterministic and prevent data loss. Clocks are trusted, monotonic across tabs, and hardened against malformed input.

- **New Features**
  - Added `EditClock` (counter `v` + device id `w`) with persisted `SYNC_DEVICE_ID` and `SYNC_EDIT_CLOCK`, plus `observe()`/`nextClock()`.
  - Chats: store `clock`/`writer`; stamp `clockVersion` on upload; advance local clock when ingesting remote.
  - Profiles: added per-field `fieldClocks` and `clockVersion`; stamp clocks only for changed fields; `ProfileSyncService` merges conflicts field‑by‑field and re‑pushes.
  - Unified arbitration via `remoteWins(...)` using trusted clocks; falls back to `updatedAt` for legacy rows.
  - Sign‑out clears in‑memory clock caches to avoid cross‑user leakage.

- **Bug Fixes**
  - Hardened clock handling: sanitize and cap remote values; round‑trip unknown clock fields to avoid data loss.
  - Ensure clocks stay unique and strictly increasing across tabs (per‑runtime writer nonce; reconcile with persisted counter).
  - Block empty/legacy remote profiles from wiping populated locals; resurrect and re‑push local on profile tombstones.

<sup>Written for commit 35024a2e017f08090feb0cb3b17a35b6d60333d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/414?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

