### PR TITLE
fix: actually remember the last selected model on this device

### DIFF
--- a/src/components/chat/hooks/use-chat-state.ts
+++ b/src/components/chat/hooks/use-chat-state.ts
@@ -5,7 +5,11 @@ import { useCallback, useEffect, useMemo, useRef } from 'react'
 import type { AIModel, Chat, LabelType, LoadingState, Message } from '../types'
 import { useChatMessaging } from './use-chat-messaging'
 import { useChatStorage } from './use-chat-storage'
-import { resolveChatModel, useModelManagement } from './use-model-management'
+import {
+  resolveChatModel,
+  saveSelectedModel,
+  useModelManagement,
+} from './use-model-management'
 import type { ReasoningEffort } from './use-reasoning-effort'
 import { useUIState, type ThemeMode } from './use-ui-state'
 
@@ -192,6 +196,7 @@ export function useChatState({
         return
       }
       updateChatModel(modelName)
+      saveSelectedModel(modelName)
       setExpandedLabel(null)
     },
     [models, updateChatModel, setExpandedLabel],

--- a/src/components/chat/hooks/use-chat-state.ts
+++ b/src/components/chat/hooks/use-chat-state.ts
@@ -5,11 +5,7 @@ import { useCallback, useEffect, useMemo, useRef } from 'react'
 import type { AIModel, Chat, LabelType, LoadingState, Message } from '../types'
 import { useChatMessaging } from './use-chat-messaging'
 import { useChatStorage } from './use-chat-storage'
-import {
-  resolveChatModel,
-  saveSelectedModel,
-  useModelManagement,
-} from './use-model-management'
+import { resolveChatModel, useModelManagement } from './use-model-management'
 import type { ReasoningEffort } from './use-reasoning-effort'
 import { useUIState, type ThemeMode } from './use-ui-state'
 
@@ -162,11 +158,13 @@ export function useChatState({
     isLocalChatUrl,
   })
 
-  // Model Management - the hook owns model validation and the label/
-  // verification UI state. The active model itself is per-chat: it is
-  // resolved from the current chat (falling back to the first available
-  // model) so concurrent chats never override each other.
+  // Model Management - the hook owns model validation, the device-local
+  // saved model, and the label/verification UI state. The active model
+  // itself is per-chat: it is resolved from the current chat (falling
+  // back to the saved model, then the first available model) so
+  // concurrent chats never override each other.
   const {
+    selectedModel: savedModel,
     hasValidatedModel,
     expandedLabel,
     setExpandedLabel,
@@ -174,6 +172,7 @@ export function useChatState({
     setVerificationSuccess,
     verificationComplete,
     verificationSuccess,
+    handleModelSelect: persistModelSelection,
     handleLabelClick,
   } = useModelManagement({
     models,
@@ -181,8 +180,8 @@ export function useChatState({
   })
 
   const selectedModel = useMemo(
-    () => resolveChatModel(currentChat, models),
-    [currentChat, models],
+    () => resolveChatModel(currentChat, models, savedModel),
+    [currentChat, models, savedModel],
   )
 
   const handleModelSelect = useCallback(
@@ -196,10 +195,10 @@ export function useChatState({
         return
       }
       updateChatModel(modelName)
-      saveSelectedModel(modelName)
+      persistModelSelection(modelName)
       setExpandedLabel(null)
     },
-    [models, updateChatModel, setExpandedLabel],
+    [models, updateChatModel, persistModelSelection, setExpandedLabel],
   )
 
   const { codeExecutionEncryptionKey } = useExecSnapshot({

--- a/src/components/chat/hooks/use-model-management.ts
+++ b/src/components/chat/hooks/use-model-management.ts
@@ -8,10 +8,23 @@ import { logWarning } from '@/utils/error-handling'
 import { useCallback, useEffect, useState } from 'react'
 import type { AIModel, Chat, LabelType } from '../types'
 
+/** Reads the device-local last selected model, if any. */
+export function getSavedSelectedModel(): AIModel | null {
+  if (typeof window === 'undefined') return null
+  return localStorage.getItem(SETTINGS_SELECTED_MODEL)
+}
+
+/** Persists the device-local last selected model. */
+export function saveSelectedModel(modelName: AIModel): void {
+  localStorage.setItem(SETTINGS_SELECTED_MODEL, modelName)
+}
+
 /**
  * Resolves the model a chat should use: the chat's own model when it is
- * still available, otherwise the default model. No per-user saved model
- * is consulted so concurrent chats never override each other's model.
+ * still available, then the device-local last selected model, otherwise
+ * the default model. The saved model is only consulted when the chat has
+ * no valid model of its own, so chats that already carry a model never
+ * override each other.
  *
  * Runs during render before the model config has loaded, so `models` may
  * be empty; the empty-string fallback keeps the selector in a neutral
@@ -23,6 +36,10 @@ export function resolveChatModel(
 ): AIModel {
   if (chat?.model && isModelNameAvailable(chat.model, models)) {
     return chat.model
+  }
+  const saved = getSavedSelectedModel()
+  if (saved && isModelNameAvailable(saved, models)) {
+    return saved
   }
   return getDefaultModelId(models)
 }

--- a/src/components/chat/hooks/use-model-management.ts
+++ b/src/components/chat/hooks/use-model-management.ts
@@ -8,23 +8,16 @@ import { logWarning } from '@/utils/error-handling'
 import { useCallback, useEffect, useState } from 'react'
 import type { AIModel, Chat, LabelType } from '../types'
 
-/** Reads the device-local last selected model, if any. */
-export function getSavedSelectedModel(): AIModel | null {
-  if (typeof window === 'undefined') return null
-  return localStorage.getItem(SETTINGS_SELECTED_MODEL)
-}
-
-/** Persists the device-local last selected model. */
-export function saveSelectedModel(modelName: AIModel): void {
-  localStorage.setItem(SETTINGS_SELECTED_MODEL, modelName)
-}
-
 /**
  * Resolves the model a chat should use: the chat's own model when it is
  * still available, then the device-local last selected model, otherwise
  * the default model. The saved model is only consulted when the chat has
  * no valid model of its own, so chats that already carry a model never
  * override each other.
+ *
+ * `savedModel` is the reactive saved-model state owned by
+ * `useModelManagement` (backed by localStorage). It is passed in rather
+ * than read from storage here so the function stays pure during render.
  *
  * Runs during render before the model config has loaded, so `models` may
  * be empty; the empty-string fallback keeps the selector in a neutral
@@ -33,13 +26,13 @@ export function saveSelectedModel(modelName: AIModel): void {
 export function resolveChatModel(
   chat: Chat | undefined,
   models: BaseModel[],
+  savedModel?: AIModel,
 ): AIModel {
   if (chat?.model && isModelNameAvailable(chat.model, models)) {
     return chat.model
   }
-  const saved = getSavedSelectedModel()
-  if (saved && isModelNameAvailable(saved, models)) {
-    return saved
+  if (savedModel && isModelNameAvailable(savedModel, models)) {
+    return savedModel
   }
   return getDefaultModelId(models)
 }

--- a/tests/components/chat/model-management.test.ts
+++ b/tests/components/chat/model-management.test.ts
@@ -44,6 +44,10 @@ vi.mock('@/utils/error-handling', () => ({
 }))
 
 describe('resolveChatModel', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
   const makeChat = (model?: string): Chat => ({
     id: 'chat-1',
     title: 'Chat',
@@ -54,6 +58,21 @@ describe('resolveChatModel', () => {
 
   it("returns the chat's own model when it is available", () => {
     expect(resolveChatModel(makeChat('model-b'), mockModels)).toBe('model-b')
+  })
+
+  it('falls back to the saved device model when the chat has no model', () => {
+    localStorage.setItem(SETTINGS_SELECTED_MODEL, 'model-b')
+    expect(resolveChatModel(makeChat(undefined), mockModels)).toBe('model-b')
+  })
+
+  it("prefers the chat's own model over the saved device model", () => {
+    localStorage.setItem(SETTINGS_SELECTED_MODEL, 'model-a')
+    expect(resolveChatModel(makeChat('model-b'), mockModels)).toBe('model-b')
+  })
+
+  it('ignores a saved device model that is no longer available', () => {
+    localStorage.setItem(SETTINGS_SELECTED_MODEL, 'removed-model')
+    expect(resolveChatModel(makeChat(undefined), mockModels)).toBe('model-a')
   })
 
   it('falls back to the first model when the chat has no model', () => {

--- a/tests/components/chat/model-management.test.ts
+++ b/tests/components/chat/model-management.test.ts
@@ -44,10 +44,6 @@ vi.mock('@/utils/error-handling', () => ({
 }))
 
 describe('resolveChatModel', () => {
-  beforeEach(() => {
-    localStorage.clear()
-  })
-
   const makeChat = (model?: string): Chat => ({
     id: 'chat-1',
     title: 'Chat',
@@ -61,18 +57,21 @@ describe('resolveChatModel', () => {
   })
 
   it('falls back to the saved device model when the chat has no model', () => {
-    localStorage.setItem(SETTINGS_SELECTED_MODEL, 'model-b')
-    expect(resolveChatModel(makeChat(undefined), mockModels)).toBe('model-b')
+    expect(resolveChatModel(makeChat(undefined), mockModels, 'model-b')).toBe(
+      'model-b',
+    )
   })
 
   it("prefers the chat's own model over the saved device model", () => {
-    localStorage.setItem(SETTINGS_SELECTED_MODEL, 'model-a')
-    expect(resolveChatModel(makeChat('model-b'), mockModels)).toBe('model-b')
+    expect(resolveChatModel(makeChat('model-b'), mockModels, 'model-a')).toBe(
+      'model-b',
+    )
   })
 
   it('ignores a saved device model that is no longer available', () => {
-    localStorage.setItem(SETTINGS_SELECTED_MODEL, 'removed-model')
-    expect(resolveChatModel(makeChat(undefined), mockModels)).toBe('model-a')
+    expect(
+      resolveChatModel(makeChat(undefined), mockModels, 'removed-model'),
+    ).toBe('model-a')
   })
 
   it('falls back to the first model when the chat has no model', () => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the app not remembering the last selected model on this device. New or model-less chats now default to the last saved device model when available, otherwise the default model.

- **Bug Fixes**
  - Persist model selection to localStorage when the user switches models.
  - Resolve the active model by passing saved model state into `resolveChatModel` (no storage reads during render); prefer chat’s model, then saved model, then default, ignoring unavailable saved models.
  - Add tests covering fallback order and invalid saved model cases.

<sup>Written for commit 5c662cb1da58a73774bc9d5ea9d45ab66ae79256. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/423?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

