### PR TITLE
Add auto model selection that picks smart or fast

### DIFF
--- a/src/components/chat/WelcomeScreen.tsx
+++ b/src/components/chat/WelcomeScreen.tsx
@@ -1,5 +1,9 @@
 import { Favicon } from '@/components/ui/favicon'
-import { type BaseModel } from '@/config/models'
+import {
+  findSelectableModel,
+  resolveModelSelection,
+  type BaseModel,
+} from '@/config/models'
 import { USER_PREFS_NICKNAME } from '@/constants/storage-keys'
 import { useUser } from '@clerk/nextjs'
 import { AnimatePresence, motion } from 'framer-motion'
@@ -498,7 +502,7 @@ export const WelcomeScreen = memo(function WelcomeScreen({
                           data-model-selector
                           aria-haspopup="menu"
                           aria-expanded={expandedLabel === 'model'}
-                          aria-label={`Current model ${models.find((m) => m.modelName === selectedModel)?.name ?? ''}`}
+                          aria-label={`Current model ${findSelectableModel(selectedModel, models)?.name ?? ''}`}
                           onClick={(e) => {
                             e.preventDefault()
                             e.stopPropagation()
@@ -509,8 +513,9 @@ export const WelcomeScreen = memo(function WelcomeScreen({
                           className="flex items-center gap-1 py-1.5 text-content-secondary transition-colors hover:text-content-primary"
                         >
                           {(() => {
-                            const model = models.find(
-                              (m) => m.modelName === selectedModel,
+                            const model = findSelectableModel(
+                              selectedModel,
+                              models,
                             )
                             if (!model) return null
                             return (
@@ -558,9 +563,10 @@ export const WelcomeScreen = memo(function WelcomeScreen({
                       !setThinkingEnabled
                     )
                       return undefined
-                    const m = models?.find(
-                      (mm) => mm.modelName === selectedModel,
-                    )
+                    const m =
+                      models && selectedModel
+                        ? resolveModelSelection(selectedModel, models).model
+                        : undefined
                     const supportsEffort = supportsReasoningEffort(m)
                     const supportsToggle = supportsThinkingToggle(m)
                     if (

--- a/src/components/chat/ask-sidebar.tsx
+++ b/src/components/chat/ask-sidebar.tsx
@@ -1,5 +1,5 @@
 import { cn } from '@/components/ui/utils'
-import { type BaseModel } from '@/config/models'
+import { findSelectableModel, type BaseModel } from '@/config/models'
 import { XMarkIcon } from '@heroicons/react/24/outline'
 import { memo, useRef } from 'react'
 import { PiChatCircleText } from 'react-icons/pi'
@@ -63,8 +63,7 @@ export function AskSidebar({
 }: AskSidebarProps) {
   const { messages, isWaitingForResponse, isStreaming } = state
   const hasMessages = messages.length > 0
-  const currentModel =
-    models.find((m) => m.modelName === selectedModel) || models[0]
+  const currentModel = findSelectableModel(selectedModel, models) || models[0]
   const sidebarScrollRef = useRef<HTMLDivElement>(null)
 
   const lastMessage = messages[messages.length - 1]

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -1,6 +1,8 @@
 import {
+  findSelectableModel,
   getAIModels,
   getSystemPromptAndRules,
+  resolveModelSelection,
   type BaseModel,
 } from '@/config/models'
 import {
@@ -1273,9 +1275,9 @@ export function ChatInterface({
   }, [setIsSidebarOpen, currentChat?.messages?.length, createNewChat])
 
   // Get the selected model details
-  const selectedModelDetails = models.find(
-    (model) => model.modelName === selectedModel,
-  ) as BaseModel | undefined
+  const selectedModelDetails = findSelectableModel(selectedModel, models) as
+    | BaseModel
+    | undefined
 
   // Initialize document uploader hook
   const { handleDocumentUpload, describeImageWithMultimodal } =
@@ -3449,7 +3451,7 @@ export function ChatInterface({
                                 data-model-selector
                                 aria-haspopup="menu"
                                 aria-expanded={expandedLabel === 'model'}
-                                aria-label={`Current model ${models.find((m) => m.modelName === selectedModel)?.name ?? ''}`}
+                                aria-label={`Current model ${findSelectableModel(selectedModel, models)?.name ?? ''}`}
                                 onClick={(e) => {
                                   e.preventDefault()
                                   e.stopPropagation()
@@ -3458,8 +3460,9 @@ export function ChatInterface({
                                 className="flex items-center gap-1 py-1.5 text-content-secondary transition-colors hover:text-content-primary"
                               >
                                 {(() => {
-                                  const model = models.find(
-                                    (m) => m.modelName === selectedModel,
+                                  const model = findSelectableModel(
+                                    selectedModel,
+                                    models,
                                   )
                                   if (!model) return null
                                   return (
@@ -3498,9 +3501,10 @@ export function ChatInterface({
                           ) : undefined
                         }
                         reasoningSelectorButton={(() => {
-                          const m = models.find(
-                            (mm) => mm.modelName === selectedModel,
-                          )
+                          const m = resolveModelSelection(
+                            selectedModel,
+                            models,
+                          ).model
                           const supportsEffort = supportsReasoningEffort(m)
                           const supportsToggle = supportsThinkingToggle(m)
                           if (

--- a/src/components/chat/chat-messages.tsx
+++ b/src/components/chat/chat-messages.tsx
@@ -1,4 +1,4 @@
-import { type BaseModel } from '@/config/models'
+import { findSelectableModel, type BaseModel } from '@/config/models'
 import { useChatPrint } from '@/hooks/use-chat-print'
 import {
   findContextStartIndex,
@@ -290,7 +290,7 @@ export function ChatMessages({
       // but TypeScript needs this check
       return models?.[0] || null
     }
-    return models.find((m) => m.modelName === selectedModel) || models[0]
+    return findSelectableModel(selectedModel, models) || models[0]
   }, [models, selectedModel])
 
   // Separate messages into archived and live sections - memoize this calculation

--- a/src/components/chat/hooks/use-chat-messaging.ts
+++ b/src/components/chat/hooks/use-chat-messaging.ts
@@ -609,14 +609,14 @@ export function useChatMessaging({
 
       try {
         // Auto selections need a multimodal candidate when the turn carries
-        // images, and a tool-calling candidate when web search / code
-        // execution is on, so the router never falls back to a model that
-        // can't service the request.
+        // images, and a tool-calling candidate when web search, code execution,
+        // or the default-enabled GenUI tools are active, so the router never
+        // falls back to a model that can't service the request.
         const requireMultimodal = updatedMessages.some(
           (m) => getMessageImages(m).length > 0,
         )
         const requireToolCalling = Boolean(
-          webSearchEnabled || codeExecutionEnabled,
+          webSearchEnabled || codeExecutionEnabled || (genUIEnabled ?? true),
         )
         const { model, autoCandidates } = resolveModelSelection(
           selectedModel,

--- a/src/components/chat/hooks/use-chat-messaging.ts
+++ b/src/components/chat/hooks/use-chat-messaging.ts
@@ -19,7 +19,7 @@
  *   this hook are derived for the currently-viewed chat
  */
 import { useProject } from '@/components/project'
-import { type BaseModel } from '@/config/models'
+import { resolveModelSelection, type BaseModel } from '@/config/models'
 import { streamingTracker } from '@/services/cloud/streaming-tracker'
 import { generateCodeExecutionAccessToken } from '@/services/exec-snapshot/access-token'
 import { getCodeExecutionContainerAuthTokenForChat } from '@/services/exec-snapshot/use-exec-snapshot'
@@ -36,7 +36,7 @@ import { logError, logInfo, logWarning } from '@/utils/error-handling'
 import { generateReverseId } from '@/utils/reverse-id'
 import { useAuth } from '@clerk/nextjs'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { getMessageAttachments } from '../attachment-helpers'
+import { getMessageAttachments, getMessageImages } from '../attachment-helpers'
 import { CONSTANTS } from '../constants'
 import type { Chat, LoadingState, Message } from '../types'
 import { createBlankChat, sortChats } from './chat-operations'
@@ -608,7 +608,21 @@ export function useChatMessaging({
       // }
 
       try {
-        const model = models.find((m) => m.modelName === selectedModel)
+        // Auto selections need a multimodal candidate when the turn carries
+        // images, and a tool-calling candidate when web search / code
+        // execution is on, so the router never falls back to a model that
+        // can't service the request.
+        const requireMultimodal = updatedMessages.some(
+          (m) => getMessageImages(m).length > 0,
+        )
+        const requireToolCalling = Boolean(
+          webSearchEnabled || codeExecutionEnabled,
+        )
+        const { model, autoCandidates } = resolveModelSelection(
+          selectedModel,
+          models,
+          { requireMultimodal, requireToolCalling },
+        )
         if (!model) {
           throw new Error(`Model ${selectedModel} not found`)
         }
@@ -641,6 +655,7 @@ export function useChatMessaging({
 
         const response = await sendChatStream({
           model,
+          autoCandidates,
           systemPrompt: baseSystemPrompt,
           rules,
           onRetry: (attempt, maxRetries, error) => {

--- a/src/components/chat/hooks/use-chat-messaging.ts
+++ b/src/components/chat/hooks/use-chat-messaging.ts
@@ -608,20 +608,20 @@ export function useChatMessaging({
       // }
 
       try {
-        // Auto selections need a multimodal candidate when the turn carries
+        // Auto selections prefer a multimodal candidate when the turn carries
         // images, and a tool-calling candidate when web search, code execution,
-        // or the default-enabled GenUI tools are active, so the router never
-        // falls back to a model that can't service the request.
-        const requireMultimodal = updatedMessages.some(
+        // or the default-enabled GenUI tools are active, so the router favors a
+        // model that can service the request when one is available.
+        const preferMultimodal = updatedMessages.some(
           (m) => getMessageImages(m).length > 0,
         )
-        const requireToolCalling = Boolean(
+        const preferToolCalling = Boolean(
           webSearchEnabled || codeExecutionEnabled || (genUIEnabled ?? true),
         )
         const { model, autoCandidates } = resolveModelSelection(
           selectedModel,
           models,
-          { requireMultimodal, requireToolCalling },
+          { preferMultimodal, preferToolCalling },
         )
         if (!model) {
           throw new Error(`Model ${selectedModel} not found`)

--- a/src/components/chat/hooks/use-model-management.ts
+++ b/src/components/chat/hooks/use-model-management.ts
@@ -1,4 +1,8 @@
-import { isModelNameAvailable, type BaseModel } from '@/config/models'
+import {
+  getDefaultModelId,
+  isModelNameAvailable,
+  type BaseModel,
+} from '@/config/models'
 import { SETTINGS_SELECTED_MODEL } from '@/constants/storage-keys'
 import { logWarning } from '@/utils/error-handling'
 import { useCallback, useEffect, useState } from 'react'
@@ -6,7 +10,7 @@ import type { AIModel, Chat, LabelType } from '../types'
 
 /**
  * Resolves the model a chat should use: the chat's own model when it is
- * still available, otherwise the first available model. No global default
+ * still available, otherwise the default model. No per-user saved model
  * is consulted so concurrent chats never override each other's model.
  *
  * Runs during render before the model config has loaded, so `models` may
@@ -20,7 +24,7 @@ export function resolveChatModel(
   if (chat?.model && isModelNameAvailable(chat.model, models)) {
     return chat.model
   }
-  return models[0]?.modelName ?? ''
+  return getDefaultModelId(models)
 }
 
 interface UseModelManagementProps {
@@ -90,10 +94,10 @@ export function useModelManagement({
         return
       }
 
-      // Otherwise fall back to the first available model
-      const targetModel = models[0].modelName as AIModel
+      // Otherwise clear the stale saved model and revert to the default
+      const targetModel = getDefaultModelId(models) as AIModel
       setSelectedModel(targetModel)
-      localStorage.setItem(SETTINGS_SELECTED_MODEL, targetModel)
+      localStorage.removeItem(SETTINGS_SELECTED_MODEL)
 
       if (selectedModel) {
         logWarning(

--- a/src/components/chat/hooks/use-sidebar-chat.ts
+++ b/src/components/chat/hooks/use-sidebar-chat.ts
@@ -11,7 +11,7 @@
  * web search, and citation processing identical to the main chat view
  * without duplicating any of that logic.
  */
-import { type BaseModel } from '@/config/models'
+import { resolveModelSelection, type BaseModel } from '@/config/models'
 import { sendChatStream } from '@/services/inference/inference-client'
 import { logError } from '@/utils/error-handling'
 import { useCallback, useRef, useState } from 'react'
@@ -130,7 +130,14 @@ export function useSidebarChat({
       setMessages([])
       setQuote(quoteText)
 
-      const model = models.find((m) => m.modelName === selectedModel)
+      // The sidebar ask only sends quoted text plus a serialized transcript,
+      // so multimodal is never required here; tool calling is needed when web
+      // search is on.
+      const { model, autoCandidates } = resolveModelSelection(
+        selectedModel,
+        models,
+        { requireToolCalling: Boolean(webSearchEnabled) },
+      )
       if (!model) {
         logError('Cannot start sidebar ask: model not found', undefined, {
           component: 'useSidebarChat',
@@ -201,6 +208,7 @@ export function useSidebarChat({
         try {
           const response = await sendChatStream({
             model,
+            autoCandidates,
             systemPrompt,
             rules,
             onRetry: (attempt, max, error) => {

--- a/src/components/chat/hooks/use-sidebar-chat.ts
+++ b/src/components/chat/hooks/use-sidebar-chat.ts
@@ -131,12 +131,12 @@ export function useSidebarChat({
       setQuote(quoteText)
 
       // The sidebar ask only sends quoted text plus a serialized transcript,
-      // so multimodal is never required here; tool calling is needed when web
+      // so multimodal is never needed here; tool calling is preferred when web
       // search is on.
       const { model, autoCandidates } = resolveModelSelection(
         selectedModel,
         models,
-        { requireToolCalling: Boolean(webSearchEnabled) },
+        { preferToolCalling: Boolean(webSearchEnabled) },
       )
       if (!model) {
         logError('Cannot start sidebar ask: model not found', undefined, {

--- a/src/components/chat/model-selector.tsx
+++ b/src/components/chat/model-selector.tsx
@@ -1,5 +1,9 @@
-import { type BaseModel } from '@/config/models'
-import { CheckIcon, ChevronDownIcon } from '@heroicons/react/24/outline'
+import { getAutoModels, type BaseModel } from '@/config/models'
+import {
+  CheckIcon,
+  ChevronDownIcon,
+  SparklesIcon,
+} from '@heroicons/react/24/outline'
 import { useLayoutEffect, useRef, useState } from 'react'
 import type { AIModel } from './types'
 
@@ -151,6 +155,8 @@ export function ModelSelector({
     }
   }, [preferredPosition])
 
+  const autoModels = getAutoModels(models)
+
   const displayModels = models.filter(
     (model) =>
       (model.type === 'chat' || model.type === 'code') && model.chat === true,
@@ -199,16 +205,26 @@ export function ModelSelector({
         }}
       >
         <div className="relative flex h-5 w-5 flex-none items-center justify-center">
-          {!loadedImages[model.modelName] && !failedImages[model.modelName] && (
-            <div className="absolute h-5 w-5 rounded-full bg-gray-300 dark:bg-gray-600" />
+          {model.isAuto ? (
+            <SparklesIcon
+              className="h-5 w-5 text-brand-accent-dark dark:text-brand-accent-light"
+              aria-hidden="true"
+            />
+          ) : (
+            <>
+              {!loadedImages[model.modelName] &&
+                !failedImages[model.modelName] && (
+                  <div className="absolute h-5 w-5 rounded-full bg-gray-300 dark:bg-gray-600" />
+                )}
+              <img
+                src={getModelIcon(model)}
+                alt=""
+                className={`h-5 w-5 transition-opacity duration-200 ${!loadedImages[model.modelName] && !failedImages[model.modelName] ? 'opacity-0' : ''}`}
+                onLoad={() => handleImageLoad(model.modelName)}
+                onError={() => handleImageError(model.modelName)}
+              />
+            </>
           )}
-          <img
-            src={getModelIcon(model)}
-            alt=""
-            className={`h-5 w-5 transition-opacity duration-200 ${!loadedImages[model.modelName] && !failedImages[model.modelName] ? 'opacity-0' : ''}`}
-            onLoad={() => handleImageLoad(model.modelName)}
-            onError={() => handleImageError(model.modelName)}
-          />
         </div>
         <div className="flex flex-1 flex-col">
           <span className="font-medium">{model.name}</span>
@@ -251,6 +267,12 @@ export function ModelSelector({
       onTouchEnd={(e) => e.stopPropagation()}
       onMouseDown={(e) => e.stopPropagation()}
     >
+      {autoModels.map((model) => renderModelItem(model))}
+
+      {autoModels.length > 0 && (
+        <div className="mx-3 my-1 border-t border-border-subtle" />
+      )}
+
       {topModels.map((model) => renderModelItem(model))}
 
       {otherModels.length > 0 && (

--- a/src/components/chat/model-selector.tsx
+++ b/src/components/chat/model-selector.tsx
@@ -1,10 +1,7 @@
 import { getAutoModels, type BaseModel } from '@/config/models'
-import {
-  CheckIcon,
-  ChevronDownIcon,
-  SparklesIcon,
-} from '@heroicons/react/24/outline'
+import { CheckIcon, ChevronDownIcon } from '@heroicons/react/24/outline'
 import { useLayoutEffect, useRef, useState } from 'react'
+import { PiShuffleAngularBold } from 'react-icons/pi'
 import type { AIModel } from './types'
 
 type ModelSelectorProps = {
@@ -206,7 +203,7 @@ export function ModelSelector({
       >
         <div className="relative flex h-5 w-5 flex-none items-center justify-center">
           {model.isAuto ? (
-            <SparklesIcon
+            <PiShuffleAngularBold
               className="h-5 w-5 text-brand-accent-dark dark:text-brand-accent-light"
               aria-hidden="true"
             />

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -87,6 +87,8 @@ export type ReasoningConfig = {
   params?: Record<string, ReasoningEndpointParams>
 }
 
+export type AutoTier = 'smart' | 'fast'
+
 // Base model type with all possible properties
 export type BaseModel = {
   modelName: string
@@ -104,17 +106,141 @@ export type BaseModel = {
   paid?: boolean
   multimodal?: boolean
   toolCalling?: boolean
+  /** Eligible for the "Auto · Smart" routing pool. */
+  smart?: boolean
+  /** Eligible for the "Auto · Fast" routing pool. */
+  fast?: boolean
+  /** True for the synthetic Auto picker entries; never a real backend model. */
+  isAuto?: boolean
+  /** Routing tier an Auto entry resolves; only set when isAuto is true. */
+  tier?: AutoTier
   reasoningConfig?: ReasoningConfig
   endpoint?: string
   /** Extra fields merged into the chat completion request body */
   requestParams?: Record<string, unknown>
 }
 
+/** Selectable picker ids for the two Auto routing options. */
+export const AUTO_SMART_ID = 'auto-smart'
+export const AUTO_FAST_ID = 'auto-fast'
+
+/**
+ * Wire value placed in the request `model` field when an Auto option is
+ * selected. The router treats this as a sentinel and reads the candidate list
+ * from the `auto_model_options` body blob.
+ */
+export const AUTO_REQUEST_MODEL = 'auto'
+
+/** Router-only body field carrying the ordered Auto candidate list. */
+export const AUTO_MODEL_OPTIONS_FIELD = 'auto_model_options'
+
+const isAutoId = (modelName: string): boolean =>
+  modelName === AUTO_SMART_ID || modelName === AUTO_FAST_ID
+
+const isChatModel = (m: BaseModel): boolean =>
+  (m.type === 'chat' || m.type === 'code') && m.chat === true
+
+/** Real chat models belonging to the given Auto tier, in priority order. */
+const tierModels = (models: BaseModel[], tier: AutoTier): BaseModel[] =>
+  models.filter((m) => isChatModel(m) && m[tier] === true)
+
+/**
+ * Builds the synthetic Auto picker entries, one per tier that has at least one
+ * member. These are display-only and are never sent to a backend; selection is
+ * resolved to a concrete model list via resolveModelSelection.
+ */
+export const getAutoModels = (models: BaseModel[]): BaseModel[] => {
+  const entries: BaseModel[] = []
+  const add = (tier: AutoTier, modelName: string, name: string): void => {
+    const members = tierModels(models, tier)
+    if (members.length === 0) return
+    entries.push({
+      modelName,
+      image: '',
+      name,
+      nameShort: name,
+      description:
+        tier === 'smart'
+          ? 'Automatically routes to the best available high-capability model'
+          : 'Automatically routes to the best available fast model',
+      type: 'chat',
+      chat: true,
+      isAuto: true,
+      tier,
+      multimodal: members.some((m) => m.multimodal === true),
+    })
+  }
+  add('smart', AUTO_SMART_ID, 'Auto · Smart')
+  add('fast', AUTO_FAST_ID, 'Auto · Fast')
+  return entries
+}
+
 export const isModelNameAvailable = (
   modelName: string,
   models: BaseModel[],
 ): boolean => {
+  if (isAutoId(modelName)) {
+    const tier: AutoTier = modelName === AUTO_SMART_ID ? 'smart' : 'fast'
+    return tierModels(models, tier).length > 0
+  }
   return models.some((m) => m.modelName === modelName)
+}
+
+/**
+ * Resolves a selected picker id to a concrete model for display: the matching
+ * Auto entry when an Auto id is selected, otherwise the real model.
+ */
+export const findSelectableModel = (
+  modelName: string,
+  models: BaseModel[],
+): BaseModel | undefined => {
+  if (isAutoId(modelName)) {
+    return getAutoModels(models).find((m) => m.modelName === modelName)
+  }
+  return models.find((m) => m.modelName === modelName)
+}
+
+export type ResolvedModelSelection = {
+  /** Representative model used to build the request body and the UI. */
+  model: BaseModel | undefined
+  /**
+   * Ordered Auto candidates (only set when an Auto option is selected). The
+   * first entry is the representative model.
+   */
+  autoCandidates?: BaseModel[]
+}
+
+/**
+ * Resolves the selected picker id (real model or Auto sentinel) into the model
+ * used to build the request plus, for Auto, the ordered candidate list. For
+ * Auto the tier pool is filtered by required capabilities (multimodal / tool
+ * calling); if filtering empties the pool it falls back to the unfiltered tier
+ * list so a request is always routable.
+ */
+export const resolveModelSelection = (
+  selectedModel: string,
+  models: BaseModel[],
+  opts?: { requireMultimodal?: boolean; requireToolCalling?: boolean },
+): ResolvedModelSelection => {
+  if (!isAutoId(selectedModel)) {
+    return { model: models.find((m) => m.modelName === selectedModel) }
+  }
+
+  const tier: AutoTier = selectedModel === AUTO_SMART_ID ? 'smart' : 'fast'
+  const pool = tierModels(models, tier)
+
+  let candidates = pool
+  if (opts?.requireMultimodal) {
+    candidates = candidates.filter((m) => m.multimodal === true)
+  }
+  if (opts?.requireToolCalling) {
+    candidates = candidates.filter((m) => m.toolCalling === true)
+  }
+  if (candidates.length === 0) {
+    candidates = pool
+  }
+
+  return { model: candidates[0], autoCandidates: candidates }
 }
 
 const isLocalDevelopment = (): boolean => {

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -180,12 +180,14 @@ export const getAutoModels = (models: BaseModel[]): BaseModel[] => {
 
 /**
  * Default picker selection: Auto · Fast when its tier has members, otherwise
- * the first available model (e.g. local dev where models carry no tier
- * attributes). Empty string when no models have loaded yet.
+ * the first chat-capable model (e.g. local dev where models carry no tier
+ * attributes). The model list also contains non-chat types (embedding, audio,
+ * title, ...) which must never become the chat default. Empty string when no
+ * chat models are available.
  */
 export const getDefaultModelId = (models: BaseModel[]): string => {
   if (tierModels(models, 'fast').length > 0) return AUTO_FAST_ID
-  return models[0]?.modelName ?? ''
+  return models.find(isChatModel)?.modelName ?? ''
 }
 
 export const isModelNameAvailable = (

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -216,16 +216,16 @@ export type ResolvedModelSelection = {
 /**
  * Resolves the selected picker id (real model or Auto sentinel) into the model
  * used to build the request plus, for Auto, the ordered candidate list. For
- * Auto each required capability (multimodal / tool calling) narrows the tier
- * pool only when at least one member satisfies it, so a satisfied requirement
- * is never silently dropped. Incapable models are kept only when no tier member
- * supports a requirement at all, which keeps the request routable (degraded)
+ * Auto each preferred capability (multimodal / tool calling) narrows the tier
+ * pool only when at least one member satisfies it, so a satisfied preference is
+ * never silently dropped. When no tier member supports a preference at all the
+ * incapable models are kept, which keeps the request routable (degraded)
  * rather than mis-routing past a capable candidate.
  */
 export const resolveModelSelection = (
   selectedModel: string,
   models: BaseModel[],
-  opts?: { requireMultimodal?: boolean; requireToolCalling?: boolean },
+  opts?: { preferMultimodal?: boolean; preferToolCalling?: boolean },
 ): ResolvedModelSelection => {
   if (!isAutoId(selectedModel)) {
     return { model: models.find((m) => m.modelName === selectedModel) }
@@ -234,11 +234,11 @@ export const resolveModelSelection = (
   const tier: AutoTier = selectedModel === AUTO_SMART_ID ? 'smart' : 'fast'
   let candidates = tierModels(models, tier)
 
-  if (opts?.requireMultimodal) {
+  if (opts?.preferMultimodal) {
     const capable = candidates.filter((m) => m.multimodal === true)
     if (capable.length > 0) candidates = capable
   }
-  if (opts?.requireToolCalling) {
+  if (opts?.preferToolCalling) {
     const capable = candidates.filter((m) => m.toolCalling === true)
     if (capable.length > 0) candidates = capable
   }

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -213,9 +213,11 @@ export type ResolvedModelSelection = {
 /**
  * Resolves the selected picker id (real model or Auto sentinel) into the model
  * used to build the request plus, for Auto, the ordered candidate list. For
- * Auto the tier pool is filtered by required capabilities (multimodal / tool
- * calling); if filtering empties the pool it falls back to the unfiltered tier
- * list so a request is always routable.
+ * Auto each required capability (multimodal / tool calling) narrows the tier
+ * pool only when at least one member satisfies it, so a satisfied requirement
+ * is never silently dropped. Incapable models are kept only when no tier member
+ * supports a requirement at all, which keeps the request routable (degraded)
+ * rather than mis-routing past a capable candidate.
  */
 export const resolveModelSelection = (
   selectedModel: string,
@@ -227,17 +229,15 @@ export const resolveModelSelection = (
   }
 
   const tier: AutoTier = selectedModel === AUTO_SMART_ID ? 'smart' : 'fast'
-  const pool = tierModels(models, tier)
+  let candidates = tierModels(models, tier)
 
-  let candidates = pool
   if (opts?.requireMultimodal) {
-    candidates = candidates.filter((m) => m.multimodal === true)
+    const capable = candidates.filter((m) => m.multimodal === true)
+    if (capable.length > 0) candidates = capable
   }
   if (opts?.requireToolCalling) {
-    candidates = candidates.filter((m) => m.toolCalling === true)
-  }
-  if (candidates.length === 0) {
-    candidates = pool
+    const capable = candidates.filter((m) => m.toolCalling === true)
+    if (capable.length > 0) candidates = capable
   }
 
   return { model: candidates[0], autoCandidates: candidates }

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -106,10 +106,8 @@ export type BaseModel = {
   paid?: boolean
   multimodal?: boolean
   toolCalling?: boolean
-  /** Eligible for the "Auto · Smart" routing pool. */
-  smart?: boolean
-  /** Eligible for the "Auto · Fast" routing pool. */
-  fast?: boolean
+  /** Open set of model tags, including Auto routing tiers ("smart", "fast"). */
+  attributes?: string[]
   /** True for the synthetic Auto picker entries; never a real backend model. */
   isAuto?: boolean
   /** Routing tier an Auto entry resolves; only set when isAuto is true. */
@@ -142,7 +140,7 @@ const isChatModel = (m: BaseModel): boolean =>
 
 /** Real chat models belonging to the given Auto tier, in priority order. */
 const tierModels = (models: BaseModel[], tier: AutoTier): BaseModel[] =>
-  models.filter((m) => isChatModel(m) && m[tier] === true)
+  models.filter((m) => isChatModel(m) && m.attributes?.includes(tier) === true)
 
 /**
  * Builds the synthetic Auto picker entries, one per tier that has at least one

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -178,6 +178,16 @@ export const getAutoModels = (models: BaseModel[]): BaseModel[] => {
   return entries
 }
 
+/**
+ * Default picker selection: Auto · Fast when its tier has members, otherwise
+ * the first available model (e.g. local dev where models carry no tier
+ * attributes). Empty string when no models have loaded yet.
+ */
+export const getDefaultModelId = (models: BaseModel[]): string => {
+  if (tierModels(models, 'fast').length > 0) return AUTO_FAST_ID
+  return models[0]?.modelName ?? ''
+}
+
 export const isModelNameAvailable = (
   modelName: string,
   models: BaseModel[],

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -140,7 +140,12 @@ const isChatModel = (m: BaseModel): boolean =>
 
 /** Real chat models belonging to the given Auto tier, in priority order. */
 const tierModels = (models: BaseModel[], tier: AutoTier): BaseModel[] =>
-  models.filter((m) => isChatModel(m) && m.attributes?.includes(tier) === true)
+  models.filter(
+    (m) =>
+      isChatModel(m) &&
+      Array.isArray(m.attributes) &&
+      m.attributes.includes(tier),
+  )
 
 /**
  * Builds the synthetic Auto picker entries, one per tier that has at least one

--- a/src/services/inference/chat-query-builder.ts
+++ b/src/services/inference/chat-query-builder.ts
@@ -36,6 +36,13 @@ export interface ChatQueryBuilderParams {
    * so non-chat callers (title gen, memory) stay unaffected.
    */
   includeGenUIHint?: boolean
+  /**
+   * Force injecting the system prompt as a leading user message instead of a
+   * system-role message. Used for Auto selection so a single built message set
+   * is valid for every candidate the router may pick, including models that
+   * don't support the system role (e.g. DeepSeek).
+   */
+  forcePrependSystemPrompt?: boolean
 }
 
 export class ChatQueryBuilder {
@@ -51,6 +58,7 @@ export class ChatQueryBuilder {
       rules,
       messages: conversationMessages,
       includeGenUIHint,
+      forcePrependSystemPrompt,
     } = params
     const modelId = model.modelName
 
@@ -67,7 +75,8 @@ export class ChatQueryBuilder {
     const result: ChatCompletionMessageParam[] = []
 
     // Determine if we should use system role or prepend to user message
-    const useSystemRole = this.shouldUseSystemRole(modelId)
+    const useSystemRole =
+      !forcePrependSystemPrompt && this.shouldUseSystemRole(modelId)
 
     // Add system message/instructions based on model requirements
     if (useSystemRole) {
@@ -168,7 +177,7 @@ export class ChatQueryBuilder {
    * Determine if the model should use system role or prepend to user message.
    * Most models support system role; DeepSeek is the known exception.
    */
-  private static shouldUseSystemRole(modelId: string): boolean {
+  static shouldUseSystemRole(modelId: string): boolean {
     return !modelId.startsWith('deepseek')
   }
 

--- a/src/services/inference/inference-client.ts
+++ b/src/services/inference/inference-client.ts
@@ -9,6 +9,7 @@ import {
 } from '@/components/chat/hooks/use-reasoning-effort'
 import type { Message } from '@/components/chat/types'
 import type { BaseModel } from '@/config/models'
+import { AUTO_MODEL_OPTIONS_FIELD, AUTO_REQUEST_MODEL } from '@/config/models'
 import { shouldRetryTestFail } from '@/utils/dev-simulator'
 import { logError, logInfo } from '@/utils/error-handling'
 import { ChatQueryBuilder } from './chat-query-builder'
@@ -40,6 +41,71 @@ function substituteEffort(value: unknown, effort: string): unknown {
     return out
   }
   return value
+}
+
+/**
+ * Builds the model-specific request-body delta for a single model: the
+ * reasoning enable/disable block (with the user's effort spliced in) plus the
+ * model's own `requestParams`. Shared, model-independent options (web search,
+ * code execution, PII check, GenUI tools) are added to the base body by the
+ * caller and are intentionally excluded here so this delta can also be sent
+ * per-candidate in the Auto `auto_model_options` blob.
+ */
+function buildModelBodyParams(
+  model: BaseModel,
+  opts: { thinkingEnabled?: boolean; reasoningEffort?: ReasoningEffort },
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {}
+
+  if (isReasoningModel(model)) {
+    const endpointParams =
+      model.reasoningConfig?.params?.[CHAT_COMPLETIONS_ENDPOINT]
+    if (endpointParams) {
+      const rawBlock = supportsThinkingToggle(model)
+        ? opts.thinkingEnabled
+          ? endpointParams.enable
+          : endpointParams.disable
+        : endpointParams.enable
+      if (rawBlock) {
+        const uiEffort =
+          supportsReasoningEffort(model) && opts.reasoningEffort
+            ? opts.reasoningEffort
+            : 'medium'
+        const effort = model.reasoningConfig?.effortMap?.[uiEffort] ?? uiEffort
+        const block = substituteEffort(rawBlock, effort) as Record<
+          string,
+          unknown
+        >
+        for (const [key, value] of Object.entries(block)) {
+          out[key] = value
+        }
+      }
+    }
+  }
+
+  // Apply model-specific params, but never let them overwrite our explicit
+  // or security-sensitive fields.
+  if (model.requestParams) {
+    const reserved = new Set([
+      'model',
+      'messages',
+      'stream',
+      'signal',
+      'reasoning_effort',
+      'web_search_options',
+      'code_execution_options',
+      'pii_check_options',
+      'tools',
+      'tool_choice',
+    ])
+    for (const [key, value] of Object.entries(model.requestParams)) {
+      if (!reserved.has(key)) {
+        out[key] = value
+      }
+    }
+  }
+
+  return out
 }
 
 function isOnline(): boolean {
@@ -104,6 +170,13 @@ function isRetryableError(error: unknown): boolean {
 
 export interface SendChatStreamParams {
   model: BaseModel
+  /**
+   * Ordered Auto candidates. When provided (an Auto option is selected), the
+   * request `model` is set to the router's "auto" sentinel and each
+   * candidate's params travel in the `auto_model_options` blob. `model` is the
+   * representative (first) candidate, used to build the shared message body.
+   */
+  autoCandidates?: BaseModel[]
   systemPrompt: string
   rules?: string
   onRetry?: (attempt: number, maxRetries: number, error?: string) => void
@@ -134,6 +207,7 @@ export async function sendChatStream(
 ): Promise<Response> {
   const {
     model,
+    autoCandidates,
     systemPrompt,
     rules,
     onRetry,
@@ -298,42 +372,6 @@ export async function sendChatStream(
         messages,
         stream: true,
       }
-      if (isReasoningModel(model)) {
-        const endpointParams =
-          model.reasoningConfig?.params?.[CHAT_COMPLETIONS_ENDPOINT]
-        if (endpointParams) {
-          // Pick enable vs disable based on the toggle. Models that don't
-          // support a toggle always take the enable block.
-          const rawBlock = supportsThinkingToggle(model)
-            ? thinkingEnabled
-              ? endpointParams.enable
-              : endpointParams.disable
-            : endpointParams.enable
-          if (rawBlock) {
-            // The config may embed "$EFFORT" anywhere inside the block; we
-            // splice in the user-selected effort here. Each model declares
-            // exactly which request key its backend expects the effort under
-            // (top-level reasoning_effort, chat_template_kwargs, etc.).
-            // When the model's chat template only accepts a non-standard set
-            // of effort values (e.g. DeepSeek V4 accepts only "high"/"max"),
-            // an effortMap on the reasoningConfig translates the UI value
-            // before substitution.
-            const uiEffort =
-              supportsReasoningEffort(model) && reasoningEffort
-                ? reasoningEffort
-                : 'medium'
-            const effort =
-              model.reasoningConfig?.effortMap?.[uiEffort] ?? uiEffort
-            const block = substituteEffort(rawBlock, effort) as Record<
-              string,
-              unknown
-            >
-            for (const [key, value] of Object.entries(block)) {
-              requestBody[key] = value
-            }
-          }
-        }
-      }
       if (webSearchEnabled) {
         requestBody.web_search_options = {}
       }
@@ -361,26 +399,22 @@ export async function sendChatStream(
         requestBody.tools = genUITools
         requestBody.tool_choice = 'auto'
       }
-      // Apply model-specific params first, then let our explicit fields win.
-      // This prevents requestParams from accidentally overwriting security-
-      // sensitive fields like web_search_options or pii_check_options.
-      if (model.requestParams) {
-        const reserved = new Set([
-          'model',
-          'messages',
-          'stream',
-          'signal',
-          'reasoning_effort',
-          'web_search_options',
-          'code_execution_options',
-          'pii_check_options',
-          'tools',
-          'tool_choice',
-        ])
-        for (const [key, value] of Object.entries(model.requestParams)) {
-          if (!reserved.has(key)) {
-            requestBody[key] = value
-          }
+
+      const modelParamOpts = { thinkingEnabled, reasoningEffort }
+      if (autoCandidates && autoCandidates.length > 0) {
+        // Auto: defer the model choice to the router. Each candidate carries
+        // its own model-specific param block so whichever one the router picks
+        // gets exactly the right reasoning/requestParams applied.
+        requestBody.model = AUTO_REQUEST_MODEL
+        requestBody[AUTO_MODEL_OPTIONS_FIELD] = autoCandidates.map((c) => ({
+          model: c.modelName,
+          params: buildModelBodyParams(c, modelParamOpts),
+        }))
+      } else {
+        // Single model: merge its params straight into the body.
+        const params = buildModelBodyParams(model, modelParamOpts)
+        for (const [key, value] of Object.entries(params)) {
+          requestBody[key] = value
         }
       }
 

--- a/src/services/inference/inference-client.ts
+++ b/src/services/inference/inference-client.ts
@@ -333,12 +333,23 @@ export async function sendChatStream(
     )
   }
 
+  // For Auto, the router may pick any candidate, so the single built message
+  // set must be valid for all of them. If any candidate doesn't support the
+  // system role (e.g. DeepSeek), inject the system prompt as a leading user
+  // message, a form every model understands.
+  const forcePrependSystemPrompt = Boolean(
+    autoCandidates?.some(
+      (c) => !ChatQueryBuilder.shouldUseSystemRole(c.modelName),
+    ),
+  )
+
   const messages = ChatQueryBuilder.buildMessages({
     model,
     systemPrompt,
     rules,
     messages: updatedMessages,
     includeGenUIHint: genUIEnabled,
+    forcePrependSystemPrompt,
   })
 
   let lastError: unknown = null

--- a/tests/components/chat/model-management.test.ts
+++ b/tests/components/chat/model-management.test.ts
@@ -77,6 +77,18 @@ describe('resolveChatModel', () => {
   it('falls back to auto-fast when available', () => {
     expect(resolveChatModel(undefined, modelsWithFastTier)).toBe('auto-fast')
   })
+
+  it('skips non-chat models when falling back to the default', () => {
+    const embeddingModel: BaseModel = {
+      ...mockModelA,
+      modelName: 'model-embedding',
+      type: 'embedding',
+      chat: undefined,
+    }
+    expect(resolveChatModel(undefined, [embeddingModel, mockModelB])).toBe(
+      'model-b',
+    )
+  })
 })
 
 describe('useModelManagement', () => {

--- a/tests/components/chat/model-management.test.ts
+++ b/tests/components/chat/model-management.test.ts
@@ -30,6 +30,14 @@ const mockModelB: BaseModel = {
 
 const mockModels: BaseModel[] = [mockModelA, mockModelB]
 
+const mockFastModel: BaseModel = {
+  ...mockModelB,
+  modelName: 'model-fast',
+  attributes: ['fast'],
+}
+
+const modelsWithFastTier: BaseModel[] = [mockModelA, mockFastModel]
+
 vi.mock('@/utils/error-handling', () => ({
   logWarning: vi.fn(),
   logError: vi.fn(),
@@ -64,6 +72,10 @@ describe('resolveChatModel', () => {
 
   it('returns an empty string when no models are available', () => {
     expect(resolveChatModel(makeChat('model-a'), [])).toBe('')
+  })
+
+  it('falls back to auto-fast when available', () => {
+    expect(resolveChatModel(undefined, modelsWithFastTier)).toBe('auto-fast')
   })
 })
 
@@ -284,13 +296,6 @@ describe('useModelManagement', () => {
   })
 
   describe('auto-fast default', () => {
-    const fastModel: BaseModel = {
-      ...mockModelB,
-      modelName: 'model-fast',
-      attributes: ['fast'],
-    }
-    const modelsWithFastTier = [mockModelA, fastModel]
-
     it('defaults to auto-fast when the fast tier has members', async () => {
       const { result } = renderHook(() =>
         useModelManagement({
@@ -322,10 +327,6 @@ describe('useModelManagement', () => {
 
       expect(result.current.selectedModel).toBe('auto-fast')
       expect(localStorage.getItem(SETTINGS_SELECTED_MODEL)).toBe('auto-fast')
-    })
-
-    it('resolveChatModel falls back to auto-fast when available', () => {
-      expect(resolveChatModel(undefined, modelsWithFastTier)).toBe('auto-fast')
     })
   })
 })

--- a/tests/components/chat/model-management.test.ts
+++ b/tests/components/chat/model-management.test.ts
@@ -249,7 +249,7 @@ describe('useModelManagement', () => {
   })
 
   describe('localStorage persistence', () => {
-    it('should save validated model to localStorage', async () => {
+    it('should not persist the fallback default when nothing was saved', async () => {
       const { result } = renderHook(() =>
         useModelManagement({
           models: mockModels,
@@ -261,7 +261,71 @@ describe('useModelManagement', () => {
         expect(result.current.hasValidatedModel).toBe(true)
       })
 
-      expect(localStorage.getItem(SETTINGS_SELECTED_MODEL)).toBe('model-a')
+      expect(localStorage.getItem(SETTINGS_SELECTED_MODEL)).toBeNull()
+    })
+
+    it('should clear localStorage when the saved model is unavailable', async () => {
+      localStorage.setItem(SETTINGS_SELECTED_MODEL, 'removed-model')
+
+      const { result } = renderHook(() =>
+        useModelManagement({
+          models: mockModels,
+          isClient: true,
+        }),
+      )
+
+      await waitFor(() => {
+        expect(result.current.hasValidatedModel).toBe(true)
+      })
+
+      expect(result.current.selectedModel).toBe('model-a')
+      expect(localStorage.getItem(SETTINGS_SELECTED_MODEL)).toBeNull()
+    })
+  })
+
+  describe('auto-fast default', () => {
+    const fastModel: BaseModel = {
+      ...mockModelB,
+      modelName: 'model-fast',
+      attributes: ['fast'],
+    }
+    const modelsWithFastTier = [mockModelA, fastModel]
+
+    it('defaults to auto-fast when the fast tier has members', async () => {
+      const { result } = renderHook(() =>
+        useModelManagement({
+          models: modelsWithFastTier,
+          isClient: true,
+        }),
+      )
+
+      await waitFor(() => {
+        expect(result.current.hasValidatedModel).toBe(true)
+      })
+
+      expect(result.current.selectedModel).toBe('auto-fast')
+    })
+
+    it('keeps a saved auto selection when its tier is still available', async () => {
+      localStorage.setItem(SETTINGS_SELECTED_MODEL, 'auto-fast')
+
+      const { result } = renderHook(() =>
+        useModelManagement({
+          models: modelsWithFastTier,
+          isClient: true,
+        }),
+      )
+
+      await waitFor(() => {
+        expect(result.current.hasValidatedModel).toBe(true)
+      })
+
+      expect(result.current.selectedModel).toBe('auto-fast')
+      expect(localStorage.getItem(SETTINGS_SELECTED_MODEL)).toBe('auto-fast')
+    })
+
+    it('resolveChatModel falls back to auto-fast when available', () => {
+      expect(resolveChatModel(undefined, modelsWithFastTier)).toBe('auto-fast')
     })
   })
 })

--- a/tests/services/inference/chat-query-builder.test.ts
+++ b/tests/services/inference/chat-query-builder.test.ts
@@ -43,4 +43,33 @@ describe('ChatQueryBuilder', () => {
 
     expect(messages).toEqual([{ role: 'user', content: 'hello' }])
   })
+
+  it('uses the system role for system-role models by default', () => {
+    const messages = ChatQueryBuilder.buildMessages({
+      model,
+      systemPrompt: 'be helpful',
+      rules: '',
+      messages: [userMessage],
+      includeGenUIHint: false,
+    })
+
+    expect(messages[0]).toEqual({ role: 'system', content: 'be helpful' })
+  })
+
+  it('prepends the system prompt as a user message when forced', () => {
+    const messages = ChatQueryBuilder.buildMessages({
+      model,
+      systemPrompt: 'be helpful',
+      rules: '',
+      messages: [userMessage],
+      includeGenUIHint: false,
+      forcePrependSystemPrompt: true,
+    })
+
+    expect(messages.some((m) => m.role === 'system')).toBe(false)
+    expect(messages[0]).toEqual({
+      role: 'user',
+      content: '<system>\nbe helpful\n</system>',
+    })
+  })
 })


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add “Auto · Smart” and “Auto · Fast” model selection that routes each turn to the best eligible model, narrowing by multimodal and tool-calling when helpful. Defaults to “Auto · Fast” when available and never to a non‑chat model; clears stale saved choices.

- **New Features**
  - Added synthetic auto options in the model picker with a shuffle icon; shows “Auto · Smart” and “Auto · Fast” when tiers have candidates.
  - Per-turn resolution via `resolveModelSelection` narrows only when at least one candidate matches the preference (multimodal for image turns; tool-calling for web search, code execution, or GenUI); otherwise stays routable.
  - Inference client supports auto routing: sends `model: "auto"` with ordered `auto_model_options`, each carrying per-candidate reasoning/request params; forces the system prompt into the first user message when any candidate lacks system-role support; preserves security-sensitive fields.
  - UI uses `findSelectableModel`/`resolveModelSelection` to show correct labels and capabilities; reasoning toggle/effort derive from the resolved model.

- **Refactors**
  - Auto routing tiers are read from model `attributes` and exposed via `getAutoModels`; helpers handle Auto IDs in `findSelectableModel` and `isModelNameAvailable`; skips models with malformed `attributes`.
  - Defaults via `getDefaultModelId`: pick “Auto · Fast” when its tier has members, otherwise the first chat-capable model; never default to non‑chat; clear stale saved model instead of persisting a fallback.

<sup>Written for commit 27332156c0b25da0cb5a1789138941a611f89115. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/419?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

