### PR TITLE
Perf: reduce browser cpu usage

### DIFF
--- a/src/components/chat/constants.ts
+++ b/src/components/chat/constants.ts
@@ -34,6 +34,11 @@ export const CONSTANTS = {
   CHAT_INIT_DELAY_MS: 300,
   // State update delay for async operations
   ASYNC_STATE_DELAY_MS: 50,
+  // Coalesce streaming UI updates to at most one render per this interval.
+  // Fast models emit content faster than the screen refreshes, so batching the
+  // flushes avoids re-parsing markdown on every network chunk while staying
+  // well above the threshold where streaming stops looking smooth (~30fps).
+  STREAM_FLUSH_INTERVAL_MS: 33,
   // Sidebar widths
   CHAT_SIDEBAR_WIDTH_PX: 300,
   CHAT_SIDEBAR_COLLAPSED_WIDTH_PX: 48,

--- a/src/components/chat/genui/widgets/Clock.tsx
+++ b/src/components/chat/genui/widgets/Clock.tsx
@@ -300,37 +300,18 @@ function ClockFace({
   showSeconds?: boolean
   showDate?: boolean
 }) {
-  // `frame` advances every animation frame so the analog hands sweep
-  // smoothly. We deliberately ignore its value — it's only here to trigger
-  // a re-render. The actual time is read from `Date.now()` fresh each render.
-  const [, setFrame] = useState(0)
-  // Digital readouts re-render once per second, since re-formatting the
-  // string at 60fps is wasteful.
-  const [digitalTick, setDigitalTick] = useState(() => Date.now())
-  const rafRef = useRef<number | null>(null)
+  // A single once-per-second tick drives both the analog hands and the
+  // digital readout. The second hand advances in discrete steps rather than
+  // sweeping continuously, which avoids a per-frame re-render loop.
+  const [tick, setTick] = useState(() => Date.now())
 
   useEffect(() => {
-    const loop = () => {
-      setFrame((n) => (n + 1) % 1_000_000)
-      rafRef.current = requestAnimationFrame(loop)
-    }
-    rafRef.current = requestAnimationFrame(loop)
-    return () => {
-      if (rafRef.current !== null) cancelAnimationFrame(rafRef.current)
-    }
-  }, [])
-
-  useEffect(() => {
-    const id = setInterval(
-      () => setDigitalTick(Date.now()),
-      DIGITAL_TICK_INTERVAL_MS,
-    )
+    const id = setInterval(() => setTick(Date.now()), DIGITAL_TICK_INTERVAL_MS)
     return () => clearInterval(id)
   }, [])
 
-  const now = new Date()
-  const parts = getTimeParts(now, timeZone)
-  const digitalNow = new Date(digitalTick)
+  const digitalNow = new Date(tick)
+  const parts = getTimeParts(digitalNow, timeZone)
   return (
     <div className="my-3 flex w-full justify-center">
       <Card className="w-full max-w-xs">

--- a/src/components/chat/hooks/streaming/process-stream.ts
+++ b/src/components/chat/hooks/streaming/process-stream.ts
@@ -7,7 +7,9 @@
  * Each event updates the TimelineBuilder (canonical state). The
  * MessageAssembler only tracks citation annotations and search reasoning;
  * all other flat Message fields are derived from the timeline in toMessage().
- * UI is flushed once per reader.read() chunk — no rAF needed.
+ * UI flushes are coalesced to at most one render per
+ * CONSTANTS.STREAM_FLUSH_INTERVAL_MS (leading + trailing edge), so a fast
+ * stream does not re-parse markdown on every network chunk.
  */
 
 import { IS_DEV } from '@/config'
@@ -16,6 +18,7 @@ import {
   createStreamLogger,
   type StreamLogger,
 } from '@/utils/dev-stream-logger'
+import { CONSTANTS } from '../../constants'
 import type { Message, URLFetchState } from '../../types'
 import { createContentPreprocessor } from './content-preprocessor'
 import { createEventNormalizer } from './event-normalizer'
@@ -52,6 +55,8 @@ export async function processStreamingResponse(
 
   let dirty = false
   let firstEventSeen = false
+  let lastFlushAt = 0
+  let trailingFlushTimer: ReturnType<typeof setTimeout> | null = null
 
   // Always write to the chat this stream owns, regardless of which chat is
   // on screen. `updateChatWithHistoryCheck` mirrors the update into
@@ -70,6 +75,36 @@ export async function processStreamingResponse(
       false,
       true, // skip IndexedDB during streaming
     )
+  }
+
+  const clearTrailingFlush = () => {
+    if (trailingFlushTimer !== null) {
+      clearTimeout(trailingFlushTimer)
+      trailingFlushTimer = null
+    }
+  }
+
+  // Coalesce flushes to one render per STREAM_FLUSH_INTERVAL_MS. The leading
+  // edge keeps the first token instant and slow streams unthrottled; the
+  // trailing timer guarantees the latest content still paints when the stream
+  // pauses (e.g. before a tool call) instead of waiting for the next chunk.
+  const flushThrottled = () => {
+    if (!dirty) return
+    const now = Date.now()
+    const elapsed = now - lastFlushAt
+    if (elapsed >= CONSTANTS.STREAM_FLUSH_INTERVAL_MS) {
+      clearTrailingFlush()
+      lastFlushAt = now
+      flushToUI()
+    } else if (trailingFlushTimer === null) {
+      trailingFlushTimer = setTimeout(() => {
+        trailingFlushTimer = null
+        if (dirty) {
+          lastFlushAt = Date.now()
+          flushToUI()
+        }
+      }, CONSTANTS.STREAM_FLUSH_INTERVAL_MS - elapsed)
+    }
   }
 
   const markFirstEvent = () => {
@@ -229,7 +264,7 @@ export async function processStreamingResponse(
         applyEvent(event)
       }
 
-      if (dirty) flushToUI()
+      flushThrottled()
     }
 
     // Flush normalizer tail (buffered first-chunk or unclosed thinking)
@@ -250,12 +285,15 @@ export async function processStreamingResponse(
       dirty = true
     }
 
-    // Final flush
+    // Final flush — always immediate so the completed message paints in full
+    clearTrailingFlush()
     if (dirty) flushToUI()
 
     streamLogger?.flush(streamingChatId)
     return assembler.toMessage(timeline.snapshot())
   } finally {
+    // Drop any pending trailing flush so it can't fire after teardown.
+    clearTrailingFlush()
     ctx.setLoadingState('idle')
     ctx.setIsStreaming(false)
     if (streamingChatId) streamingTracker.endStreaming(streamingChatId)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Reduce browser CPU usage by batching chat streaming renders and removing per-frame updates in the clock widget. This cuts render churn during fast streams and lowers idle cost.

- **Refactors**
  - Coalesce chat stream UI flushes to at most one every 33ms via `CONSTANTS.STREAM_FLUSH_INTERVAL_MS` with leading/trailing scheduling; final flush is immediate and timers are cleaned up.
  - Replace `Clock`’s per-frame `requestAnimationFrame` loop with a 1-second interval tick that drives both analog and digital time.

<sup>Written for commit f0e8b1585be7694dbe390dcd005856d26c7fa201. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/415?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

