### PR TITLE
fix: keep model choice per device instead of syncing it

### DIFF
--- a/src/hooks/use-profile-sync.ts
+++ b/src/hooks/use-profile-sync.ts
@@ -516,7 +516,6 @@ export function useProfileSync() {
       'languageChanged',
       'customSystemPromptChanged',
       'promptLibraryChanged',
-      'selectedModelChanged',
       'reasoningSettingsChanged',
       'webSearchEnabledChanged',
       'codeExecutionEnabledChanged',

--- a/src/services/cloud/profile-merge.ts
+++ b/src/services/cloud/profile-merge.ts
@@ -20,7 +20,6 @@ export const PROFILE_MERGE_FIELDS = [
   'customSystemPrompt',
   'customPromptPresets',
   'favoritePromptPresetIds',
-  'selectedModel',
   'reasoningEffort',
   'thinkingEnabled',
   'webSearchEnabled',

--- a/src/services/cloud/profile-settings-serializer.ts
+++ b/src/services/cloud/profile-settings-serializer.ts
@@ -4,7 +4,6 @@ import {
   SETTINGS_GENUI_ENABLED,
   SETTINGS_PII_CHECK_ENABLED,
   SETTINGS_REASONING_EFFORT,
-  SETTINGS_SELECTED_MODEL,
   SETTINGS_THEME,
   SETTINGS_THEME_MODE,
   SETTINGS_THINKING_ENABLED,
@@ -86,7 +85,6 @@ export function hasProfileChanged(
       JSON.stringify(profile2.customPromptPresets) ||
     JSON.stringify(profile1.favoritePromptPresetIds) !==
       JSON.stringify(profile2.favoritePromptPresetIds) ||
-    profile1.selectedModel !== profile2.selectedModel ||
     profile1.reasoningEffort !== profile2.reasoningEffort ||
     profile1.thinkingEnabled !== profile2.thinkingEnabled ||
     profile1.webSearchEnabled !== profile2.webSearchEnabled ||
@@ -178,11 +176,6 @@ export function loadLocalSettings(): ProfileData {
     settings.favoritePromptPresetIds = safeParseFavoritePresetIds(
       favoritePromptPresetIds,
     )
-  }
-
-  const selectedModel = localStorage.getItem(SETTINGS_SELECTED_MODEL)
-  if (selectedModel !== null) {
-    settings.selectedModel = selectedModel
   }
 
   const reasoningEffort = localStorage.getItem(SETTINGS_REASONING_EFFORT)
@@ -389,15 +382,6 @@ export function applySettingsToLocal(settings: ProfileData): void {
       JSON.stringify(settings.favoritePromptPresetIds),
     )
     window.dispatchEvent(new CustomEvent('promptLibraryChanged'))
-  }
-
-  if (settings.selectedModel !== undefined) {
-    localStorage.setItem(SETTINGS_SELECTED_MODEL, settings.selectedModel)
-    window.dispatchEvent(
-      new CustomEvent('selectedModelChanged', {
-        detail: settings.selectedModel,
-      }),
-    )
   }
 
   const shouldApplyReasoning =

--- a/src/services/cloud/profile-sync.ts
+++ b/src/services/cloud/profile-sync.ts
@@ -70,7 +70,6 @@ export interface ProfileData {
   favoritePromptPresetIds?: string[]
 
   // Shared chat defaults
-  selectedModel?: string
   reasoningEffort?: 'low' | 'medium' | 'high'
   thinkingEnabled?: boolean
   webSearchEnabled?: boolean

--- a/src/services/cloud/schemas.ts
+++ b/src/services/cloud/schemas.ts
@@ -78,7 +78,6 @@ export const ProfileDataSchema = z
       )
       .optional(),
     favoritePromptPresetIds: z.array(z.string()).optional(),
-    selectedModel: z.string().optional(),
     reasoningEffort: z.enum(['low', 'medium', 'high']).optional(),
     thinkingEnabled: z.boolean().optional(),
     webSearchEnabled: z.boolean().optional(),

--- a/tests/services/cloud/profile-merge.test.ts
+++ b/tests/services/cloud/profile-merge.test.ts
@@ -139,7 +139,6 @@ describe('mergeProfiles', () => {
     // so the field clocks are ignored and the newer blob wins wholesale.
     const local: ProfileData = {
       nickname: 'local',
-      selectedModel: 'gpt-oss-120b',
       version: 4,
       clockVersion: 2,
       fieldClocks: { nickname: { v: 99, w: 'A' } },
@@ -147,7 +146,6 @@ describe('mergeProfiles', () => {
     }
     const remote: ProfileData = {
       nickname: 'remote',
-      selectedModel: 'gpt-oss-120b',
       version: 5,
       clockVersion: 2,
       fieldClocks: { nickname: { v: 1, w: 'B' } },

--- a/tests/services/cloud/profile-settings-serializer.test.ts
+++ b/tests/services/cloud/profile-settings-serializer.test.ts
@@ -106,10 +106,11 @@ describe('profile-settings-serializer', () => {
     localStorage.setItem(SETTINGS_CHAT_FONT, 'mono')
     localStorage.setItem(USER_PREFS_PROJECT_UPLOAD, 'project')
 
-    expect(loadLocalSettings()).toMatchObject({
+    const loaded = loadLocalSettings()
+    expect('selectedModel' in loaded).toBe(false)
+    expect(loaded).toMatchObject({
       customPromptPresets: presets,
       favoritePromptPresetIds: ['builtin:tutor', 'user:abc'],
-      selectedModel: 'gpt-oss-120b',
       reasoningEffort: 'high',
       thinkingEnabled: false,
       webSearchEnabled: false,
@@ -162,7 +163,6 @@ describe('profile-settings-serializer', () => {
     applySettingsToLocal({
       customPromptPresets: presets,
       favoritePromptPresetIds: ['builtin:translator', 'user:def'],
-      selectedModel: 'gpt-oss-120b',
       reasoningEffort: 'low',
       thinkingEnabled: true,
       webSearchEnabled: true,
@@ -178,7 +178,7 @@ describe('profile-settings-serializer', () => {
     expect(localStorage.getItem(USER_PREFS_FAVORITE_PROMPT_PRESETS)).toBe(
       JSON.stringify(['builtin:translator', 'user:def']),
     )
-    expect(localStorage.getItem(SETTINGS_SELECTED_MODEL)).toBe('gpt-oss-120b')
+    expect(localStorage.getItem(SETTINGS_SELECTED_MODEL)).toBeNull()
     expect(localStorage.getItem(SETTINGS_REASONING_EFFORT)).toBe('low')
     expect(localStorage.getItem(SETTINGS_THINKING_ENABLED)).toBe('true')
     expect(localStorage.getItem(SETTINGS_WEB_SEARCH_ENABLED)).toBe('true')


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Keep the selected model choice per device by removing it from cloud profile sync. This prevents cross‑device model changes and keeps each device’s pick local.

- **Bug Fixes**
  - Removed `selectedModel` from `ProfileData` schema and `PROFILE_MERGE_FIELDS`.
  - Stopped reading/writing `selectedModel` in the profile settings serializer and removed the `selectedModelChanged` event.
  - Updated tests to reflect that `selectedModel` is no longer synced or persisted via settings.

<sup>Written for commit 459f1c354cbc390a567a8be4ba29d971d64b29bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/422?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

