### PR TITLE
Stop chat view from snapping back while scrolling during replies

### DIFF
--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -82,17 +82,7 @@ import {
 import { TfTinSad } from '@tinfoilsh/tinfoil-icons'
 import dynamic from 'next/dynamic'
 import Head from 'next/head'
-import {
-  useLayoutEffect as reactUseLayoutEffect,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react'
-
-const useLayoutEffect =
-  typeof window !== 'undefined' ? reactUseLayoutEffect : useEffect
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { SubscribePromptModal } from '../modals/subscribe-prompt-modal'
 import { UrlHashMessageHandler } from '../url-hash-message-handler'
@@ -2456,29 +2446,6 @@ export function ChatInterface({
     isWaitingForResponse,
     loadingState,
   ])
-
-  // Preserve scroll position when user has scrolled up during streaming.
-  // When new content appears below the viewport (e.g., thoughts start streaming),
-  // some mobile browsers may jump the scroll position. This saves scrollTop
-  // before React commits DOM changes and restores it after.
-  const savedScrollTopRef = useRef<number | null>(null)
-  if (showScrollButton && scrollContainerRef.current) {
-    savedScrollTopRef.current = scrollContainerRef.current.scrollTop
-  } else {
-    savedScrollTopRef.current = null
-  }
-  useLayoutEffect(() => {
-    if (
-      savedScrollTopRef.current !== null &&
-      scrollContainerRef.current &&
-      showScrollButton
-    ) {
-      const el = scrollContainerRef.current
-      if (el.scrollTop !== savedScrollTopRef.current) {
-        el.scrollTop = savedScrollTopRef.current
-      }
-    }
-  }, [currentChat?.messages, showScrollButton])
 
   // Nudge scroll slightly when content starts after thinking, only if near bottom
   const contentStartSnapshotRef = useRef<{


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes a bug where the chat view snapped back while you scrolled during a streaming reply. Removes the scroll-position restore logic (and the related layout-effect polyfill) so the viewport stays stable as new messages arrive.

<sup>Written for commit 106a1b56ef973a7ffe8a6233eaaff6da9879df70. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/421?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

