### PR TITLE
fix: use a fast vision model for image descriptions

### DIFF
--- a/src/components/chat/document-uploader.tsx
+++ b/src/components/chat/document-uploader.tsx
@@ -1,4 +1,4 @@
-import { getAIModels } from '@/config/models'
+import { getAIModels, type AutoTier, type BaseModel } from '@/config/models'
 import {
   getSecureFetch,
   getSessionToken,
@@ -93,9 +93,14 @@ export const useDocumentUploader = (isCurrentModelMultimodal?: boolean) => {
     mimeType: string,
   ): Promise<string> => {
     const models = await getAIModels()
-    const multimodalModel = models.find(
-      (m) => m.multimodal && m.chat && m.type === 'chat',
-    )
+    const fastTier: AutoTier = 'fast'
+    const isMultimodalChat = (m: BaseModel) =>
+      Boolean(m.multimodal && m.chat && m.type === 'chat')
+    // Prefer a fast multimodal model over larger reasoning-heavy ones
+    const multimodalModel =
+      models.find(
+        (m) => isMultimodalChat(m) && m.attributes?.includes(fastTier),
+      ) ?? models.find(isMultimodalChat)
     if (!multimodalModel) {
       throw new Error('No multimodal model available')
     }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Use a `fast` multimodal chat model for image descriptions to reduce latency, falling back to any multimodal chat model if none is available. Updates the document uploader to prefer models tagged `fast`.

<sup>Written for commit f627cded30c1ea1b5db05a873e331826a610fa2a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/424?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

