### PR TITLE
Add authenticator app setup to settings

### DIFF
--- a/src/components/chat/mfa-settings-card.tsx
+++ b/src/components/chat/mfa-settings-card.tsx
@@ -1,0 +1,411 @@
+import { cn } from '@/components/ui/utils'
+import { getClerkErrorMessage } from '@/utils/clerk-errors'
+import { logError } from '@/utils/error-handling'
+import { useReverification, useUser } from '@clerk/nextjs'
+import { isReverificationCancelledError } from '@clerk/nextjs/errors'
+import {
+  CheckCircleIcon,
+  ClipboardDocumentIcon,
+  ShieldCheckIcon,
+} from '@heroicons/react/24/outline'
+import { memo, useCallback, useState, type FormEvent } from 'react'
+import { createPortal } from 'react-dom'
+import { PiSpinner } from 'react-icons/pi'
+import QRCode from 'react-qr-code'
+import { ConfirmDialog } from './components/confirm-dialog'
+
+const TOTP_CODE_LENGTH = 6
+const MFA_ERROR_MESSAGE =
+  'Could not update multi-factor authentication. Please try again.'
+
+type MfaSettingsCardProps = {
+  isDarkMode: boolean
+}
+
+type TotpSetup = {
+  uri?: string
+  secret?: string
+}
+
+const TotpQrCode = memo(function TotpQrCode({ uri }: { uri: string }) {
+  return <QRCode value={uri} size={160} level="M" />
+})
+
+export function MfaSettingsCard({ isDarkMode }: MfaSettingsCardProps) {
+  const { isLoaded, user } = useUser()
+  const [totpSetup, setTotpSetup] = useState<TotpSetup | null>(null)
+  const [verificationCode, setVerificationCode] = useState('')
+  const [backupCodes, setBackupCodes] = useState<string[] | null>(null)
+  const [isStartingSetup, setIsStartingSetup] = useState(false)
+  const [isVerifying, setIsVerifying] = useState(false)
+  const [isDisabling, setIsDisabling] = useState(false)
+  const [showDisableConfirm, setShowDisableConfirm] = useState(false)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [copiedTarget, setCopiedTarget] = useState<
+    'setup-key' | 'backup-codes' | null
+  >(null)
+
+  const createTOTP = useReverification(
+    useCallback(async () => {
+      if (!user) {
+        throw new Error('User is not available')
+      }
+      return user.createTOTP()
+    }, [user]),
+  )
+
+  const disableTOTP = useReverification(
+    useCallback(async () => {
+      if (!user) {
+        throw new Error('User is not available')
+      }
+      return user.disableTOTP()
+    }, [user]),
+  )
+
+  const totpEnabled = user?.totpEnabled ?? false
+
+  const handleStartSetup = async () => {
+    setIsStartingSetup(true)
+    setErrorMessage(null)
+    try {
+      const resource = await createTOTP()
+      setTotpSetup({ uri: resource.uri, secret: resource.secret })
+      setVerificationCode('')
+      setBackupCodes(null)
+      setCopiedTarget(null)
+    } catch (error) {
+      if (!isReverificationCancelledError(error)) {
+        logError('Could not start authenticator app setup', error, {
+          component: 'MfaSettingsCard',
+          action: 'handleStartSetup',
+        })
+        setErrorMessage(getClerkErrorMessage(error, MFA_ERROR_MESSAGE))
+      }
+    } finally {
+      setIsStartingSetup(false)
+    }
+  }
+
+  const handleVerify = async (event: FormEvent) => {
+    event.preventDefault()
+    if (!user) return
+
+    setIsVerifying(true)
+    setErrorMessage(null)
+    try {
+      const resource = await user.verifyTOTP({ code: verificationCode })
+      if (!resource.verified) {
+        setErrorMessage('That code could not be verified. Please try again.')
+        return
+      }
+
+      setTotpSetup(null)
+      setVerificationCode('')
+      setBackupCodes(resource.backupCodes?.length ? resource.backupCodes : [])
+      setCopiedTarget(null)
+    } catch (error) {
+      logError('Could not verify authenticator app setup', error, {
+        component: 'MfaSettingsCard',
+        action: 'handleVerify',
+      })
+      setErrorMessage(getClerkErrorMessage(error, MFA_ERROR_MESSAGE))
+    } finally {
+      setIsVerifying(false)
+    }
+  }
+
+  const handleCancelSetup = () => {
+    setTotpSetup(null)
+    setVerificationCode('')
+    setErrorMessage(null)
+  }
+
+  const handleDisable = async () => {
+    setIsDisabling(true)
+    setShowDisableConfirm(false)
+    setErrorMessage(null)
+    try {
+      await disableTOTP()
+      setBackupCodes(null)
+    } catch (error) {
+      if (!isReverificationCancelledError(error)) {
+        logError('Could not disable authenticator app', error, {
+          component: 'MfaSettingsCard',
+          action: 'handleDisable',
+        })
+        setErrorMessage(getClerkErrorMessage(error, MFA_ERROR_MESSAGE))
+      }
+    } finally {
+      setIsDisabling(false)
+    }
+  }
+
+  const handleCopy = async (
+    value: string,
+    target: 'setup-key' | 'backup-codes',
+  ) => {
+    try {
+      await navigator.clipboard.writeText(value)
+      setCopiedTarget(target)
+    } catch (error) {
+      logError('Could not copy MFA setup information', error, {
+        component: 'MfaSettingsCard',
+        action: 'handleCopy',
+      })
+      setErrorMessage('Could not copy to the clipboard.')
+    }
+  }
+
+  if (backupCodes) {
+    return createPortal(
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="mfa-enabled-title"
+        className="fixed inset-0 z-[70] flex items-center justify-center bg-black/60 p-4"
+      >
+        <div
+          className={cn(
+            'w-full max-w-md rounded-site-lg border border-border-subtle p-5 shadow-xl',
+            isDarkMode ? 'bg-surface-sidebar' : 'bg-white',
+          )}
+        >
+          <div className="flex items-start gap-3">
+            <CheckCircleIcon className="mt-0.5 h-5 w-5 shrink-0 text-emerald-500" />
+            <div>
+              <h3
+                id="mfa-enabled-title"
+                className="font-aeonik text-base font-medium text-content-primary"
+              >
+                Authenticator app enabled
+              </h3>
+              <p className="mt-1 text-xs text-content-muted">
+                You will use an authenticator code when signing in.
+              </p>
+            </div>
+          </div>
+
+          {backupCodes.length > 0 && (
+            <div className="mt-4">
+              <p className="text-sm font-medium text-content-primary">
+                Save your backup codes
+              </p>
+              <p className="mt-1 text-xs text-content-muted">
+                Store these somewhere safe. Each code can only be used once.
+              </p>
+              <div className="mt-3 grid grid-cols-2 gap-2 rounded-lg bg-surface-chat p-3 font-aeonik-fono text-xs text-content-primary">
+                {backupCodes.map((code) => (
+                  <span key={code}>{code}</span>
+                ))}
+              </div>
+              <button
+                type="button"
+                onClick={() =>
+                  void handleCopy(backupCodes.join('\n'), 'backup-codes')
+                }
+                className="mt-3 flex items-center gap-2 text-xs font-medium text-content-secondary transition-colors hover:text-content-primary"
+              >
+                <ClipboardDocumentIcon className="h-4 w-4" />
+                {copiedTarget === 'backup-codes' ? 'Copied' : 'Copy'} all codes
+              </button>
+            </div>
+          )}
+
+          <button
+            type="button"
+            onClick={() => setBackupCodes(null)}
+            className="mt-4 w-full rounded-md bg-brand-accent-dark px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-brand-accent-dark/90"
+          >
+            Done
+          </button>
+        </div>
+      </div>,
+      document.body,
+    )
+  }
+
+  return (
+    <div className="space-y-3">
+      <h3 className="font-aeonik text-sm font-medium text-content-secondary">
+        Security
+      </h3>
+      <div
+        className={cn(
+          'rounded-lg border border-border-subtle p-4',
+          isDarkMode ? 'bg-surface-sidebar' : 'bg-white',
+        )}
+      >
+        <div className="flex items-start gap-3">
+          <ShieldCheckIcon className="mt-0.5 h-5 w-5 shrink-0 text-content-muted" />
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <div className="font-aeonik text-sm font-medium text-content-primary">
+                  Authenticator app
+                </div>
+                <p className="mt-1 text-xs text-content-muted">
+                  Add an extra layer of security with time-based codes.
+                </p>
+              </div>
+              <span
+                className={cn(
+                  'shrink-0 rounded-full px-2.5 py-1 text-xs font-medium',
+                  totpEnabled
+                    ? 'bg-emerald-500/20 text-emerald-500'
+                    : 'bg-content-muted/20 text-content-muted',
+                )}
+              >
+                {totpEnabled ? 'On' : 'Off'}
+              </span>
+            </div>
+
+            {!totpSetup && (
+              <button
+                type="button"
+                disabled={!isLoaded || !user || isStartingSetup || isDisabling}
+                onClick={
+                  totpEnabled
+                    ? () => setShowDisableConfirm(true)
+                    : () => void handleStartSetup()
+                }
+                className={cn(
+                  'mt-4 flex items-center justify-center gap-2 rounded-md border px-3 py-2 text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-60',
+                  totpEnabled
+                    ? 'border-red-500/30 text-red-500 hover:bg-red-500/10'
+                    : 'border-border-subtle text-content-primary hover:bg-surface-chat',
+                )}
+              >
+                {(isStartingSetup || isDisabling) && (
+                  <PiSpinner className="h-4 w-4 animate-spin" />
+                )}
+                {isStartingSetup
+                  ? 'Starting setup...'
+                  : isDisabling
+                    ? 'Turning off...'
+                    : totpEnabled
+                      ? 'Turn off'
+                      : 'Set up'}
+              </button>
+            )}
+          </div>
+        </div>
+
+        {totpSetup && (
+          <form
+            onSubmit={handleVerify}
+            className="mt-5 border-t border-border-subtle pt-5"
+          >
+            <p className="text-sm font-medium text-content-primary">
+              Scan this code with your authenticator app
+            </p>
+            <div
+              data-testid="totp-qr-code"
+              className="mx-auto mt-4 w-fit rounded-lg bg-white p-3"
+            >
+              {totpSetup.uri && <TotpQrCode uri={totpSetup.uri} />}
+            </div>
+
+            {totpSetup.secret && (
+              <div className="mt-4">
+                <p className="text-xs text-content-muted">
+                  Or enter this setup key manually:
+                </p>
+                <div className="mt-2 flex items-center gap-2 rounded-md bg-surface-chat px-3 py-2">
+                  <code className="min-w-0 flex-1 break-all font-aeonik-fono text-xs text-content-primary">
+                    {totpSetup.secret}
+                  </code>
+                  <button
+                    type="button"
+                    aria-label={
+                      copiedTarget === 'setup-key'
+                        ? 'Setup key copied'
+                        : 'Copy setup key'
+                    }
+                    onClick={() =>
+                      void handleCopy(totpSetup.secret ?? '', 'setup-key')
+                    }
+                    className="shrink-0 text-content-muted transition-colors hover:text-content-primary"
+                  >
+                    {copiedTarget === 'setup-key' ? (
+                      <CheckCircleIcon className="h-4 w-4 text-emerald-500" />
+                    ) : (
+                      <ClipboardDocumentIcon className="h-4 w-4" />
+                    )}
+                  </button>
+                </div>
+              </div>
+            )}
+
+            <label
+              htmlFor="totp-verification-code"
+              className="mt-4 block text-xs font-medium text-content-secondary"
+            >
+              Enter the 6-digit code
+            </label>
+            <input
+              id="totp-verification-code"
+              type="text"
+              inputMode="numeric"
+              autoComplete="one-time-code"
+              required
+              maxLength={TOTP_CODE_LENGTH}
+              value={verificationCode}
+              onChange={(event) =>
+                setVerificationCode(
+                  event.target.value
+                    .replace(/\D/g, '')
+                    .slice(0, TOTP_CODE_LENGTH),
+                )
+              }
+              className="mt-2 h-10 w-full rounded-md border border-border-subtle bg-surface-chat px-3 font-aeonik-fono text-sm tracking-[0.25em] text-content-primary outline-none transition-colors focus:border-border-strong"
+            />
+
+            {errorMessage && (
+              <p role="alert" className="mt-3 text-xs text-destructive">
+                {errorMessage}
+              </p>
+            )}
+
+            <div className="mt-4 flex gap-2">
+              <button
+                type="button"
+                disabled={isVerifying}
+                onClick={handleCancelSetup}
+                className="flex-1 rounded-md border border-border-subtle px-3 py-2 text-xs font-medium text-content-primary transition-colors hover:bg-surface-chat disabled:opacity-60"
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                disabled={
+                  isVerifying || verificationCode.length !== TOTP_CODE_LENGTH
+                }
+                className="flex flex-1 items-center justify-center gap-2 rounded-md bg-brand-accent-dark px-3 py-2 text-xs font-medium text-white transition-colors hover:bg-brand-accent-dark/90 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {isVerifying && <PiSpinner className="h-4 w-4 animate-spin" />}
+                {isVerifying ? 'Verifying...' : 'Verify and enable'}
+              </button>
+            </div>
+          </form>
+        )}
+
+        {!totpSetup && errorMessage && (
+          <p role="alert" className="mt-3 text-xs text-destructive">
+            {errorMessage}
+          </p>
+        )}
+      </div>
+
+      <ConfirmDialog
+        isOpen={showDisableConfirm}
+        title="Turn off authenticator MFA?"
+        description="Authenticator codes will no longer protect your account. You may still be asked for an email code."
+        confirmLabel="Turn off"
+        variant="destructive"
+        onConfirm={() => void handleDisable()}
+        onCancel={() => setShowDisableConfirm(false)}
+      />
+    </div>
+  )
+}

--- a/src/components/chat/mfa-settings-card.tsx
+++ b/src/components/chat/mfa-settings-card.tsx
@@ -10,14 +10,7 @@ import {
   ShieldCheckIcon,
 } from '@heroicons/react/24/outline'
 import * as DialogPrimitive from '@radix-ui/react-dialog'
-import {
-  memo,
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-  type FormEvent,
-} from 'react'
+import { memo, useCallback, useRef, useState, type FormEvent } from 'react'
 import { PiSpinner } from 'react-icons/pi'
 import QRCode from 'react-qr-code'
 import { ConfirmDialog } from './components/confirm-dialog'
@@ -57,8 +50,6 @@ export function MfaSettingsCard({ isDarkMode }: MfaSettingsCardProps) {
   const [totpEnabledOverride, setTotpEnabledOverride] = useState<{
     userId: string
     enabled: boolean
-    sourceEnabled: boolean
-    sourceUpdatedAt: number | null
   } | null>(null)
   const mfaActionButtonRef = useRef<HTMLButtonElement>(null)
 
@@ -80,30 +71,10 @@ export function MfaSettingsCard({ isDarkMode }: MfaSettingsCardProps) {
     }, [user]),
   )
 
-  const userId = user?.id
-  const userTotpEnabled = user?.totpEnabled
-  const userUpdatedAt = user?.updatedAt?.getTime() ?? null
   const totpEnabled =
     user && totpEnabledOverride?.userId === user.id
       ? totpEnabledOverride.enabled
       : (user?.totpEnabled ?? false)
-
-  useEffect(() => {
-    if (
-      !totpEnabledOverride ||
-      userId !== totpEnabledOverride.userId ||
-      userTotpEnabled === undefined
-    ) {
-      return
-    }
-
-    if (
-      userTotpEnabled !== totpEnabledOverride.sourceEnabled ||
-      userUpdatedAt !== totpEnabledOverride.sourceUpdatedAt
-    ) {
-      setTotpEnabledOverride(null)
-    }
-  }, [totpEnabledOverride, userId, userTotpEnabled, userUpdatedAt])
 
   const refreshUserAfterMfaMutation = async (enabled: boolean) => {
     if (!user) return
@@ -111,8 +82,6 @@ export function MfaSettingsCard({ isDarkMode }: MfaSettingsCardProps) {
     setTotpEnabledOverride({
       userId: user.id,
       enabled,
-      sourceEnabled: user.totpEnabled,
-      sourceUpdatedAt: user.updatedAt?.getTime() ?? null,
     })
     try {
       await user.reload()

--- a/src/components/chat/mfa-settings-card.tsx
+++ b/src/components/chat/mfa-settings-card.tsx
@@ -1,6 +1,6 @@
 import { cn } from '@/components/ui/utils'
 import { getClerkErrorMessage } from '@/utils/clerk-errors'
-import { logError } from '@/utils/error-handling'
+import { logError, logWarning } from '@/utils/error-handling'
 import { useReverification, useUser } from '@clerk/nextjs'
 import { isReverificationCancelledError } from '@clerk/nextjs/errors'
 import {
@@ -8,8 +8,8 @@ import {
   ClipboardDocumentIcon,
   ShieldCheckIcon,
 } from '@heroicons/react/24/outline'
-import { memo, useCallback, useState, type FormEvent } from 'react'
-import { createPortal } from 'react-dom'
+import * as DialogPrimitive from '@radix-ui/react-dialog'
+import { memo, useCallback, useRef, useState, type FormEvent } from 'react'
 import { PiSpinner } from 'react-icons/pi'
 import QRCode from 'react-qr-code'
 import { ConfirmDialog } from './components/confirm-dialog'
@@ -44,6 +44,11 @@ export function MfaSettingsCard({ isDarkMode }: MfaSettingsCardProps) {
   const [copiedTarget, setCopiedTarget] = useState<
     'setup-key' | 'backup-codes' | null
   >(null)
+  const [totpEnabledOverride, setTotpEnabledOverride] = useState<{
+    userId: string
+    enabled: boolean
+  } | null>(null)
+  const mfaActionButtonRef = useRef<HTMLButtonElement>(null)
 
   const createTOTP = useReverification(
     useCallback(async () => {
@@ -63,7 +68,25 @@ export function MfaSettingsCard({ isDarkMode }: MfaSettingsCardProps) {
     }, [user]),
   )
 
-  const totpEnabled = user?.totpEnabled ?? false
+  const totpEnabled =
+    user && totpEnabledOverride?.userId === user.id
+      ? totpEnabledOverride.enabled
+      : (user?.totpEnabled ?? false)
+
+  const refreshUserAfterMfaMutation = async (enabled: boolean) => {
+    if (!user) return
+
+    setTotpEnabledOverride({ userId: user.id, enabled })
+    try {
+      await user.reload()
+      setTotpEnabledOverride(null)
+    } catch {
+      logWarning('Could not refresh user after MFA update', {
+        component: 'MfaSettingsCard',
+        action: 'refreshUserAfterMfaMutation',
+      })
+    }
+  }
 
   const handleStartSetup = async () => {
     setIsStartingSetup(true)
@@ -100,6 +123,7 @@ export function MfaSettingsCard({ isDarkMode }: MfaSettingsCardProps) {
         return
       }
 
+      await refreshUserAfterMfaMutation(true)
       setTotpSetup(null)
       setVerificationCode('')
       setBackupCodes(resource.backupCodes?.length ? resource.backupCodes : [])
@@ -127,6 +151,7 @@ export function MfaSettingsCard({ isDarkMode }: MfaSettingsCardProps) {
     setErrorMessage(null)
     try {
       await disableTOTP()
+      await refreshUserAfterMfaMutation(false)
       setBackupCodes(null)
     } catch (error) {
       if (!isReverificationCancelledError(error)) {
@@ -155,74 +180,6 @@ export function MfaSettingsCard({ isDarkMode }: MfaSettingsCardProps) {
       })
       setErrorMessage('Could not copy to the clipboard.')
     }
-  }
-
-  if (backupCodes) {
-    return createPortal(
-      <div
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="mfa-enabled-title"
-        className="fixed inset-0 z-[70] flex items-center justify-center bg-black/60 p-4"
-      >
-        <div
-          className={cn(
-            'w-full max-w-md rounded-site-lg border border-border-subtle p-5 shadow-xl',
-            isDarkMode ? 'bg-surface-sidebar' : 'bg-white',
-          )}
-        >
-          <div className="flex items-start gap-3">
-            <CheckCircleIcon className="mt-0.5 h-5 w-5 shrink-0 text-emerald-500" />
-            <div>
-              <h3
-                id="mfa-enabled-title"
-                className="font-aeonik text-base font-medium text-content-primary"
-              >
-                Authenticator app enabled
-              </h3>
-              <p className="mt-1 text-xs text-content-muted">
-                You will use an authenticator code when signing in.
-              </p>
-            </div>
-          </div>
-
-          {backupCodes.length > 0 && (
-            <div className="mt-4">
-              <p className="text-sm font-medium text-content-primary">
-                Save your backup codes
-              </p>
-              <p className="mt-1 text-xs text-content-muted">
-                Store these somewhere safe. Each code can only be used once.
-              </p>
-              <div className="mt-3 grid grid-cols-2 gap-2 rounded-lg bg-surface-chat p-3 font-aeonik-fono text-xs text-content-primary">
-                {backupCodes.map((code) => (
-                  <span key={code}>{code}</span>
-                ))}
-              </div>
-              <button
-                type="button"
-                onClick={() =>
-                  void handleCopy(backupCodes.join('\n'), 'backup-codes')
-                }
-                className="mt-3 flex items-center gap-2 text-xs font-medium text-content-secondary transition-colors hover:text-content-primary"
-              >
-                <ClipboardDocumentIcon className="h-4 w-4" />
-                {copiedTarget === 'backup-codes' ? 'Copied' : 'Copy'} all codes
-              </button>
-            </div>
-          )}
-
-          <button
-            type="button"
-            onClick={() => setBackupCodes(null)}
-            className="mt-4 w-full rounded-md bg-brand-accent-dark px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-brand-accent-dark/90"
-          >
-            Done
-          </button>
-        </div>
-      </div>,
-      document.body,
-    )
   }
 
   return (
@@ -262,6 +219,7 @@ export function MfaSettingsCard({ isDarkMode }: MfaSettingsCardProps) {
 
             {!totpSetup && (
               <button
+                ref={mfaActionButtonRef}
                 type="button"
                 disabled={!isLoaded || !user || isStartingSetup || isDisabling}
                 onClick={
@@ -396,6 +354,80 @@ export function MfaSettingsCard({ isDarkMode }: MfaSettingsCardProps) {
           </p>
         )}
       </div>
+
+      <DialogPrimitive.Root
+        open={backupCodes !== null}
+        onOpenChange={(open) => {
+          if (!open) setBackupCodes(null)
+        }}
+      >
+        <DialogPrimitive.Portal>
+          <DialogPrimitive.Overlay className="fixed inset-0 z-[70] bg-black/60" />
+          <DialogPrimitive.Content
+            aria-modal="true"
+            aria-describedby="mfa-enabled-description"
+            onCloseAutoFocus={(event) => {
+              event.preventDefault()
+              mfaActionButtonRef.current?.focus()
+            }}
+            className={cn(
+              'fixed left-1/2 top-1/2 z-[70] w-[92vw] max-w-md -translate-x-1/2 -translate-y-1/2 rounded-site-lg border border-border-subtle p-5 shadow-xl focus:outline-none',
+              isDarkMode ? 'bg-surface-sidebar' : 'bg-white',
+            )}
+          >
+            <div className="flex items-start gap-3">
+              <CheckCircleIcon className="mt-0.5 h-5 w-5 shrink-0 text-emerald-500" />
+              <div>
+                <DialogPrimitive.Title className="font-aeonik text-base font-medium text-content-primary">
+                  Authenticator app enabled
+                </DialogPrimitive.Title>
+                <DialogPrimitive.Description
+                  id="mfa-enabled-description"
+                  className="mt-1 text-xs text-content-muted"
+                >
+                  You will use an authenticator code when signing in.
+                </DialogPrimitive.Description>
+              </div>
+            </div>
+
+            {backupCodes && backupCodes.length > 0 && (
+              <div className="mt-4">
+                <p className="text-sm font-medium text-content-primary">
+                  Save your backup codes
+                </p>
+                <p className="mt-1 text-xs text-content-muted">
+                  Store these somewhere safe. Each code can only be used once.
+                </p>
+                <div className="mt-3 grid grid-cols-2 gap-2 rounded-lg bg-surface-chat p-3 font-aeonik-fono text-xs text-content-primary">
+                  {backupCodes.map((code) => (
+                    <span key={code}>{code}</span>
+                  ))}
+                </div>
+                <button
+                  type="button"
+                  onClick={() =>
+                    void handleCopy(backupCodes.join('\n'), 'backup-codes')
+                  }
+                  className="mt-3 flex items-center gap-2 text-xs font-medium text-content-secondary transition-colors hover:text-content-primary"
+                >
+                  <ClipboardDocumentIcon className="h-4 w-4" />
+                  {copiedTarget === 'backup-codes' ? 'Copied' : 'Copy'} all
+                  codes
+                </button>
+              </div>
+            )}
+
+            <DialogPrimitive.Close asChild>
+              <button
+                type="button"
+                className="mt-4 w-full rounded-md bg-brand-accent-dark px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-brand-accent-dark/90"
+              >
+                Done
+              </button>
+            </DialogPrimitive.Close>
+          </DialogPrimitive.Content>
+        </DialogPrimitive.Portal>
+      </DialogPrimitive.Root>
 
       <ConfirmDialog
         isOpen={showDisableConfirm}

--- a/src/components/chat/mfa-settings-card.tsx
+++ b/src/components/chat/mfa-settings-card.tsx
@@ -4,6 +4,7 @@ import { logError, logWarning } from '@/utils/error-handling'
 import { useReverification, useUser } from '@clerk/nextjs'
 import { isReverificationCancelledError } from '@clerk/nextjs/errors'
 import {
+  ArrowDownTrayIcon,
   CheckCircleIcon,
   ClipboardDocumentIcon,
   ShieldCheckIcon,
@@ -15,6 +16,8 @@ import QRCode from 'react-qr-code'
 import { ConfirmDialog } from './components/confirm-dialog'
 
 const TOTP_CODE_LENGTH = 6
+const BACKUP_CODES_FILENAME = 'tinfoil-backup-codes.txt'
+const BACKUP_CODES_MIME_TYPE = 'text/plain;charset=utf-8'
 const MFA_ERROR_MESSAGE =
   'Could not update multi-factor authentication. Please try again.'
 
@@ -180,6 +183,21 @@ export function MfaSettingsCard({ isDarkMode }: MfaSettingsCardProps) {
       })
       setErrorMessage('Could not copy to the clipboard.')
     }
+  }
+
+  const handleDownloadBackupCodes = () => {
+    if (!backupCodes?.length) return
+
+    const content = ['Tinfoil backup codes', '', ...backupCodes, ''].join('\n')
+    const blob = new Blob([content], { type: BACKUP_CODES_MIME_TYPE })
+    const url = URL.createObjectURL(blob)
+    const anchor = document.createElement('a')
+    anchor.href = url
+    anchor.download = BACKUP_CODES_FILENAME
+    document.body.appendChild(anchor)
+    anchor.click()
+    document.body.removeChild(anchor)
+    URL.revokeObjectURL(url)
   }
 
   return (
@@ -403,17 +421,27 @@ export function MfaSettingsCard({ isDarkMode }: MfaSettingsCardProps) {
                     <span key={code}>{code}</span>
                   ))}
                 </div>
-                <button
-                  type="button"
-                  onClick={() =>
-                    void handleCopy(backupCodes.join('\n'), 'backup-codes')
-                  }
-                  className="mt-3 flex items-center gap-2 text-xs font-medium text-content-secondary transition-colors hover:text-content-primary"
-                >
-                  <ClipboardDocumentIcon className="h-4 w-4" />
-                  {copiedTarget === 'backup-codes' ? 'Copied' : 'Copy'} all
-                  codes
-                </button>
+                <div className="mt-3 flex flex-wrap items-center gap-5">
+                  <button
+                    type="button"
+                    onClick={() =>
+                      void handleCopy(backupCodes.join('\n'), 'backup-codes')
+                    }
+                    className="flex items-center gap-2 text-xs font-medium text-content-secondary transition-colors hover:text-content-primary"
+                  >
+                    <ClipboardDocumentIcon className="h-4 w-4" />
+                    {copiedTarget === 'backup-codes' ? 'Copied' : 'Copy'} all
+                    codes
+                  </button>
+                  <button
+                    type="button"
+                    onClick={handleDownloadBackupCodes}
+                    className="flex items-center gap-2 text-xs font-medium text-content-secondary transition-colors hover:text-content-primary"
+                  >
+                    <ArrowDownTrayIcon className="h-4 w-4" />
+                    Download .txt
+                  </button>
+                </div>
               </div>
             )}
 

--- a/src/components/chat/mfa-settings-card.tsx
+++ b/src/components/chat/mfa-settings-card.tsx
@@ -10,7 +10,14 @@ import {
   ShieldCheckIcon,
 } from '@heroicons/react/24/outline'
 import * as DialogPrimitive from '@radix-ui/react-dialog'
-import { memo, useCallback, useRef, useState, type FormEvent } from 'react'
+import {
+  memo,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type FormEvent,
+} from 'react'
 import { PiSpinner } from 'react-icons/pi'
 import QRCode from 'react-qr-code'
 import { ConfirmDialog } from './components/confirm-dialog'
@@ -50,6 +57,8 @@ export function MfaSettingsCard({ isDarkMode }: MfaSettingsCardProps) {
   const [totpEnabledOverride, setTotpEnabledOverride] = useState<{
     userId: string
     enabled: boolean
+    sourceEnabled: boolean
+    sourceUpdatedAt: number | null
   } | null>(null)
   const mfaActionButtonRef = useRef<HTMLButtonElement>(null)
 
@@ -71,15 +80,40 @@ export function MfaSettingsCard({ isDarkMode }: MfaSettingsCardProps) {
     }, [user]),
   )
 
+  const userId = user?.id
+  const userTotpEnabled = user?.totpEnabled
+  const userUpdatedAt = user?.updatedAt?.getTime() ?? null
   const totpEnabled =
     user && totpEnabledOverride?.userId === user.id
       ? totpEnabledOverride.enabled
       : (user?.totpEnabled ?? false)
 
+  useEffect(() => {
+    if (
+      !totpEnabledOverride ||
+      userId !== totpEnabledOverride.userId ||
+      userTotpEnabled === undefined
+    ) {
+      return
+    }
+
+    if (
+      userTotpEnabled !== totpEnabledOverride.sourceEnabled ||
+      userUpdatedAt !== totpEnabledOverride.sourceUpdatedAt
+    ) {
+      setTotpEnabledOverride(null)
+    }
+  }, [totpEnabledOverride, userId, userTotpEnabled, userUpdatedAt])
+
   const refreshUserAfterMfaMutation = async (enabled: boolean) => {
     if (!user) return
 
-    setTotpEnabledOverride({ userId: user.id, enabled })
+    setTotpEnabledOverride({
+      userId: user.id,
+      enabled,
+      sourceEnabled: user.totpEnabled,
+      sourceUpdatedAt: user.updatedAt?.getTime() ?? null,
+    })
     try {
       await user.reload()
       setTotpEnabledOverride(null)

--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -97,6 +97,7 @@ import { CloudSyncHealthCard } from './cloud-sync-health-card'
 import { ConfirmDialog } from './components/confirm-dialog'
 import { normalizeChatFont, type ChatFont } from './hooks/use-chat-font'
 import { usePromptLibrary } from './hooks/use-prompt-library'
+import { MfaSettingsCard } from './mfa-settings-card'
 import {
   EMPTY_PRESET_EDITOR_STATE,
   PresetEditor,
@@ -4429,6 +4430,8 @@ ${encryptionKey.replace('key_', '')}
                           </p>
                         )}
                       </div>
+
+                      <MfaSettingsCard isDarkMode={isDarkMode} />
 
                       {/* Account Management */}
                       <div className="space-y-3">

--- a/src/pages/signin.tsx
+++ b/src/pages/signin.tsx
@@ -2,6 +2,7 @@
 
 import { Logo } from '@/components/logo'
 import { Button } from '@/components/ui/button'
+import { getClerkErrorMessage } from '@/utils/clerk-errors'
 import { logError } from '@/utils/error-handling'
 import { sanitizeRelativeRedirect } from '@/utils/redirect-url'
 import { useSignIn, useSignUp } from '@clerk/nextjs'
@@ -36,36 +37,6 @@ type SignInFinalizeParams = NonNullable<
 type FinalizeNavigateParams = Parameters<
   NonNullable<SignInFinalizeParams['navigate']>
 >[0]
-
-function clerkErrorMessage(error: unknown, fallback: string): string {
-  if (
-    typeof error === 'object' &&
-    error !== null &&
-    'errors' in error &&
-    Array.isArray(error.errors)
-  ) {
-    const firstError = error.errors[0]
-    if (
-      typeof firstError === 'object' &&
-      firstError !== null &&
-      'longMessage' in firstError &&
-      typeof firstError.longMessage === 'string'
-    ) {
-      return firstError.longMessage
-    }
-  }
-
-  if (typeof error === 'object' && error !== null) {
-    if ('longMessage' in error && typeof error.longMessage === 'string') {
-      return error.longMessage
-    }
-    if ('message' in error && typeof error.message === 'string') {
-      return error.message
-    }
-  }
-
-  return fallback
-}
 
 function clerkErrorCode(error: unknown): string | undefined {
   if (typeof error !== 'object' || error === null) return undefined
@@ -155,7 +126,7 @@ export default function SignInPage() {
     ) {
       const { error } = await signUp.update({ legalAccepted: true })
       if (error) {
-        setErrorMessage(clerkErrorMessage(error, AUTH_ERROR_MESSAGE))
+        setErrorMessage(getClerkErrorMessage(error, AUTH_ERROR_MESSAGE))
         return
       }
       if (signUp.status === 'complete') {
@@ -170,7 +141,7 @@ export default function SignInPage() {
   const transferToSignUp = async () => {
     const { error } = await signUp.create({ transfer: true })
     if (error) {
-      setErrorMessage(clerkErrorMessage(error, AUTH_ERROR_MESSAGE))
+      setErrorMessage(getClerkErrorMessage(error, AUTH_ERROR_MESSAGE))
       return
     }
 
@@ -220,7 +191,7 @@ export default function SignInPage() {
 
       const { error } = await signIn.mfa.sendEmailCode()
       if (error) {
-        setErrorMessage(clerkErrorMessage(error, AUTH_ERROR_MESSAGE))
+        setErrorMessage(getClerkErrorMessage(error, AUTH_ERROR_MESSAGE))
         return
       }
 
@@ -276,7 +247,7 @@ export default function SignInPage() {
           redirectUrl: postAuthRedirectUrl,
         })
         if (error) {
-          setErrorMessage(clerkErrorMessage(error, AUTH_ERROR_MESSAGE))
+          setErrorMessage(getClerkErrorMessage(error, AUTH_ERROR_MESSAGE))
         }
       },
     )
@@ -294,13 +265,13 @@ export default function SignInPage() {
           signUpIfMissing: true,
         })
         if (createError) {
-          setErrorMessage(clerkErrorMessage(createError, AUTH_ERROR_MESSAGE))
+          setErrorMessage(getClerkErrorMessage(createError, AUTH_ERROR_MESSAGE))
           return
         }
 
         const { error: sendError } = await signIn.emailCode.sendCode()
         if (sendError) {
-          setErrorMessage(clerkErrorMessage(sendError, AUTH_ERROR_MESSAGE))
+          setErrorMessage(getClerkErrorMessage(sendError, AUTH_ERROR_MESSAGE))
           return
         }
 
@@ -334,7 +305,7 @@ export default function SignInPage() {
             return
           }
 
-          setErrorMessage(clerkErrorMessage(error, AUTH_ERROR_MESSAGE))
+          setErrorMessage(getClerkErrorMessage(error, AUTH_ERROR_MESSAGE))
           return
         }
 
@@ -354,7 +325,7 @@ export default function SignInPage() {
             ? await signIn.emailCode.sendCode()
             : await signIn.mfa.sendEmailCode()
         if (error) {
-          setErrorMessage(clerkErrorMessage(error, AUTH_ERROR_MESSAGE))
+          setErrorMessage(getClerkErrorMessage(error, AUTH_ERROR_MESSAGE))
         }
       },
     )
@@ -368,7 +339,7 @@ export default function SignInPage() {
       async () => {
         const { error } = await signIn.mfa.sendEmailCode()
         if (error) {
-          setErrorMessage(clerkErrorMessage(error, AUTH_ERROR_MESSAGE))
+          setErrorMessage(getClerkErrorMessage(error, AUTH_ERROR_MESSAGE))
           return
         }
         setCode('')
@@ -396,7 +367,7 @@ export default function SignInPage() {
             : undefined,
         })
         if (error) {
-          setErrorMessage(clerkErrorMessage(error, AUTH_ERROR_MESSAGE))
+          setErrorMessage(getClerkErrorMessage(error, AUTH_ERROR_MESSAGE))
           return
         }
 
@@ -454,7 +425,7 @@ export default function SignInPage() {
         async () => {
           const { error } = await signIn.emailCode.sendCode()
           if (error) {
-            setErrorMessage(clerkErrorMessage(error, AUTH_ERROR_MESSAGE))
+            setErrorMessage(getClerkErrorMessage(error, AUTH_ERROR_MESSAGE))
             return
           }
           setVerificationKind('primary')

--- a/src/utils/clerk-errors.ts
+++ b/src/utils/clerk-errors.ts
@@ -1,0 +1,29 @@
+export function getClerkErrorMessage(error: unknown, fallback: string): string {
+  if (
+    typeof error === 'object' &&
+    error !== null &&
+    'errors' in error &&
+    Array.isArray(error.errors)
+  ) {
+    const firstError = error.errors[0]
+    if (
+      typeof firstError === 'object' &&
+      firstError !== null &&
+      'longMessage' in firstError &&
+      typeof firstError.longMessage === 'string'
+    ) {
+      return firstError.longMessage
+    }
+  }
+
+  if (typeof error === 'object' && error !== null) {
+    if ('longMessage' in error && typeof error.longMessage === 'string') {
+      return error.longMessage
+    }
+    if ('message' in error && typeof error.message === 'string') {
+      return error.message
+    }
+  }
+
+  return fallback
+}

--- a/src/utils/clerk-errors.ts
+++ b/src/utils/clerk-errors.ts
@@ -14,6 +14,14 @@ export function getClerkErrorMessage(error: unknown, fallback: string): string {
     ) {
       return firstError.longMessage
     }
+    if (
+      typeof firstError === 'object' &&
+      firstError !== null &&
+      'message' in firstError &&
+      typeof firstError.message === 'string'
+    ) {
+      return firstError.message
+    }
   }
 
   if (typeof error === 'object' && error !== null) {

--- a/tests/components/mfa-settings-card.test.tsx
+++ b/tests/components/mfa-settings-card.test.tsx
@@ -1,0 +1,132 @@
+import { MfaSettingsCard } from '@/components/chat/mfa-settings-card'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => {
+  const user = {
+    totpEnabled: false,
+    createTOTP: vi.fn(),
+    verifyTOTP: vi.fn(),
+    disableTOTP: vi.fn(),
+  }
+
+  return {
+    user,
+    logError: vi.fn(),
+  }
+})
+
+vi.mock('@clerk/nextjs', () => ({
+  useUser: () => ({
+    isLoaded: true,
+    user: mocks.user,
+  }),
+  useReverification: (operation: (...args: unknown[]) => unknown) => operation,
+}))
+
+vi.mock('@clerk/nextjs/errors', () => ({
+  isReverificationCancelledError: () => false,
+}))
+
+vi.mock('@/utils/error-handling', () => ({
+  logError: mocks.logError,
+}))
+
+afterEach(() => {
+  vi.clearAllMocks()
+  mocks.user.totpEnabled = false
+})
+
+describe('MfaSettingsCard', () => {
+  it('enrolls an authenticator app and displays new backup codes', async () => {
+    mocks.user.createTOTP.mockResolvedValue({
+      uri: 'otpauth://totp/Tinfoil:user@example.com?secret=SETUPKEY',
+      secret: 'SETUPKEY',
+    })
+    mocks.user.verifyTOTP.mockImplementation(async () => {
+      mocks.user.totpEnabled = true
+      return {
+        verified: true,
+        backupCodes: ['backup-one', 'backup-two'],
+      }
+    })
+
+    render(<MfaSettingsCard isDarkMode />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Set up' }))
+
+    expect(await screen.findByTestId('totp-qr-code')).toBeInTheDocument()
+    expect(screen.getByText('SETUPKEY')).toBeInTheDocument()
+    expect(mocks.user.createTOTP).toHaveBeenCalledTimes(1)
+    fireEvent.click(screen.getByRole('button', { name: 'Copy setup key' }))
+    expect(
+      await screen.findByRole('button', { name: 'Setup key copied' }),
+    ).toBeInTheDocument()
+
+    fireEvent.change(screen.getByLabelText('Enter the 6-digit code'), {
+      target: { value: '12a3456' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Verify and enable' }))
+
+    await waitFor(() => {
+      expect(mocks.user.verifyTOTP).toHaveBeenCalledWith({ code: '123456' })
+    })
+    expect(
+      await screen.findByText('Authenticator app enabled'),
+    ).toBeInTheDocument()
+    expect(screen.getByText('backup-one')).toBeInTheDocument()
+    expect(screen.getByText('backup-two')).toBeInTheDocument()
+    expect(screen.getByRole('dialog')).toHaveAttribute('aria-modal', 'true')
+    fireEvent.click(screen.getByRole('button', { name: 'Done' }))
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('requires confirmation before disabling authenticator MFA', async () => {
+    mocks.user.totpEnabled = true
+    mocks.user.disableTOTP.mockImplementation(async () => {
+      mocks.user.totpEnabled = false
+      return {}
+    })
+
+    render(<MfaSettingsCard isDarkMode={false} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Turn off' }))
+
+    expect(
+      screen.getByRole('heading', {
+        name: 'Turn off authenticator MFA?',
+      }),
+    ).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Turn off' }))
+
+    await waitFor(() => {
+      expect(mocks.user.disableTOTP).toHaveBeenCalledTimes(1)
+    })
+    expect(screen.getByRole('button', { name: 'Set up' })).toBeInTheDocument()
+  })
+
+  it('shows Clerk verification errors without completing setup', async () => {
+    mocks.user.createTOTP.mockResolvedValue({
+      uri: 'otpauth://totp/Tinfoil:user@example.com?secret=SETUPKEY',
+      secret: 'SETUPKEY',
+    })
+    mocks.user.verifyTOTP.mockRejectedValue({
+      errors: [{ longMessage: 'The code is incorrect.' }],
+    })
+
+    render(<MfaSettingsCard isDarkMode />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Set up' }))
+    await screen.findByTestId('totp-qr-code')
+    fireEvent.change(screen.getByLabelText('Enter the 6-digit code'), {
+      target: { value: '123456' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Verify and enable' }))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'The code is incorrect.',
+    )
+    expect(screen.getByTestId('totp-qr-code')).toBeInTheDocument()
+    expect(mocks.logError).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tests/components/mfa-settings-card.test.tsx
+++ b/tests/components/mfa-settings-card.test.tsx
@@ -1,12 +1,11 @@
 import { MfaSettingsCard } from '@/components/chat/mfa-settings-card'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => {
   const user = {
     id: 'user_123',
     totpEnabled: false,
-    updatedAt: new Date('2026-07-20T00:00:00.000Z'),
     createTOTP: vi.fn(),
     verifyTOTP: vi.fn(),
     disableTOTP: vi.fn(),
@@ -42,7 +41,6 @@ vi.mock('@/utils/error-handling', () => ({
 beforeEach(() => {
   vi.resetAllMocks()
   mocks.user.totpEnabled = false
-  mocks.user.updatedAt = new Date('2026-07-20T00:00:00.000Z')
   mocks.user.reload.mockResolvedValue(mocks.user)
   mocks.createObjectURL.mockReturnValue('blob:backup-codes')
   Object.defineProperty(URL, 'createObjectURL', {
@@ -53,6 +51,10 @@ beforeEach(() => {
     configurable: true,
     value: mocks.revokeObjectURL,
   })
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
 })
 
 describe('MfaSettingsCard', () => {
@@ -150,7 +152,9 @@ describe('MfaSettingsCard', () => {
       expect(mocks.user.disableTOTP).toHaveBeenCalledTimes(1)
     })
     expect(mocks.user.reload).toHaveBeenCalledTimes(1)
-    expect(screen.getByRole('button', { name: 'Set up' })).toBeInTheDocument()
+    expect(
+      await screen.findByRole('button', { name: 'Set up' }),
+    ).toBeInTheDocument()
   })
 
   it('keeps the enabled status when refreshing Clerk fails', async () => {
@@ -164,7 +168,7 @@ describe('MfaSettingsCard', () => {
     })
     mocks.user.reload.mockRejectedValue(new Error('Refresh failed'))
 
-    const { rerender } = render(<MfaSettingsCard isDarkMode />)
+    render(<MfaSettingsCard isDarkMode />)
 
     fireEvent.click(screen.getByRole('button', { name: 'Set up' }))
     await screen.findByTestId('totp-qr-code')
@@ -179,14 +183,6 @@ describe('MfaSettingsCard', () => {
     expect(screen.getByText('On')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Turn off' })).toBeInTheDocument()
     expect(mocks.logWarning).toHaveBeenCalledTimes(1)
-
-    mocks.user.updatedAt = new Date('2026-07-20T00:01:00.000Z')
-    rerender(<MfaSettingsCard isDarkMode />)
-
-    await waitFor(() => {
-      expect(screen.getByText('Off')).toBeInTheDocument()
-    })
-    expect(screen.getByRole('button', { name: 'Set up' })).toBeInTheDocument()
   })
 
   it('shows Clerk verification errors without completing setup', async () => {

--- a/tests/components/mfa-settings-card.test.tsx
+++ b/tests/components/mfa-settings-card.test.tsx
@@ -6,6 +6,7 @@ const mocks = vi.hoisted(() => {
   const user = {
     id: 'user_123',
     totpEnabled: false,
+    updatedAt: new Date('2026-07-20T00:00:00.000Z'),
     createTOTP: vi.fn(),
     verifyTOTP: vi.fn(),
     disableTOTP: vi.fn(),
@@ -41,6 +42,7 @@ vi.mock('@/utils/error-handling', () => ({
 beforeEach(() => {
   vi.resetAllMocks()
   mocks.user.totpEnabled = false
+  mocks.user.updatedAt = new Date('2026-07-20T00:00:00.000Z')
   mocks.user.reload.mockResolvedValue(mocks.user)
   mocks.createObjectURL.mockReturnValue('blob:backup-codes')
   Object.defineProperty(URL, 'createObjectURL', {
@@ -162,7 +164,7 @@ describe('MfaSettingsCard', () => {
     })
     mocks.user.reload.mockRejectedValue(new Error('Refresh failed'))
 
-    render(<MfaSettingsCard isDarkMode />)
+    const { rerender } = render(<MfaSettingsCard isDarkMode />)
 
     fireEvent.click(screen.getByRole('button', { name: 'Set up' }))
     await screen.findByTestId('totp-qr-code')
@@ -177,6 +179,14 @@ describe('MfaSettingsCard', () => {
     expect(screen.getByText('On')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Turn off' })).toBeInTheDocument()
     expect(mocks.logWarning).toHaveBeenCalledTimes(1)
+
+    mocks.user.updatedAt = new Date('2026-07-20T00:01:00.000Z')
+    rerender(<MfaSettingsCard isDarkMode />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Off')).toBeInTheDocument()
+    })
+    expect(screen.getByRole('button', { name: 'Set up' })).toBeInTheDocument()
   })
 
   it('shows Clerk verification errors without completing setup', async () => {

--- a/tests/components/mfa-settings-card.test.tsx
+++ b/tests/components/mfa-settings-card.test.tsx
@@ -16,6 +16,8 @@ const mocks = vi.hoisted(() => {
     user,
     logError: vi.fn(),
     logWarning: vi.fn(),
+    createObjectURL: vi.fn(),
+    revokeObjectURL: vi.fn(),
   }
 })
 
@@ -40,6 +42,15 @@ beforeEach(() => {
   vi.resetAllMocks()
   mocks.user.totpEnabled = false
   mocks.user.reload.mockResolvedValue(mocks.user)
+  mocks.createObjectURL.mockReturnValue('blob:backup-codes')
+  Object.defineProperty(URL, 'createObjectURL', {
+    configurable: true,
+    value: mocks.createObjectURL,
+  })
+  Object.defineProperty(URL, 'revokeObjectURL', {
+    configurable: true,
+    value: mocks.revokeObjectURL,
+  })
 })
 
 describe('MfaSettingsCard', () => {
@@ -88,6 +99,23 @@ describe('MfaSettingsCard', () => {
       expect(dialog).toContainElement(document.activeElement as HTMLElement)
     })
     expect(mocks.user.reload).toHaveBeenCalledTimes(1)
+
+    const appendChild = vi.spyOn(document.body, 'appendChild')
+    const anchorClick = vi
+      .spyOn(HTMLAnchorElement.prototype, 'click')
+      .mockImplementation(() => {})
+
+    fireEvent.click(screen.getByRole('button', { name: 'Download .txt' }))
+
+    const anchor = appendChild.mock.calls[0][0] as HTMLAnchorElement
+    expect(anchor.download).toBe('tinfoil-backup-codes.txt')
+    expect(anchor.href).toBe('blob:backup-codes')
+    expect(anchorClick).toHaveBeenCalledTimes(1)
+    expect(mocks.revokeObjectURL).toHaveBeenCalledWith('blob:backup-codes')
+    const backupCodesFile = mocks.createObjectURL.mock.calls[0][0] as Blob
+    expect(await backupCodesFile.text()).toBe(
+      'Tinfoil backup codes\n\nbackup-one\nbackup-two\n',
+    )
 
     fireEvent.keyDown(document, { key: 'Escape' })
 

--- a/tests/components/mfa-settings-card.test.tsx
+++ b/tests/components/mfa-settings-card.test.tsx
@@ -1,18 +1,21 @@
 import { MfaSettingsCard } from '@/components/chat/mfa-settings-card'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => {
   const user = {
+    id: 'user_123',
     totpEnabled: false,
     createTOTP: vi.fn(),
     verifyTOTP: vi.fn(),
     disableTOTP: vi.fn(),
+    reload: vi.fn(),
   }
 
   return {
     user,
     logError: vi.fn(),
+    logWarning: vi.fn(),
   }
 })
 
@@ -30,11 +33,13 @@ vi.mock('@clerk/nextjs/errors', () => ({
 
 vi.mock('@/utils/error-handling', () => ({
   logError: mocks.logError,
+  logWarning: mocks.logWarning,
 }))
 
-afterEach(() => {
-  vi.clearAllMocks()
+beforeEach(() => {
+  vi.resetAllMocks()
   mocks.user.totpEnabled = false
+  mocks.user.reload.mockResolvedValue(mocks.user)
 })
 
 describe('MfaSettingsCard', () => {
@@ -43,12 +48,13 @@ describe('MfaSettingsCard', () => {
       uri: 'otpauth://totp/Tinfoil:user@example.com?secret=SETUPKEY',
       secret: 'SETUPKEY',
     })
-    mocks.user.verifyTOTP.mockImplementation(async () => {
+    mocks.user.verifyTOTP.mockResolvedValue({
+      verified: true,
+      backupCodes: ['backup-one', 'backup-two'],
+    })
+    mocks.user.reload.mockImplementation(async () => {
       mocks.user.totpEnabled = true
-      return {
-        verified: true,
-        backupCodes: ['backup-one', 'backup-two'],
-      }
+      return mocks.user
     })
 
     render(<MfaSettingsCard isDarkMode />)
@@ -76,16 +82,27 @@ describe('MfaSettingsCard', () => {
     ).toBeInTheDocument()
     expect(screen.getByText('backup-one')).toBeInTheDocument()
     expect(screen.getByText('backup-two')).toBeInTheDocument()
-    expect(screen.getByRole('dialog')).toHaveAttribute('aria-modal', 'true')
-    fireEvent.click(screen.getByRole('button', { name: 'Done' }))
-    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    const dialog = screen.getByRole('dialog')
+    expect(dialog).toHaveAttribute('aria-modal', 'true')
+    await waitFor(() => {
+      expect(dialog).toContainElement(document.activeElement as HTMLElement)
+    })
+    expect(mocks.user.reload).toHaveBeenCalledTimes(1)
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    })
+    expect(screen.getByRole('button', { name: 'Turn off' })).toHaveFocus()
   })
 
   it('requires confirmation before disabling authenticator MFA', async () => {
     mocks.user.totpEnabled = true
-    mocks.user.disableTOTP.mockImplementation(async () => {
+    mocks.user.disableTOTP.mockResolvedValue({})
+    mocks.user.reload.mockImplementation(async () => {
       mocks.user.totpEnabled = false
-      return {}
+      return mocks.user
     })
 
     render(<MfaSettingsCard isDarkMode={false} />)
@@ -102,7 +119,36 @@ describe('MfaSettingsCard', () => {
     await waitFor(() => {
       expect(mocks.user.disableTOTP).toHaveBeenCalledTimes(1)
     })
+    expect(mocks.user.reload).toHaveBeenCalledTimes(1)
     expect(screen.getByRole('button', { name: 'Set up' })).toBeInTheDocument()
+  })
+
+  it('keeps the enabled status when refreshing Clerk fails', async () => {
+    mocks.user.createTOTP.mockResolvedValue({
+      uri: 'otpauth://totp/Tinfoil:user@example.com?secret=SETUPKEY',
+      secret: 'SETUPKEY',
+    })
+    mocks.user.verifyTOTP.mockResolvedValue({
+      verified: true,
+      backupCodes: [],
+    })
+    mocks.user.reload.mockRejectedValue(new Error('Refresh failed'))
+
+    render(<MfaSettingsCard isDarkMode />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Set up' }))
+    await screen.findByTestId('totp-qr-code')
+    fireEvent.change(screen.getByLabelText('Enter the 6-digit code'), {
+      target: { value: '123456' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Verify and enable' }))
+
+    await screen.findByRole('dialog')
+    fireEvent.click(screen.getByRole('button', { name: 'Done' }))
+
+    expect(screen.getByText('On')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Turn off' })).toBeInTheDocument()
+    expect(mocks.logWarning).toHaveBeenCalledTimes(1)
   })
 
   it('shows Clerk verification errors without completing setup', async () => {

--- a/tests/utils/clerk-errors.test.ts
+++ b/tests/utils/clerk-errors.test.ts
@@ -1,0 +1,32 @@
+import { getClerkErrorMessage } from '@/utils/clerk-errors'
+import { describe, expect, it } from 'vitest'
+
+describe('getClerkErrorMessage', () => {
+  it('prefers an actionable nested message over the generic API message', () => {
+    expect(
+      getClerkErrorMessage(
+        {
+          message: 'Clerk API error',
+          errors: [{ message: 'Enter the current authenticator code.' }],
+        },
+        'Something went wrong.',
+      ),
+    ).toBe('Enter the current authenticator code.')
+  })
+
+  it('prefers a nested long message when Clerk provides both forms', () => {
+    expect(
+      getClerkErrorMessage(
+        {
+          errors: [
+            {
+              message: 'Incorrect code.',
+              longMessage: 'The authenticator code is incorrect.',
+            },
+          ],
+        },
+        'Something went wrong.',
+      ),
+    ).toBe('The authenticator code is incorrect.')
+  })
+})


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds authenticator app (TOTP) setup to Settings so users can enable, verify, and disable MFA with backup codes (copy and .txt download). Uses `@clerk/nextjs` re-verification with simplified status handling to keep the UI accurate even if reload fails.

- **New Features**
  - Added `MfaSettingsCard` under Security for setup (QR or manual key), code verification, backup code copy/download, and turn-off with confirmation.
  - Wraps TOTP enable/disable in `useReverification` from `@clerk/nextjs`, handles cancelled flows, and reconciles status when Clerk updates the user.
  - Included tests for enroll/disable/error flows, backup code downloads, and status reconciliation.

- **Refactors**
  - Extracted `getClerkErrorMessage` and replaced ad‑hoc error parsing in `signin.tsx`.
  - Simplified `totpEnabled` handling with a temporary local override cleared after `user.reload()`.

<sup>Written for commit 0946cc0884c8d9872e979ff4bea0ef4d8e8cf6d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/437?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

