### PR TITLE
Perf: keep prompts cacheable by moving current time out of them

### DIFF
--- a/src/components/chat/hooks/use-custom-system-prompt.ts
+++ b/src/components/chat/hooks/use-custom-system-prompt.ts
@@ -25,13 +25,6 @@ type UseCustomSystemPromptReturn = {
   isUsingPersonalization: boolean
 }
 
-// Stable replacement for the legacy {CURRENT_DATETIME} placeholder. The live
-// timestamp is delivered via an ephemeral reminder message at the end of the
-// request instead, so the system prompt stays byte-stable and server-side
-// prefix caching keeps working.
-const CURRENT_DATETIME_POINTER =
-  'provided in a reminder message at the end of the conversation'
-
 const stripSystemTags = (prompt: string): string =>
   prompt
     .replace(/^<system>\s*\n?/, '')
@@ -234,7 +227,6 @@ export const useCustomSystemPrompt = (
     return text
       .replace('{USER_PREFERENCES}', userPreferencesXML)
       .replace('{LANGUAGE}', effectiveLanguage)
-      .replace('{CURRENT_DATETIME}', CURRENT_DATETIME_POINTER)
       .replace('{TIMEZONE}', timezone)
   }
 

--- a/src/components/chat/hooks/use-custom-system-prompt.ts
+++ b/src/components/chat/hooks/use-custom-system-prompt.ts
@@ -25,6 +25,13 @@ type UseCustomSystemPromptReturn = {
   isUsingPersonalization: boolean
 }
 
+// Stable replacement for the legacy {CURRENT_DATETIME} placeholder. The live
+// timestamp is delivered via an ephemeral reminder message at the end of the
+// request instead, so the system prompt stays byte-stable and server-side
+// prefix caching keeps working.
+const CURRENT_DATETIME_POINTER =
+  'provided in a reminder message at the end of the conversation'
+
 const stripSystemTags = (prompt: string): string =>
   prompt
     .replace(/^<system>\s*\n?/, '')
@@ -220,19 +227,6 @@ export const useCustomSystemPrompt = (
     // Get the effective language (default to English if not set)
     const effectiveLanguage = personalization.language.trim() || 'English'
 
-    // Generate current date/time string and timezone
-    const now = new Date()
-    const currentDateTime = now.toLocaleString('en-US', {
-      weekday: 'long',
-      year: 'numeric',
-      month: 'long',
-      day: 'numeric',
-      hour: '2-digit',
-      minute: '2-digit',
-      second: '2-digit',
-      timeZoneName: 'short',
-    })
-
     // Extract timezone separately
     const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone
 
@@ -240,7 +234,7 @@ export const useCustomSystemPrompt = (
     return text
       .replace('{USER_PREFERENCES}', userPreferencesXML)
       .replace('{LANGUAGE}', effectiveLanguage)
-      .replace('{CURRENT_DATETIME}', currentDateTime)
+      .replace('{CURRENT_DATETIME}', CURRENT_DATETIME_POINTER)
       .replace('{TIMEZONE}', timezone)
   }
 

--- a/src/components/chat/prompts/built-in-presets.ts
+++ b/src/components/chat/prompts/built-in-presets.ts
@@ -37,7 +37,7 @@ praise; acknowledge progress only when it reflects real understanding.
 
 {USER_PREFERENCES}
 
-Respond in {LANGUAGE}. Current time: {CURRENT_DATETIME} ({TIMEZONE}).
+Respond in {LANGUAGE}. The user's timezone is {TIMEZONE}.
 `),
   },
   {
@@ -71,7 +71,7 @@ doesn't reproduce on a careful second look. Don't pad the review.
 
 {USER_PREFERENCES}
 
-Respond in {LANGUAGE}. Current time: {CURRENT_DATETIME} ({TIMEZONE}).
+Respond in {LANGUAGE}. The user's timezone is {TIMEZONE}.
 `),
   },
   {
@@ -102,7 +102,7 @@ fragments; if they write in long periodic sentences, do the same.
 
 {USER_PREFERENCES}
 
-Respond in {LANGUAGE}. Current time: {CURRENT_DATETIME} ({TIMEZONE}).
+Respond in {LANGUAGE}. The user's timezone is {TIMEZONE}.
 `),
   },
   {
@@ -136,7 +136,7 @@ recommendation unless the user explicitly asks.
 
 {USER_PREFERENCES}
 
-Respond in {LANGUAGE}. Current time: {CURRENT_DATETIME} ({TIMEZONE}).
+Respond in {LANGUAGE}. The user's timezone is {TIMEZONE}.
 `),
   },
   {
@@ -171,7 +171,7 @@ expanding into every alternative.
 
 {USER_PREFERENCES}
 
-Respond in {LANGUAGE}. Current time: {CURRENT_DATETIME} ({TIMEZONE}).
+Respond in {LANGUAGE}. The user's timezone is {TIMEZONE}.
 `),
   },
   {
@@ -242,7 +242,7 @@ Once the scene is set, dive straight in.
 
 {USER_PREFERENCES}
 
-Respond in {LANGUAGE}. Current time: {CURRENT_DATETIME} ({TIMEZONE}).
+Respond in {LANGUAGE}. The user's timezone is {TIMEZONE}.
 `),
   },
   {
@@ -269,7 +269,7 @@ depth, they'll ask.
 
 {USER_PREFERENCES}
 
-Respond in {LANGUAGE}. Current time: {CURRENT_DATETIME} ({TIMEZONE}).
+Respond in {LANGUAGE}. The user's timezone is {TIMEZONE}.
 `),
   },
 ]

--- a/src/components/chat/prompts/preset-editor.tsx
+++ b/src/components/chat/prompts/preset-editor.tsx
@@ -110,7 +110,8 @@ export function PresetEditor({
           />
           <span className="text-[11px] text-content-muted">
             Placeholders supported: {`{USER_PREFERENCES}`}, {`{LANGUAGE}`},{' '}
-            {`{CURRENT_DATETIME}`}, {`{TIMEZONE}`}.
+            {`{TIMEZONE}`}. The current time is always provided to the model
+            automatically.
           </span>
         </label>
       </div>

--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -3094,10 +3094,10 @@ ${encryptionKey.replace('key_', '')}
                                       Tip:
                                     </span>{' '}
                                     Use placeholders like {'{USER_PREFERENCES}'}
-                                    , {'{LANGUAGE}'}, {'{CURRENT_DATETIME}'},
-                                    and {'{TIMEZONE}'} to tell the model about
-                                    your preferences, timezone, and the current
-                                    time and date.
+                                    , {'{LANGUAGE}'}, and {'{TIMEZONE}'} to tell
+                                    the model about your preferences and
+                                    timezone. The current time and date are
+                                    always provided to the model automatically.
                                   </div>
                                 </div>
                                 <div className="flex justify-center">

--- a/src/services/inference/chat-query-builder.ts
+++ b/src/services/inference/chat-query-builder.ts
@@ -5,6 +5,7 @@ import {
 import { buildGenUIPromptHint } from '@/components/chat/genui/system-prompt'
 import type { Message } from '@/components/chat/types'
 import type { BaseModel } from '@/config/models'
+import { formatCurrentTimeReminder } from '@/utils/time-reminder'
 import { selectMessagesWithinBudget } from '@/utils/token-estimation'
 import type {
   ChatCompletionAssistantMessageParam,
@@ -43,6 +44,14 @@ export interface ChatQueryBuilderParams {
    * don't support the system role (e.g. DeepSeek).
    */
   forcePrependSystemPrompt?: boolean
+  /**
+   * Append an ephemeral current-time reminder as the final message. The
+   * reminder is built at request time and never persisted, keeping the
+   * system prompt and history byte-stable so prefix caching works.
+   * Defaults to `false` so internal utilities (title gen, memory) stay
+   * unaffected.
+   */
+  includeTimeReminder?: boolean
 }
 
 export class ChatQueryBuilder {
@@ -59,6 +68,7 @@ export class ChatQueryBuilder {
       messages: conversationMessages,
       includeGenUIHint,
       forcePrependSystemPrompt,
+      includeTimeReminder,
     } = params
     const modelId = model.modelName
 
@@ -168,6 +178,13 @@ export class ChatQueryBuilder {
           }
         }
       }
+    }
+
+    if (includeTimeReminder) {
+      result.push({
+        role: 'user',
+        content: formatCurrentTimeReminder(),
+      } as ChatCompletionUserMessageParam)
     }
 
     return result

--- a/src/services/inference/inference-client.ts
+++ b/src/services/inference/inference-client.ts
@@ -222,6 +222,7 @@ export async function sendChatStream(
       rules,
       messages: updatedMessages,
       includeGenUIHint: genUIEnabled,
+      includeTimeReminder: true,
     })
 
     // Get the last user message for retry test check
@@ -340,6 +341,7 @@ export async function sendChatStream(
     messages: updatedMessages,
     includeGenUIHint: genUIEnabled,
     forcePrependSystemPrompt,
+    includeTimeReminder: true,
   })
 
   let lastError: unknown = null

--- a/src/utils/time-reminder.ts
+++ b/src/utils/time-reminder.ts
@@ -16,10 +16,20 @@ const TIME_REMINDER_FORMAT: Intl.DateTimeFormatOptions = {
   hour: '2-digit',
   minute: '2-digit',
   timeZoneName: 'short',
+  // Explicit hour cycle so OS-level 24-hour preferences cannot alter the
+  // fixed format on engines that let them leak into explicit locales.
+  hour12: true,
 }
 
+// Cached because Intl.DateTimeFormat construction is expensive and this
+// runs on every chat request build.
+const timeReminderFormatter = new Intl.DateTimeFormat(
+  'en-US',
+  TIME_REMINDER_FORMAT,
+)
+
 export function formatCurrentTimeReminder(now: Date = new Date()): string {
-  const dateTime = now.toLocaleString('en-US', TIME_REMINDER_FORMAT)
-  const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone
+  const dateTime = timeReminderFormatter.format(now)
+  const timezone = timeReminderFormatter.resolvedOptions().timeZone
   return `<system-reminder>Current time: ${dateTime} (${timezone})</system-reminder>`
 }

--- a/src/utils/time-reminder.ts
+++ b/src/utils/time-reminder.ts
@@ -1,0 +1,25 @@
+/**
+ * Builds the ephemeral current-time reminder appended to the end of chat
+ * requests. Keeping the timestamp out of the system prompt (the first
+ * message) preserves server-side prefix caching: only the tail of the
+ * prompt changes between turns.
+ *
+ * Minute granularity (no seconds) so retries and regenerations within the
+ * same minute produce byte-identical requests.
+ */
+
+const TIME_REMINDER_FORMAT: Intl.DateTimeFormatOptions = {
+  weekday: 'long',
+  year: 'numeric',
+  month: 'long',
+  day: 'numeric',
+  hour: '2-digit',
+  minute: '2-digit',
+  timeZoneName: 'short',
+}
+
+export function formatCurrentTimeReminder(now: Date = new Date()): string {
+  const dateTime = now.toLocaleString('en-US', TIME_REMINDER_FORMAT)
+  const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone
+  return `<system-reminder>Current time: ${dateTime} (${timezone})</system-reminder>`
+}

--- a/tests/services/inference/chat-query-builder.test.ts
+++ b/tests/services/inference/chat-query-builder.test.ts
@@ -1,7 +1,7 @@
 import type { Message } from '@/components/chat/types'
 import type { BaseModel } from '@/config/models'
 import { ChatQueryBuilder } from '@/services/inference/chat-query-builder'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 const model: BaseModel = {
   modelName: 'gpt-oss-120b',
@@ -71,5 +71,73 @@ describe('ChatQueryBuilder', () => {
       role: 'user',
       content: '<system>\nbe helpful\n</system>',
     })
+  })
+
+  it('appends a current-time reminder as the last message when requested', () => {
+    const messages = ChatQueryBuilder.buildMessages({
+      model,
+      systemPrompt: 'be helpful',
+      rules: '',
+      messages: [userMessage],
+      includeGenUIHint: false,
+      includeTimeReminder: true,
+    })
+
+    const last = messages[messages.length - 1]
+    expect(last.role).toBe('user')
+    expect(last.content).toMatch(
+      /^<system-reminder>Current time: .+<\/system-reminder>$/,
+    )
+    expect(messages[messages.length - 2]).toEqual({
+      role: 'user',
+      content: 'hello',
+    })
+  })
+
+  it('omits the time reminder by default', () => {
+    const messages = ChatQueryBuilder.buildMessages({
+      model,
+      systemPrompt: 'be helpful',
+      rules: '',
+      messages: [userMessage],
+      includeGenUIHint: false,
+    })
+
+    expect(
+      messages.some(
+        (m) =>
+          typeof m.content === 'string' &&
+          m.content.includes('<system-reminder>'),
+      ),
+    ).toBe(false)
+  })
+
+  it('builds byte-identical messages across calls when the wall clock advances within a minute', () => {
+    vi.useFakeTimers()
+    try {
+      vi.setSystemTime(new Date('2026-07-20T10:15:01Z'))
+      const first = ChatQueryBuilder.buildMessages({
+        model,
+        systemPrompt: 'be helpful',
+        rules: '',
+        messages: [userMessage],
+        includeGenUIHint: false,
+        includeTimeReminder: true,
+      })
+
+      vi.setSystemTime(new Date('2026-07-20T10:15:42Z'))
+      const second = ChatQueryBuilder.buildMessages({
+        model,
+        systemPrompt: 'be helpful',
+        rules: '',
+        messages: [userMessage],
+        includeGenUIHint: false,
+        includeTimeReminder: true,
+      })
+
+      expect(second).toEqual(first)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Move dynamic timestamps out of system prompts to keep prompts cacheable. Append a minute-granular time reminder as the last user message so prefix caching and retries stay deterministic.

- New Features
  - Append an ephemeral current-time reminder as the final user message (`includeTimeReminder`) for chat streams.
  - `formatCurrentTimeReminder()` builds an invariant, minute-granular string so retries within a minute are byte-identical.

- Refactors
  - Remove `{CURRENT_DATETIME}` from presets and custom prompts; keep `{TIMEZONE}`. Update editor and settings copy accordingly.
  - Cache and reuse the `Intl.DateTimeFormat` used by the reminder. Add tests for appending, omission by default, and minute-stable requests.

<sup>Written for commit a10f3bab03edeb6fd3e002b08faa1eabec56722e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/436?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

