### PR TITLE
Fix: sign in TOTP and 404 errors

### DIFF
--- a/src/pages/signin.tsx
+++ b/src/pages/signin.tsx
@@ -25,15 +25,9 @@ const UNSUPPORTED_REQUIREMENTS_MESSAGE =
   'Your account needs additional setup. Please contact support.'
 
 type AuthStep = 'email' | 'code' | 'details'
-type VerificationKind = 'primary' | 'mfa'
+type VerificationKind = 'primary' | 'mfa' | 'totp'
 type PendingAction =
-  | 'google'
-  | 'apple'
-  | 'email'
-  | 'verify'
-  | 'resend'
-  | 'details'
-  | null
+  'google' | 'apple' | 'email' | 'verify' | 'resend' | 'details' | null
 type ActiveAuthAction = Exclude<PendingAction, null>
 
 type SignInFinalizeParams = NonNullable<
@@ -104,6 +98,7 @@ export default function SignInPage() {
   const [lastName, setLastName] = useState('')
   const [pendingAction, setPendingAction] = useState<PendingAction>(null)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [emailMfaAvailable, setEmailMfaAvailable] = useState(false)
 
   useEffect(() => {
     const root = document.documentElement
@@ -202,9 +197,22 @@ export default function SignInPage() {
       signIn.status === 'needs_second_factor' ||
       signIn.status === 'needs_client_trust'
     ) {
+      const hasTotp = signIn.supportedSecondFactors.some(
+        (factor) => factor.strategy === 'totp',
+      )
       const hasEmailCode = signIn.supportedSecondFactors.some(
         (factor) => factor.strategy === 'email_code',
       )
+
+      // Prefer the authenticator app when enrolled; it needs no send step.
+      if (hasTotp) {
+        setCode('')
+        setEmailMfaAvailable(hasEmailCode)
+        setVerificationKind('totp')
+        setStep('code')
+        return
+      }
+
       if (!hasEmailCode) {
         setErrorMessage(UNSUPPORTED_REQUIREMENTS_MESSAGE)
         return
@@ -312,7 +320,9 @@ export default function SignInPage() {
         const { error } =
           verificationKind === 'primary'
             ? await signIn.emailCode.verifyCode({ code })
-            : await signIn.mfa.verifyEmailCode({ code })
+            : verificationKind === 'mfa'
+              ? await signIn.mfa.verifyEmailCode({ code })
+              : await signIn.mfa.verifyTOTP({ code })
 
         if (error) {
           const errorCode = clerkErrorCode(error)
@@ -346,6 +356,23 @@ export default function SignInPage() {
         if (error) {
           setErrorMessage(clerkErrorMessage(error, AUTH_ERROR_MESSAGE))
         }
+      },
+    )
+  }
+
+  const handleUseEmailMfa = async () => {
+    await runAuthAction(
+      'resend',
+      'Could not send sign-in code',
+      'handleUseEmailMfa',
+      async () => {
+        const { error } = await signIn.mfa.sendEmailCode()
+        if (error) {
+          setErrorMessage(clerkErrorMessage(error, AUTH_ERROR_MESSAGE))
+          return
+        }
+        setCode('')
+        setVerificationKind('mfa')
       },
     )
   }
@@ -454,6 +481,7 @@ export default function SignInPage() {
     setCode('')
     setErrorMessage(null)
     setVerificationKind('primary')
+    setEmailMfaAvailable(false)
     setStep('email')
   }
 
@@ -473,12 +501,18 @@ export default function SignInPage() {
         {step !== 'email' && (
           <div className="mb-8">
             <h1 className="text-2xl font-medium leading-tight text-content-primary">
-              {step === 'code' ? 'Check your email' : 'Complete your account'}
+              {step !== 'code'
+                ? 'Complete your account'
+                : verificationKind === 'totp'
+                  ? 'Two-step verification'
+                  : 'Check your email'}
             </h1>
             <p className="mt-1 text-lg leading-tight text-content-muted">
-              {step === 'code'
-                ? `We sent a verification code to ${emailAddress}`
-                : 'Your email is verified'}
+              {step !== 'code'
+                ? 'Your email is verified'
+                : verificationKind === 'totp'
+                  ? 'Enter the code from your authenticator app'
+                  : `We sent a verification code to ${emailAddress}`}
             </p>
           </div>
         )}
@@ -607,14 +641,29 @@ export default function SignInPage() {
               Verify
             </Button>
             <div className="flex justify-center gap-4 text-sm">
-              <button
-                type="button"
-                disabled={isPending}
-                onClick={handleResendCode}
-                className="text-content-secondary transition-colors hover:text-content-primary disabled:opacity-60"
-              >
-                {pendingAction === 'resend' ? 'Sending...' : 'Resend code'}
-              </button>
+              {verificationKind !== 'totp' ? (
+                <button
+                  type="button"
+                  disabled={isPending}
+                  onClick={handleResendCode}
+                  className="text-content-secondary transition-colors hover:text-content-primary disabled:opacity-60"
+                >
+                  {pendingAction === 'resend' ? 'Sending...' : 'Resend code'}
+                </button>
+              ) : (
+                emailMfaAvailable && (
+                  <button
+                    type="button"
+                    disabled={isPending}
+                    onClick={handleUseEmailMfa}
+                    className="text-content-secondary transition-colors hover:text-content-primary disabled:opacity-60"
+                  >
+                    {pendingAction === 'resend'
+                      ? 'Sending...'
+                      : 'Email me a code instead'}
+                  </button>
+                )
+              )}
               <button
                 type="button"
                 disabled={isPending}

--- a/tests/pages/signin.test.tsx
+++ b/tests/pages/signin.test.tsx
@@ -14,6 +14,7 @@ const auth = vi.hoisted(() => {
     mfa: {
       sendEmailCode: vi.fn(),
       verifyEmailCode: vi.fn(),
+      verifyTOTP: vi.fn(),
     },
     sso: vi.fn(),
     finalize: vi.fn(),
@@ -59,6 +60,7 @@ describe('SignInPage', () => {
     auth.signIn.emailCode.verifyCode.mockResolvedValue({ error: null })
     auth.signIn.mfa.sendEmailCode.mockResolvedValue({ error: null })
     auth.signIn.mfa.verifyEmailCode.mockResolvedValue({ error: null })
+    auth.signIn.mfa.verifyTOTP.mockResolvedValue({ error: null })
     auth.signIn.sso.mockResolvedValue({ error: null })
     auth.signUp.create.mockResolvedValue({ error: null })
     auth.signUp.update.mockResolvedValue({ error: null })
@@ -170,6 +172,99 @@ describe('SignInPage', () => {
       expect(auth.signUp.finalize).toHaveBeenCalledWith({
         navigate: expect.any(Function),
       })
+    })
+  })
+
+  it('verifies an authenticator app code when TOTP is the second factor', async () => {
+    auth.signIn.emailCode.verifyCode.mockImplementation(async () => {
+      auth.signIn.status = 'needs_second_factor'
+      auth.signIn.supportedSecondFactors = [{ strategy: 'totp' }]
+      return { error: null }
+    })
+    auth.signIn.mfa.verifyTOTP.mockImplementation(async () => {
+      auth.signIn.status = 'complete'
+      return { error: null }
+    })
+    render(<SignInPage />)
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Email' }), {
+      target: { value: 'person@example.com' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
+    fireEvent.change(
+      await screen.findByRole('textbox', { name: 'Verification code' }),
+      { target: { value: '123456' } },
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Verify' }))
+
+    expect(
+      await screen.findByRole('heading', { name: 'Two-step verification' }),
+    ).toBeInTheDocument()
+    expect(auth.signIn.mfa.sendEmailCode).not.toHaveBeenCalled()
+
+    fireEvent.change(
+      screen.getByRole('textbox', { name: 'Verification code' }),
+      { target: { value: '987654' } },
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Verify' }))
+
+    await waitFor(() => {
+      expect(auth.signIn.mfa.verifyTOTP).toHaveBeenCalledWith({
+        code: '987654',
+      })
+      expect(auth.signIn.finalize).toHaveBeenCalledWith({
+        navigate: expect.any(Function),
+      })
+    })
+  })
+
+  it('lets the user fall back to an email MFA code from the TOTP prompt', async () => {
+    auth.signIn.emailCode.verifyCode.mockImplementation(async () => {
+      auth.signIn.status = 'needs_second_factor'
+      auth.signIn.supportedSecondFactors = [
+        { strategy: 'totp' },
+        { strategy: 'email_code' },
+      ]
+      return { error: null }
+    })
+    render(<SignInPage />)
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Email' }), {
+      target: { value: 'person@example.com' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
+    fireEvent.change(
+      await screen.findByRole('textbox', { name: 'Verification code' }),
+      { target: { value: '123456' } },
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Verify' }))
+
+    fireEvent.click(
+      await screen.findByRole('button', { name: 'Email me a code instead' }),
+    )
+
+    await waitFor(() => {
+      expect(auth.signIn.mfa.sendEmailCode).toHaveBeenCalledTimes(1)
+    })
+    expect(
+      await screen.findByRole('heading', { name: 'Check your email' }),
+    ).toBeInTheDocument()
+
+    fireEvent.change(
+      screen.getByRole('textbox', { name: 'Verification code' }),
+      { target: { value: '555555' } },
+    )
+    auth.signIn.mfa.verifyEmailCode.mockImplementation(async () => {
+      auth.signIn.status = 'complete'
+      return { error: null }
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Verify' }))
+
+    await waitFor(() => {
+      expect(auth.signIn.mfa.verifyEmailCode).toHaveBeenCalledWith({
+        code: '555555',
+      })
+      expect(auth.signIn.finalize).toHaveBeenCalled()
     })
   })
 

--- a/vercel.json
+++ b/vercel.json
@@ -35,7 +35,11 @@
       "destination": "/share/%5B%5B...slug%5D%5D.html"
     },
     { "source": "/newchat", "destination": "/newchat.html" },
-    { "source": "/newchat/", "destination": "/newchat.html" }
+    { "source": "/newchat/", "destination": "/newchat.html" },
+    { "source": "/signin", "destination": "/signin.html" },
+    { "source": "/signin/", "destination": "/signin.html" },
+    { "source": "/sso-callback", "destination": "/sso-callback.html" },
+    { "source": "/sso-callback/", "destination": "/sso-callback.html" }
   ],
   "headers": [
     {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds authenticator app (TOTP) support to the sign-in flow and fixes 404s when visiting the sign-in and SSO callback pages directly. TOTP is preferred when available, with an email code fallback.

- **New Features**
  - Prefer TOTP for the second factor and verify via `signIn.mfa.verifyTOTP`; show “Email me a code instead” when email MFA is available.
  - Keep email MFA as fallback; hide resend for TOTP; updated copy (“Two-step verification”).
  - Added tests covering the TOTP path and the fallback to email codes.

- **Bug Fixes**
  - Added `vercel.json` rewrites for `/signin` and `/sso-callback` (with/without trailing slash) to their `.html` pages to prevent direct-navigation 404s.

<sup>Written for commit 3a97ca6582808b118e3411c08b38e96ab6b47014. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/433?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

