### PR TITLE
Stop unlocking chats with a stale recovery passkey

### DIFF
--- a/src/services/passkey/passkey-key-storage.ts
+++ b/src/services/passkey/passkey-key-storage.ts
@@ -529,16 +529,17 @@ export async function retrieveEncryptedKeys(
   try {
     const lookup = await tryRetrieveFromEnclave(credentialId, kek)
     if (lookup.bundle) return lookup.bundle
-    if (!lookup.enclaveKeyExists) {
-      // No registered key yet (or an orphan key with no bundles) — safe
-      // to revive any legacy bundle for this credential.
+    if (!lookup.currentKeyId) {
+      // No registered key at all — safe to revive any legacy bundle for
+      // this credential, since there is no current key_id to mismatch.
       return await tryRetrieveFromLegacy(credentialId, kek)
     }
-    // A key exists but this credential has no enclave bundle. Revive the
-    // legacy bundle only when it wraps the SAME current CEK — i.e. a v1
-    // user with the same passkey on another platform that hasn't been
-    // enrolled yet. A legacy bundle deriving a different key_id is a
-    // rotated-away CEK and must never be adopted as primary.
+    // A key is registered (even an orphan key with no bundles of its
+    // own). Revive the legacy bundle only when it wraps the SAME current
+    // CEK — i.e. a v1 user with the same passkey on another platform that
+    // hasn't been enrolled yet. A legacy bundle deriving a different
+    // key_id is a rotated-away CEK (e.g. left behind by a start_fresh)
+    // and must never be adopted as primary.
     return await tryRetrieveFromLegacyIfCurrent(
       credentialId,
       kek,
@@ -555,7 +556,6 @@ export async function retrieveEncryptedKeys(
 
 interface EnclaveBundleLookup {
   bundle: KeyBundle | null
-  enclaveKeyExists: boolean
   currentKeyId: string | null
 }
 
@@ -566,19 +566,17 @@ async function tryRetrieveFromEnclave(
   try {
     const resp = await enclaveKeyCurrent()
     if (!resp.key_id) {
-      return { bundle: null, enclaveKeyExists: false, currentKeyId: null }
+      return { bundle: null, currentKeyId: null }
     }
     const bundle = resp.bundles[credentialId]
     if (!bundle) {
-      // Treat a key with no bundles at all as "no enclave key" so the
-      // legacy passkey fallback runs (orphan key from the migrate-all
-      // bootstrap). When other bundles exist but none for this
-      // credential, the caller verifies the legacy bundle still wraps
-      // the current key before reviving it.
-      const hasAnyBundle = Object.keys(resp.bundles).length > 0
+      // This credential has no enclave bundle under the current key
+      // (including the orphan-key case where the key has no bundles at
+      // all). The caller verifies any legacy bundle still wraps the
+      // current key_id before reviving it, so a rotated-away CEK is
+      // never adopted.
       return {
         bundle: null,
-        enclaveKeyExists: hasAnyBundle,
         currentKeyId: resp.key_id,
       }
     }
@@ -595,7 +593,6 @@ async function tryRetrieveFromEnclave(
           primary: encryptionService.encodeKeyFromBytes(cekBytes),
           alternatives: [],
         },
-        enclaveKeyExists: true,
         currentKeyId: resp.key_id,
       }
     } catch {
@@ -608,13 +605,12 @@ async function tryRetrieveFromEnclave(
       })
       return {
         bundle: decrypted,
-        enclaveKeyExists: true,
         currentKeyId: resp.key_id,
       }
     }
   } catch (err) {
     if (err instanceof SyncEnclaveError && err.status === 404) {
-      return { bundle: null, enclaveKeyExists: false, currentKeyId: null }
+      return { bundle: null, currentKeyId: null }
     }
     throw err
   }
@@ -656,6 +652,7 @@ async function tryRetrieveFromLegacyIfCurrent(
     logInfo('skipping legacy passkey bundle for a rotated-away key', {
       component: 'PasskeyKeyStorage',
       action: 'retrieveEncryptedKeys',
+      metadata: { credentialId, legacyKeyId, currentKeyId },
     })
     return null
   }

--- a/src/services/passkey/passkey-service.ts
+++ b/src/services/passkey/passkey-service.ts
@@ -298,6 +298,11 @@ export async function authenticatePrfPasskey(
     )) as PublicKeyCredential | null
 
     if (!assertion) {
+      logInfo('passkey assertion returned no credential', {
+        component: 'PasskeyService',
+        action: 'authenticatePrfPasskey',
+        metadata: { allowedCredentials: credentialIds.length },
+      })
       return null
     }
 
@@ -323,10 +328,18 @@ export async function authenticatePrfPasskey(
     if (error instanceof PasskeyTimeoutError) throw error
 
     if (error instanceof DOMException && error.name === 'NotAllowedError') {
-      logInfo('User cancelled passkey authentication', {
-        component: 'PasskeyService',
-        action: 'authenticatePrfPasskey',
-      })
+      // NotAllowedError covers both a user cancel and the case where the
+      // provider has no usable credential for any of the allowed ids
+      // (e.g. the passkey was created in a different browser/profile and
+      // never persisted on this device).
+      logInfo(
+        'passkey authentication not allowed (cancelled or no usable credential)',
+        {
+          component: 'PasskeyService',
+          action: 'authenticatePrfPasskey',
+          metadata: { allowedCredentials: credentialIds.length },
+        },
+      )
       if (throwOnCancel) throw error
       return null
     }

--- a/tests/services/passkey/passkey-key-storage-retrieve.test.ts
+++ b/tests/services/passkey/passkey-key-storage-retrieve.test.ts
@@ -243,7 +243,7 @@ describe('retrieveEncryptedKeys', () => {
     expect(bundle).toBeNull()
   })
 
-  it('falls back to the legacy passkey when the enclave key has no bundles (orphan key)', async () => {
+  it('revives the legacy passkey for an orphan key (no bundles) when it wraps the current CEK', async () => {
     const prf = crypto.getRandomValues(new Uint8Array(32)).buffer as ArrayBuffer
     const kek = await deriveKeyEncryptionKey(prf)
     const original = {
@@ -251,8 +251,13 @@ describe('retrieveEncryptedKeys', () => {
       alternatives: [] as string[],
     }
     const encrypted = await encryptKeyBundle(kek, original)
+    // The orphan key_id is derived from the SAME CEK the device's legacy
+    // passkey wraps, so the bundle must be revived even though the key
+    // has no enclave bundles of its own.
+    mockAlternativeKeyBytes = CEK_BYTES
+    const keyId = await deriveKeyIdHex(CEK_BYTES)
     mockKeyCurrent.mockResolvedValue({
-      key_id: 'feedface'.repeat(8).slice(0, 64),
+      key_id: keyId,
       etag: '1',
       bundles: {},
     })
@@ -271,5 +276,36 @@ describe('retrieveEncryptedKeys', () => {
     expect(bundle).not.toBeNull()
     expect(bundle?.primary).toBe(original.primary)
     expect(mockFetchLegacy).toHaveBeenCalledOnce()
+  })
+
+  it('drops the legacy passkey for an orphan key when it wraps a rotated-away key', async () => {
+    const prf = crypto.getRandomValues(new Uint8Array(32)).buffer as ArrayBuffer
+    const kek = await deriveKeyEncryptionKey(prf)
+    const original = {
+      primary: 'key_orphan_rotated_away',
+      alternatives: [] as string[],
+    }
+    const encrypted = await encryptKeyBundle(kek, original)
+    // Orphan key_id does not match the CEK the legacy passkey wraps, so
+    // the rotated-away bundle must not be adopted as primary.
+    mockAlternativeKeyBytes = CEK_BYTES
+    mockKeyCurrent.mockResolvedValue({
+      key_id: 'ff'.repeat(32),
+      etag: '1',
+      bundles: {},
+    })
+    mockFetchLegacy.mockResolvedValue([
+      {
+        id: CRED_ID,
+        iv: encrypted.iv,
+        encrypted_keys: encrypted.data,
+        created_at: '2024-01-01T00:00:00.000Z',
+        version: 1,
+        sync_version: 1,
+      },
+    ])
+
+    const bundle = await retrieveEncryptedKeys(CRED_ID, kek)
+    expect(bundle).toBeNull()
   })
 })


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevents chats from unlocking with a stale recovery passkey. We now only revive a legacy bundle when it matches the current CEK; rotated-away keys are ignored.

- **Bug Fixes**
  - Adopt legacy bundles only if they wrap the current CEK (orphan keys included); drops bundles from rotated-away keys.
  - Replaced `enclaveKeyExists` with `currentKeyId` to make checks explicit and safer.
  - Added logs in `authenticatePrfPasskey` for missing assertions and NotAllowedError (includes allowed credential count); tests cover both revival and rejection paths.

<sup>Written for commit ccb302c0ea48f7b0892a7c7fe3deecf6a6faa1fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/417?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

