### PR TITLE
Address UI nits

### DIFF
--- a/src/components/chat/chat-sidebar.tsx
+++ b/src/components/chat/chat-sidebar.tsx
@@ -1905,7 +1905,7 @@ export function ChatSidebar({
                         placeholder="Search chats..."
                         aria-label="Search chats"
                         className={cn(
-                          'w-full rounded-md border py-1.5 pl-8 pr-7 text-xs',
+                          'h-9 w-full rounded-md border pl-8 pr-7 text-sm',
                           isDarkMode
                             ? 'border-border-strong bg-surface-chat text-content-secondary placeholder:text-content-muted'
                             : 'border-border-subtle bg-surface-sidebar text-content-primary placeholder:text-content-muted',

--- a/src/components/chat/chat-sidebar.tsx
+++ b/src/components/chat/chat-sidebar.tsx
@@ -2121,7 +2121,7 @@ export function ChatSidebar({
                               No matching chats
                             </p>
                             {chatSearch.isIndexing && (
-                              <p className="mt-1 text-xs text-content-muted">
+                              <p className="mt-1 text-balance text-xs text-content-muted">
                                 The search index is still being built; results
                                 will fill in shortly
                               </p>

--- a/src/hooks/use-chat-search.ts
+++ b/src/hooks/use-chat-search.ts
@@ -1,7 +1,7 @@
 import {
-  ensureSearchIndex,
   resolveSearchResultChats,
   searchSyncedChats,
+  type ReindexSettleResult,
   type SearchResultChat,
 } from '@/services/cloud/chat-search'
 import { logError } from '@/utils/error-handling'
@@ -63,12 +63,12 @@ export function useChatSearch(term: string, enabled: boolean): ChatSearchState {
         if (cancelled) return
         setResults(chats)
         setIsSearching(false)
-        if (outcome.indexing) {
+        if (outcome.reindexSettled) {
           // Re-query only after a successful rebuild. Refreshing on a
           // failed or skipped settle would report needs_reindex again
           // and kick another full rebuild, looping a persistent
           // failure at full embedding cost.
-          void ensureSearchIndex().then((settled) => {
+          outcome.reindexSettled.then((settled: ReindexSettleResult) => {
             if (cancelled) return
             if (settled === 'completed') {
               setRefreshNonce((n) => n + 1)

--- a/src/services/cloud/chat-search.ts
+++ b/src/services/cloud/chat-search.ts
@@ -54,10 +54,22 @@ export interface ChatSearchOutcome {
    * UI should fall back to local title filtering.
    */
   available: boolean
+  /**
+   * Settles when the in-flight reindex completes; null when no reindex
+   * was kicked. Callers should re-query once this resolves
+   * `completed` so results fill in without a user action.
+   */
+  reindexSettled: Promise<ReindexSettleResult> | null
 }
 
 function unavailableOutcome(): ChatSearchOutcome {
-  return { results: [], totalIndexed: 0, indexing: false, available: false }
+  return {
+    results: [],
+    totalIndexed: 0,
+    indexing: false,
+    available: false,
+    reindexSettled: null,
+  }
 }
 
 /**
@@ -90,14 +102,13 @@ export async function searchSyncedChats(
     throw err
   }
   const indexing = resp.needs_reindex === true
-  if (indexing) {
-    void ensureSearchIndex()
-  }
+  const reindexSettled = indexing ? ensureSearchIndex() : null
   return {
     results: resp.results,
     totalIndexed: resp.total_indexed,
     indexing,
     available: true,
+    reindexSettled,
   }
 }
 

--- a/tests/services/cloud/chat-search.test.ts
+++ b/tests/services/cloud/chat-search.test.ts
@@ -79,6 +79,7 @@ describe('chat-search', () => {
       totalIndexed: 0,
       indexing: false,
       available: false,
+      reindexSettled: null,
     })
     expect(mockSearchQuery).not.toHaveBeenCalled()
   })
@@ -125,6 +126,7 @@ describe('chat-search', () => {
       totalIndexed: 9,
       indexing: false,
       available: true,
+      reindexSettled: null,
     })
     expect(mockSearchQuery).toHaveBeenCalledWith({
       keyB64: 'primary-b64',
@@ -154,10 +156,13 @@ describe('chat-search', () => {
     expect(first.indexing).toBe(true)
     expect(second.indexing).toBe(true)
 
-    const settled = search.ensureSearchIndex()
+    // Both calls share the same in-flight reindex promise.
+    expect(first.reindexSettled).not.toBeNull()
+    expect(first.reindexSettled).toBe(second.reindexSettled)
+
     await vi.advanceTimersByTimeAsync(search.SEARCH_REINDEX_POLL_INTERVAL_MS)
     await vi.advanceTimersByTimeAsync(search.SEARCH_REINDEX_POLL_INTERVAL_MS)
-    await expect(settled).resolves.toBe('completed')
+    await expect(first.reindexSettled).resolves.toBe('completed')
 
     const { pullKey } = await import('@/services/cloud/cek-encoding')
     expect(mockSearchReindex).toHaveBeenCalledTimes(1)

--- a/tests/utils/signout-cleanup.test.ts
+++ b/tests/utils/signout-cleanup.test.ts
@@ -3,6 +3,7 @@ import { SETTINGS_HAS_SEEN_ONBOARDING } from '@/constants/storage-keys'
 import { cloudSync } from '@/services/cloud/cloud-sync'
 import { resetEditClockCache } from '@/services/cloud/edit-clock'
 import { profileSync } from '@/services/cloud/profile-sync'
+import { invalidateProfileSyncGeneration } from '@/services/cloud/profile-sync-coordinator'
 import { resetSyncHealth } from '@/services/cloud/sync-health'
 import { encryptionService } from '@/services/encryption/encryption-service'
 import { resetTinfoilClient } from '@/services/inference/tinfoil-client'
@@ -18,7 +19,7 @@ vi.mock('@/components/chat/renderers', () => ({
 }))
 
 vi.mock('@/services/cloud/cloud-sync', () => ({
-  cloudSync: { clearSyncStatus: vi.fn() },
+  cloudSync: { resetForAccountChange: vi.fn() },
 }))
 
 vi.mock('@/services/cloud/edit-clock', () => ({
@@ -27,6 +28,10 @@ vi.mock('@/services/cloud/edit-clock', () => ({
 
 vi.mock('@/services/cloud/profile-sync', () => ({
   profileSync: { clearCache: vi.fn() },
+}))
+
+vi.mock('@/services/cloud/profile-sync-coordinator', () => ({
+  invalidateProfileSyncGeneration: vi.fn(),
 }))
 
 vi.mock('@/services/cloud/sync-health', () => ({
@@ -50,7 +55,7 @@ vi.mock('@/services/storage/deleted-chats-tracker', () => ({
 }))
 
 vi.mock('@/services/storage/indexed-db', () => ({
-  indexedDBStorage: { clearAll: vi.fn().mockResolvedValue(undefined) },
+  indexedDBStorage: { deleteAllChats: vi.fn().mockResolvedValue(0) },
 }))
 
 vi.mock('@/services/sync-enclave', () => ({
@@ -95,18 +100,19 @@ describe('performSignoutCleanup', () => {
     expect(resetTinfoilClient).toHaveBeenCalled()
     expect(resetSyncEnclaveClient).toHaveBeenCalled()
     expect(profileSync.clearCache).toHaveBeenCalled()
-    expect(cloudSync.clearSyncStatus).toHaveBeenCalled()
+    expect(invalidateProfileSyncGeneration).toHaveBeenCalledWith(true)
+    expect(cloudSync.resetForAccountChange).toHaveBeenCalled()
     expect(deletedChatsTracker.clear).toHaveBeenCalled()
     expect(resetSyncHealth).toHaveBeenCalled()
     expect(resetEditClockCache).toHaveBeenCalled()
     expect(projectEvents.clear).toHaveBeenCalled()
-    expect(indexedDBStorage.clearAll).toHaveBeenCalled()
+    expect(indexedDBStorage.deleteAllChats).toHaveBeenCalled()
   })
 
   it('keeps the encryption key when preserveEncryptionKey is set', async () => {
     await performSignoutCleanup({ preserveEncryptionKey: true })
 
     expect(encryptionService.clearKey).not.toHaveBeenCalled()
-    expect(indexedDBStorage.clearAll).toHaveBeenCalled()
+    expect(indexedDBStorage.deleteAllChats).toHaveBeenCalled()
   })
 })


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enlarged the chat search field and balanced the indexing message for better readability. Chat search now auto-refreshes after a successful reindex so results appear without user action.

- **Bug Fixes**
  - Added a `reindexSettled` promise to `searchSyncedChats` and used it in `useChatSearch` to refresh only after reindex completes, preventing repeated rebuild loops.
  - Updated chat search tests to verify the shared in-flight reindex promise and successful completion.
  - Aligned signout cleanup tests with current behavior: call `invalidateProfileSyncGeneration(true)`, use `cloudSync.resetForAccountChange`, and `indexedDBStorage.deleteAllChats`.

<sup>Written for commit 8d5e7df3d23ca04e3dce6d728477c4d7bd6aea58. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/434?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

