### PR TITLE
feat: remember the selected model per conversation

### DIFF
--- a/src/components/chat/hooks/use-chat-messaging.ts
+++ b/src/components/chat/hooks/use-chat-messaging.ts
@@ -497,6 +497,7 @@ export function useChatMessaging({
           isBlankChat: false,
           createdAt: new Date(),
           pendingSave: true,
+          model: selectedModel,
         }
 
         moveStatus(streamChatIdRef.current, updatedChat.id)
@@ -540,6 +541,7 @@ export function useChatMessaging({
         updatedChat = {
           ...updatedChat,
           messages: updatedMessages,
+          model: selectedModel,
           // Backfill for chats created before this field existed.
           codeExecutionAccessToken:
             updatedChat.codeExecutionAccessToken ??
@@ -742,6 +744,7 @@ export function useChatMessaging({
             title: resolvedTitle,
             titleState: resolvedTitleState,
             messages: finalMessages,
+            model: selectedModel,
             // Keep the pending flag set through the real upload. The
             // sidebar badge is suppressed while streaming, so it now
             // surfaces only here - once the stream stops and the chat

--- a/src/components/chat/hooks/use-chat-messaging.ts
+++ b/src/components/chat/hooks/use-chat-messaging.ts
@@ -422,6 +422,7 @@ export function useChatMessaging({
           createdAt: new Date(),
           isLocalOnly: currentChat.isLocalOnly || !isCloudSyncEnabled(),
           pendingSave: true,
+          model: selectedModel,
           projectId:
             isProjectMode && activeProject ? activeProject.id : undefined,
         }

--- a/src/components/chat/hooks/use-chat-state.ts
+++ b/src/components/chat/hooks/use-chat-state.ts
@@ -1,10 +1,11 @@
-import type { BaseModel } from '@/config/models'
+import { isModelNameAvailable, type BaseModel } from '@/config/models'
 import { useExecSnapshot } from '@/services/exec-snapshot/use-exec-snapshot'
-import { useEffect, useRef } from 'react'
+import { logWarning } from '@/utils/error-handling'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
 import type { AIModel, Chat, LabelType, LoadingState, Message } from '../types'
 import { useChatMessaging } from './use-chat-messaging'
 import { useChatStorage } from './use-chat-storage'
-import { useModelManagement } from './use-model-management'
+import { resolveChatModel, useModelManagement } from './use-model-management'
 import type { ReasoningEffort } from './use-reasoning-effort'
 import { useUIState, type ThemeMode } from './use-ui-state'
 
@@ -142,6 +143,7 @@ export function useChatState({
     createNewChat,
     deleteChat,
     updateChatTitle,
+    updateChatModel,
     handleChatSelect,
     setIsInitialLoad,
     isInitialLoad,
@@ -156,9 +158,11 @@ export function useChatState({
     isLocalChatUrl,
   })
 
-  // Model Management
+  // Model Management - the hook owns model validation and the label/
+  // verification UI state. The active model itself is per-chat: it is
+  // resolved from the current chat (falling back to the first available
+  // model) so concurrent chats never override each other.
   const {
-    selectedModel,
     hasValidatedModel,
     expandedLabel,
     setExpandedLabel,
@@ -166,12 +170,32 @@ export function useChatState({
     setVerificationSuccess,
     verificationComplete,
     verificationSuccess,
-    handleModelSelect,
     handleLabelClick,
   } = useModelManagement({
     models,
     isClient,
   })
+
+  const selectedModel = useMemo(
+    () => resolveChatModel(currentChat, models),
+    [currentChat, models],
+  )
+
+  const handleModelSelect = useCallback(
+    (modelName: AIModel) => {
+      if (!isModelNameAvailable(modelName, models)) {
+        logWarning(`Model ${modelName} is not available`, {
+          component: 'useChatState',
+          action: 'handleModelSelect',
+          metadata: { modelName },
+        })
+        return
+      }
+      updateChatModel(modelName)
+      setExpandedLabel(null)
+    },
+    [models, updateChatModel, setExpandedLabel],
+  )
 
   const { codeExecutionEncryptionKey } = useExecSnapshot({
     enabled: canUseCodeExecution,

--- a/src/components/chat/hooks/use-chat-storage.ts
+++ b/src/components/chat/hooks/use-chat-storage.ts
@@ -32,6 +32,7 @@ interface UseChatStorageReturn {
   createNewChat: (isLocalOnly?: boolean, fromUserAction?: boolean) => void
   deleteChat: (chatId: string) => void
   updateChatTitle: (chatId: string, newTitle: string) => void
+  updateChatModel: (model: string) => void
   switchChat: (chat: Chat) => Promise<void>
   handleChatSelect: (chatId: string) => void
   setIsInitialLoad: (loading: boolean) => void
@@ -303,6 +304,36 @@ export function useChatStorage({
     [storeHistory, currentChat?.id, persistenceManager],
   )
 
+  // Set the model for the currently active chat. Blank chats are matched by
+  // reference (they share an empty id) and kept as a single object so the
+  // send path's reference-based blank-chat replacement still works; real
+  // chats are persisted so the choice survives reloads and syncs to cloud.
+  const updateChatModel = useCallback(
+    (model: string) => {
+      const target = currentChat
+      const updated = { ...target, model }
+
+      setCurrentChat(updated)
+      setChats((prevChats) =>
+        prevChats.map((c) =>
+          (target.isBlankChat ? c === target : c.id === target.id)
+            ? updated
+            : c,
+        ),
+      )
+
+      if (!target.isBlankChat && !target.isTemporary && storeHistory) {
+        persistenceManager.save(updated).catch((error) => {
+          logError('Failed to save chat model update', error, {
+            component: 'useChatStorage',
+            metadata: { chatId: target.id },
+          })
+        })
+      }
+    },
+    [currentChat, storeHistory, persistenceManager],
+  )
+
   // Track when we're in the middle of switching chats to prevent reloadChats from interfering
   const isSwitchingChatRef = useRef(false)
   const switchChatTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -435,6 +466,7 @@ export function useChatStorage({
           locallyModified: downloadedChat.locallyModified,
           decryptionFailed: downloadedChat.decryptionFailed,
           projectId: downloadedChat.projectId,
+          model: downloadedChat.model,
         }
 
         // Add to chats list and select it
@@ -554,6 +586,7 @@ export function useChatStorage({
     createNewChat,
     deleteChat,
     updateChatTitle,
+    updateChatModel,
     switchChat,
     handleChatSelect,
     setIsInitialLoad,

--- a/src/components/chat/hooks/use-model-management.ts
+++ b/src/components/chat/hooks/use-model-management.ts
@@ -2,7 +2,22 @@ import { isModelNameAvailable, type BaseModel } from '@/config/models'
 import { SETTINGS_SELECTED_MODEL } from '@/constants/storage-keys'
 import { logWarning } from '@/utils/error-handling'
 import { useCallback, useEffect, useState } from 'react'
-import type { AIModel, LabelType } from '../types'
+import type { AIModel, Chat, LabelType } from '../types'
+
+/**
+ * Resolves the model a chat should use: the chat's own model when it is
+ * still available, otherwise the first available model. No global default
+ * is consulted so concurrent chats never override each other's model.
+ */
+export function resolveChatModel(
+  chat: Chat | undefined,
+  models: BaseModel[],
+): AIModel {
+  if (chat?.model && isModelNameAvailable(chat.model, models)) {
+    return chat.model
+  }
+  return (models[0]?.modelName as AIModel) ?? ''
+}
 
 interface UseModelManagementProps {
   models: BaseModel[]

--- a/src/components/chat/hooks/use-model-management.ts
+++ b/src/components/chat/hooks/use-model-management.ts
@@ -8,6 +8,10 @@ import type { AIModel, Chat, LabelType } from '../types'
  * Resolves the model a chat should use: the chat's own model when it is
  * still available, otherwise the first available model. No global default
  * is consulted so concurrent chats never override each other's model.
+ *
+ * Runs during render before the model config has loaded, so `models` may
+ * be empty; the empty-string fallback keeps the selector in a neutral
+ * placeholder state until the config arrives.
  */
 export function resolveChatModel(
   chat: Chat | undefined,
@@ -16,7 +20,7 @@ export function resolveChatModel(
   if (chat?.model && isModelNameAvailable(chat.model, models)) {
     return chat.model
   }
-  return (models[0]?.modelName as AIModel) ?? ''
+  return models[0]?.modelName ?? ''
 }
 
 interface UseModelManagementProps {

--- a/src/components/chat/types.ts
+++ b/src/components/chat/types.ts
@@ -185,6 +185,10 @@ export type Chat = {
   // Prompt library preset association - when set, this preset's system
   // prompt overrides the default for this chat.
   presetId?: string
+  // Model this chat is associated with. Drives the selector when the chat
+  // is active and the model used for new messages. Falls back to the first
+  // available model when unset or no longer available.
+  model?: string
   // For code execution.
   codeExecutionAccessToken?: string
 }

--- a/src/services/storage/chat-storage.ts
+++ b/src/services/storage/chat-storage.ts
@@ -132,7 +132,6 @@ export class ChatStorageService {
       locallyModified,
       syncVersion,
       decryptionFailed,
-      model,
       version,
       pendingSave,
       ...baseChat
@@ -283,7 +282,6 @@ export class ChatStorageService {
         locallyModified,
         syncVersion,
         decryptionFailed,
-        model,
         version,
         pendingSave,
         ...baseChat
@@ -309,7 +307,6 @@ export class ChatStorageService {
       ({
         lastAccessedAt,
         syncVersion,
-        model,
         version,
         pendingSave,
         ...chatWithSyncData

--- a/tests/components/chat/model-management.test.ts
+++ b/tests/components/chat/model-management.test.ts
@@ -1,4 +1,8 @@
-import { useModelManagement } from '@/components/chat/hooks/use-model-management'
+import {
+  resolveChatModel,
+  useModelManagement,
+} from '@/components/chat/hooks/use-model-management'
+import type { Chat } from '@/components/chat/types'
 import type { BaseModel } from '@/config/models'
 import { SETTINGS_SELECTED_MODEL } from '@/constants/storage-keys'
 import { act, renderHook, waitFor } from '@testing-library/react'
@@ -30,6 +34,38 @@ vi.mock('@/utils/error-handling', () => ({
   logWarning: vi.fn(),
   logError: vi.fn(),
 }))
+
+describe('resolveChatModel', () => {
+  const makeChat = (model?: string): Chat => ({
+    id: 'chat-1',
+    title: 'Chat',
+    messages: [],
+    createdAt: new Date(),
+    model,
+  })
+
+  it("returns the chat's own model when it is available", () => {
+    expect(resolveChatModel(makeChat('model-b'), mockModels)).toBe('model-b')
+  })
+
+  it('falls back to the first model when the chat has no model', () => {
+    expect(resolveChatModel(makeChat(undefined), mockModels)).toBe('model-a')
+  })
+
+  it('falls back to the first model when the chat model is unavailable', () => {
+    expect(resolveChatModel(makeChat('removed-model'), mockModels)).toBe(
+      'model-a',
+    )
+  })
+
+  it('falls back to the first model when there is no chat', () => {
+    expect(resolveChatModel(undefined, mockModels)).toBe('model-a')
+  })
+
+  it('returns an empty string when no models are available', () => {
+    expect(resolveChatModel(makeChat('model-a'), [])).toBe('')
+  })
+})
 
 describe('useModelManagement', () => {
   beforeEach(() => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Remembers the selected model per conversation and keeps it even if you cancel the first generation. The picker reflects and updates only the active chat.

- **New Features**
  - Added a `model` field to `Chat` and persist it across reloads and cloud sync.
  - Per-chat model selection; changing the model updates only the current chat.
  - Introduced `resolveChatModel` to use the chat’s model when available, otherwise fall back to the first available model; new messages and title updates carry the chat’s model, and older chats are backfilled on update.

- **Bug Fixes**
  - Saved the chat’s `model` as part of the base chat payload so it’s preserved on save/load and sync.
  - New chats keep their selected model when generation is cancelled.

<sup>Written for commit 0d609b00fadf4ce8e54e0eeff3a78a1ff2e56d30. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/418?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

