### PR TITLE
Fix: cloud sync attention badge

### DIFF
--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -17,6 +17,7 @@ import {
 import { useChatRouter } from '@/hooks/use-chat-router'
 import { useProjects } from '@/hooks/use-projects'
 import { useSubscriptionStatus } from '@/hooks/use-subscription-status'
+import { useSyncHealthAttention } from '@/hooks/use-sync-health'
 import { useToast } from '@/hooks/use-toast'
 import {
   getRateLimitInfo,
@@ -412,6 +413,7 @@ export function ChatInterface({
   const [settingsInitialTab, setSettingsInitialTab] = useState<
     SettingsTab | undefined
   >(undefined)
+  const syncNeedsAttention = useSyncHealthAttention()
 
   // State for share modal
   const [isShareModalOpen, setIsShareModalOpen] = useState(false)
@@ -1506,7 +1508,7 @@ export function ChatInterface({
       setIsSettingsModalOpen(false)
     } else {
       // Open settings and close verifier if open
-      setSettingsInitialTab(undefined)
+      setSettingsInitialTab(syncNeedsAttention ? 'cloud-sync' : undefined)
       setIsSettingsModalOpen(true)
       handleSetVerifierSidebarOpen(false)
       setIsAskSidebarOpen(false)

--- a/src/components/chat/cloud-sync-health-card.tsx
+++ b/src/components/chat/cloud-sync-health-card.tsx
@@ -87,9 +87,12 @@ function describeStatus(health: SyncHealthSnapshot): {
   }
 }
 
+const MAX_FAILED_CHAT_DETAILS = 5
+
 interface CloudSyncHealthCardProps {
   isDarkMode: boolean
   onRecoverClick?: () => void
+  chats?: ReadonlyArray<{ id: string; title: string }>
 }
 
 /**
@@ -101,10 +104,14 @@ interface CloudSyncHealthCardProps {
 export function CloudSyncHealthCard({
   isDarkMode,
   onRecoverClick,
+  chats = [],
 }: CloudSyncHealthCardProps) {
   const health = useSyncHealth()
   const status = describeStatus(health)
-  const failedCount = Object.keys(health.failedChats).length
+  const failedEntries = Object.entries(health.failedChats)
+  const failedCount = failedEntries.length
+  const chatTitle = (chatId: string) =>
+    chats.find((chat) => chat.id === chatId)?.title ?? 'Untitled chat'
 
   return (
     <div
@@ -149,6 +156,20 @@ export function CloudSyncHealthCard({
                   ? "1 chat couldn't be synced."
                   : `${failedCount} chats couldn't be synced.`}{' '}
                 Affected chats are marked in the sidebar.
+                <ul className="mt-1 space-y-0.5">
+                  {failedEntries
+                    .slice(0, MAX_FAILED_CHAT_DETAILS)
+                    .map(([chatId, message]) => (
+                      <li key={chatId} className="truncate">
+                        <span className="font-medium">{chatTitle(chatId)}</span>
+                        {': '}
+                        {message}
+                      </li>
+                    ))}
+                  {failedCount > MAX_FAILED_CHAT_DETAILS && (
+                    <li>and {failedCount - MAX_FAILED_CHAT_DETAILS} more…</li>
+                  )}
+                </ul>
               </div>
             )}
           </div>

--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -3205,6 +3205,7 @@ ${encryptionKey.replace('key_', '')}
                     {cloudSyncEnabled && (
                       <CloudSyncHealthCard
                         isDarkMode={isDarkMode}
+                        chats={chats}
                         onRecoverClick={
                           onCloudSyncSetupClick
                             ? () => {

--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -17,6 +17,7 @@ import {
   USER_PREFS_TRAITS,
 } from '@/constants/storage-keys'
 import { useProjects } from '@/hooks/use-projects'
+import { useSyncHealthAttention } from '@/hooks/use-sync-health'
 import { useToast } from '@/hooks/use-toast'
 import { authTokenManager } from '@/services/auth'
 import { buildChatExport } from '@/services/chat-export/export-archive'
@@ -457,6 +458,7 @@ export function SettingsModal({
   const [activeTab, setActiveTab] = useState<SettingsTab>(
     initialTab ?? 'account',
   )
+  const syncNeedsAttention = useSyncHealthAttention()
 
   // Update active tab when initialTab prop changes (e.g., opening to a specific tab)
   useEffect(() => {
@@ -2150,6 +2152,13 @@ ${encryptionKey.replace('key_', '')}
                   <item.icon className="h-4 w-4" />
                 )}
                 {item.label}
+                {item.id === 'cloud-sync' && syncNeedsAttention && (
+                  <span
+                    className="h-2 w-2 shrink-0 rounded-full bg-orange-500"
+                    title="Cloud sync needs attention"
+                    aria-hidden="true"
+                  />
+                )}
               </button>
             ))}
           </nav>
@@ -2186,6 +2195,13 @@ ${encryptionKey.replace('key_', '')}
                   <item.icon className="h-5 w-5" />
                 )}
                 {item.label}
+                {item.id === 'cloud-sync' && syncNeedsAttention && (
+                  <span
+                    className="h-2 w-2 shrink-0 rounded-full bg-orange-500"
+                    title="Cloud sync needs attention"
+                    aria-hidden="true"
+                  />
+                )}
               </button>
             ))}
           </nav>

--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -2139,6 +2139,11 @@ ${encryptionKey.replace('key_', '')}
               <button
                 key={item.id}
                 onClick={() => setActiveTab(item.id)}
+                aria-label={
+                  item.id === 'cloud-sync' && syncNeedsAttention
+                    ? `${item.label} (needs attention)`
+                    : undefined
+                }
                 className={cn(
                   'flex shrink-0 items-center gap-1.5 rounded-lg px-3 py-2 text-xs font-medium transition-colors',
                   activeTab === item.id
@@ -2182,6 +2187,11 @@ ${encryptionKey.replace('key_', '')}
               <button
                 key={item.id}
                 onClick={() => setActiveTab(item.id)}
+                aria-label={
+                  item.id === 'cloud-sync' && syncNeedsAttention
+                    ? `${item.label} (needs attention)`
+                    : undefined
+                }
                 className={cn(
                   'flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium transition-colors',
                   activeTab === item.id


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the Cloud Sync attention badge in Settings, auto-opens the Cloud Sync tab when sync needs attention, and announces this state to screen readers. Also shows which chats failed to sync and why to help users recover faster.

- **Bug Fixes**
  - Show an orange attention dot on the `Cloud Sync` tab when sync needs attention (desktop and mobile).
  - Opening Settings defaults to the `Cloud Sync` tab if attention is required.
  - Announce the attention state to screen readers via `aria-label` on the `Cloud Sync` tab.

- **New Features**
  - Cloud Sync health card lists up to 5 failed chats with titles and error messages, with “and N more…” when applicable.
  - `CloudSyncHealthCard` now receives `chats` to display chat titles.

<sup>Written for commit 58d802abebd359b8aeff8dedb47118f94c92ce23. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/432?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

