### PR TITLE
Support chat search

### DIFF
--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -752,6 +752,7 @@ export function ChatInterface({
     initialChatLoadFailed,
     cloudChatNotFound,
     retryInitialChatLoad,
+    loadChatById,
   } = useChatState({
     systemPrompt: finalSystemPrompt,
     rules: processedRules,
@@ -3102,6 +3103,7 @@ export function ChatInterface({
                 isDarkMode={isDarkMode}
                 createNewChat={createNewChat}
                 handleChatSelect={handleChatSelect}
+                onOpenChatById={(chatId) => loadChatById(chatId, false)}
                 updateChatTitle={updateChatTitle}
                 deleteChat={deleteChat}
                 isClient={isClient}

--- a/src/components/chat/chat-sidebar.tsx
+++ b/src/components/chat/chat-sidebar.tsx
@@ -31,6 +31,7 @@ import {
   ExclamationTriangleIcon,
   FolderIcon,
   FolderPlusIcon,
+  MagnifyingGlassIcon,
   TrashIcon,
   XMarkIcon,
 } from '@heroicons/react/24/outline'
@@ -60,6 +61,7 @@ import {
 } from '@/constants/project-colors'
 import { useCloudPagination } from '@/hooks/use-cloud-pagination'
 
+import { useChatSearch } from '@/hooks/use-chat-search'
 import { logError } from '@/utils/error-handling'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Link } from '../link'
@@ -82,6 +84,11 @@ type ChatSidebarProps = {
   isDarkMode: boolean
   createNewChat: (isLocalOnly?: boolean, fromUserAction?: boolean) => void
   handleChatSelect: (chatId: string) => void
+  /**
+   * Opens a chat that is not in the loaded `chats` pages (search
+   * results can reach past pagination); downloads and selects it.
+   */
+  onOpenChatById?: (chatId: string) => Promise<void>
   updateChatTitle: (chatId: string, newTitle: string) => void
   deleteChat: (chatId: string) => void
   isClient: boolean
@@ -159,6 +166,7 @@ export function ChatSidebar({
   isDarkMode,
   createNewChat,
   handleChatSelect,
+  onOpenChatById,
   updateChatTitle,
   deleteChat,
   isClient,
@@ -658,6 +666,62 @@ export function ChatSidebar({
       onCloudSyncSetupClick()
     }
   }
+
+  // Encrypted server-side search over synced chats. Only offered on
+  // the cloud tab: local-only chats never reach the enclave, so the
+  // index cannot know about them.
+  const [chatSearchTerm, setChatSearchTerm] = useState('')
+  const searchEnabled =
+    !!isSignedIn &&
+    cloudSyncEnabled &&
+    !(localOnlyModeEnabled && activeTab === 'local')
+  const chatSearch = useChatSearch(chatSearchTerm, searchEnabled)
+  const isSearchActive = searchEnabled && chatSearchTerm.trim().length > 0
+
+  const searchResultChats = useMemo((): ChatItemData[] => {
+    if (!isSearchActive) return []
+    // Enclave unavailable (older deploy, no key): degrade to filtering
+    // the locally loaded titles so the box still does something useful.
+    if (!chatSearch.available) {
+      const needle = chatSearchTerm.trim().toLowerCase()
+      return (sortedChats as ChatItemData[]).filter(
+        (chat) =>
+          !chat.isBlankChat && chat.title.toLowerCase().includes(needle),
+      )
+    }
+    return chatSearch.results.map((r) => ({
+      id: r.id,
+      title: r.title,
+      updatedAt: r.updatedAt,
+      messageCount: r.messageCount,
+    }))
+  }, [
+    isSearchActive,
+    chatSearch.available,
+    chatSearch.results,
+    chatSearchTerm,
+    sortedChats,
+  ])
+
+  const handleSearchResultSelect = useCallback(
+    (chatId: string) => {
+      if (chats.some((c) => c.id === chatId)) {
+        handleChatSelect(chatId)
+        return
+      }
+      // A hit outside the loaded pagination pages: download + select.
+      if (onOpenChatById) {
+        void onOpenChatById(chatId).catch((error) => {
+          logError('Failed to open searched chat', error, {
+            component: 'ChatSidebar',
+            action: 'handleSearchResultSelect',
+            metadata: { chatId },
+          })
+        })
+      }
+    },
+    [chats, handleChatSelect, onOpenChatById],
+  )
 
   const handleCloudSyncToggle = async (enabled: boolean) => {
     if (enabled) {
@@ -1830,6 +1894,37 @@ export function ChatSidebar({
                     </div>
                   )}
 
+                  {/* Encrypted search over synced chats */}
+                  {searchEnabled && (
+                    <div className="relative mx-4 mb-2">
+                      <MagnifyingGlassIcon className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-content-muted" />
+                      <input
+                        type="text"
+                        value={chatSearchTerm}
+                        onChange={(e) => setChatSearchTerm(e.target.value)}
+                        placeholder="Search chats..."
+                        aria-label="Search chats"
+                        className={cn(
+                          'w-full rounded-md border py-1.5 pl-8 pr-7 text-xs',
+                          isDarkMode
+                            ? 'border-border-strong bg-surface-chat text-content-secondary placeholder:text-content-muted'
+                            : 'border-border-subtle bg-surface-sidebar text-content-primary placeholder:text-content-muted',
+                          'focus:outline-none focus:ring-1 focus:ring-border-strong',
+                        )}
+                      />
+                      {chatSearchTerm.length > 0 && (
+                        <button
+                          type="button"
+                          onClick={() => setChatSearchTerm('')}
+                          aria-label="Clear search"
+                          className="absolute right-1.5 top-1/2 -translate-y-1/2 rounded p-0.5 text-content-muted transition-colors hover:text-content-secondary"
+                        >
+                          <XMarkIcon className="h-3.5 w-3.5" />
+                        </button>
+                      )}
+                    </div>
+                  )}
+
                   {/* Cloud Sync Setup - show when signed in and cloud sync is OFF */}
                   {isSignedIn && !cloudSyncEnabled && (
                     <div className="px-3 py-2">
@@ -1936,15 +2031,25 @@ export function ChatSidebar({
                 >
                   {isClient && (
                     <ChatList
-                      chats={sortedChats as ChatItemData[]}
+                      chats={
+                        isSearchActive
+                          ? searchResultChats
+                          : (sortedChats as ChatItemData[])
+                      }
                       currentChatId={currentChat?.id}
                       currentChatIsBlank={currentChat?.isBlankChat}
                       currentChatIsLocalOnly={currentChat?.isLocalOnly}
                       isDarkMode={isDarkMode}
+                      isLoading={
+                        isSearchActive &&
+                        chatSearch.isSearching &&
+                        searchResultChats.length === 0
+                      }
                       showEncryptionStatus={true}
                       showSyncStatus={true}
                       enableTitleAnimation={true}
                       isDraggable={
+                        !isSearchActive &&
                         isSignedIn &&
                         cloudSyncEnabled &&
                         (!!onMoveChatToProject ||
@@ -1952,12 +2057,17 @@ export function ChatSidebar({
                           !!onConvertChatToLocal)
                       }
                       showMoveToProject={
+                        !isSearchActive &&
                         isSignedIn &&
                         isPremium &&
                         cloudSyncEnabled &&
                         !!onMoveChatToProject
                       }
-                      onSelectChat={handleChatSelect}
+                      onSelectChat={
+                        isSearchActive
+                          ? handleSearchResultSelect
+                          : handleChatSelect
+                      }
                       onAfterSelect={undefined}
                       onUpdateTitle={updateChatTitle}
                       onDeleteChat={deleteChat}
@@ -1983,7 +2093,14 @@ export function ChatSidebar({
                           : undefined
                       }
                       loadingIndicator={
-                        chatDecryptionProgress?.isDecrypting ? (
+                        isSearchActive && chatSearch.isIndexing ? (
+                          <div className="flex items-center gap-2 px-4 py-2 text-content-secondary">
+                            <PiSpinner className="h-4 w-4 animate-spin" />
+                            <span className="text-sm">
+                              Building search index...
+                            </span>
+                          </div>
+                        ) : chatDecryptionProgress?.isDecrypting ? (
                           <div className="flex items-center gap-2 px-4 py-2 text-content-secondary">
                             <PiSpinner className="h-4 w-4 animate-spin" />
                             <span className="text-sm">
@@ -1998,7 +2115,19 @@ export function ChatSidebar({
                       onConvertToCloud={onConvertChatToCloud}
                       onConvertToLocal={onConvertChatToLocal}
                       emptyState={
-                        activeTab === 'local' ? (
+                        isSearchActive ? (
+                          <div className="rounded-lg border border-border-subtle bg-surface-sidebar p-4 text-center">
+                            <p className="text-sm text-content-muted">
+                              No matching chats
+                            </p>
+                            {chatSearch.isIndexing && (
+                              <p className="mt-1 text-xs text-content-muted">
+                                The search index is still being built; results
+                                will fill in shortly
+                              </p>
+                            )}
+                          </div>
+                        ) : activeTab === 'local' ? (
                           <div className="rounded-lg border border-border-subtle bg-surface-sidebar p-4 text-center">
                             <p className="text-sm text-content-muted">
                               No local chats yet
@@ -2011,46 +2140,48 @@ export function ChatSidebar({
                         ) : undefined
                       }
                       loadMoreButton={
-                        <>
-                          {/* Sentinel element for intersection observer */}
-                          <div ref={loadMoreSentinelRef} className="h-1" />
-                          {/* Shimmer placeholder while loading or waiting for chats to render */}
-                          {(isLoadingMore || pendingChatsRender) && (
-                            <div className="space-y-1 px-2">
-                              {[...Array(3)].map((_, i) => (
-                                <div
-                                  key={i}
-                                  className="animate-pulse rounded-lg px-3 py-2"
-                                >
+                        isSearchActive ? undefined : (
+                          <>
+                            {/* Sentinel element for intersection observer */}
+                            <div ref={loadMoreSentinelRef} className="h-1" />
+                            {/* Shimmer placeholder while loading or waiting for chats to render */}
+                            {(isLoadingMore || pendingChatsRender) && (
+                              <div className="space-y-1 px-2">
+                                {[...Array(3)].map((_, i) => (
                                   <div
-                                    className={cn(
-                                      'mb-1.5 h-3.5 w-3/4 rounded',
-                                      isDarkMode
-                                        ? 'bg-gray-700'
-                                        : 'bg-gray-200',
-                                    )}
-                                  />
-                                  <div
-                                    className={cn(
-                                      'h-3 w-1/3 rounded',
-                                      isDarkMode
-                                        ? 'bg-gray-700'
-                                        : 'bg-gray-200',
-                                    )}
-                                  />
-                                </div>
-                              ))}
-                            </div>
-                          )}
-                          {isSignedIn &&
-                            !shouldShowLoadMore &&
-                            !hasMoreRemote &&
-                            hasAttemptedLoadMore && (
-                              <div className="px-3 py-2 text-center text-xs text-content-muted">
-                                No more chats
+                                    key={i}
+                                    className="animate-pulse rounded-lg px-3 py-2"
+                                  >
+                                    <div
+                                      className={cn(
+                                        'mb-1.5 h-3.5 w-3/4 rounded',
+                                        isDarkMode
+                                          ? 'bg-gray-700'
+                                          : 'bg-gray-200',
+                                      )}
+                                    />
+                                    <div
+                                      className={cn(
+                                        'h-3 w-1/3 rounded',
+                                        isDarkMode
+                                          ? 'bg-gray-700'
+                                          : 'bg-gray-200',
+                                      )}
+                                    />
+                                  </div>
+                                ))}
                               </div>
                             )}
-                        </>
+                            {isSignedIn &&
+                              !shouldShowLoadMore &&
+                              !hasMoreRemote &&
+                              hasAttemptedLoadMore && (
+                                <div className="px-3 py-2 text-center text-xs text-content-muted">
+                                  No more chats
+                                </div>
+                              )}
+                          </>
+                        )
                       }
                     />
                   )}

--- a/src/components/chat/hooks/use-chat-state.ts
+++ b/src/components/chat/hooks/use-chat-state.ts
@@ -58,6 +58,7 @@ interface UseChatStateReturn {
   createNewChat: (isLocalOnly?: boolean, fromUserAction?: boolean) => void
   deleteChat: (chatId: string) => void
   handleChatSelect: (chatId: string) => void
+  loadChatById: (chatId: string, isLocalUrl: boolean) => Promise<void>
   toggleTheme: () => void
   setThemeMode: (mode: ThemeMode) => void
   openAndExpandVerifier: () => void
@@ -148,6 +149,7 @@ export function useChatState({
     updateChatTitle,
     updateChatModel,
     handleChatSelect,
+    loadChatById,
     setIsInitialLoad,
     isInitialLoad,
     reloadChats,
@@ -370,6 +372,7 @@ export function useChatState({
     createNewChat,
     deleteChat,
     handleChatSelect,
+    loadChatById,
     toggleTheme,
     setThemeMode,
     openAndExpandVerifier,

--- a/src/components/chat/hooks/use-chat-storage.ts
+++ b/src/components/chat/hooks/use-chat-storage.ts
@@ -35,6 +35,7 @@ interface UseChatStorageReturn {
   updateChatModel: (model: string) => void
   switchChat: (chat: Chat) => Promise<void>
   handleChatSelect: (chatId: string) => void
+  loadChatById: (chatId: string, isLocalUrl: boolean) => Promise<void>
   setIsInitialLoad: (loading: boolean) => void
   isInitialLoad: boolean
   reloadChats: () => Promise<void>
@@ -606,6 +607,7 @@ export function useChatStorage({
     updateChatModel,
     switchChat,
     handleChatSelect,
+    loadChatById,
     setIsInitialLoad,
     isInitialLoad,
     reloadChats,

--- a/src/hooks/use-chat-search.ts
+++ b/src/hooks/use-chat-search.ts
@@ -1,0 +1,89 @@
+import {
+  ensureSearchIndex,
+  resolveSearchResultChats,
+  searchSyncedChats,
+  type SearchResultChat,
+} from '@/services/cloud/chat-search'
+import { logError } from '@/utils/error-handling'
+import { useEffect, useState } from 'react'
+
+const SEARCH_DEBOUNCE_MS = 300
+const SEARCH_RESULT_LIMIT = 20
+
+export interface ChatSearchState {
+  /** Ranked, title-resolved hits for the current term. */
+  results: SearchResultChat[]
+  /** True from the first keystroke until the current term's results land. */
+  isSearching: boolean
+  /** True while the enclave rebuilds the index; results may be partial. */
+  isIndexing: boolean
+  /**
+   * False when server-side search cannot run (no key loaded, enclave
+   * without a search backend). Callers should fall back to filtering
+   * locally loaded chats by title.
+   */
+  available: boolean
+}
+
+/**
+ * Debounced encrypted search over synced chats. When the enclave
+ * reports it is rebuilding the index, the hook waits for the job to
+ * settle and re-runs the current term so results fill in without any
+ * user action.
+ */
+export function useChatSearch(term: string, enabled: boolean): ChatSearchState {
+  const trimmed = term.trim()
+  const active = enabled && trimmed.length > 0
+
+  const [results, setResults] = useState<SearchResultChat[]>([])
+  const [isSearching, setIsSearching] = useState(false)
+  const [isIndexing, setIsIndexing] = useState(false)
+  const [available, setAvailable] = useState(true)
+  const [refreshNonce, setRefreshNonce] = useState(0)
+
+  useEffect(() => {
+    if (!active) {
+      setResults([])
+      setIsSearching(false)
+      setIsIndexing(false)
+      return
+    }
+    // Set on cleanup so completions from a superseded term (or an
+    // unmounted component) know they lost the race and must not set
+    // state or schedule a refresh.
+    let cancelled = false
+    setIsSearching(true)
+    const run = async () => {
+      try {
+        const outcome = await searchSyncedChats(trimmed, SEARCH_RESULT_LIMIT)
+        if (cancelled) return
+        setAvailable(outcome.available)
+        setIsIndexing(outcome.indexing)
+        const chats = await resolveSearchResultChats(outcome.results)
+        if (cancelled) return
+        setResults(chats)
+        setIsSearching(false)
+        if (outcome.indexing) {
+          void ensureSearchIndex().then(() => {
+            if (!cancelled) setRefreshNonce((n) => n + 1)
+          })
+        }
+      } catch (err) {
+        if (cancelled) return
+        logError('chat search failed', err, {
+          component: 'useChatSearch',
+          action: 'search',
+        })
+        setResults([])
+        setIsSearching(false)
+      }
+    }
+    const timer = setTimeout(() => void run(), SEARCH_DEBOUNCE_MS)
+    return () => {
+      cancelled = true
+      clearTimeout(timer)
+    }
+  }, [trimmed, active, refreshNonce])
+
+  return { results, isSearching, isIndexing, available }
+}

--- a/src/hooks/use-chat-search.ts
+++ b/src/hooks/use-chat-search.ts
@@ -64,8 +64,17 @@ export function useChatSearch(term: string, enabled: boolean): ChatSearchState {
         setResults(chats)
         setIsSearching(false)
         if (outcome.indexing) {
-          void ensureSearchIndex().then(() => {
-            if (!cancelled) setRefreshNonce((n) => n + 1)
+          // Re-query only after a successful rebuild. Refreshing on a
+          // failed or skipped settle would report needs_reindex again
+          // and kick another full rebuild, looping a persistent
+          // failure at full embedding cost.
+          void ensureSearchIndex().then((settled) => {
+            if (cancelled) return
+            if (settled === 'completed') {
+              setRefreshNonce((n) => n + 1)
+            } else {
+              setIsIndexing(false)
+            }
           })
         }
       } catch (err) {

--- a/src/services/cloud/chat-search.ts
+++ b/src/services/cloud/chat-search.ts
@@ -29,6 +29,15 @@ import { processRemoteChat } from './chat-codec'
 
 export const SEARCH_REINDEX_POLL_INTERVAL_MS = 2_000
 export const SEARCH_REINDEX_POLL_BUDGET_MS = 10 * 60 * 1_000
+export const SEARCH_REINDEX_FAILURE_COOLDOWN_MS = 60_000
+
+/**
+ * How a reindex request settled. `skipped` means no kick was sent
+ * (no keys loaded, or a recent failure put kicks on cooldown);
+ * `timeout` means the poll budget ran out while the job was still
+ * running server-side.
+ */
+export type ReindexSettleResult = 'completed' | 'failed' | 'timeout' | 'skipped'
 
 export interface ChatSearchOutcome {
   results: SearchQueryResult[]
@@ -91,25 +100,43 @@ export async function searchSyncedChats(
   }
 }
 
-let reindexInFlight: Promise<void> | null = null
+let reindexInFlight: Promise<ReindexSettleResult> | null = null
+let lastReindexFailureAt = 0
 
 /**
- * Kick (or join) the enclave-side index rebuild and resolve when it
- * reaches a terminal state. Concurrent callers share one poll loop;
- * the enclave itself dedupes kickoffs for the same key set, so an
- * extra kick after a settle is harmless. Never rejects: failures are
- * logged and surface to users as a persistent `indexing` flag on the
- * next query instead of an unhandled rejection from a fire-and-forget
- * call site.
+ * Kick (or join) the enclave-side index rebuild and resolve with how
+ * it settled. Concurrent callers share one poll loop; the enclave
+ * itself dedupes kickoffs for the same key set, so an extra kick
+ * after a settle is harmless. A failed run puts further kicks on a
+ * cooldown: the enclave allows an immediate re-kick after a failure,
+ * and every attempt re-pulls and re-embeds chats, so retrying on each
+ * query would loop a persistent failure at full rebuild cost. Never
+ * rejects: failures are logged and resolve as `failed` so
+ * fire-and-forget call sites cannot leak unhandled rejections.
  */
-export function ensureSearchIndex(): Promise<void> {
+export function ensureSearchIndex(): Promise<ReindexSettleResult> {
   if (!reindexInFlight) {
+    if (
+      Date.now() - lastReindexFailureAt <
+      SEARCH_REINDEX_FAILURE_COOLDOWN_MS
+    ) {
+      return Promise.resolve('skipped')
+    }
     reindexInFlight = runReindex()
-      .catch((err) => {
+      .catch((err): ReindexSettleResult => {
         logError('search reindex failed', err, {
           component: 'chat-search',
           action: 'ensureSearchIndex',
         })
+        return 'failed'
+      })
+      .then((result) => {
+        if (result === 'failed') {
+          lastReindexFailureAt = Date.now()
+        } else if (result === 'completed') {
+          lastReindexFailureAt = 0
+        }
+        return result
       })
       .finally(() => {
         reindexInFlight = null
@@ -122,16 +149,20 @@ function isTerminalStatus(status: SearchReindexStatus): boolean {
   return status !== 'running'
 }
 
-async function runReindex(): Promise<void> {
+function settleResult(status: SearchReindexStatus): ReindexSettleResult {
+  return status === 'completed' ? 'completed' : 'failed'
+}
+
+async function runReindex(): Promise<ReindexSettleResult> {
   const keys = pullKey()
-  if (keys.length === 0) return
+  if (keys.length === 0) return 'skipped'
   const kicked = await searchReindex(keys)
   logInfo('search reindex kicked', {
     component: 'chat-search',
     action: 'runReindex',
     metadata: { jobId: kicked.job_id, status: kicked.status },
   })
-  if (isTerminalStatus(kicked.status)) return
+  if (isTerminalStatus(kicked.status)) return settleResult(kicked.status)
   const deadline = Date.now() + SEARCH_REINDEX_POLL_BUDGET_MS
   while (Date.now() < deadline) {
     await sleep(SEARCH_REINDEX_POLL_INTERVAL_MS)
@@ -148,9 +179,10 @@ async function runReindex(): Promise<void> {
           partial: status.partial,
         },
       })
-      return
+      return settleResult(status.status)
     }
   }
+  return 'timeout'
 }
 
 function sleep(ms: number): Promise<void> {

--- a/src/services/cloud/chat-search.ts
+++ b/src/services/cloud/chat-search.ts
@@ -17,6 +17,7 @@ import { logError, logInfo } from '@/utils/error-handling'
 import { chatStorage } from '../storage/chat-storage'
 import {
   pull,
+  pullItemPlaintext,
   searchQuery,
   searchReindex,
   searchReindexStatus,
@@ -156,7 +157,7 @@ function settleResult(status: SearchReindexStatus): ReindexSettleResult {
 async function runReindex(): Promise<ReindexSettleResult> {
   const keys = pullKey()
   if (keys.length === 0) return 'skipped'
-  const kicked = await searchReindex(keys)
+  const kicked = await searchReindex({ keys })
   logInfo('search reindex kicked', {
     component: 'chat-search',
     action: 'runReindex',
@@ -226,11 +227,12 @@ export async function resolveSearchResultChats(
     try {
       const resp = await pull({ scope: 'chat', ids: missing, keys: pullKey() })
       for (const item of resp.items) {
-        if (!item.ok || item.plaintext == null) continue
+        const plaintextBytes = pullItemPlaintext(item)
+        if (plaintextBytes == null) continue
         try {
           const { chat } = await processRemoteChat({
             id: item.id,
-            plaintext: item.plaintext,
+            plaintext: new TextDecoder().decode(plaintextBytes),
           })
           byId.set(item.id, {
             id: chat.id,

--- a/src/services/cloud/chat-search.ts
+++ b/src/services/cloud/chat-search.ts
@@ -1,0 +1,231 @@
+/**
+ * Encrypted chat search over the sync enclave.
+ *
+ * The enclave keeps a per-user search index sealed under a key derived
+ * from the CEK, so queries need the primary key on every call. Results
+ * are chat ids + scores only; `resolveSearchResultChats` maps them back
+ * to locally stored chats (falling back to a pull for chats outside the
+ * loaded pages).
+ *
+ * When the enclave reports `needs_reindex` (index never built, sealed
+ * under a different key, or embedding model changed) this module kicks
+ * the background rebuild automatically and exposes the in-flight job as
+ * a promise so callers can re-query once it settles.
+ */
+
+import { logError, logInfo } from '@/utils/error-handling'
+import { chatStorage } from '../storage/chat-storage'
+import {
+  pull,
+  searchQuery,
+  searchReindex,
+  searchReindexStatus,
+  SyncEnclaveError,
+  type SearchQueryResult,
+  type SearchReindexStatus,
+} from '../sync-enclave/sync-api'
+import { hasPrimaryKey, pullKey, requirePrimaryKeyB64 } from './cek-encoding'
+import { processRemoteChat } from './chat-codec'
+
+export const SEARCH_REINDEX_POLL_INTERVAL_MS = 2_000
+export const SEARCH_REINDEX_POLL_BUDGET_MS = 10 * 60 * 1_000
+
+export interface ChatSearchOutcome {
+  results: SearchQueryResult[]
+  totalIndexed: number
+  /**
+   * True when the enclave has no complete index for this key yet and a
+   * rebuild has been kicked; results may be partial until it settles.
+   */
+  indexing: boolean
+  /**
+   * False when search cannot run at all: no primary key loaded, or the
+   * enclave has no search backend (older deploy / unconfigured). The
+   * UI should fall back to local title filtering.
+   */
+  available: boolean
+}
+
+function unavailableOutcome(): ChatSearchOutcome {
+  return { results: [], totalIndexed: 0, indexing: false, available: false }
+}
+
+/**
+ * The enclave answers 503 when the search backend is not configured;
+ * an older enclave without the routes answers 404/405. Both mean
+ * "no server-side search here", not a transient failure.
+ */
+export function isSearchUnavailableError(err: unknown): boolean {
+  return (
+    err instanceof SyncEnclaveError &&
+    (err.status === 503 || err.status === 404 || err.status === 405)
+  )
+}
+
+/**
+ * Rank synced chats against a query using the caller's primary CEK.
+ * Kicks a background reindex (once per settled job) when the enclave
+ * reports the index is missing or incomplete.
+ */
+export async function searchSyncedChats(
+  query: string,
+  limit?: number,
+): Promise<ChatSearchOutcome> {
+  if (!hasPrimaryKey()) return unavailableOutcome()
+  let resp
+  try {
+    resp = await searchQuery({ keyB64: requirePrimaryKeyB64(), query, limit })
+  } catch (err) {
+    if (isSearchUnavailableError(err)) return unavailableOutcome()
+    throw err
+  }
+  const indexing = resp.needs_reindex === true
+  if (indexing) {
+    void ensureSearchIndex()
+  }
+  return {
+    results: resp.results,
+    totalIndexed: resp.total_indexed,
+    indexing,
+    available: true,
+  }
+}
+
+let reindexInFlight: Promise<void> | null = null
+
+/**
+ * Kick (or join) the enclave-side index rebuild and resolve when it
+ * reaches a terminal state. Concurrent callers share one poll loop;
+ * the enclave itself dedupes kickoffs for the same key set, so an
+ * extra kick after a settle is harmless. Never rejects: failures are
+ * logged and surface to users as a persistent `indexing` flag on the
+ * next query instead of an unhandled rejection from a fire-and-forget
+ * call site.
+ */
+export function ensureSearchIndex(): Promise<void> {
+  if (!reindexInFlight) {
+    reindexInFlight = runReindex()
+      .catch((err) => {
+        logError('search reindex failed', err, {
+          component: 'chat-search',
+          action: 'ensureSearchIndex',
+        })
+      })
+      .finally(() => {
+        reindexInFlight = null
+      })
+  }
+  return reindexInFlight
+}
+
+function isTerminalStatus(status: SearchReindexStatus): boolean {
+  return status !== 'running'
+}
+
+async function runReindex(): Promise<void> {
+  const keys = pullKey()
+  if (keys.length === 0) return
+  const kicked = await searchReindex(keys)
+  logInfo('search reindex kicked', {
+    component: 'chat-search',
+    action: 'runReindex',
+    metadata: { jobId: kicked.job_id, status: kicked.status },
+  })
+  if (isTerminalStatus(kicked.status)) return
+  const deadline = Date.now() + SEARCH_REINDEX_POLL_BUDGET_MS
+  while (Date.now() < deadline) {
+    await sleep(SEARCH_REINDEX_POLL_INTERVAL_MS)
+    const status = await searchReindexStatus()
+    if (isTerminalStatus(status.status)) {
+      logInfo('search reindex settled', {
+        component: 'chat-search',
+        action: 'runReindex',
+        metadata: {
+          jobId: status.job_id,
+          status: status.status,
+          indexed: status.indexed,
+          failed: status.failed,
+          partial: status.partial,
+        },
+      })
+      return
+    }
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+/** Display data for one search hit, ready for the sidebar chat list. */
+export interface SearchResultChat {
+  id: string
+  title: string
+  updatedAt?: string
+  messageCount: number
+}
+
+/**
+ * Resolve search result ids to chat display data, preserving the
+ * enclave's ranking. Local storage is the fast path; anything not on
+ * this device yet (results can reach past the loaded sidebar pages) is
+ * pulled and decoded without being written back. Unresolvable ids
+ * (e.g. a chat deleted between indexing and the query) are dropped.
+ */
+export async function resolveSearchResultChats(
+  results: SearchQueryResult[],
+): Promise<SearchResultChat[]> {
+  const byId = new Map<string, SearchResultChat>()
+  const missing: string[] = []
+  for (const r of results) {
+    const local = await chatStorage.getChat(r.id)
+    if (local) {
+      byId.set(r.id, {
+        id: local.id,
+        title: local.title,
+        updatedAt: local.updatedAt,
+        messageCount: local.messages.length,
+      })
+    } else {
+      missing.push(r.id)
+    }
+  }
+  if (missing.length > 0 && hasPrimaryKey()) {
+    try {
+      const resp = await pull({ scope: 'chat', ids: missing, keys: pullKey() })
+      for (const item of resp.items) {
+        if (!item.ok || item.plaintext == null) continue
+        try {
+          const { chat } = await processRemoteChat({
+            id: item.id,
+            plaintext: item.plaintext,
+          })
+          byId.set(item.id, {
+            id: chat.id,
+            title: chat.title,
+            updatedAt: chat.updatedAt,
+            messageCount: chat.messages.length,
+          })
+        } catch (err) {
+          logError('search result chat decode failed', err, {
+            component: 'chat-search',
+            action: 'resolveSearchResultChats',
+            metadata: { chatId: item.id },
+          })
+        }
+      }
+    } catch (err) {
+      logError('search result pull failed', err, {
+        component: 'chat-search',
+        action: 'resolveSearchResultChats',
+        metadata: { count: missing.length },
+      })
+    }
+  }
+  const chats: SearchResultChat[] = []
+  for (const r of results) {
+    const chat = byId.get(r.id)
+    if (chat) chats.push(chat)
+  }
+  return chats
+}

--- a/src/services/cloud/cloud-storage.ts
+++ b/src/services/cloud/cloud-storage.ts
@@ -287,6 +287,17 @@ export class CloudStorageService {
       metadata,
     })
 
+    // The blob stored fine but the enclave's inline search-index
+    // update failed; the chat won't surface in search until the next
+    // reindex (the search UI kicks one when queries report the gap).
+    if (pushResp.search_indexed === false) {
+      logWarning('Chat stored but not search-indexed', {
+        component: 'CloudStorage',
+        action: 'uploadChat',
+        metadata: { chatId: chat.id },
+      })
+    }
+
     return {
       syncVersion: etagToSyncVersion(pushResp.etag) ?? null,
       rewrites,

--- a/src/services/sync-enclave/sync-api.ts
+++ b/src/services/sync-enclave/sync-api.ts
@@ -53,6 +53,13 @@ export interface PushResponse {
   ok: true
   etag: string
   key_id: string
+  /**
+   * Whether the enclave's inline search-index update succeeded for a
+   * chat push. `false` means the blob stored fine but the chat won't
+   * surface in search until a reindex runs. Absent when search does
+   * not apply (non-chat scope or search backend unconfigured).
+   */
+  search_indexed?: boolean
 }
 
 export interface PullKey {
@@ -286,6 +293,57 @@ export interface MigrateAllResponse {
    */
   status?: MigrateAllStatus
   job_id?: string
+  started_at?: string
+  updated_at?: string
+  error?: string
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Encrypted chat search                                                     */
+/* -------------------------------------------------------------------------- */
+
+export interface SearchQueryRequest {
+  /** User's CEK, base64 raw 32 bytes. The enclave derives the
+   *  search-index subkey from it; the index never leaves the enclave
+   *  unencrypted. */
+  keyB64: string
+  query: string
+  limit?: number
+}
+
+export interface SearchQueryResult {
+  /** Chat id; contents come from the normal pull path. */
+  id: string
+  score: number
+}
+
+export interface SearchQueryResponse {
+  results: SearchQueryResult[]
+  total_indexed: number
+  /**
+   * True when no readable index exists for the supplied key (never
+   * built, different key, or the enclave's embedding model changed).
+   * The client should kick /v1/search/reindex and poll status.
+   */
+  needs_reindex?: boolean
+}
+
+export type SearchReindexStatus = 'idle' | 'running' | 'completed' | 'failed'
+
+/**
+ * Wire shape returned by both the reindex kickoff and the status
+ * poll. The kickoff joins an already-running job for the same key
+ * set instead of starting a second one.
+ */
+export interface SearchReindexStatusResponse {
+  job_id?: string
+  status: SearchReindexStatus
+  indexed: number
+  failed: number
+  total_indexed: number
+  /** True when the run stopped at its wall-clock budget before
+   *  draining every chat; a fresh kickoff restarts the build. */
+  partial: boolean
   started_at?: string
   updated_at?: string
   error?: string
@@ -617,6 +675,48 @@ function normalizeMigrateAllResponse(
       blocked: s.blocked ?? [],
     })),
   }
+}
+
+/**
+ * Rank the caller's synced chats against a natural-language query.
+ * Returns chat ids + scores only; resolve titles/contents through the
+ * normal pull path. `needs_reindex: true` means the enclave has no
+ * readable index for this key and the caller should drive a reindex.
+ */
+export async function searchQuery(
+  req: SearchQueryRequest,
+): Promise<SearchQueryResponse> {
+  const client = await getSyncEnclaveClient()
+  const resp = await client.post<SearchQueryResponse>('/v1/search/query', {
+    key: req.keyB64,
+    query: req.query,
+    limit: req.limit,
+  })
+  return { ...resp, results: resp.results ?? [] }
+}
+
+/**
+ * Kick off (or join) the enclave-side background job that rebuilds
+ * the search index from the stored chat blobs. Returns the job's
+ * current status snapshot; poll `searchReindexStatus()` until the
+ * status is terminal.
+ */
+export async function searchReindex(
+  keys: PullKey[],
+): Promise<SearchReindexStatusResponse> {
+  const client = await getSyncEnclaveClient()
+  return client.post<SearchReindexStatusResponse>('/v1/search/reindex', {
+    keys,
+  })
+}
+
+/** Poll the caller's current reindex job; `status: 'idle'` when none. */
+export async function searchReindexStatus(): Promise<SearchReindexStatusResponse> {
+  const client = await getSyncEnclaveClient()
+  return client.post<SearchReindexStatusResponse>(
+    '/v1/search/reindex-status',
+    {},
+  )
 }
 
 /* -------------------------------------------------------------------------- */

--- a/src/services/sync-enclave/sync-api.ts
+++ b/src/services/sync-enclave/sync-api.ts
@@ -328,6 +328,11 @@ export interface SearchQueryResponse {
   needs_reindex?: boolean
 }
 
+export interface SearchReindexRequest {
+  /** Primary key first, then any legacy keys still sealing old rows. */
+  keys: PullKey[]
+}
+
 export type SearchReindexStatus = 'idle' | 'running' | 'completed' | 'failed'
 
 /**
@@ -702,11 +707,11 @@ export async function searchQuery(
  * status is terminal.
  */
 export async function searchReindex(
-  keys: PullKey[],
+  req: SearchReindexRequest,
 ): Promise<SearchReindexStatusResponse> {
   const client = await getSyncEnclaveClient()
   return client.post<SearchReindexStatusResponse>('/v1/search/reindex', {
-    keys,
+    keys: req.keys,
   })
 }
 

--- a/tests/services/cloud/chat-search.test.ts
+++ b/tests/services/cloud/chat-search.test.ts
@@ -1,0 +1,229 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockSearchQuery = vi.fn()
+const mockSearchReindex = vi.fn()
+const mockSearchReindexStatus = vi.fn()
+const mockPull = vi.fn()
+const mockGetChat = vi.fn()
+const mockHasPrimaryKey = vi.fn()
+
+vi.mock('@/services/sync-enclave/sync-api', async () => {
+  const actual: any = await vi.importActual('@/services/sync-enclave/sync-api')
+  return {
+    ...actual,
+    searchQuery: (...args: any[]) => mockSearchQuery(...args),
+    searchReindex: (...args: any[]) => mockSearchReindex(...args),
+    searchReindexStatus: (...args: any[]) => mockSearchReindexStatus(...args),
+    pull: (...args: any[]) => mockPull(...args),
+  }
+})
+
+vi.mock('@/services/cloud/cek-encoding', () => ({
+  hasPrimaryKey: () => mockHasPrimaryKey(),
+  requirePrimaryKeyB64: () => 'primary-b64',
+  pullKey: () => [{ key: 'primary-b64' }],
+}))
+
+vi.mock('@/services/storage/chat-storage', () => ({
+  chatStorage: {
+    getChat: (...args: any[]) => mockGetChat(...args),
+  },
+}))
+
+async function importChatSearch() {
+  return import('@/services/cloud/chat-search')
+}
+
+function runningStatus() {
+  return {
+    job_id: 'job-1',
+    status: 'running',
+    indexed: 0,
+    failed: 0,
+    total_indexed: 0,
+    partial: false,
+  }
+}
+
+function completedStatus() {
+  return {
+    job_id: 'job-1',
+    status: 'completed',
+    indexed: 4,
+    failed: 0,
+    total_indexed: 4,
+    partial: false,
+  }
+}
+
+describe('chat-search', () => {
+  beforeEach(() => {
+    // Reset module state (the shared in-flight reindex promise) so
+    // tests cannot observe each other's poll loops.
+    vi.resetModules()
+    vi.clearAllMocks()
+    mockHasPrimaryKey.mockReturnValue(true)
+    mockGetChat.mockResolvedValue(null)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('reports unavailable when no primary key is loaded', async () => {
+    mockHasPrimaryKey.mockReturnValue(false)
+    const search = await importChatSearch()
+    const outcome = await search.searchSyncedChats('ducks')
+    expect(outcome).toEqual({
+      results: [],
+      totalIndexed: 0,
+      indexing: false,
+      available: false,
+    })
+    expect(mockSearchQuery).not.toHaveBeenCalled()
+  })
+
+  it('maps a 503 from the enclave to unavailable instead of throwing', async () => {
+    const { SyncEnclaveError } =
+      await import('@/services/sync-enclave/sync-api')
+    mockSearchQuery.mockRejectedValue(
+      new SyncEnclaveError('search backend not configured', 503, 'INTERNAL'),
+    )
+    const search = await importChatSearch()
+    const outcome = await search.searchSyncedChats('ducks')
+    expect(outcome.available).toBe(false)
+    expect(outcome.results).toEqual([])
+  })
+
+  it('rethrows transient errors so callers can distinguish them', async () => {
+    const { SyncEnclaveError } =
+      await import('@/services/sync-enclave/sync-api')
+    mockSearchQuery.mockRejectedValue(
+      new SyncEnclaveError('embedding service failed', 502, 'UPSTREAM'),
+    )
+    const search = await importChatSearch()
+    await expect(search.searchSyncedChats('ducks')).rejects.toThrow(
+      /embedding service failed/,
+    )
+  })
+
+  it('returns ranked results and passes key + limit to the enclave', async () => {
+    mockSearchQuery.mockResolvedValue({
+      results: [
+        { id: 'b', score: 2 },
+        { id: 'a', score: 1 },
+      ],
+      total_indexed: 9,
+    })
+    const search = await importChatSearch()
+    const outcome = await search.searchSyncedChats('duck pond', 7)
+    expect(outcome).toEqual({
+      results: [
+        { id: 'b', score: 2 },
+        { id: 'a', score: 1 },
+      ],
+      totalIndexed: 9,
+      indexing: false,
+      available: true,
+    })
+    expect(mockSearchQuery).toHaveBeenCalledWith({
+      keyB64: 'primary-b64',
+      query: 'duck pond',
+      limit: 7,
+    })
+    expect(mockSearchReindex).not.toHaveBeenCalled()
+  })
+
+  it('kicks one shared reindex when queries report needs_reindex and polls it to completion', async () => {
+    vi.useFakeTimers()
+    mockSearchQuery.mockResolvedValue({
+      results: [],
+      total_indexed: 0,
+      needs_reindex: true,
+    })
+    mockSearchReindex.mockResolvedValue(runningStatus())
+    mockSearchReindexStatus
+      .mockResolvedValueOnce(runningStatus())
+      .mockResolvedValueOnce(completedStatus())
+
+    const search = await importChatSearch()
+    const [first, second] = await Promise.all([
+      search.searchSyncedChats('ducks'),
+      search.searchSyncedChats('taxes'),
+    ])
+    expect(first.indexing).toBe(true)
+    expect(second.indexing).toBe(true)
+
+    const settled = search.ensureSearchIndex()
+    await vi.advanceTimersByTimeAsync(2_000)
+    await vi.advanceTimersByTimeAsync(2_000)
+    await settled
+
+    expect(mockSearchReindex).toHaveBeenCalledTimes(1)
+    expect(mockSearchReindex).toHaveBeenCalledWith([{ key: 'primary-b64' }])
+    expect(mockSearchReindexStatus).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not poll when the kickoff already reports a terminal status', async () => {
+    mockSearchReindex.mockResolvedValue(completedStatus())
+    const search = await importChatSearch()
+    await search.ensureSearchIndex()
+    expect(mockSearchReindexStatus).not.toHaveBeenCalled()
+  })
+
+  it('resolves result titles locally first, pulls the rest, and preserves ranking', async () => {
+    mockGetChat.mockImplementation(async (id: string) =>
+      id === 'a'
+        ? {
+            id: 'a',
+            title: 'Local pond notes',
+            updatedAt: '2026-07-01T00:00:00Z',
+            messages: [{}, {}],
+          }
+        : null,
+    )
+    mockPull.mockResolvedValue({
+      items: [
+        {
+          id: 'b',
+          ok: true,
+          plaintext: JSON.stringify({
+            title: 'Remote tax chat',
+            messages: [{ role: 'user', content: 'tax return time' }],
+            createdAt: '2026-06-01T00:00:00Z',
+          }),
+        },
+        { id: 'c', ok: false, code: 'NOT_FOUND' },
+      ],
+    })
+    const search = await importChatSearch()
+    const chats = await search.resolveSearchResultChats([
+      { id: 'b', score: 3 },
+      { id: 'a', score: 2 },
+      { id: 'c', score: 1 },
+    ])
+    expect(chats.map((c) => c.id)).toEqual(['b', 'a'])
+    expect(chats[0].title).toBe('Remote tax chat')
+    expect(chats[0].messageCount).toBe(1)
+    expect(chats[1].title).toBe('Local pond notes')
+    expect(chats[1].messageCount).toBe(2)
+    expect(mockPull).toHaveBeenCalledWith({
+      scope: 'chat',
+      ids: ['b', 'c'],
+      keys: [{ key: 'primary-b64' }],
+    })
+  })
+
+  it('skips the pull entirely when every result resolves locally', async () => {
+    mockGetChat.mockResolvedValue({
+      id: 'a',
+      title: 'Local',
+      updatedAt: '2026-07-01T00:00:00Z',
+      messages: [],
+    })
+    const search = await importChatSearch()
+    const chats = await search.resolveSearchResultChats([{ id: 'a', score: 1 }])
+    expect(chats).toHaveLength(1)
+    expect(mockPull).not.toHaveBeenCalled()
+  })
+})

--- a/tests/services/cloud/chat-search.test.ts
+++ b/tests/services/cloud/chat-search.test.ts
@@ -157,7 +157,7 @@ describe('chat-search', () => {
     const settled = search.ensureSearchIndex()
     await vi.advanceTimersByTimeAsync(2_000)
     await vi.advanceTimersByTimeAsync(2_000)
-    await settled
+    await expect(settled).resolves.toBe('completed')
 
     expect(mockSearchReindex).toHaveBeenCalledTimes(1)
     expect(mockSearchReindex).toHaveBeenCalledWith([{ key: 'primary-b64' }])
@@ -167,8 +167,34 @@ describe('chat-search', () => {
   it('does not poll when the kickoff already reports a terminal status', async () => {
     mockSearchReindex.mockResolvedValue(completedStatus())
     const search = await importChatSearch()
-    await search.ensureSearchIndex()
+    await expect(search.ensureSearchIndex()).resolves.toBe('completed')
     expect(mockSearchReindexStatus).not.toHaveBeenCalled()
+  })
+
+  it('puts kicks on cooldown after a failed run instead of looping rebuilds', async () => {
+    vi.useFakeTimers()
+    mockSearchReindex.mockResolvedValue({
+      ...runningStatus(),
+      status: 'failed',
+      error: 'embedding service failed',
+    })
+    const search = await importChatSearch()
+    await expect(search.ensureSearchIndex()).resolves.toBe('failed')
+    expect(mockSearchReindex).toHaveBeenCalledTimes(1)
+
+    await expect(search.ensureSearchIndex()).resolves.toBe('skipped')
+    expect(mockSearchReindex).toHaveBeenCalledTimes(1)
+
+    vi.advanceTimersByTime(search.SEARCH_REINDEX_FAILURE_COOLDOWN_MS)
+    mockSearchReindex.mockResolvedValue(completedStatus())
+    await expect(search.ensureSearchIndex()).resolves.toBe('completed')
+    expect(mockSearchReindex).toHaveBeenCalledTimes(2)
+  })
+
+  it('resolves as failed when the rebuild kick throws', async () => {
+    mockSearchReindex.mockRejectedValue(new Error('network down'))
+    const search = await importChatSearch()
+    await expect(search.ensureSearchIndex()).resolves.toBe('failed')
   })
 
   it('resolves result titles locally first, pulls the rest, and preserves ranking', async () => {

--- a/tests/services/cloud/chat-search.test.ts
+++ b/tests/services/cloud/chat-search.test.ts
@@ -155,12 +155,13 @@ describe('chat-search', () => {
     expect(second.indexing).toBe(true)
 
     const settled = search.ensureSearchIndex()
-    await vi.advanceTimersByTimeAsync(2_000)
-    await vi.advanceTimersByTimeAsync(2_000)
+    await vi.advanceTimersByTimeAsync(search.SEARCH_REINDEX_POLL_INTERVAL_MS)
+    await vi.advanceTimersByTimeAsync(search.SEARCH_REINDEX_POLL_INTERVAL_MS)
     await expect(settled).resolves.toBe('completed')
 
+    const { pullKey } = await import('@/services/cloud/cek-encoding')
     expect(mockSearchReindex).toHaveBeenCalledTimes(1)
-    expect(mockSearchReindex).toHaveBeenCalledWith([{ key: 'primary-b64' }])
+    expect(mockSearchReindex).toHaveBeenCalledWith({ keys: pullKey() })
     expect(mockSearchReindexStatus).toHaveBeenCalledTimes(2)
   })
 
@@ -213,11 +214,14 @@ describe('chat-search', () => {
         {
           id: 'b',
           ok: true,
-          plaintext: JSON.stringify({
-            title: 'Remote tax chat',
-            messages: [{ role: 'user', content: 'tax return time' }],
-            createdAt: '2026-06-01T00:00:00Z',
-          }),
+          // The enclave returns base64-encoded plaintext bytes.
+          plaintext: Buffer.from(
+            JSON.stringify({
+              title: 'Remote tax chat',
+              messages: [{ role: 'user', content: 'tax return time' }],
+              createdAt: '2026-06-01T00:00:00Z',
+            }),
+          ).toString('base64'),
         },
         { id: 'c', ok: false, code: 'NOT_FOUND' },
       ],

--- a/tests/services/sync-enclave/sync-api.test.ts
+++ b/tests/services/sync-enclave/sync-api.test.ts
@@ -229,7 +229,7 @@ describe('sync-api (enclave JSON-RPC)', () => {
         partial: false,
       }),
     )
-    const kicked = await api.searchReindex([{ key: 'key-b64' }])
+    const kicked = await api.searchReindex({ keys: [{ key: 'key-b64' }] })
     expect(kicked.status).toBe('running')
     expect(lastRequest()[0]).toBe('/v1/search/reindex')
     expect(lastBody<{ keys: Array<{ key: string }> }>().keys).toEqual([

--- a/tests/services/sync-enclave/sync-api.test.ts
+++ b/tests/services/sync-enclave/sync-api.test.ts
@@ -197,6 +197,61 @@ describe('sync-api (enclave JSON-RPC)', () => {
     expect(lastRequest()[0]).toBe('/v1/blobs/migrate')
   })
 
+  it('searchQuery posts /v1/search/query and normalizes null results', async () => {
+    const api = await import('@/services/sync-enclave/sync-api')
+    mockFetch.mockResolvedValueOnce(
+      ok({ results: null, total_indexed: 3, needs_reindex: true }),
+    )
+    const resp = await api.searchQuery({
+      keyB64: 'key-b64',
+      query: 'duck pond',
+      limit: 5,
+    })
+    expect(resp.results).toEqual([])
+    expect(resp.total_indexed).toBe(3)
+    expect(resp.needs_reindex).toBe(true)
+    expect(lastRequest()[0]).toBe('/v1/search/query')
+    const body = lastBody<{ key: string; query: string; limit: number }>()
+    expect(body.key).toBe('key-b64')
+    expect(body.query).toBe('duck pond')
+    expect(body.limit).toBe(5)
+  })
+
+  it('searchReindex kicks the job and searchReindexStatus polls it', async () => {
+    const api = await import('@/services/sync-enclave/sync-api')
+    mockFetch.mockResolvedValueOnce(
+      ok({
+        job_id: 'job-1',
+        status: 'running',
+        indexed: 0,
+        failed: 0,
+        total_indexed: 0,
+        partial: false,
+      }),
+    )
+    const kicked = await api.searchReindex([{ key: 'key-b64' }])
+    expect(kicked.status).toBe('running')
+    expect(lastRequest()[0]).toBe('/v1/search/reindex')
+    expect(lastBody<{ keys: Array<{ key: string }> }>().keys).toEqual([
+      { key: 'key-b64' },
+    ])
+
+    mockFetch.mockResolvedValueOnce(
+      ok({
+        job_id: 'job-1',
+        status: 'completed',
+        indexed: 7,
+        failed: 0,
+        total_indexed: 7,
+        partial: false,
+      }),
+    )
+    const status = await api.searchReindexStatus()
+    expect(status.status).toBe('completed')
+    expect(status.indexed).toBe(7)
+    expect(lastRequest()[0]).toBe('/v1/search/reindex-status')
+  })
+
   it('health hits GET /v1/health', async () => {
     const api = await import('@/services/sync-enclave/sync-api')
     mockFetch.mockResolvedValueOnce(ok({ status: 'ok' }))


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds encrypted search for synced chats in the sidebar (cloud tab). Results are ranked, can open chats beyond pagination, automatically trigger index rebuilds when needed, and fall back to local title filtering if search isn’t available.

- **New Features**
  - Search box in the cloud tab (only when signed in with Cloud Sync), with a clear button and a “Building search index...” status.
  - Debounced search via `useChatSearch` with loading states; degrades to local title filtering when search is unavailable or no key is loaded.
  - Auto index rebuild through `ensureSearchIndex` with shared polling and a cooldown after failures to avoid loops.
  - Open search hits not in loaded pages using `onOpenChatById`/`loadChatById`; shows “No matching chats” when empty.
  - Sync enclave API bindings for `searchQuery`, `searchReindex`, and `searchReindexStatus`; map 404/405/503 to “search unavailable” and log when `search_indexed` is false on upload.
  - Sidebar disables pagination and drag/move/convert controls while searching.

- **Bug Fixes**
  - Correctly decode pulled search-result chats so titles and message counts render, and selecting a result opens the chat even if it isn’t loaded locally.

<sup>Written for commit 820119c3643c462c83eb66dde1f89deb1fd28cd1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/426?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

