### PR TITLE
Recover interrupted chats across devices

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
         "remark-math": "^6.0.0",
         "tailwind-merge": "^2.6.0",
         "tailwindcss-animate": "^1.0.7",
-        "tinfoil": "^1.1.10",
+        "tinfoil": "^1.1.12",
         "uuid": "^11.1.1",
         "yet-another-react-lightbox": "^3.32.0",
         "zod": "^3.25.76",
@@ -3363,9 +3363,9 @@
       }
     },
     "node_modules/@tinfoilsh/verifier": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/@tinfoilsh/verifier/-/verifier-1.1.10.tgz",
-      "integrity": "sha512-aSP8C6Vyn4p0Ho9LQaasVvi3jBP0XNqa+Njs4wFUsQNSB7wYm1YcQOlJKDh3Dq7adcxTLMOxQoupCnQw5FpBZg==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@tinfoilsh/verifier/-/verifier-1.1.12.tgz",
+      "integrity": "sha512-O8MueAaGiCjKD2V0aTPJd0XXChKLeUmXREzfzNJ2BVB/EQtmmwrGmAZ52trU3wgWZsQuUUBsOzW+Xb85iPmbzw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@freedomofpress/crypto-browser": "^0.1.7",
@@ -6586,9 +6586,9 @@
       }
     },
     "node_modules/ehbp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/ehbp/-/ehbp-0.2.5.tgz",
-      "integrity": "sha512-Fjos3ct9f1Fxf2xckV+dXUez9vRa+k+pn3gqkivg0WaJ4WIQwXBCdT8iphr/+DmAQE9JKo4FdedwR3gwlA2kvA==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/ehbp/-/ehbp-0.3.1.tgz",
+      "integrity": "sha512-Y0g5OWSBWis5rJgw3mEftnvJtW5vD+5LSuzYwAy39HlmMWHm6KFBtw+Wr50IrCKWyRVW2VdxkMMwA8yAnBmkag==",
       "license": "MIT",
       "dependencies": {
         "@panva/hpke-noble": "^1.0.3",
@@ -13814,16 +13814,16 @@
       }
     },
     "node_modules/tinfoil": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/tinfoil/-/tinfoil-1.1.10.tgz",
-      "integrity": "sha512-4zMmiACaizuPqlEzTqQY2XXni+x2Nut5+WZERY/UFQqYb4JW7UEM+BPfmWrRzjpE+JELMen3Fh3/aDPaUEOPbA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/tinfoil/-/tinfoil-1.1.12.tgz",
+      "integrity": "sha512-fBNAKvGS9zTbzOicCm5Bv1UfICB4vWHza0S4FavvhtIU7I8KhUa1407CqFDTKTYdJUjHH8fAPMbdvkaW1bFecA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/openai-compatible": "^3.0.7",
         "@freedomofpress/sigstore-browser": "^0.1.14",
-        "@tinfoilsh/verifier": "1.1.10",
+        "@tinfoilsh/verifier": "1.1.12",
         "@types/ws": "^8.18.1",
-        "ehbp": "^0.2.5",
+        "ehbp": "^0.3.1",
         "openai": "^6.46.0",
         "ws": "^8.21.0"
       },

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "remark-math": "^6.0.0",
     "tailwind-merge": "^2.6.0",
     "tailwindcss-animate": "^1.0.7",
-    "tinfoil": "^1.1.10",
+    "tinfoil": "^1.1.12",
     "uuid": "^11.1.1",
     "yet-another-react-lightbox": "^3.32.0",
     "zod": "^3.25.76",

--- a/src/components/chat/chat-input.tsx
+++ b/src/components/chat/chat-input.tsx
@@ -1318,8 +1318,7 @@ export function ChatInput({
                 </button>
               )}
               {(() => {
-                const isBusy =
-                  loadingState === 'loading' || loadingState === 'retrying'
+                const isBusy = loadingState !== 'idle'
                 const hasCompletedDocuments = Boolean(
                   processedDocuments &&
                   processedDocuments.some((doc) => isDocumentSubmittable(doc)),

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -13,11 +13,16 @@ import {
   SETTINGS_WEB_SEARCH_AVAILABLE,
   UI_EXPAND_PROJECT_DOCUMENTS,
 } from '@/constants/storage-keys'
+import {
+  useChatRecoveryActiveTurnIds,
+  useChatRecoveryDrafts,
+} from '@/hooks/use-chat-recovery-drafts'
 import { useChatRouter } from '@/hooks/use-chat-router'
 import { useProjects } from '@/hooks/use-projects'
 import { useSubscriptionStatus } from '@/hooks/use-subscription-status'
 import { useSyncHealthAttention } from '@/hooks/use-sync-health'
 import { useToast } from '@/hooks/use-toast'
+import { isChatRecoveryActive } from '@/services/inference/chat-recovery-drafts'
 import {
   getRateLimitInfo,
   getSessionToken,
@@ -25,7 +30,7 @@ import {
   snapshotAndDecrementRemaining,
   type RateLimitInfo,
 } from '@/services/inference/tinfoil-client'
-import { generateTitle } from '@/services/inference/title'
+import { generateTitle, getTitleContent } from '@/services/inference/title'
 import { useAuth, useUser } from '@clerk/nextjs'
 import {
   ArrowDownIcon,
@@ -776,6 +781,14 @@ export function ChatInterface({
   })
 
   const isTemporaryMode = currentChat?.isTemporary === true
+  const currentChatId = currentChat?.id
+  const recoveryDrafts = useChatRecoveryDrafts(currentChatId ?? '')
+  const activeRecoveryTurnIds = useChatRecoveryActiveTurnIds(
+    currentChatId ?? '',
+  )
+  const hasPendingRecovery = Boolean(currentChat?.pendingRecoveries?.length)
+  const hasPendingRecoveryRef = useRef(hasPendingRecovery)
+  hasPendingRecoveryRef.current = hasPendingRecovery
 
   const effectiveWebSearchEnabled = resolveWebSearchEnabled(
     webSearchAvailable,
@@ -858,6 +871,10 @@ export function ChatInterface({
     loadingState,
     handleQuery,
     isRateLimited,
+    isDispatchBlocked: () =>
+      hasPendingRecoveryRef.current ||
+      (currentChatId ? isChatRecoveryActive(currentChatId) : false),
+    dispatchBlocked: hasPendingRecovery || activeRecoveryTurnIds.length > 0,
     onBeforeDispatch: handleQueueDispatch,
     onRateLimited: handleQueueRateLimited,
     cancelGeneration,
@@ -1259,7 +1276,6 @@ export function ChatInterface({
   // Keyed on the chat id, not the chat object: the object's identity changes
   // on every stream flush and sync update, which would re-run this effect and
   // repeatedly steal focus from whatever the user is typing in.
-  const currentChatId = currentChat?.id
   useEffect(() => {
     if (isClient && !isLoadingConfig && currentChatId) {
       // Skip auto-focus when sidebar is open on mobile — focusing the input
@@ -1734,13 +1750,7 @@ export function ChatInterface({
           const firstUser = permanentChat.messages.find(
             (m) => m.role === 'user',
           )
-          const titleContent =
-            firstUser?.content?.trim() ||
-            (firstUser?.attachments
-              ?.map((a) => a.textContent || a.description || a.fileName)
-              .filter(Boolean)
-              .join('\n') ??
-              '')
+          const titleContent = firstUser ? getTitleContent(firstUser) : ''
           if (titleContent) {
             generateTitle([{ role: 'user', content: titleContent }])
               .then((generated) => {
@@ -3368,6 +3378,9 @@ export function ChatInterface({
                 <div className="flex min-h-full min-w-0 flex-1 [container-type:inline-size]">
                   <ChatMessages
                     messages={currentChat?.messages || []}
+                    pendingRecoveries={currentChat?.pendingRecoveries}
+                    recoveryDrafts={recoveryDrafts}
+                    activeRecoveryTurnIds={activeRecoveryTurnIds}
                     isDarkMode={isDarkMode}
                     chatId={currentChat.id}
                     isWaitingForResponse={isWaitingForResponse}

--- a/src/components/chat/chat-messages.tsx
+++ b/src/components/chat/chat-messages.tsx
@@ -6,7 +6,7 @@ import {
   getContextTokenBudget,
 } from '@/utils/token-estimation'
 import 'katex/dist/katex.min.css'
-import React, { memo, useEffect, useMemo, useRef, useState } from 'react'
+import React, { memo, useEffect, useId, useMemo, useRef, useState } from 'react'
 import { CONSTANTS } from './constants'
 import { ensureTimeline } from './ensure-timeline'
 import type { ReasoningEffort } from './hooks/use-reasoning-effort'
@@ -15,11 +15,14 @@ import { PrintableChat } from './PrintableChat'
 import type { PromptPreset } from './prompts/types'
 import { getRendererRegistry } from './renderers/client'
 import { StreamingTracerDot } from './renderers/components/StreamingTracerDot'
-import type { LabelType, Message } from './types'
+import type { LabelType, Message, PendingRecoveryEnvelope } from './types'
 import { WelcomeScreen } from './WelcomeScreen'
 
 type ChatMessagesProps = {
   messages: Message[]
+  pendingRecoveries?: PendingRecoveryEnvelope[]
+  recoveryDrafts?: ReadonlyArray<{ turnId: string; message: Message }>
+  activeRecoveryTurnIds?: readonly string[]
   isDarkMode: boolean
   chatId: string
   messagesEndRef?: React.RefObject<HTMLDivElement | null>
@@ -71,6 +74,7 @@ const ChatMessage = memo(
     isDarkMode,
     isLastMessage = false,
     isStreaming = false,
+    hideActions = false,
     onEditMessage,
     onRegenerateMessage,
   }: {
@@ -80,6 +84,7 @@ const ChatMessage = memo(
     isDarkMode: boolean
     isLastMessage?: boolean
     isStreaming?: boolean
+    hideActions?: boolean
     onEditMessage?: (messageIndex: number, newContent: string) => void
     onRegenerateMessage?: (messageIndex: number) => void
   }) {
@@ -95,6 +100,7 @@ const ChatMessage = memo(
         isDarkMode={isDarkMode}
         isLastMessage={isLastMessage}
         isStreaming={isStreaming}
+        hideActions={hideActions}
         onEditMessage={onEditMessage}
         onRegenerateMessage={onRegenerateMessage}
       />
@@ -111,6 +117,7 @@ const ChatMessage = memo(
       prevProps.isDarkMode === nextProps.isDarkMode &&
       prevProps.isLastMessage === nextProps.isLastMessage &&
       prevProps.isStreaming === nextProps.isStreaming &&
+      prevProps.hideActions === nextProps.hideActions &&
       prevProps.onEditMessage === nextProps.onEditMessage &&
       prevProps.onRegenerateMessage === nextProps.onRegenerateMessage
     )
@@ -166,6 +173,27 @@ const LoadingMessage = memo(function LoadingMessage({
   )
 })
 
+const RecoveryMessage = memo(function RecoveryMessage() {
+  const titleId = useId()
+
+  return (
+    <div
+      className="no-scroll-anchoring mx-auto -mt-6 mb-6 flex w-full max-w-3xl px-4"
+      role="status"
+      aria-labelledby={titleId}
+    >
+      <div className="flex items-start gap-2.5 py-1.5">
+        <span aria-hidden="true" className="flex h-5 items-center">
+          <StreamingTracerDot tone="secondary" />
+        </span>
+        <span id={titleId} className="text-sm font-medium text-content-primary">
+          Recovering stream...
+        </span>
+      </div>
+    </div>
+  )
+})
+
 const getMessageKey = (
   prefix: string,
   message: Message,
@@ -197,6 +225,9 @@ const MessagesSeparator = memo(function MessagesSeparator({
 
 export function ChatMessages({
   messages,
+  pendingRecoveries = [],
+  recoveryDrafts = [],
+  activeRecoveryTurnIds = [],
   isDarkMode,
   chatId,
   isWaitingForResponse = false,
@@ -366,6 +397,74 @@ export function ChatMessages({
     (lastMessage.isThinking || (lastMessage.thoughts && !lastMessage.content)),
   )
   const showLoadingPlaceholder = isWaitingForResponse && !hasAssistantThinking
+  const pendingRecoveryTurnIds = new Set(
+    pendingRecoveries.map((recovery) => recovery.turnId),
+  )
+  const recoveryDraftsByTurnId = new Map(
+    recoveryDrafts.map((draft) => [draft.turnId, draft.message]),
+  )
+  const persistedAssistantTurnIds = new Set(
+    messages.flatMap((message) =>
+      message.role === 'assistant' && message.turnId ? [message.turnId] : [],
+    ),
+  )
+  const activeRecoveryTurns = new Set(
+    activeRecoveryTurnIds.filter((turnId) =>
+      pendingRecoveryTurnIds.has(turnId),
+    ),
+  )
+  const hasActiveRecovery =
+    activeRecoveryTurns.size > 0 ||
+    recoveryDrafts.some((draft) => pendingRecoveryTurnIds.has(draft.turnId))
+  const activeTurnCandidate =
+    isWaitingForResponse || isStreamingResponse
+      ? [...messages].reverse().find((message) => message.role === 'user')
+          ?.turnId
+      : undefined
+  const activeTurnId =
+    activeTurnCandidate && !activeRecoveryTurns.has(activeTurnCandidate)
+      ? activeTurnCandidate
+      : undefined
+  const showRecoveryAfter = (message: Message) =>
+    message.role === 'user' &&
+    message.turnId !== undefined &&
+    message.turnId !== activeTurnId &&
+    pendingRecoveryTurnIds.has(message.turnId) &&
+    !persistedAssistantTurnIds.has(message.turnId)
+  const recoveryDraftForMessage = (message: Message) =>
+    message.role === 'assistant' &&
+    message.turnId &&
+    message.turnId !== activeTurnId &&
+    pendingRecoveryTurnIds.has(message.turnId)
+      ? recoveryDraftsByTurnId.get(message.turnId)
+      : undefined
+  const showRecoveryStatusAfter = (message: Message) =>
+    message.role === 'assistant' &&
+    message.turnId !== undefined &&
+    message.turnId !== activeTurnId &&
+    pendingRecoveryTurnIds.has(message.turnId) &&
+    !recoveryDraftsByTurnId.has(message.turnId)
+  const renderRecoveryAfter = (message: Message, messageIndex: number) => {
+    if (!showRecoveryAfter(message)) return null
+    const draft = message.turnId
+      ? recoveryDraftsByTurnId.get(message.turnId)
+      : undefined
+    return (
+      <>
+        {draft && (
+          <ChatMessage
+            message={draft}
+            messageIndex={messageIndex + 1}
+            model={currentModel}
+            isDarkMode={isDarkMode}
+            isLastMessage
+            isStreaming
+          />
+        )}
+        {!draft && <RecoveryMessage />}
+      </>
+    )
+  }
 
   return (
     <ImageGalleryProvider messages={messages}>
@@ -373,26 +472,35 @@ export function ChatMessages({
         role="log"
         aria-label="Conversation"
         aria-live="polite"
-        aria-busy={isStreamingResponse}
+        aria-busy={isStreamingResponse || hasActiveRecovery}
         className="mx-auto w-full min-w-0 px-0 pb-6 pt-24 font-chat md:px-4"
       >
         {/* Archived Messages - only shown if there are more than the max prompt messages */}
         {archivedMessages.length > 0 && (
           <>
             <div className={`opacity-70`}>
-              {archivedMessages.map((message, i) => (
-                <ChatMessage
-                  key={getMessageKey(`${chatId}-archived`, message, i)}
-                  message={message}
-                  messageIndex={i}
-                  model={currentModel}
-                  isDarkMode={isDarkMode}
-                  isLastMessage={false}
-                  isStreaming={false}
-                  onEditMessage={onEditMessage}
-                  onRegenerateMessage={onRegenerateMessage}
-                />
-              ))}
+              {archivedMessages.map((message, i) => {
+                const key = getMessageKey(`${chatId}-archived`, message, i)
+                const recoveryDraft = recoveryDraftForMessage(message)
+                return (
+                  <React.Fragment key={key}>
+                    <ChatMessage
+                      message={recoveryDraft ?? message}
+                      messageIndex={i}
+                      model={currentModel}
+                      isDarkMode={isDarkMode}
+                      isLastMessage={Boolean(recoveryDraft)}
+                      isStreaming={Boolean(recoveryDraft)}
+                      onEditMessage={recoveryDraft ? undefined : onEditMessage}
+                      onRegenerateMessage={
+                        recoveryDraft ? undefined : onRegenerateMessage
+                      }
+                    />
+                    {showRecoveryStatusAfter(message) && <RecoveryMessage />}
+                    {renderRecoveryAfter(message, i)}
+                  </React.Fragment>
+                )
+              })}
             </div>
 
             {/* Separator */}
@@ -401,19 +509,33 @@ export function ChatMessages({
         )}
 
         {/* Live Messages - the last messages up to max prompt limit */}
-        {liveMessages.map((message, i) => (
-          <ChatMessage
-            key={getMessageKey(`${chatId}-live`, message, i)}
-            message={message}
-            messageIndex={archivedMessages.length + i}
-            model={currentModel}
-            isDarkMode={isDarkMode}
-            isLastMessage={i === liveMessages.length - 1}
-            isStreaming={i === liveMessages.length - 1 && isStreamingResponse}
-            onEditMessage={onEditMessage}
-            onRegenerateMessage={onRegenerateMessage}
-          />
-        ))}
+        {liveMessages.map((message, i) => {
+          const key = getMessageKey(`${chatId}-live`, message, i)
+          const recoveryDraft = recoveryDraftForMessage(message)
+          return (
+            <React.Fragment key={key}>
+              <ChatMessage
+                message={recoveryDraft ?? message}
+                messageIndex={archivedMessages.length + i}
+                model={currentModel}
+                isDarkMode={isDarkMode}
+                isLastMessage={
+                  Boolean(recoveryDraft) || i === liveMessages.length - 1
+                }
+                isStreaming={
+                  Boolean(recoveryDraft) ||
+                  (i === liveMessages.length - 1 && isStreamingResponse)
+                }
+                onEditMessage={recoveryDraft ? undefined : onEditMessage}
+                onRegenerateMessage={
+                  recoveryDraft ? undefined : onRegenerateMessage
+                }
+              />
+              {showRecoveryStatusAfter(message) && <RecoveryMessage />}
+              {renderRecoveryAfter(message, archivedMessages.length + i)}
+            </React.Fragment>
+          )
+        })}
         {showLoadingPlaceholder && (
           <LoadingMessage
             isDarkMode={isDarkMode}

--- a/src/components/chat/hooks/streaming/event-normalizer.ts
+++ b/src/components/chat/hooks/streaming/event-normalizer.ts
@@ -161,6 +161,7 @@ export interface EventNormalizer {
     logger?: StreamLogger,
   ): NormalizedEvent[]
   flush(): NormalizedEvent[]
+  assertComplete(): void
 }
 
 /**
@@ -219,6 +220,7 @@ export function createEventNormalizer(): EventNormalizer {
   let initialBuffer = ''
   let isInThinking = false
   let isReasoningFormat = false
+  let receivedFinishReason = false
   // True while the last thinking block was closed by content (not by a
   // tool boundary). Reasoning arriving in that state is the late tail of
   // that block — routers/upstreams race the think-close boundary so the
@@ -230,6 +232,16 @@ export function createEventNormalizer(): EventNormalizer {
   return {
     processChunk(sseJson, preprocessor, logger): NormalizedEvent[] {
       const events: NormalizedEvent[] = []
+      if (
+        Array.isArray(sseJson.choices) &&
+        sseJson.choices.some(
+          (choice: SSEJson) =>
+            choice?.finish_reason !== null &&
+            choice?.finish_reason !== undefined,
+        )
+      ) {
+        receivedFinishReason = true
+      }
 
       // Legacy top-level web_search_call records
       if (sseJson.type === 'web_search_call') {
@@ -464,6 +476,12 @@ export function createEventNormalizer(): EventNormalizer {
         isInThinking = false
       }
       return events
+    },
+
+    assertComplete(): void {
+      if (!receivedFinishReason) {
+        throw new Error('Chat response ended before its completion marker')
+      }
     },
   }
 }

--- a/src/components/chat/hooks/streaming/index.ts
+++ b/src/components/chat/hooks/streaming/index.ts
@@ -1,2 +1,3 @@
 export { getThinkingDuration, processStreamingResponse } from './process-stream'
+export { parseRichStreamingResponse } from './rich-response-parser'
 export type { StreamingContext, StreamingHandlers } from './types'

--- a/src/components/chat/hooks/streaming/process-stream.ts
+++ b/src/components/chat/hooks/streaming/process-stream.ts
@@ -267,6 +267,8 @@ export async function processStreamingResponse(
       flushThrottled()
     }
 
+    normalizer.assertComplete()
+
     // Flush normalizer tail (buffered first-chunk or unclosed thinking)
     for (const event of normalizer.flush()) {
       applyEvent(event)

--- a/src/components/chat/hooks/streaming/rich-response-parser.ts
+++ b/src/components/chat/hooks/streaming/rich-response-parser.ts
@@ -1,0 +1,232 @@
+import type { Message, URLFetchState } from '../../types'
+import { createContentPreprocessor } from './content-preprocessor'
+import { createEventNormalizer } from './event-normalizer'
+import { MessageAssembler } from './message-assembler'
+import { readSSEStream } from './sse-reader'
+import { TimelineBuilder } from './timeline-builder'
+import type { NormalizedEvent } from './types'
+
+export interface RichResponseParserOptions {
+  trackThinkingDuration?: boolean
+  onUpdate?: (message: Message) => void
+  onFirstEvent?: () => void
+  onThinkingChange?: (isThinking: boolean) => void
+}
+
+export async function parseRichStreamingResponse(
+  response: Response,
+  options: RichResponseParserOptions = {},
+): Promise<Message> {
+  const preprocessor = createContentPreprocessor()
+  const normalizer = createEventNormalizer()
+  const timeline = new TimelineBuilder()
+  const assembler = new MessageAssembler()
+  const webSearchBlocks = new Map<string, string>()
+  let firstEventSeen = false
+  let thinkingStartedAt: number | null = null
+
+  const markFirstEvent = () => {
+    if (firstEventSeen) return
+    firstEventSeen = true
+    options.onFirstEvent?.()
+  }
+
+  const thinkingDuration = (): number | undefined => {
+    if (!options.trackThinkingDuration || thinkingStartedAt === null) {
+      thinkingStartedAt = null
+      return undefined
+    }
+    const duration = (Date.now() - thinkingStartedAt) / 1000
+    thinkingStartedAt = null
+    return duration
+  }
+
+  const findWebSearchBlock = (id?: string, query?: string) => {
+    if (id) {
+      const blockId = webSearchBlocks.get(id)
+      if (blockId) {
+        return {
+          blockId,
+          current: timeline.getWebSearchState(blockId),
+        }
+      }
+    }
+    const searching = timeline.findSearchingWebSearch(query)
+    if (id && searching) webSearchBlocks.set(id, searching.id)
+    return { blockId: searching?.id, current: searching?.state }
+  }
+
+  const applyWebSearch = (
+    event: Extract<NormalizedEvent, { type: 'web_search' }>,
+  ) => {
+    const { id, status, query, sources, reason } = event
+    if (status === 'in_progress' && query) {
+      const blockId = timeline.pushWebSearch({ query, status: 'searching' })
+      if (id) webSearchBlocks.set(id, blockId)
+    } else if (status === 'completed') {
+      const { blockId, current } = findWebSearchBlock(id, query)
+      const completed = {
+        query: current?.query ?? query,
+        status: 'completed' as const,
+        sources: sources
+          ? sources.map((source) => ({
+              title: source.title || source.url,
+              url: source.url,
+            }))
+          : current?.sources,
+      }
+      if (current) {
+        timeline.updateWebSearch(completed, blockId)
+      } else {
+        timeline.pushWebSearch({
+          ...completed,
+          query,
+          sources: completed.sources ?? [],
+        })
+      }
+    } else if (status === 'failed') {
+      const { blockId, current } = findWebSearchBlock(id, query)
+      const failed = {
+        query: current?.query ?? query,
+        status: 'failed' as const,
+        sources: [],
+      }
+      if (current) {
+        timeline.updateWebSearch(failed, blockId)
+      } else {
+        timeline.pushWebSearch({ ...failed, query })
+      }
+    } else if (status === 'blocked') {
+      const { blockId, current } = findWebSearchBlock(id, query)
+      const blocked = {
+        query: current?.query ?? query,
+        status: 'blocked' as const,
+        reason,
+      }
+      if (current) {
+        timeline.updateWebSearch(blocked, blockId)
+      } else {
+        timeline.pushWebSearch(blocked)
+      }
+    }
+  }
+
+  const applyURLFetch = (
+    event: Extract<NormalizedEvent, { type: 'url_fetch' }>,
+  ) => {
+    if (event.status === 'in_progress') {
+      timeline.addURLFetch({
+        id: event.id,
+        url: event.url,
+        status: 'fetching',
+      })
+      return
+    }
+    const status: URLFetchState['status'] =
+      event.status === 'blocked' ? 'failed' : event.status
+    timeline.updateURLFetch(event.id, status)
+  }
+
+  const applyCodeExec = (
+    event: Extract<NormalizedEvent, { type: 'code_exec_tool_call' }>,
+  ) => {
+    if (event.status === 'in_progress') {
+      timeline.pushCodeExecCall({
+        id: event.id,
+        toolName: event.toolName,
+        arguments: event.arguments,
+        status: 'running',
+      })
+      return
+    }
+    timeline.updateCodeExecCall(event.id, {
+      status: event.status === 'blocked' ? 'failed' : event.status,
+      output: event.output,
+    })
+  }
+
+  const applyEvent = (event: NormalizedEvent) => {
+    switch (event.type) {
+      case 'thinking_start':
+        timeline.startThinking()
+        thinkingStartedAt = options.trackThinkingDuration ? Date.now() : null
+        options.onThinkingChange?.(true)
+        markFirstEvent()
+        break
+      case 'thinking_delta':
+        timeline.appendThinking(event.content)
+        break
+      case 'thinking_tail_delta':
+        timeline.appendThinkingTail(event.content)
+        break
+      case 'thinking_end':
+        timeline.endThinking(thinkingDuration())
+        options.onThinkingChange?.(false)
+        break
+      case 'content_delta':
+        timeline.appendContent(event.content)
+        markFirstEvent()
+        break
+      case 'web_search':
+        applyWebSearch(event)
+        markFirstEvent()
+        break
+      case 'url_fetch':
+        applyURLFetch(event)
+        break
+      case 'code_exec_tool_call':
+        applyCodeExec(event)
+        markFirstEvent()
+        break
+      case 'annotation': {
+        assembler.addAnnotation(event.url, event.title)
+        const current = timeline.getLastWebSearchState()
+        if (current) {
+          timeline.updateWebSearch({
+            ...current,
+            sources: [...assembler.collectedSources],
+          })
+        }
+        break
+      }
+      case 'search_reasoning':
+        assembler.addSearchReasoning(event.content)
+        break
+      case 'genui_tool_call_start':
+        timeline.startToolCall(event.id, event.name)
+        markFirstEvent()
+        break
+      case 'genui_tool_call_delta':
+        timeline.appendToolCallArguments(event.id, event.argumentsDelta)
+        break
+    }
+  }
+
+  try {
+    for await (const json of readSSEStream(response)) {
+      for (const event of normalizer.processChunk(json, preprocessor)) {
+        applyEvent(event)
+      }
+      options.onUpdate?.(assembler.toMessage(timeline.snapshot()))
+    }
+
+    normalizer.assertComplete()
+
+    for (const event of normalizer.flush()) {
+      applyEvent(event)
+    }
+    const { text: tail } = preprocessor.flush()
+    if (tail) {
+      applyEvent({ type: 'content_delta', content: tail })
+    }
+  } finally {
+    if (timeline.isThinkingOpen) {
+      timeline.endThinking(thinkingDuration())
+      options.onThinkingChange?.(false)
+    }
+  }
+
+  const message = assembler.toMessage(timeline.snapshot())
+  options.onUpdate?.(message)
+  return message
+}

--- a/src/components/chat/hooks/streaming/timeline-builder.ts
+++ b/src/components/chat/hooks/streaming/timeline-builder.ts
@@ -103,18 +103,23 @@ export class TimelineBuilder {
 
   // -- Web Search ---------------------------------------------------------
 
-  pushWebSearch(state: WebSearchState): void {
+  pushWebSearch(state: WebSearchState): string {
     this.finalizeThinkingForTool()
+    const id = `web-search-${this.blocks.length}`
     this.blocks.push({
       type: 'web_search',
-      id: `web-search-${this.blocks.length}`,
+      id,
       state: { ...state },
     })
+    return id
   }
 
-  updateWebSearch(state: WebSearchState): void {
+  updateWebSearch(state: WebSearchState, id?: string): void {
     for (let i = this.blocks.length - 1; i >= 0; i--) {
-      if (this.blocks[i].type === 'web_search') {
+      if (
+        this.blocks[i].type === 'web_search' &&
+        (!id || this.blocks[i].id === id)
+      ) {
         this.blocks[i] = {
           ...this.blocks[i],
           state: { ...state },
@@ -122,6 +127,33 @@ export class TimelineBuilder {
         break
       }
     }
+  }
+
+  getWebSearchState(id: string): WebSearchState | undefined {
+    const block = this.blocks.find(
+      (candidate) => candidate.type === 'web_search' && candidate.id === id,
+    )
+    return block?.type === 'web_search' ? { ...block.state } : undefined
+  }
+
+  findSearchingWebSearch(
+    query?: string,
+  ): { id: string; state: WebSearchState } | undefined {
+    let uniqueMatch: { id: string; state: WebSearchState } | undefined
+    for (let i = this.blocks.length - 1; i >= 0; i--) {
+      const block = this.blocks[i]
+      if (
+        block.type === 'web_search' &&
+        block.state.status === 'searching' &&
+        (query === undefined || block.state.query === query)
+      ) {
+        const match = { id: block.id, state: { ...block.state } }
+        if (query !== undefined) return match
+        if (uniqueMatch) return undefined
+        uniqueMatch = match
+      }
+    }
+    return uniqueMatch
   }
 
   // -- URL Fetches --------------------------------------------------------

--- a/src/components/chat/hooks/use-chat-messaging.ts
+++ b/src/components/chat/hooks/use-chat-messaging.ts
@@ -20,15 +20,28 @@
  */
 import { useProject } from '@/components/project'
 import { resolveModelSelection, type BaseModel } from '@/config/models'
+import { useChatRecoveryActive } from '@/hooks/use-chat-recovery-drafts'
 import { streamingTracker } from '@/services/cloud/streaming-tracker'
+import { ENCRYPTION_KEY_CHANGED_EVENT } from '@/services/encryption/encryption-service'
 import { generateCodeExecutionAccessToken } from '@/services/exec-snapshot/access-token'
 import { getCodeExecutionContainerAuthTokenForChat } from '@/services/exec-snapshot/use-exec-snapshot'
+import {
+  abandonChatRecoveryAttempt,
+  cancelChatRecovery,
+  completeLiveChatRecovery,
+  persistChatRecoveryToken,
+  releaseActiveChatRecovery,
+  scanPendingChatRecoveries,
+  startChatRecoveryAttempt,
+} from '@/services/inference/chat-recovery'
 import { sendChatStream } from '@/services/inference/inference-client'
 import {
   getRateLimitInfo,
+  isChatRecoveryAvailable,
   refreshRateLimit,
 } from '@/services/inference/tinfoil-client'
-import { generateTitle } from '@/services/inference/title'
+import { generateTitle, getTitleContent } from '@/services/inference/title'
+import { chatEvents } from '@/services/storage/chat-events'
 import { chatStorage } from '@/services/storage/chat-storage'
 import { sessionChatStorage } from '@/services/storage/session-storage'
 import { isCloudSyncEnabled } from '@/utils/cloud-sync-settings'
@@ -104,6 +117,25 @@ interface UseChatMessagingReturn {
   ) => void
 }
 
+const CHAT_RECOVERY_POLL_INTERVAL_MS = 10_000
+
+function canUseChatRecovery(options: {
+  isSignedIn: boolean | null | undefined
+  userId: string | null | undefined
+  storeHistory: boolean
+  chat?: Pick<Chat, 'isTemporary'>
+}): boolean {
+  const { isSignedIn, userId, storeHistory, chat } = options
+  return (
+    isSignedIn === true &&
+    typeof userId === 'string' &&
+    userId.length > 0 &&
+    storeHistory &&
+    isChatRecoveryAvailable() &&
+    chat?.isTemporary !== true
+  )
+}
+
 export function useChatMessaging({
   systemPrompt,
   rules = '',
@@ -124,10 +156,70 @@ export function useChatMessaging({
   genUIEnabled,
   codeExecutionEncryptionKey,
 }: UseChatMessagingProps): UseChatMessagingReturn {
-  const { isSignedIn } = useAuth()
+  const { isSignedIn, userId } = useAuth()
   const { isProjectMode, activeProject } = useProject()
 
   const [input, setInput] = useState('')
+  const currentChatId = currentChat?.id ?? ''
+  const currentChatIsTemporary = currentChat?.isTemporary
+  const recoveryScanKey =
+    currentChat?.pendingRecoveries
+      ?.map((envelope) => envelope.turnId)
+      .join('\u0000') ?? ''
+
+  useEffect(() => {
+    if (!isSignedIn || !userId || !storeHistory) return
+
+    const scan = (refreshPending = false) => {
+      if (!canUseChatRecovery({ isSignedIn, userId, storeHistory })) return
+      void scanPendingChatRecoveries(userId, refreshPending)
+    }
+    scan()
+    const scanCurrent = () => scan()
+    const refreshScan = () => scan(true)
+    window.addEventListener('online', scanCurrent)
+    window.addEventListener(ENCRYPTION_KEY_CHANGED_EVENT, refreshScan)
+    const unsubscribe = chatEvents.on((event) => {
+      if (event.reason === 'sync' || event.reason === 'pagination') {
+        scanCurrent()
+      }
+    })
+    const interval = window.setInterval(
+      scanCurrent,
+      CHAT_RECOVERY_POLL_INTERVAL_MS,
+    )
+    return () => {
+      window.removeEventListener('online', scanCurrent)
+      window.removeEventListener(ENCRYPTION_KEY_CHANGED_EVENT, refreshScan)
+      unsubscribe()
+      window.clearInterval(interval)
+    }
+  }, [isSignedIn, storeHistory, userId])
+
+  useEffect(() => {
+    if (
+      !recoveryScanKey ||
+      !userId ||
+      !canUseChatRecovery({
+        isSignedIn,
+        userId,
+        storeHistory,
+        chat: currentChatIsTemporary
+          ? { isTemporary: currentChatIsTemporary }
+          : undefined,
+      })
+    ) {
+      return
+    }
+    void scanPendingChatRecoveries(userId, true)
+  }, [
+    currentChatId,
+    currentChatIsTemporary,
+    isSignedIn,
+    recoveryScanKey,
+    storeHistory,
+    userId,
+  ])
 
   // Per-chat stream status so several conversations can stream at once.
   const {
@@ -147,16 +239,21 @@ export function useChatMessaging({
 
   // Status for the chat on screen drives the input area, stop button,
   // thinking indicator, and error banner.
-  const currentStatus =
-    statusByChat[currentChat?.id ?? ''] ?? IDLE_STREAM_STATUS
+  const currentStatus = statusByChat[currentChatId] ?? IDLE_STREAM_STATUS
   const {
-    loadingState,
+    loadingState: streamLoadingState,
     retryInfo,
     isThinking,
     isWaitingForResponse,
-    isStreaming,
+    isStreaming: isLiveStreaming,
     streamError,
   } = currentStatus
+  const isRecoveryActive = useChatRecoveryActive(currentChatId)
+  const isStreaming = isLiveStreaming || isRecoveryActive
+  const loadingState =
+    isStreaming && streamLoadingState !== 'retrying'
+      ? 'loading'
+      : streamLoadingState
 
   const inputRef = useRef<HTMLTextAreaElement>(null)
 
@@ -196,6 +293,7 @@ export function useChatMessaging({
     async (chatId?: string) => {
       const targetId = chatId ?? viewedChatIdRef.current
 
+      const recoveryCancellation = cancelChatRecovery(targetId)
       abort(targetId)
       patchStatus(targetId, {
         loadingState: 'idle',
@@ -270,6 +368,8 @@ export function useChatMessaging({
         streamingTracker.endStreaming(targetId)
       }
 
+      await recoveryCancellation
+
       // Wait for any pending state updates
       await new Promise((resolve) =>
         setTimeout(resolve, CONSTANTS.ASYNC_STATE_DELAY_MS),
@@ -305,7 +405,8 @@ export function useChatMessaging({
           !systemPromptOverride &&
           !attachments?.length &&
           !quote) ||
-        targetChatStatus.loadingState !== 'idle'
+        targetChatStatus.loadingState !== 'idle' ||
+        isRecoveryActive
       )
         return
 
@@ -362,11 +463,13 @@ export function useChatMessaging({
         query.trim() !== '' ||
         (attachments && attachments.length > 0) ||
         Boolean(quote)
+      const turnId = hasUserContent ? crypto.randomUUID() : null
 
       const userMessage: Message | null = hasUserContent
         ? {
             role: 'user',
             content: query,
+            turnId: turnId as string,
             attachments:
               attachments && attachments.length > 0 ? attachments : undefined,
             timestamp: new Date(),
@@ -590,13 +693,7 @@ export function useChatMessaging({
         // When the user pastes long text it is captured as a document
         // attachment rather than message text, leaving content empty. Fall
         // back to attachment text/description so these chats still get a title.
-        const titleContent =
-          userMessage.content?.trim() ||
-          (userMessage.attachments
-            ?.map((a) => a.textContent || a.description || a.fileName)
-            .filter(Boolean)
-            .join('\n') ??
-            '')
+        const titleContent = getTitleContent(userMessage)
         const titlePromise = generateTitle([
           { role: 'user', content: titleContent },
         ])
@@ -663,6 +760,40 @@ export function useChatMessaging({
             )) ?? undefined)
           : undefined
 
+        const recoveryUserId = typeof userId === 'string' ? userId : null
+        const recoveryEligible =
+          recoveryUserId !== null &&
+          turnId !== null &&
+          canUseChatRecovery({
+            isSignedIn,
+            userId: recoveryUserId,
+            storeHistory,
+            chat: updatedChat,
+          })
+        // Recovery is best-effort: the user turn must be durable before the
+        // recovery token is captured, locally or across devices.
+        let recoveryEnabled = recoveryEligible
+
+        if (recoveryEnabled) {
+          try {
+            updatedChat =
+              updatedChat.isLocalOnly || !isCloudSyncEnabled()
+                ? await chatStorage.saveChat(updatedChat, true)
+                : await chatStorage.saveChatAndWaitForSync(updatedChat)
+          } catch (error) {
+            recoveryEnabled = false
+            logError(
+              'Chat persistence for recovery failed; streaming without recovery',
+              error,
+              {
+                component: 'useChatMessaging',
+                action: 'handleQuery.recoveryPreUpload',
+                metadata: { chatId: updatedChat.id },
+              },
+            )
+          }
+        }
+
         // Mark the chat as streaming up front (after the initial creation
         // save above) so the sidebar indicator and cloud-sync gating cover
         // the whole request, including the wait for the first token. The
@@ -689,6 +820,27 @@ export function useChatMessaging({
           codeExecutionAccessToken: updatedChat.codeExecutionAccessToken,
           codeExecutionEncryptionKey: codeExecutionEncryptionKey ?? undefined,
           codeExecutionContainerAuthToken,
+          recovery:
+            recoveryEligible && recoveryEnabled
+              ? {
+                  onAttemptStarted: (sessionId) => {
+                    startChatRecoveryAttempt(
+                      streamChatIdRef.current,
+                      turnId,
+                      sessionId,
+                    )
+                  },
+                  onTokenCaptured: (sessionId, token) =>
+                    persistChatRecoveryToken({
+                      userId: recoveryUserId as string,
+                      chatId: streamChatIdRef.current,
+                      turnId,
+                      sessionId,
+                      token,
+                    }),
+                  onAttemptAbandoned: abandonChatRecoveryAttempt,
+                }
+              : undefined,
         })
 
         const assistantMessage = await processStreamingResponse(response, {
@@ -708,6 +860,9 @@ export function useChatMessaging({
           storeHistory,
           startingChatId,
         })
+        if (assistantMessage && turnId) {
+          assistantMessage.turnId = turnId
+        }
 
         const hasAssistantMessageToSave =
           !!assistantMessage &&
@@ -724,6 +879,40 @@ export function useChatMessaging({
           // The response is always saved to that chat, even if the user has
           // navigated to a different conversation while it streamed.
           const chatId = streamChatIdRef.current
+          let recoveryFinalized = false
+
+          if (recoveryEnabled && turnId) {
+            try {
+              await completeLiveChatRecovery({
+                chatId,
+                turnId,
+                assistantMessage,
+                chatPatch: {
+                  title: updatedChat.title,
+                  titleState: updatedChat.titleState,
+                  model: selectedModel,
+                  projectId: updatedChat.projectId,
+                },
+              })
+              recoveryFinalized = true
+            } catch (error) {
+              if (
+                error instanceof DOMException &&
+                error.name === 'AbortError'
+              ) {
+                throw error
+              }
+              logError(
+                'Failed to promptly finalize recoverable chat response',
+                error,
+                {
+                  component: 'useChatMessaging',
+                  action: 'handleQuery.recoveryPromptComplete',
+                  metadata: { chatId },
+                },
+              )
+            }
+          }
 
           logInfo('[handleQuery] Streaming completed, processing response', {
             component: 'useChatMessaging',
@@ -822,21 +1011,68 @@ export function useChatMessaging({
             },
           })
 
-          updateChatWithHistoryCheck(
-            setChats,
-            chatToSave,
-            setCurrentChat,
-            chatId,
-            finalMessages,
-            false,
-          )
+          if (recoveryEnabled && turnId && !recoveryFinalized) {
+            try {
+              await completeLiveChatRecovery({
+                chatId,
+                turnId,
+                assistantMessage,
+                chatPatch: {
+                  title: resolvedTitle,
+                  titleState: resolvedTitleState,
+                  model: selectedModel,
+                  projectId: updatedChat.projectId,
+                },
+              })
+            } catch (error) {
+              releaseActiveChatRecovery(chatId)
+              if (
+                error instanceof DOMException &&
+                error.name === 'AbortError'
+              ) {
+                throw error
+              }
+              logError('Failed to finalize recoverable chat response', error, {
+                component: 'useChatMessaging',
+                action: 'handleQuery.recoveryComplete',
+                metadata: { chatId },
+              })
+              updateChatWithHistoryCheck(
+                setChats,
+                chatToSave,
+                setCurrentChat,
+                chatId,
+                finalMessages,
+                false,
+              )
+            }
+          } else {
+            updateChatWithHistoryCheck(
+              setChats,
+              chatToSave,
+              setCurrentChat,
+              chatId,
+              finalMessages,
+              false,
+            )
+          }
         } else {
+          if (recoveryEnabled) {
+            await cancelChatRecovery(streamChatIdRef.current)
+          }
           logWarning('No assistant content to save after streaming', {
             component: 'useChatMessaging',
             action: 'handleQuery',
           })
         }
       } catch (error) {
+        releaseActiveChatRecovery(streamChatIdRef.current)
+        if (
+          typeof userId === 'string' &&
+          canUseChatRecovery({ isSignedIn, userId, storeHistory })
+        ) {
+          void scanPendingChatRecoveries(userId)
+        }
         // Ensure UI loading flags are reset on pre-stream errors
         setIsWaitingForResponseFor(false)
         setIsStreamingFor(false)
@@ -911,6 +1147,8 @@ export function useChatMessaging({
     },
     [
       currentChat,
+      isSignedIn,
+      userId,
       storeHistory,
       setChats,
       setCurrentChat,
@@ -929,6 +1167,7 @@ export function useChatMessaging({
       piiCheckEnabled,
       genUIEnabled,
       codeExecutionEncryptionKey,
+      isRecoveryActive,
       patchStatus,
       resetStatus,
       moveStatus,

--- a/src/components/chat/hooks/use-chat-storage.ts
+++ b/src/components/chat/hooks/use-chat-storage.ts
@@ -1,12 +1,16 @@
 import { cloudStorage } from '@/services/cloud/cloud-storage'
+import { streamingTracker } from '@/services/cloud/streaming-tracker'
+import { sameRecoveredResponse } from '@/services/inference/chat-recovery-sync'
 import { chatEvents } from '@/services/storage/chat-events'
 import { chatStorage } from '@/services/storage/chat-storage'
 import { deletedChatsTracker } from '@/services/storage/deleted-chats-tracker'
+import { indexedDBStorage } from '@/services/storage/indexed-db'
+import { samePendingRecoveryEnvelope } from '@/types/chat-recovery'
 import { logError, logInfo } from '@/utils/error-handling'
 import { useAuth } from '@clerk/nextjs'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { CONSTANTS } from '../constants'
-import type { Chat } from '../types'
+import type { Chat, PendingRecoveryEnvelope } from '../types'
 import {
   createBlankChat,
   deleteChat as deleteChatFromStorage,
@@ -48,6 +52,20 @@ interface UseChatStorageReturn {
   retryInitialChatLoad: () => void
 }
 
+function pendingRecoveriesMatch(
+  left: readonly PendingRecoveryEnvelope[] = [],
+  right: readonly PendingRecoveryEnvelope[] = [],
+): boolean {
+  return (
+    left.length === right.length &&
+    left.every((envelope, index) =>
+      right[index]
+        ? samePendingRecoveryEnvelope(envelope, right[index])
+        : false,
+    )
+  )
+}
+
 export function useChatStorage({
   storeHistory,
   initialChatId,
@@ -57,6 +75,8 @@ export function useChatStorage({
   const { isSignedIn } = useAuth()
   const [isInitialLoad, setIsInitialLoad] = useState(true)
   const initialChatLoadedRef = useRef(false)
+  const reloadGenerationRef = useRef(0)
+  const pendingRecoveryReloadIdsRef = useRef(new Set<string>())
   const [initialChatDecryptionFailed, setInitialChatDecryptionFailed] =
     useState(false)
   const [localChatNotFound, setLocalChatNotFound] = useState(false)
@@ -94,71 +114,142 @@ export function useChatStorage({
   }, [persistenceManager])
 
   // Load chats from storage
-  const reloadChats = useCallback(async () => {
-    if (typeof window === 'undefined') return
+  const reloadChats = useCallback(
+    async (recoveryIds?: readonly string[]) => {
+      if (typeof window === 'undefined') return
 
-    try {
-      const loadedChats = await loadChats(storeHistory && !!isSignedIn)
-
-      setChats((prevChats) => {
-        // Always ensure we have blank chats for both modes
-        const cloudBlank =
-          getBlankChat(prevChats, false) || createBlankChat(false)
-        const localBlank =
-          getBlankChat(prevChats, true) || createBlankChat(true)
-
-        // Merge loaded chats with state (excluding blank chats). Re-check the
-        // deleted tracker at apply-time: a chat can be deleted after this
-        // reload's loadChats() snapshot resolved but before this setChats runs.
-        // Without this re-filter, an in-flight reload would resurrect a chat
-        // the user just deleted until the next page refresh.
-        const nonBlankChats = loadedChats.filter(
-          (c) => !c.isBlankChat && !deletedChatsTracker.isDeleted(c.id),
-        )
-
-        // Combine blank chats with loaded chats and sort
-        const finalChats = sortChats([cloudBlank, localBlank, ...nonBlankChats])
-
-        return finalChats
-      })
-
-      // Update current chat metadata only - NEVER switch to a different chat.
-      // Chat switching should only happen through explicit user actions.
-      // This prevents race conditions in Safari PWA where timing differences
-      // could cause unexpected chat resets.
-      setCurrentChat((prev) => {
-        if (isSwitchingChatRef.current || prev.isBlankChat) {
-          return prev
+      recoveryIds?.forEach((id) => pendingRecoveryReloadIdsRef.current.add(id))
+      const reloadGeneration = ++reloadGenerationRef.current
+      try {
+        const loadedChats = await loadChats(storeHistory && !!isSignedIn)
+        if (reloadGeneration !== reloadGenerationRef.current) {
+          return
         }
+        const pendingRecoveryIds = [...pendingRecoveryReloadIdsRef.current]
+        pendingRecoveryReloadIdsRef.current.clear()
 
-        // Only update metadata (syncedAt, title) if the same chat exists in storage
-        const existingChat = loadedChats.find((c) => c.id === prev.id)
-        if (existingChat) {
-          if (
-            prev.syncedAt !== existingChat.syncedAt ||
-            prev.title !== existingChat.title
-          ) {
-            return {
-              ...prev,
-              syncedAt: existingChat.syncedAt,
-              title: existingChat.title,
+        setChats((prevChats) => {
+          // Always ensure we have blank chats for both modes
+          const cloudBlank =
+            getBlankChat(prevChats, false) || createBlankChat(false)
+          const localBlank =
+            getBlankChat(prevChats, true) || createBlankChat(true)
+
+          // Merge loaded chats with state (excluding blank chats). Re-check the
+          // deleted tracker at apply-time: a chat can be deleted after this
+          // reload's loadChats() snapshot resolved but before this setChats runs.
+          // Without this re-filter, an in-flight reload would resurrect a chat
+          // the user just deleted until the next page refresh.
+          const nonBlankChats = loadedChats.filter(
+            (c) => !c.isBlankChat && !deletedChatsTracker.isDeleted(c.id),
+          )
+
+          // Combine blank chats with loaded chats and sort
+          const finalChats = sortChats([
+            cloudBlank,
+            localBlank,
+            ...nonBlankChats,
+          ])
+
+          return finalChats
+        })
+
+        // Update current chat metadata only - NEVER switch to a different chat.
+        // Chat switching should only happen through explicit user actions.
+        // This prevents race conditions in Safari PWA where timing differences
+        // could cause unexpected chat resets.
+        setCurrentChat((prev) => {
+          if (prev.isBlankChat) {
+            return prev
+          }
+
+          // Only update metadata (syncedAt, title) if the same chat exists in storage
+          const existingChat = loadedChats.find((c) => c.id === prev.id)
+          if (existingChat) {
+            const isStreaming = streamingTracker.isStreaming(prev.id)
+            const isRecoveryReload = pendingRecoveryIds.includes(prev.id)
+            if (isRecoveryReload && isStreaming) {
+              return {
+                ...prev,
+                pendingRecoveries: existingChat.pendingRecoveries,
+              }
+            }
+            // A turn this view still tracks as pending recovery may have been
+            // completed elsewhere (another device, or a background scan) and
+            // reached storage through a plain sync. Metadata-only merging
+            // would clear the indicator but keep the stale on-screen
+            // messages, so adopt the stored chat that carries the recovered
+            // response.
+            const recoveryResolvedElsewhere = (
+              prev.pendingRecoveries ?? []
+            ).some(
+              (envelope) =>
+                !existingChat.pendingRecoveries?.some(
+                  (candidate) => candidate.turnId === envelope.turnId,
+                ) &&
+                existingChat.messages.some((message) => {
+                  if (
+                    message.role !== 'assistant' ||
+                    message.turnId !== envelope.turnId
+                  ) {
+                    return false
+                  }
+                  const currentResponse = prev.messages.find(
+                    (candidate) =>
+                      candidate.role === 'assistant' &&
+                      candidate.turnId === envelope.turnId,
+                  )
+                  return (
+                    currentResponse === undefined ||
+                    !sameRecoveredResponse(currentResponse, message)
+                  )
+                }),
+            )
+            if (
+              (isRecoveryReload || recoveryResolvedElsewhere) &&
+              !isStreaming
+            ) {
+              return {
+                ...existingChat,
+                pendingSave: prev.pendingSave,
+              }
+            }
+            if (
+              prev.syncedAt !== existingChat.syncedAt ||
+              prev.title !== existingChat.title ||
+              !pendingRecoveriesMatch(
+                prev.pendingRecoveries,
+                existingChat.pendingRecoveries,
+              )
+            ) {
+              return {
+                ...prev,
+                syncedAt: existingChat.syncedAt,
+                title: existingChat.title,
+                pendingRecoveries: existingChat.pendingRecoveries,
+              }
             }
           }
-        }
 
-        return prev
-      })
-    } catch (error) {
-      logError('Failed to reload chats', error, {
-        component: 'useChatStorage',
-      })
-    }
-  }, [storeHistory, isSignedIn])
+          return prev
+        })
+      } catch (error) {
+        logError('Failed to reload chats', error, {
+          component: 'useChatStorage',
+        })
+      }
+    },
+    [storeHistory, isSignedIn],
+  )
 
   // Listen for chat events (cloud sync, pagination, etc.)
   useEffect(() => {
     const cleanup = chatEvents.on((event) => {
-      if (event.reason === 'sync' || event.reason === 'pagination') {
+      if (
+        event.reason === 'sync' ||
+        event.reason === 'pagination' ||
+        event.reason === 'recovery'
+      ) {
         // Apply ID changes eagerly to avoid temp/server ID mismatch races before reload
         if (event.idChanges && event.idChanges.length > 0) {
           const idMap = new Map(event.idChanges.map((c) => [c.from, c.to]))
@@ -174,7 +265,11 @@ export function useChatStorage({
           )
         }
 
-        reloadChats()
+        if (event.reason === 'recovery') {
+          void reloadChats(event.ids)
+        } else {
+          void reloadChats()
+        }
       }
     })
 
@@ -499,6 +594,22 @@ export function useChatStorage({
           decryptionFailed: downloadedChat.decryptionFailed,
           projectId: downloadedChat.projectId,
           model: downloadedChat.model,
+          pendingRecoveries: downloadedChat.pendingRecoveries,
+        }
+
+        if (storeHistory) {
+          try {
+            await indexedDBStorage.applyRemoteChatIfFresh({
+              chat: downloadedChat,
+              syncVersion: downloadedChat.syncVersion ?? 1,
+              expectedLocalUpdatedAt: null,
+            })
+          } catch (error) {
+            logError('Failed to cache URL-loaded chat', error, {
+              component: 'useChatStorage',
+              metadata: { chatId },
+            })
+          }
         }
 
         // Add to chats list and select it
@@ -529,7 +640,7 @@ export function useChatStorage({
         setInitialChatLoadFailed(true)
       }
     },
-    [chats, isSignedIn, switchChat],
+    [chats, isSignedIn, storeHistory, switchChat],
   )
 
   // Load initial chat from URL if provided

--- a/src/components/chat/hooks/use-message-queue.ts
+++ b/src/components/chat/hooks/use-message-queue.ts
@@ -21,6 +21,8 @@ type UseMessageQueueArgs = {
   loadingState: LoadingState
   handleQuery: HandleQuery
   isRateLimited: () => boolean
+  isDispatchBlocked?: () => boolean
+  dispatchBlocked?: boolean
   onBeforeDispatch?: () => void
   onRateLimited?: () => void
   cancelGeneration?: (chatId?: string) => void | Promise<void>
@@ -116,6 +118,8 @@ export function useMessageQueue({
   loadingState,
   handleQuery,
   isRateLimited,
+  isDispatchBlocked,
+  dispatchBlocked = false,
   onBeforeDispatch,
   onRateLimited,
   cancelGeneration,
@@ -160,11 +164,13 @@ export function useMessageQueue({
   // pump dispatches in a microtask (an effect would lag a paint behind).
   const handleQueryRef = useRef(handleQuery)
   const isRateLimitedRef = useRef(isRateLimited)
+  const isDispatchBlockedRef = useRef(isDispatchBlocked)
   const onBeforeDispatchRef = useRef(onBeforeDispatch)
   const onRateLimitedRef = useRef(onRateLimited)
   const cancelGenerationRef = useRef(cancelGeneration)
   handleQueryRef.current = handleQuery
   isRateLimitedRef.current = isRateLimited
+  isDispatchBlockedRef.current = isDispatchBlocked
   onBeforeDispatchRef.current = onBeforeDispatch
   onRateLimitedRef.current = onRateLimited
   cancelGenerationRef.current = cancelGeneration
@@ -266,6 +272,7 @@ export function useMessageQueue({
             return
           }
           rateLimitPromptShownRef.current = false
+          if (isDispatchBlockedRef.current?.()) return
 
           const [next, ...rest] = getQueue(pump.id)
           if (!next) break
@@ -314,7 +321,8 @@ export function useMessageQueue({
         if (
           pump.id === currentChatIdRef.current &&
           getQueue(pump.id).length > 0 &&
-          !isRateLimitedRef.current()
+          !isRateLimitedRef.current() &&
+          !isDispatchBlockedRef.current?.()
         ) {
           queueMicrotask(() => {
             void runPump(pump.id)
@@ -337,6 +345,14 @@ export function useMessageQueue({
       }
     }
   }, [isRateLimited, getQueue, runPump])
+
+  useEffect(() => {
+    if (dispatchBlocked) return
+    const id = currentChatIdRef.current
+    if (id != null && getQueue(id).length > 0) {
+      void runPump(id)
+    }
+  }, [dispatchBlocked, getQueue, runPump])
 
   const submit = useCallback(
     (input: QueueSubmitInput): void => {

--- a/src/components/chat/renderers/default/DefaultMessageRenderer.tsx
+++ b/src/components/chat/renderers/default/DefaultMessageRenderer.tsx
@@ -31,6 +31,7 @@ const DefaultMessageComponent = ({
   isDarkMode,
   isLastMessage,
   isStreaming,
+  hideActions,
   onEditMessage,
   onRegenerateMessage,
 }: MessageRenderProps) => {
@@ -211,6 +212,11 @@ const DefaultMessageComponent = ({
       }),
     }
   }, [message.timestamp])
+  const showAssistantActions =
+    !isUser &&
+    message.content &&
+    !hideActions &&
+    !(isStreaming && isLastMessage)
 
   return (
     <div
@@ -675,7 +681,7 @@ const DefaultMessageComponent = ({
         )}
 
       {/* Actions for assistant messages - hidden while streaming the last response */}
-      {!isUser && message.content && !(isStreaming && isLastMessage) && (
+      {showAssistantActions && (
         <div
           className={`mt-4 flex items-center justify-between gap-3 px-4 transition-opacity duration-500 ease-in-out ${
             showActions ? 'opacity-100' : 'pointer-events-none opacity-0'

--- a/src/components/chat/renderers/types.ts
+++ b/src/components/chat/renderers/types.ts
@@ -25,6 +25,7 @@ export interface MessageRenderProps {
   isDarkMode: boolean
   isLastMessage?: boolean
   isStreaming?: boolean
+  hideActions?: boolean
   onEditMessage?: (messageIndex: number, newContent: string) => void
   onRegenerateMessage?: (messageIndex: number) => void
 }

--- a/src/components/chat/types.ts
+++ b/src/components/chat/types.ts
@@ -1,3 +1,11 @@
+import type { PendingRecoveryEnvelope } from '@/types/chat-recovery'
+
+export {
+  MAX_PENDING_RECOVERIES_PER_CHAT,
+  RECOVERY_ENVELOPE_EXPIRY_MS,
+  type PendingRecoveryEnvelope,
+} from '@/types/chat-recovery'
+
 export type URLCitation = {
   title: string
   url: string
@@ -126,6 +134,7 @@ export type Attachment = {
 export type Message = {
   role: 'user' | 'assistant'
   content: string
+  turnId?: string
   attachments?: Attachment[]
   // Legacy fields — kept for reading old messages, not written for new ones
   documentContent?: string
@@ -163,6 +172,7 @@ export type Chat = {
   title: string
   titleState?: TitleState
   messages: Message[]
+  pendingRecoveries?: PendingRecoveryEnvelope[]
   createdAt: Date
   // Latest server-bumped write time, used as the canonical sort
   // key for the sidebar. Absent for chats that have never been

--- a/src/hooks/use-chat-recovery-drafts.ts
+++ b/src/hooks/use-chat-recovery-drafts.ts
@@ -1,0 +1,40 @@
+import {
+  getActiveChatRecoverySnapshot,
+  getChatRecoveryDraftSnapshot,
+  subscribeChatRecoveryDrafts,
+} from '@/services/inference/chat-recovery-drafts'
+import { useMemo, useSyncExternalStore } from 'react'
+
+const emptySnapshot = [] as const
+
+export function useChatRecoveryDrafts(chatId: string) {
+  const drafts = useSyncExternalStore(
+    subscribeChatRecoveryDrafts,
+    getChatRecoveryDraftSnapshot,
+    () => emptySnapshot,
+  )
+  return useMemo(
+    () => drafts.filter((draft) => draft.chatId === chatId),
+    [chatId, drafts],
+  )
+}
+
+export function useChatRecoveryActiveTurnIds(
+  chatId: string,
+): readonly string[] {
+  const activeTurns = useSyncExternalStore(
+    subscribeChatRecoveryDrafts,
+    getActiveChatRecoverySnapshot,
+    () => emptySnapshot,
+  )
+  return useMemo(() => {
+    const prefix = `${chatId}\u0000`
+    return activeTurns
+      .filter((key) => key.startsWith(prefix))
+      .map((key) => key.slice(prefix.length))
+  }, [activeTurns, chatId])
+}
+
+export function useChatRecoveryActive(chatId: string): boolean {
+  return useChatRecoveryActiveTurnIds(chatId).length > 0
+}

--- a/src/services/cloud/chat-codec.ts
+++ b/src/services/cloud/chat-codec.ts
@@ -118,6 +118,8 @@ export async function processRemoteChat(
     syncedAt: Date.now(),
     locallyModified: false,
     syncVersion: remote.syncVersion ?? decrypted.syncVersion ?? 1,
+    clockVersion:
+      remote.syncVersion === undefined ? undefined : decrypted.clockVersion,
     formatVersion: 2,
     projectId: projectId ?? decrypted.projectId ?? localChat?.projectId,
   }

--- a/src/services/cloud/cloud-storage.ts
+++ b/src/services/cloud/cloud-storage.ts
@@ -1,5 +1,6 @@
 import type { Message } from '@/components/chat/types'
 import { AUTH_ACTIVE_USER_ID } from '@/constants/storage-keys'
+import { isLocalRecoveryEnvelope } from '@/types/chat-recovery'
 import {
   base64ToUint8Array,
   decryptAttachment,
@@ -258,9 +259,16 @@ export class CloudStorageService {
     // can tell the clock is current (etag === clockVersion) versus a
     // later clock-unaware write that would force the updatedAt fallback.
     const baseVersion = options.restoreDeleted ? 0 : (chat.syncVersion ?? 0)
+    const syncedRecoveries = chat.pendingRecoveries?.filter(
+      (recovery) => !isLocalRecoveryEnvelope(recovery),
+    )
     const strippedChat = {
       ...chat,
       messages: stripBase64FromMessages(messages),
+      pendingRecoveries:
+        syncedRecoveries && syncedRecoveries.length > 0
+          ? syncedRecoveries
+          : undefined,
       clockVersion: baseVersion + 1,
     }
     const plaintext = new TextEncoder().encode(JSON.stringify(strippedChat))

--- a/src/services/cloud/cloud-sync.ts
+++ b/src/services/cloud/cloud-sync.ts
@@ -27,10 +27,12 @@ import {
   type ChatSyncStatus,
   type UploadChatOptions,
 } from './cloud-storage'
-import type { EditClock } from './edit-clock'
 import { adoptLocalKeyForMigration } from './ensure-current-key'
 import {
   finalizeAlternativesIfMigrated,
+  markRecoveryHistoryReady,
+  needsRecoveryHistorySync,
+  resetAlternativesFinalizationState,
   runLegacyBlobMigration,
   type MigrationReport,
 } from './legacy-blob-migration'
@@ -44,7 +46,11 @@ import {
   reportSyncPaused,
   reportSyncSuccess,
 } from './sync-health'
-import { isUploadableChat, remoteWins } from './sync-predicates'
+import {
+  isUploadableChat,
+  remoteWins,
+  trustedChatClock,
+} from './sync-predicates'
 import { SyncStatusCache } from './sync-status-cache'
 import { UploadCoalescer, type UploadAttempt } from './upload-coalescer'
 
@@ -144,6 +150,7 @@ export class CloudSyncService {
     this.accountGeneration++
     this.uploadCoalescer.clear()
     this.streamingCallbacks.clear()
+    resetAlternativesFinalizationState()
     this.clearSyncStatus()
     // The deletes watermark is scoped to the account's tombstone history,
     // so the next account (or re-login) must replay from epoch rather than
@@ -626,6 +633,30 @@ export class CloudSyncService {
     }
   }
 
+  private async markRecoveryHistoryReadyIfAuthoritative(
+    generation: number,
+    expectedCloudVersions: ReadonlyMap<string, number>,
+  ): Promise<void> {
+    if (!this.isCurrentGeneration(generation) || !needsRecoveryHistorySync()) {
+      return
+    }
+    try {
+      const authoritative = await indexedDBStorage.isChatHistoryAuthoritative(
+        expectedCloudVersions,
+      )
+      if (this.isCurrentGeneration(generation) && authoritative) {
+        await markRecoveryHistoryReady(() =>
+          this.isCurrentGeneration(generation),
+        )
+      }
+    } catch (error) {
+      logError('Failed to verify recovery history after sync', error, {
+        component: 'CloudSync',
+        action: 'markRecoveryHistoryReadyIfAuthoritative',
+      })
+    }
+  }
+
   // Backup a single chat to the cloud with coalescing and retry
   async backupChat(chatId: string): Promise<void> {
     const generation = this.accountGeneration
@@ -660,6 +691,43 @@ export class CloudSyncService {
     // - Proper concurrency control per chat
     if (!this.isCurrentGeneration(generation)) return
     this.uploadCoalescer.enqueue(chatId)
+  }
+
+  async backupChatAndWait(chatId: string): Promise<void> {
+    const generation = this.accountGeneration
+    if (!(await cloudStorage.isAuthenticated())) {
+      throw new Error('Cloud authentication is unavailable')
+    }
+    if (!this.isCurrentGeneration(generation) || !(await canWriteToCloud())) {
+      throw new Error('Cloud synchronization is unavailable')
+    }
+
+    const chat = await indexedDBStorage.getChat(chatId)
+    if (!this.isCurrentGeneration(generation)) {
+      throw new Error('Cloud account changed during synchronization')
+    }
+    if (!chat || !isUploadableChat(chat, isStreaming)) {
+      throw new Error('Chat is not eligible for cloud synchronization')
+    }
+
+    await this.uploadCoalescer.ensureUploadAndWait(chatId)
+    const latest = await indexedDBStorage.getChat(chatId)
+    if (!this.isCurrentGeneration(generation)) {
+      throw new Error('Cloud account changed during synchronization')
+    }
+    if (!latest) {
+      throw new Error('Chat changed during required cloud synchronization')
+    }
+    if (!latest.locallyModified) {
+      if (latest.updatedAt !== chat.updatedAt) {
+        throw new Error('Chat changed on another device before synchronization')
+      }
+      return
+    }
+    await this.backupChatNow(chatId)
+    if (!this.isCurrentGeneration(generation)) {
+      throw new Error('Cloud account changed during synchronization')
+    }
   }
 
   /**
@@ -999,27 +1067,9 @@ export class CloudSyncService {
       }
       if (!this.isCurrentGeneration(generation)) return
 
-      // A chat's edit clock is trusted only when it was maintained at
-      // the row's current synced version; otherwise a clock-unaware
-      // write intervened and we fall back to updatedAt arbitration.
-      const trustedClock = (
-        c: typeof localChat | typeof remoteChat,
-      ): EditClock | undefined => {
-        if (
-          !c ||
-          typeof c.clock !== 'number' ||
-          typeof c.writer !== 'string' ||
-          c.clockVersion == null ||
-          c.clockVersion !== (c.syncVersion ?? -1)
-        ) {
-          return undefined
-        }
-        return { v: c.clock, w: c.writer }
-      }
-
       const remoteIsWinner = remoteWins({
-        localClock: trustedClock(localChat),
-        remoteClock: trustedClock(remoteChat),
+        localClock: trustedChatClock(localChat),
+        remoteClock: trustedChatClock(remoteChat),
         localUpdatedAt: localChat?.updatedAt,
         remoteUpdatedAt: remoteChat.updatedAt,
       })
@@ -1220,8 +1270,26 @@ export class CloudSyncService {
       downloaded: 0,
       errors: [],
     }
+    let recoveryHistoryStatusBefore: ChatSyncStatus | null = null
+    let recoveryHistoryStatusAfter: ChatSyncStatus | null = null
 
     try {
+      if (deep && needsRecoveryHistorySync()) {
+        try {
+          recoveryHistoryStatusBefore = await cloudStorage.getChatSyncStatus()
+        } catch (statusError) {
+          logError(
+            'Failed to capture recovery history status before full sync',
+            statusError,
+            {
+              component: 'CloudSync',
+              action: 'syncAllChats',
+            },
+          )
+        }
+      }
+      if (!this.isCurrentGeneration(generation)) return result
+
       // Apply remote deletions BEFORE uploading local changes so a chat
       // deleted on another device is dropped locally first, instead of
       // getting re-uploaded by backupUnsyncedChats.
@@ -1250,6 +1318,15 @@ export class CloudSyncService {
       if (!this.isCurrentGeneration(generation)) return result
 
       const remoteConversations = [...(remoteList.conversations || [])]
+      const remoteChatIds = new Set(
+        remoteConversations.map((conversation) => conversation.id),
+      )
+      const remoteChatVersions = new Map<string, number>()
+      for (const conversation of remoteConversations) {
+        if (typeof conversation.syncVersion === 'number') {
+          remoteChatVersions.set(conversation.id, conversation.syncVersion)
+        }
+      }
 
       // Only sync the first page - new chats always appear at the top
       // No need to fetch older chats every 15 seconds
@@ -1289,6 +1366,12 @@ export class CloudSyncService {
             limit: PAGINATION.CHATS_PER_PAGE,
             continuationToken,
           })
+          for (const conversation of nextPage.conversations || []) {
+            remoteChatIds.add(conversation.id)
+            if (typeof conversation.syncVersion === 'number') {
+              remoteChatVersions.set(conversation.id, conversation.syncVersion)
+            }
+          }
           const nextIngest = await ingestRemoteChats(
             [...(nextPage.conversations || [])],
             {
@@ -1313,6 +1396,7 @@ export class CloudSyncService {
         if (localCount !== null) {
           newStatus.localCount = localCount
         }
+        recoveryHistoryStatusAfter = newStatus
         this.chatSyncCache.save(newStatus)
       } catch (statusError) {
         // Non-fatal: continue even if we can't update status
@@ -1324,6 +1408,20 @@ export class CloudSyncService {
 
       // Detect cross-scope moves (chats moving between projects)
       await this.syncCrossScope(result, generation)
+      const recoveryHistorySnapshotStable =
+        recoveryHistoryStatusBefore !== null &&
+        recoveryHistoryStatusAfter !== null &&
+        recoveryHistoryStatusBefore.count === remoteChatIds.size &&
+        recoveryHistoryStatusAfter.count === remoteChatIds.size &&
+        recoveryHistoryStatusBefore.lastUpdated ===
+          recoveryHistoryStatusAfter.lastUpdated &&
+        remoteChatVersions.size === remoteChatIds.size
+      if (deep && result.errors.length === 0 && recoveryHistorySnapshotStable) {
+        await this.markRecoveryHistoryReadyIfAuthoritative(
+          generation,
+          remoteChatVersions,
+        )
+      }
       if (this.isCurrentGeneration(generation)) {
         void this.kickLegacyBlobMigration()
       }
@@ -1436,7 +1534,7 @@ export class CloudSyncService {
     void runLegacyBlobMigration()
       .then(async (report) => {
         if (!this.isCurrentGeneration(generation)) return
-        finalizeAlternativesIfMigrated(report)
+        await finalizeAlternativesIfMigrated(report)
         logInfo('Legacy blob migration completed', {
           component: 'CloudSync',
           action: 'kickLegacyBlobMigration',
@@ -1556,6 +1654,9 @@ export class CloudSyncService {
     if (this.syncLock) {
       throw new Error('Sync already in progress')
     }
+    if (!projectId && needsRecoveryHistorySync()) {
+      return this.syncAllChats({ deep: true })
+    }
 
     const status = await this.checkSyncStatus(projectId)
     if (!this.isCurrentGeneration(generation)) {
@@ -1578,7 +1679,6 @@ export class CloudSyncService {
       if (!this.isCurrentGeneration(generation)) {
         return { uploaded: 0, downloaded: 0, errors: [] }
       }
-
       logInfo('Smart sync: no changes detected, skipping sync', {
         component: 'CloudSync',
         action: 'smartSync',

--- a/src/services/cloud/legacy-blob-migration.ts
+++ b/src/services/cloud/legacy-blob-migration.ts
@@ -25,6 +25,7 @@
 
 import { logError, logInfo } from '@/utils/error-handling'
 import { encryptionService } from '../encryption/encryption-service'
+import { indexedDBStorage } from '../storage/indexed-db'
 import {
   migrateAll as enclaveMigrateAll,
   migrateStatus as enclaveMigrateStatus,
@@ -38,6 +39,9 @@ const MIGRATION_POLL_INTERVAL_MS = 2_000
 const MIGRATION_POLL_TIMEOUT_MS = 15 * 60_000
 /** Terminal coordinator status for a job that died mid-run. */
 const FAILED_JOB_STATUS = 'failed'
+let deferredFinalizationReport: MigrationReport | null = null
+let finalizedFinalizationReport: MigrationReport | null = null
+let recoveryHistoryReady = false
 
 export interface ScopeMigrationResult {
   scope: Scope
@@ -203,14 +207,32 @@ function sleep(ms: number): Promise<void> {
  * Idempotent and a no-op when `report.fullyMigrated` is false.
  * Returns true when the local state was cleared (or already empty).
  */
-export function finalizeAlternativesIfMigrated(
+export async function finalizeAlternativesIfMigrated(
   report: MigrationReport,
-): boolean {
-  if (!report.fullyMigrated) {
+  isCurrent: () => boolean = () => true,
+): Promise<boolean> {
+  if (!report.fullyMigrated || !isCurrent()) {
+    return false
+  }
+  if (finalizedFinalizationReport === report) {
+    return true
+  }
+  if (deferredFinalizationReport !== report) {
+    deferredFinalizationReport = report
+  }
+  if (
+    !recoveryHistoryReady ||
+    (await indexedDBStorage.hasPendingChatRecoveries())
+  ) {
+    return false
+  }
+  if (deferredFinalizationReport !== report || !isCurrent()) {
     return false
   }
   const before = encryptionService.getFallbackKeyCount()
   encryptionService.clearFallbackKeys()
+  deferredFinalizationReport = null
+  finalizedFinalizationReport = report
   logInfo('Cleared alternative keys after enclave migration', {
     component: 'LegacyBlobMigration',
     action: 'finalizeAlternativesIfMigrated',
@@ -223,6 +245,37 @@ export function finalizeAlternativesIfMigrated(
   return true
 }
 
+export async function markRecoveryHistoryReady(
+  isCurrent: () => boolean = () => true,
+): Promise<void> {
+  if (!isCurrent()) return
+  recoveryHistoryReady = true
+  await retryDeferredAlternativesFinalization(isCurrent)
+}
+
+export async function retryDeferredAlternativesFinalization(
+  isCurrent: () => boolean = () => true,
+): Promise<void> {
+  const report = deferredFinalizationReport
+  if (report) {
+    await finalizeAlternativesIfMigrated(report, isCurrent)
+  }
+}
+
+export function hasDeferredAlternativesFinalization(): boolean {
+  return deferredFinalizationReport !== null
+}
+
+export function needsRecoveryHistorySync(): boolean {
+  return deferredFinalizationReport !== null && !recoveryHistoryReady
+}
+
+export function resetAlternativesFinalizationState(): void {
+  deferredFinalizationReport = null
+  finalizedFinalizationReport = null
+  recoveryHistoryReady = false
+}
+
 /**
  * Convenience: run the migration and, on success, drop the
  * client-side alternatives. Returns the report so callers can still
@@ -230,6 +283,6 @@ export function finalizeAlternativesIfMigrated(
  */
 export async function runLegacyBlobMigrationAndFinalize(): Promise<MigrationReport> {
   const report = await runLegacyBlobMigration()
-  finalizeAlternativesIfMigrated(report)
+  await finalizeAlternativesIfMigrated(report)
   return report
 }

--- a/src/services/cloud/schemas.ts
+++ b/src/services/cloud/schemas.ts
@@ -10,14 +10,60 @@
  * survive a round-trip while the fields we depend on are type-checked.
  */
 
+import {
+  MAX_PENDING_RECOVERIES_PER_CHAT,
+  MAX_RECOVERY_ID_LENGTH,
+  type SyncedRecoveryEnvelope,
+} from '@/types/chat-recovery'
+import { validateRecoveryEnvelope } from '@/utils/chat-recovery-envelope'
 import { z } from 'zod'
+
+const RecoveryIdSchema = z
+  .string()
+  .min(1)
+  .max(MAX_RECOVERY_ID_LENGTH)
+  .refine((value) => value.trim().length > 0)
+const RecoveryTimestampSchema = z.string().datetime({ offset: true })
+const RecoveryKeyIdSchema = z.string().regex(/^[0-9a-f]{32}$/)
 
 const MessageSchema = z
   .object({
     role: z.enum(['user', 'assistant']),
     content: z.string(),
+    turnId: RecoveryIdSchema.optional(),
   })
   .passthrough()
+
+export const PendingRecoveryEnvelopeSchema = z
+  .object({
+    v: z.literal(1),
+    turnId: RecoveryIdSchema,
+    keyId: RecoveryKeyIdSchema,
+    createdAt: RecoveryTimestampSchema,
+    expiresAt: RecoveryTimestampSchema,
+    nonce: z.string(),
+    ciphertext: z.string(),
+  })
+  .passthrough()
+  .superRefine((envelope, context) => {
+    if ('storage' in envelope) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'device-local recovery envelopes cannot be synced',
+        path: ['storage'],
+      })
+      return
+    }
+    try {
+      validateRecoveryEnvelope(envelope as SyncedRecoveryEnvelope)
+    } catch (error) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          error instanceof Error ? error.message : 'invalid recovery envelope',
+      })
+    }
+  })
 
 // Per-unit logical edit clock: `v` is a Lamport counter, `w` the
 // writing device id used as a deterministic tiebreak. Passthrough keeps
@@ -34,6 +80,23 @@ export const RemoteChatPlaintextSchema = z
   .object({
     title: z.string().optional(),
     messages: z.array(MessageSchema),
+    pendingRecoveries: z
+      .array(PendingRecoveryEnvelopeSchema)
+      .max(MAX_PENDING_RECOVERIES_PER_CHAT)
+      .superRefine((envelopes, context) => {
+        const seen = new Set<string>()
+        for (const [index, envelope] of envelopes.entries()) {
+          if (seen.has(envelope.turnId)) {
+            context.addIssue({
+              code: z.ZodIssueCode.custom,
+              message: 'recovery turn identifiers must be unique',
+              path: [index, 'turnId'],
+            })
+          }
+          seen.add(envelope.turnId)
+        }
+      })
+      .optional(),
     createdAt: z.union([z.string(), z.number()]).optional(),
     updatedAt: z.union([z.string(), z.number()]).optional(),
     model: z.string().optional(),

--- a/src/services/cloud/sync-predicates.ts
+++ b/src/services/cloud/sync-predicates.ts
@@ -9,6 +9,29 @@
 import type { StoredChat } from '@/services/storage/indexed-db'
 import type { EditClock } from './edit-clock'
 
+export function trustedChatClock(
+  chat:
+    | Pick<StoredChat, 'clock' | 'writer' | 'clockVersion' | 'syncVersion'>
+    | null
+    | undefined,
+): EditClock | undefined {
+  if (
+    !chat ||
+    typeof chat.clock !== 'number' ||
+    !Number.isSafeInteger(chat.clock) ||
+    chat.clock <= 0 ||
+    typeof chat.writer !== 'string' ||
+    chat.writer.trim().length === 0 ||
+    typeof chat.clockVersion !== 'number' ||
+    !Number.isSafeInteger(chat.clockVersion) ||
+    chat.clockVersion <= 0 ||
+    chat.clockVersion !== (chat.syncVersion ?? -1)
+  ) {
+    return undefined
+  }
+  return { v: chat.clock, w: chat.writer }
+}
+
 /**
  * Determines if a chat is eligible for upload to the cloud.
  *

--- a/src/services/cloud/upload-coalescer.ts
+++ b/src/services/cloud/upload-coalescer.ts
@@ -232,7 +232,24 @@ export class UploadCoalescer {
       return
     }
 
-    await new Promise<void>((resolve, reject) => {
+    await this.waitForResult(state)
+  }
+
+  async ensureUploadAndWait(chatId: string): Promise<void> {
+    const existing = this.states.get(chatId)
+    if (!existing?.inFlight) {
+      this.enqueue(chatId)
+    }
+    const state = this.states.get(chatId)
+    if (!state?.inFlight) {
+      return
+    }
+
+    await this.waitForResult(state)
+  }
+
+  private waitForResult(state: ChatUploadState): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
       state.resultWaiters.push({ resolve, reject })
     })
   }

--- a/src/services/inference/chat-recovery-client.ts
+++ b/src/services/inference/chat-recovery-client.ts
@@ -1,0 +1,156 @@
+import { decryptResponseWithToken, type SessionRecoveryToken } from 'tinfoil'
+import { getRecoveryBaseURL } from './tinfoil-client'
+
+const RECOVERY_SESSION_ID_PATTERN = /^[0-9a-f]{32}$/
+const RECOVERY_REQUEST_TIMEOUT_MS = 30_000
+const EHBP_RESPONSE_NONCE_HEADER = 'Ehbp-Response-Nonce'
+
+export type RecoveryState = 'processing' | 'complete' | 'failed' | 'missing'
+export type RecoveryStatus = {
+  state: RecoveryState
+  persistedBytes: number
+}
+
+export class ChatRecoveryError extends Error {
+  constructor(
+    message: string,
+    public readonly state?: RecoveryState,
+    public readonly retryable = false,
+    options?: ErrorOptions,
+  ) {
+    super(message, options)
+    this.name = 'ChatRecoveryError'
+  }
+}
+
+function assertSessionId(sessionId: string): void {
+  if (!RECOVERY_SESSION_ID_PATTERN.test(sessionId)) {
+    throw new ChatRecoveryError('Invalid recovery session identifier')
+  }
+}
+
+async function recoveryURL(sessionId: string, suffix = ''): Promise<string> {
+  assertSessionId(sessionId)
+  const baseURL = getRecoveryBaseURL()
+  const base = new URL(baseURL)
+  return new URL(`/recovery/${sessionId}${suffix}`, base.origin).toString()
+}
+
+async function recoveryFetch(
+  sessionId: string,
+  suffix = '',
+  init: RequestInit = {},
+): Promise<Response> {
+  const signal = init.signal ?? AbortSignal.timeout(RECOVERY_REQUEST_TIMEOUT_MS)
+  try {
+    return await fetch(await recoveryURL(sessionId, suffix), {
+      ...init,
+      signal,
+      credentials: 'omit',
+      referrerPolicy: 'no-referrer',
+    })
+  } catch (error) {
+    throw new ChatRecoveryError(
+      'Encrypted response recovery request failed',
+      undefined,
+      true,
+      { cause: error },
+    )
+  }
+}
+
+export async function getChatRecoveryStatus(
+  sessionId: string,
+): Promise<RecoveryStatus> {
+  const response = await recoveryFetch(sessionId, '/status')
+  if (response.status === 404) return { state: 'missing', persistedBytes: 0 }
+  if (response.status === 410) return { state: 'failed', persistedBytes: 0 }
+  if (!response.ok) {
+    throw new ChatRecoveryError(
+      'Encrypted response recovery status failed',
+      undefined,
+      response.status >= 500,
+    )
+  }
+  const body: unknown = await response.json()
+  const status =
+    typeof body === 'object' && body !== null && 'status' in body
+      ? body.status
+      : undefined
+  const persistedBytes =
+    typeof body === 'object' && body !== null && 'bytes' in body
+      ? body.bytes
+      : undefined
+  if (status !== 'processing' && status !== 'complete' && status !== 'failed') {
+    throw new ChatRecoveryError('Invalid encrypted recovery status response')
+  }
+  if (
+    typeof persistedBytes !== 'number' ||
+    !Number.isSafeInteger(persistedBytes) ||
+    persistedBytes < 0
+  ) {
+    throw new ChatRecoveryError('Invalid encrypted recovery byte count')
+  }
+  return { state: status, persistedBytes }
+}
+
+export async function getChatRecoveryState(
+  sessionId: string,
+): Promise<RecoveryState> {
+  return (await getChatRecoveryStatus(sessionId)).state
+}
+
+export async function fetchRecoveredChatResponse(
+  sessionId: string,
+  token: SessionRecoveryToken,
+  signal?: AbortSignal,
+  onEncryptedBytes?: (bytes: number) => void,
+): Promise<Response> {
+  const response = await recoveryFetch(sessionId, '', { signal })
+  const encryptedResponse = response.headers.has(EHBP_RESPONSE_NONCE_HEADER)
+  if (!encryptedResponse && response.status === 404) {
+    throw new ChatRecoveryError('Recovery session not found', 'missing')
+  }
+  if (!encryptedResponse && response.status === 410) {
+    throw new ChatRecoveryError('Recovery session failed', 'failed')
+  }
+  if (!encryptedResponse && !response.ok) {
+    throw new ChatRecoveryError(
+      'Encrypted response recovery failed',
+      undefined,
+      response.status >= 500,
+    )
+  }
+  if (!response.body || !onEncryptedBytes) {
+    return decryptResponseWithToken(response, token)
+  }
+
+  onEncryptedBytes(0)
+  const body = response.body.pipeThrough(
+    new TransformStream<Uint8Array, Uint8Array>({
+      transform(chunk, controller) {
+        onEncryptedBytes(chunk.byteLength)
+        controller.enqueue(chunk)
+      },
+    }),
+  )
+  return decryptResponseWithToken(
+    new Response(body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers,
+    }),
+    token,
+  )
+}
+
+export async function deleteChatRecovery(sessionId: string): Promise<void> {
+  const response = await recoveryFetch(sessionId, '', { method: 'DELETE' })
+  if (!response.ok && response.status !== 404) {
+    throw new ChatRecoveryError(
+      'Failed to delete encrypted response recovery session',
+      undefined,
+      response.status >= 500,
+    )
+  }
+}

--- a/src/services/inference/chat-recovery-crypto.ts
+++ b/src/services/inference/chat-recovery-crypto.ts
@@ -1,0 +1,342 @@
+import { deriveKeyIdHex } from '@/services/sync-enclave/key-bundle'
+import {
+  RECOVERY_ENVELOPE_EXPIRY_MS,
+  type SyncedRecoveryEnvelope,
+} from '@/types/chat-recovery'
+import { uint8ArrayToBase64 } from '@/utils/binary-codec'
+import {
+  decodeRecoveryBase64,
+  requireRecoveryId,
+  requireRecoveryLowercaseHex,
+  validateRecoveryEnvelope,
+} from '@/utils/chat-recovery-envelope'
+
+export { validateRecoveryEnvelope } from '@/utils/chat-recovery-envelope'
+
+const AES_GCM = 'AES-GCM'
+const HKDF = 'HKDF'
+const SHA_256 = 'SHA-256'
+const CEK_BYTES = 32
+const NONCE_BYTES = 12
+const AES_GCM_TAG_BYTES = 16
+const RECOVERY_TOKEN_HEX_LENGTH = 64
+const SESSION_ID_HEX_LENGTH = 32
+const KEY_ID_HEX_LENGTH = 32
+const RECOVERY_ENVELOPE_VERSION = 1
+
+export const RECOVERY_ENVELOPE_HKDF_INFO = 'tinfoil-chat-recovery-envelope-v1'
+
+const textEncoder = new TextEncoder()
+const textDecoder = new TextDecoder('utf-8', { fatal: true })
+
+export type RecoveryTokenFields = {
+  exportedSecret: string
+  requestEnc: string
+}
+
+export type RecoveryTokenPayload = string | RecoveryTokenFields
+
+export type RecoveryEnvelopePayload = {
+  sessionId: string
+  recoveryToken: RecoveryTokenPayload
+}
+
+export type EncryptRecoveryEnvelopeOptions = {
+  cek: Uint8Array
+  userId: string
+  chatId: string
+  turnId: string
+  sessionId: string
+  recoveryToken: RecoveryTokenPayload
+  keyId?: string
+  now?: Date | number
+}
+
+export type DecryptRecoveryEnvelopeOptions = {
+  cek: Uint8Array
+  userId: string
+  chatId: string
+  envelope: SyncedRecoveryEnvelope
+  keyId?: string
+  now?: Date | number
+}
+
+export type RewrapRecoveryEnvelopeOptions = {
+  envelope: SyncedRecoveryEnvelope
+  userId: string
+  chatId: string
+  oldCek: Uint8Array
+  newCek: Uint8Array
+  oldKeyId?: string
+  newKeyId?: string
+  now?: Date | number
+}
+
+function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  return bytes.buffer.slice(
+    bytes.byteOffset,
+    bytes.byteOffset + bytes.byteLength,
+  ) as ArrayBuffer
+}
+
+function validateRecoveryTokenFields(
+  value: unknown,
+): asserts value is RecoveryTokenFields {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error('chat recovery: recovery token must be an object')
+  }
+  const fields = value as Record<string, unknown>
+  const keys = Object.keys(fields)
+  if (
+    keys.length !== 2 ||
+    !keys.includes('exportedSecret') ||
+    !keys.includes('requestEnc')
+  ) {
+    throw new Error(
+      'chat recovery: recovery token must contain exactly exportedSecret and requestEnc',
+    )
+  }
+  requireRecoveryLowercaseHex(
+    fields.exportedSecret as string,
+    RECOVERY_TOKEN_HEX_LENGTH,
+    'recovery token exportedSecret',
+  )
+  requireRecoveryLowercaseHex(
+    fields.requestEnc as string,
+    RECOVERY_TOKEN_HEX_LENGTH,
+    'recovery token requestEnc',
+  )
+}
+
+function validateRecoveryToken(
+  token: unknown,
+): asserts token is RecoveryTokenPayload {
+  if (typeof token === 'string') {
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(token)
+    } catch {
+      throw new Error(
+        'chat recovery: serialized recovery token must be valid JSON',
+      )
+    }
+    validateRecoveryTokenFields(parsed)
+    return
+  }
+  validateRecoveryTokenFields(token)
+}
+
+function validatePayload(
+  value: unknown,
+): asserts value is RecoveryEnvelopePayload {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error('chat recovery: decrypted payload must be an object')
+  }
+  const payload = value as Record<string, unknown>
+  const keys = Object.keys(payload)
+  if (
+    keys.length !== 2 ||
+    !keys.includes('sessionId') ||
+    !keys.includes('recoveryToken')
+  ) {
+    throw new Error(
+      'chat recovery: decrypted payload must contain exactly sessionId and recoveryToken',
+    )
+  }
+  requireRecoveryLowercaseHex(
+    payload.sessionId as string,
+    SESSION_ID_HEX_LENGTH,
+    'sessionId',
+  )
+  validateRecoveryToken(payload.recoveryToken)
+}
+
+function aadBytes(
+  userId: string,
+  chatId: string,
+  envelope: Pick<
+    SyncedRecoveryEnvelope,
+    'v' | 'turnId' | 'keyId' | 'createdAt' | 'expiresAt'
+  >,
+): Uint8Array {
+  requireRecoveryId(userId, 'userId')
+  requireRecoveryId(chatId, 'chatId')
+  return textEncoder.encode(
+    JSON.stringify([
+      'tinfoil-chat-recovery-envelope-aad-v1',
+      userId,
+      chatId,
+      envelope.turnId,
+      envelope.keyId,
+      envelope.v,
+      envelope.createdAt,
+      envelope.expiresAt,
+    ]),
+  )
+}
+
+async function deriveEnvelopeKey(cek: Uint8Array): Promise<CryptoKey> {
+  if (cek.length !== CEK_BYTES) {
+    throw new Error(`chat recovery: CEK must be ${CEK_BYTES} bytes`)
+  }
+  const keyMaterial = await crypto.subtle.importKey(
+    'raw',
+    toArrayBuffer(cek),
+    HKDF,
+    false,
+    ['deriveKey'],
+  )
+  return crypto.subtle.deriveKey(
+    {
+      name: HKDF,
+      hash: SHA_256,
+      salt: new Uint8Array(0),
+      info: textEncoder.encode(RECOVERY_ENVELOPE_HKDF_INFO),
+    },
+    keyMaterial,
+    { name: AES_GCM, length: 256 },
+    false,
+    ['encrypt', 'decrypt'],
+  )
+}
+
+async function resolveKeyId(
+  cek: Uint8Array,
+  suppliedKeyId?: string,
+): Promise<string> {
+  const derivedKeyId = await deriveKeyIdHex(cek)
+  if (suppliedKeyId !== undefined) {
+    requireRecoveryLowercaseHex(suppliedKeyId, KEY_ID_HEX_LENGTH, 'keyId')
+    if (suppliedKeyId !== derivedKeyId) {
+      throw new Error('chat recovery: keyId does not match CEK')
+    }
+  }
+  return derivedKeyId
+}
+
+function nowMilliseconds(now?: Date | number): number {
+  const value = now instanceof Date ? now.getTime() : (now ?? Date.now())
+  if (!Number.isFinite(value)) {
+    throw new Error('chat recovery: now must be a valid timestamp')
+  }
+  return value
+}
+
+async function sealPayload(
+  payload: RecoveryEnvelopePayload,
+  cek: Uint8Array,
+  userId: string,
+  chatId: string,
+  metadata: Pick<
+    SyncedRecoveryEnvelope,
+    'v' | 'turnId' | 'keyId' | 'createdAt' | 'expiresAt'
+  >,
+): Promise<SyncedRecoveryEnvelope> {
+  validatePayload(payload)
+  const key = await deriveEnvelopeKey(cek)
+  const nonce = crypto.getRandomValues(new Uint8Array(NONCE_BYTES))
+  const ciphertext = await crypto.subtle.encrypt(
+    {
+      name: AES_GCM,
+      iv: toArrayBuffer(nonce),
+      additionalData: toArrayBuffer(aadBytes(userId, chatId, metadata)),
+      tagLength: AES_GCM_TAG_BYTES * 8,
+    },
+    key,
+    textEncoder.encode(JSON.stringify(payload)),
+  )
+  const envelope: SyncedRecoveryEnvelope = {
+    ...metadata,
+    nonce: uint8ArrayToBase64(nonce),
+    ciphertext: uint8ArrayToBase64(new Uint8Array(ciphertext)),
+  }
+  validateRecoveryEnvelope(envelope)
+  return envelope
+}
+
+export async function encryptRecoveryEnvelope(
+  options: EncryptRecoveryEnvelopeOptions,
+): Promise<SyncedRecoveryEnvelope> {
+  requireRecoveryId(options.turnId, 'turnId')
+  const keyId = await resolveKeyId(options.cek, options.keyId)
+  const createdAtMilliseconds = nowMilliseconds(options.now)
+  const metadata = {
+    v: RECOVERY_ENVELOPE_VERSION,
+    turnId: options.turnId,
+    keyId,
+    createdAt: new Date(createdAtMilliseconds).toISOString(),
+    expiresAt: new Date(
+      createdAtMilliseconds + RECOVERY_ENVELOPE_EXPIRY_MS,
+    ).toISOString(),
+  } as const
+
+  return sealPayload(
+    {
+      sessionId: options.sessionId,
+      recoveryToken: options.recoveryToken,
+    },
+    options.cek,
+    options.userId,
+    options.chatId,
+    metadata,
+  )
+}
+
+export async function decryptRecoveryEnvelope(
+  options: DecryptRecoveryEnvelopeOptions,
+): Promise<RecoveryEnvelopePayload> {
+  validateRecoveryEnvelope(options.envelope)
+  const keyId = await resolveKeyId(options.cek, options.keyId)
+  if (keyId !== options.envelope.keyId) {
+    throw new Error('chat recovery: envelope keyId does not match CEK')
+  }
+  if (nowMilliseconds(options.now) >= Date.parse(options.envelope.expiresAt)) {
+    throw new Error('chat recovery: envelope has expired')
+  }
+
+  const key = await deriveEnvelopeKey(options.cek)
+  const plaintext = await crypto.subtle.decrypt(
+    {
+      name: AES_GCM,
+      iv: toArrayBuffer(decodeRecoveryBase64(options.envelope.nonce, 'nonce')),
+      additionalData: toArrayBuffer(
+        aadBytes(options.userId, options.chatId, options.envelope),
+      ),
+      tagLength: AES_GCM_TAG_BYTES * 8,
+    },
+    key,
+    toArrayBuffer(
+      decodeRecoveryBase64(options.envelope.ciphertext, 'ciphertext'),
+    ),
+  )
+
+  let payload: unknown
+  try {
+    payload = JSON.parse(textDecoder.decode(plaintext))
+  } catch {
+    throw new Error('chat recovery: decrypted payload is invalid')
+  }
+  validatePayload(payload)
+  return payload
+}
+
+export async function rewrapRecoveryEnvelope(
+  options: RewrapRecoveryEnvelopeOptions,
+): Promise<SyncedRecoveryEnvelope> {
+  const payload = await decryptRecoveryEnvelope({
+    cek: options.oldCek,
+    keyId: options.oldKeyId,
+    userId: options.userId,
+    chatId: options.chatId,
+    envelope: options.envelope,
+    now: options.now,
+  })
+  const newKeyId = await resolveKeyId(options.newCek, options.newKeyId)
+  return sealPayload(payload, options.newCek, options.userId, options.chatId, {
+    v: RECOVERY_ENVELOPE_VERSION,
+    turnId: options.envelope.turnId,
+    keyId: newKeyId,
+    createdAt: options.envelope.createdAt,
+    expiresAt: options.envelope.expiresAt,
+  })
+}

--- a/src/services/inference/chat-recovery-drafts.ts
+++ b/src/services/inference/chat-recovery-drafts.ts
@@ -1,0 +1,118 @@
+import type { Message } from '@/components/chat/types'
+
+export type ChatRecoveryDraft = {
+  chatId: string
+  turnId: string
+  sessionId: string
+  message: Message
+}
+
+type Listener = () => void
+
+const drafts = new Map<string, ChatRecoveryDraft>()
+const activeTurns = new Set<string>()
+const listeners = new Set<Listener>()
+let snapshot: readonly ChatRecoveryDraft[] = []
+let activeSnapshot: readonly string[] = []
+
+function draftKey(chatId: string, turnId: string): string {
+  return `${chatId}\u0000${turnId}`
+}
+
+function publish(): void {
+  snapshot = [...drafts.values()]
+  activeSnapshot = [...activeTurns]
+  listeners.forEach((listener) => listener())
+}
+
+function subscribe(listener: Listener): () => void {
+  listeners.add(listener)
+  return () => listeners.delete(listener)
+}
+
+export function subscribeChatRecoveryDrafts(listener: Listener): () => void {
+  return subscribe(listener)
+}
+
+export function getChatRecoveryDraftSnapshot(): readonly ChatRecoveryDraft[] {
+  return snapshot
+}
+
+export function getChatRecoveryDraft(
+  chatId: string,
+  turnId: string,
+): ChatRecoveryDraft | undefined {
+  return drafts.get(draftKey(chatId, turnId))
+}
+
+export function getActiveChatRecoverySnapshot(): readonly string[] {
+  return activeSnapshot
+}
+
+export function isChatRecoveryActive(chatId: string): boolean {
+  const prefix = `${chatId}\u0000`
+  return [...activeTurns].some((key) => key.startsWith(prefix))
+}
+
+export function setChatRecoveryActive(
+  chatId: string,
+  turnId: string,
+  active: boolean,
+): void {
+  const key = draftKey(chatId, turnId)
+  const changed = active ? !activeTurns.has(key) : activeTurns.has(key)
+  if (!changed) return
+  if (active) {
+    activeTurns.add(key)
+  } else {
+    activeTurns.delete(key)
+  }
+  publish()
+}
+
+export function setChatRecoveryDraft(draft: ChatRecoveryDraft): void {
+  drafts.set(draftKey(draft.chatId, draft.turnId), draft)
+  publish()
+}
+
+export function clearChatRecoveryDraft(sessionId: string): void {
+  let changed = false
+  for (const [key, draft] of drafts) {
+    if (draft.sessionId === sessionId) {
+      drafts.delete(key)
+      changed = true
+    }
+  }
+  if (changed) {
+    publish()
+  }
+}
+
+export function pruneChatRecoveryDrafts(
+  pendingTurns: ReadonlySet<string>,
+): void {
+  let changed = false
+  for (const key of drafts.keys()) {
+    if (!pendingTurns.has(key)) {
+      drafts.delete(key)
+      changed = true
+    }
+  }
+  if (changed) {
+    publish()
+  }
+}
+
+export function clearChatRecoveryDrafts(): void {
+  if (drafts.size > 0) {
+    drafts.clear()
+    publish()
+  }
+}
+
+export function clearActiveChatRecoveries(): void {
+  if (activeTurns.size > 0) {
+    activeTurns.clear()
+    publish()
+  }
+}

--- a/src/services/inference/chat-recovery-sync.ts
+++ b/src/services/inference/chat-recovery-sync.ts
@@ -1,0 +1,433 @@
+import type { Message } from '@/components/chat/types'
+import { cloudStorage } from '@/services/cloud/cloud-storage'
+import { nextClock } from '@/services/cloud/edit-clock'
+import { remoteWins, trustedChatClock } from '@/services/cloud/sync-predicates'
+import { chatEvents } from '@/services/storage/chat-events'
+import {
+  indexedDBStorage,
+  type StoredChat,
+} from '@/services/storage/indexed-db'
+import { decideRecovery } from '@/services/sync-enclave'
+import { newIdempotencyKey } from '@/services/sync-enclave/sync-api'
+import {
+  isLocalRecoveryEnvelope,
+  MAX_PENDING_RECOVERIES_PER_CHAT,
+  samePendingRecoveryEnvelope,
+  type PendingRecoveryEnvelope,
+  type SyncedRecoveryEnvelope,
+} from '@/types/chat-recovery'
+import { isCloudSyncEnabled } from '@/utils/cloud-sync-settings'
+
+const RECOVERY_MUTATION_MAX_ATTEMPTS = 3
+
+type ChatMutation = (chat: StoredChat) => { chat: StoredChat; changed: boolean }
+
+const mutationTails = new Map<string, Promise<void>>()
+let mutationGeneration = 0
+
+function rejectWhenAborted<T>(
+  promise: Promise<T>,
+  signal?: AbortSignal,
+): Promise<T> {
+  if (!signal) return promise
+  return new Promise<T>((resolve, reject) => {
+    let settled = false
+    const onAbort = () => {
+      if (settled) return
+      settled = true
+      reject(new DOMException('Aborted', 'AbortError'))
+    }
+    signal.addEventListener('abort', onAbort, { once: true })
+    promise.then(
+      (value) => {
+        if (settled) return
+        settled = true
+        signal.removeEventListener('abort', onAbort)
+        resolve(value)
+      },
+      (error) => {
+        if (settled) return
+        settled = true
+        signal.removeEventListener('abort', onAbort)
+        reject(error)
+      },
+    )
+    if (signal.aborted) onAbort()
+  })
+}
+
+function enqueueMutation<T>(
+  chatId: string,
+  operation: () => Promise<T>,
+  signal?: AbortSignal,
+) {
+  const previous = mutationTails.get(chatId) ?? Promise.resolve()
+  const started = previous.then(operation)
+  const result = rejectWhenAborted(started, signal)
+  const settledResult = result.then(
+    () => undefined,
+    () => undefined,
+  )
+  const tail = Promise.all([previous, settledResult]).then(() => undefined)
+  mutationTails.set(chatId, tail)
+  void tail.then(() => {
+    if (mutationTails.get(chatId) === tail) {
+      mutationTails.delete(chatId)
+    }
+  })
+  return result
+}
+
+function isSyncConflict(error: unknown): boolean {
+  return decideRecovery(error).action.type === 'surface-conflict'
+}
+
+async function mutateSyncedChat(
+  chatId: string,
+  mutation: ChatMutation,
+  isCurrent: () => boolean = () => true,
+  signal?: AbortSignal,
+): Promise<StoredChat> {
+  const generation = mutationGeneration
+  const mutationIsCurrent = () =>
+    generation === mutationGeneration && isCurrent() && !signal?.aborted
+  const operation = async () => {
+    const initialLocal = await indexedDBStorage.getChat(chatId)
+    if (!mutationIsCurrent()) {
+      throw new DOMException('Aborted', 'AbortError')
+    }
+    const hasLocalRecovery = initialLocal?.pendingRecoveries?.some(
+      isLocalRecoveryEnvelope,
+    )
+    if (
+      initialLocal?.isLocalOnly ||
+      !isCloudSyncEnabled() ||
+      hasLocalRecovery
+    ) {
+      let changed = false
+      const local = await indexedDBStorage.mutateChat(chatId, (chat) => {
+        if (!mutationIsCurrent()) {
+          throw new DOMException('Aborted', 'AbortError')
+        }
+        const result = mutation(chat)
+        changed = result.changed
+        return result.changed
+          ? {
+              chat: {
+                ...result.chat,
+                updatedAt: new Date().toISOString(),
+              },
+              changed: true,
+            }
+          : result
+      })
+      if (!local) {
+        throw new Error('Chat recovery could not find the target chat')
+      }
+      if (!mutationIsCurrent()) {
+        throw new DOMException('Aborted', 'AbortError')
+      }
+      if (changed) {
+        chatEvents.emit({ reason: 'recovery', ids: [chatId] })
+      }
+      return local
+    }
+
+    for (let attempt = 0; attempt < RECOVERY_MUTATION_MAX_ATTEMPTS; attempt++) {
+      if (!mutationIsCurrent()) {
+        throw new DOMException('Aborted', 'AbortError')
+      }
+      const [remote, local] = await Promise.all([
+        cloudStorage.downloadChat(chatId),
+        indexedDBStorage.getChat(chatId),
+      ])
+      if (!mutationIsCurrent()) {
+        throw new DOMException('Aborted', 'AbortError')
+      }
+      let base = remote ?? local
+      if (!base) {
+        throw new Error('Chat recovery could not find the target chat')
+      }
+      if (
+        remote &&
+        local?.locallyModified &&
+        !remoteWins({
+          localClock: trustedChatClock(local),
+          remoteClock: trustedChatClock(remote),
+          localUpdatedAt: local.updatedAt,
+          remoteUpdatedAt: remote.updatedAt,
+        })
+      ) {
+        base = {
+          ...local,
+          syncVersion: remote.syncVersion,
+        }
+      }
+
+      const result = mutation(base)
+      if (!result.changed) {
+        if (remote && base === remote && local !== remote) {
+          const syncVersion = remote.syncVersion ?? 0
+          const applied = await indexedDBStorage.applyRemoteChatIfFresh({
+            chat: remote,
+            syncVersion,
+            expectedLocalUpdatedAt: local?.updatedAt ?? null,
+            allowLocallyModified: true,
+            isCurrent: mutationIsCurrent,
+          })
+          if (!applied.applied) {
+            continue
+          }
+          chatEvents.emit({ reason: 'recovery', ids: [chatId] })
+        }
+        return result.chat
+      }
+
+      const clock = nextClock(base.clock)
+      const nextChat: StoredChat = {
+        ...result.chat,
+        updatedAt: new Date().toISOString(),
+        clock: clock.v,
+        writer: clock.w,
+        clockVersion: (base.syncVersion ?? 0) + 1,
+        syncVersion: base.syncVersion ?? 0,
+      }
+
+      try {
+        if (!mutationIsCurrent()) {
+          throw new DOMException('Aborted', 'AbortError')
+        }
+        const uploaded = await cloudStorage.uploadChat(nextChat, {
+          idempotencyKey: newIdempotencyKey(),
+        })
+        if (!mutationIsCurrent()) {
+          throw new DOMException('Aborted', 'AbortError')
+        }
+        const syncVersion = uploaded.syncVersion ?? (base.syncVersion ?? 0) + 1
+        const syncedChat: StoredChat = {
+          ...nextChat,
+          syncVersion,
+          clockVersion: syncVersion,
+          syncedAt: Date.now(),
+          locallyModified: false,
+        }
+        const applied = await indexedDBStorage.applyRemoteChatIfFresh({
+          chat: syncedChat,
+          syncVersion,
+          expectedLocalUpdatedAt: local?.updatedAt ?? null,
+          allowLocallyModified: true,
+          isCurrent: mutationIsCurrent,
+        })
+        if (applied.applied) {
+          chatEvents.emit({ reason: 'recovery', ids: [chatId] })
+          return syncedChat
+        }
+        continue
+      } catch (error) {
+        if (!isSyncConflict(error)) {
+          throw error
+        }
+      }
+    }
+    throw new Error('Chat recovery could not resolve a sync conflict')
+  }
+  return enqueueMutation(chatId, operation, signal)
+}
+
+export function resetChatRecoverySyncState(): void {
+  mutationGeneration += 1
+  mutationTails.clear()
+}
+
+export function addPendingRecovery(
+  chatId: string,
+  envelope: PendingRecoveryEnvelope,
+): Promise<StoredChat> {
+  return mutateSyncedChat(chatId, (chat) => {
+    const existing = chat.pendingRecoveries ?? []
+    const now = Date.now()
+    const pending = existing.filter(
+      (candidate) =>
+        candidate.turnId !== envelope.turnId &&
+        Date.parse(candidate.expiresAt) > now,
+    )
+    if (pending.length >= MAX_PENDING_RECOVERIES_PER_CHAT) {
+      throw new Error('Chat has too many pending recovery sessions')
+    }
+    pending.push(envelope)
+    return {
+      chat: { ...chat, pendingRecoveries: pending },
+      changed: true,
+    }
+  })
+}
+
+export function replacePendingRecovery(
+  chatId: string,
+  current: SyncedRecoveryEnvelope,
+  replacement: SyncedRecoveryEnvelope,
+  isCurrent?: () => boolean,
+  signal?: AbortSignal,
+): Promise<StoredChat> {
+  return mutateSyncedChat(
+    chatId,
+    (chat) => {
+      const pending = chat.pendingRecoveries ?? []
+      const index = pending.findIndex((envelope) =>
+        samePendingRecoveryEnvelope(envelope, current),
+      )
+      if (index < 0) {
+        return { chat, changed: false }
+      }
+      const next = [...pending]
+      next[index] = replacement
+      return {
+        chat: { ...chat, pendingRecoveries: next },
+        changed: true,
+      }
+    },
+    isCurrent,
+    signal,
+  )
+}
+
+export function removePendingRecovery(
+  chatId: string,
+  expected: PendingRecoveryEnvelope,
+  isCurrent?: () => boolean,
+  signal?: AbortSignal,
+): Promise<StoredChat> {
+  return mutateSyncedChat(
+    chatId,
+    (chat) => {
+      const pending = chat.pendingRecoveries ?? []
+      const index = pending.findIndex((envelope) =>
+        samePendingRecoveryEnvelope(envelope, expected),
+      )
+      if (index < 0) {
+        return { chat, changed: false }
+      }
+      const next = [...pending]
+      next.splice(index, 1)
+      return {
+        chat: {
+          ...chat,
+          pendingRecoveries: next.length > 0 ? next : undefined,
+        },
+        changed: true,
+      }
+    },
+    isCurrent,
+    signal,
+  )
+}
+
+export function sameRecoveredResponse(
+  existing: Message,
+  recovered: Message,
+): boolean {
+  const snapshot = (message: Message) =>
+    JSON.stringify({
+      content: message.content,
+      thoughts: message.thoughts ?? null,
+      isThinking: message.isThinking ?? false,
+      thinkingDuration: message.thinkingDuration ?? null,
+      webSearch: message.webSearch ?? null,
+      urlFetches: message.urlFetches ?? null,
+      annotations: message.annotations ?? null,
+      timeline: message.timeline ?? null,
+      toolCalls: message.toolCalls ?? null,
+      codeExecCalls: message.codeExecCalls ?? null,
+      searchReasoning: message.searchReasoning ?? null,
+    })
+  return snapshot(existing) === snapshot(recovered)
+}
+
+export function completePendingRecovery(
+  chatId: string,
+  expected: PendingRecoveryEnvelope,
+  assistantMessage: Message,
+  chatPatch: Partial<
+    Pick<StoredChat, 'title' | 'titleState' | 'model' | 'projectId'>
+  > & { expectedTitleState?: StoredChat['titleState'] } = {},
+  isCurrent?: () => boolean,
+  signal?: AbortSignal,
+): Promise<StoredChat> {
+  return mutateSyncedChat(
+    chatId,
+    (chat) => {
+      const { expectedTitleState, ...patch } = chatPatch
+      if (
+        expectedTitleState !== undefined &&
+        chat.titleState !== expectedTitleState
+      ) {
+        delete patch.title
+        delete patch.titleState
+      }
+      const currentPending = chat.pendingRecoveries ?? []
+      const pendingIndex = currentPending.findIndex((envelope) =>
+        samePendingRecoveryEnvelope(envelope, expected),
+      )
+      const hasPending = pendingIndex >= 0
+      const pending = [...currentPending]
+      if (hasPending) pending.splice(pendingIndex, 1)
+      const turnId = expected.turnId
+      const assistantIndex = chat.messages.findIndex(
+        (message) => message.role === 'assistant' && message.turnId === turnId,
+      )
+      const hasAssistant = assistantIndex >= 0
+      if (!hasPending && !hasAssistant) {
+        return { chat, changed: false }
+      }
+      const recoveredMessage: Message = {
+        ...assistantMessage,
+        role: 'assistant',
+        turnId,
+      }
+      let messages = chat.messages
+      let messagesChanged = false
+      if (!hasAssistant) {
+        // Insert after the originating user turn, or append when the user
+        // message has not reached this copy of the chat yet. Throwing here
+        // would leave the envelope stuck in a permanent retry loop.
+        const userIndex = chat.messages.findIndex(
+          (message) => message.role === 'user' && message.turnId === turnId,
+        )
+        const insertAt = userIndex >= 0 ? userIndex + 1 : chat.messages.length
+        messages = [
+          ...chat.messages.slice(0, insertAt),
+          recoveredMessage,
+          ...chat.messages.slice(insertAt),
+        ]
+        messagesChanged = true
+      } else if (
+        hasPending &&
+        !sameRecoveredResponse(chat.messages[assistantIndex], recoveredMessage)
+      ) {
+        // An assistant message with this turnId may be a partial persisted
+        // before the stream was interrupted; the recovered response is the
+        // complete one, so it wins.
+        messages = [...chat.messages]
+        messages[assistantIndex] = recoveredMessage
+        messagesChanged = true
+      }
+      const patchChanged = Object.entries(patch).some(
+        ([key, value]) => chat[key as keyof StoredChat] !== value,
+      )
+      return {
+        chat: {
+          ...chat,
+          ...patch,
+          messages,
+          pendingRecoveries: pending.length > 0 ? pending : undefined,
+        },
+        changed:
+          messagesChanged ||
+          pending.length !== currentPending.length ||
+          patchChanged,
+      }
+    },
+    isCurrent,
+    signal,
+  )
+}

--- a/src/services/inference/chat-recovery-sync.ts
+++ b/src/services/inference/chat-recovery-sync.ts
@@ -245,11 +245,8 @@ export function addPendingRecovery(
 ): Promise<StoredChat> {
   return mutateSyncedChat(chatId, (chat) => {
     const existing = chat.pendingRecoveries ?? []
-    const now = Date.now()
     const pending = existing.filter(
-      (candidate) =>
-        candidate.turnId !== envelope.turnId &&
-        Date.parse(candidate.expiresAt) > now,
+      (candidate) => candidate.turnId !== envelope.turnId,
     )
     if (pending.length >= MAX_PENDING_RECOVERIES_PER_CHAT) {
       throw new Error('Chat has too many pending recovery sessions')

--- a/src/services/inference/chat-recovery.ts
+++ b/src/services/inference/chat-recovery.ts
@@ -1,0 +1,877 @@
+import { parseRichStreamingResponse } from '@/components/chat/hooks/streaming'
+import type { Message } from '@/components/chat/types'
+import { retryDeferredAlternativesFinalization } from '@/services/cloud/legacy-blob-migration'
+import { encryptionService } from '@/services/encryption/encryption-service'
+import { indexedDBStorage } from '@/services/storage/indexed-db'
+import {
+  RECOVERY_ENVELOPE_EXPIRY_MS,
+  isLocalRecoveryEnvelope,
+  samePendingRecoveryEnvelope,
+  type PendingRecoveryEnvelope,
+  type SyncedRecoveryEnvelope,
+} from '@/types/chat-recovery'
+import { isCloudSyncEnabled } from '@/utils/cloud-sync-settings'
+import { logError } from '@/utils/error-handling'
+import {
+  deserializeSessionRecoveryToken,
+  serializeSessionRecoveryToken,
+  type SessionRecoveryToken,
+} from 'tinfoil'
+import {
+  ChatRecoveryError,
+  deleteChatRecovery,
+  fetchRecoveredChatResponse,
+  getChatRecoveryStatus,
+} from './chat-recovery-client'
+import {
+  decryptRecoveryEnvelope,
+  encryptRecoveryEnvelope,
+  rewrapRecoveryEnvelope,
+} from './chat-recovery-crypto'
+import {
+  clearActiveChatRecoveries,
+  clearChatRecoveryDrafts,
+  getChatRecoveryDraft,
+  pruneChatRecoveryDrafts,
+  setChatRecoveryActive,
+  setChatRecoveryDraft,
+} from './chat-recovery-drafts'
+import {
+  addPendingRecovery,
+  completePendingRecovery,
+  removePendingRecovery,
+  replacePendingRecovery,
+  resetChatRecoverySyncState,
+  sameRecoveredResponse,
+} from './chat-recovery-sync'
+import { generateTitle, getTitleContent } from './title'
+
+type ActiveRecovery = {
+  chatId: string
+  turnId: string
+  sessionId: string
+  generation: number
+  envelope?: PendingRecoveryEnvelope
+}
+
+type ScannedRecovery = {
+  chatId: string
+  turnId: string
+  sessionId: string
+  generation: number
+  envelope: PendingRecoveryEnvelope
+  controller: AbortController
+}
+
+const activeRecoveries = new Map<string, ActiveRecovery>()
+const scannedRecoveries = new Map<string, ScannedRecovery>()
+const cancelledTurns = new Set<string>()
+const RECOVERY_SCAN_CONCURRENCY = 4
+const RECOVERY_RETRY_BASE_DELAY_MS = 100
+const RECOVERY_RETRY_MAX_DELAY_MS = 10_000
+// Upper bound on how long a scan may make no progress while holding the
+// dedupe slot. A stream wedged on a dead socket (e.g. after laptop sleep)
+// would otherwise absorb every future scan and silently disable recovery
+// for the rest of the session.
+const RECOVERY_SCAN_MAX_AGE_MS = 120_000
+let recoveryGeneration = 0
+let recoveryScanGeneration = 0
+let queuedScanUserId: string | null = null
+let scanInFlight: {
+  userId: string
+  promise: Promise<void>
+  lastProgressAt: number
+  controller: AbortController
+} | null = null
+
+function turnKey(chatId: string, turnId: string): string {
+  return `${chatId}\u0000${turnId}`
+}
+
+function hasVisibleRecoveryDraft(message: Message): boolean {
+  return Boolean(
+    message.content ||
+    message.thoughts ||
+    message.isThinking ||
+    message.timeline?.length ||
+    message.urlFetches?.length ||
+    message.webSearch ||
+    message.toolCalls?.length ||
+    message.codeExecCalls?.length,
+  )
+}
+
+async function recoveredTitlePatch(
+  chatId: string,
+  turnId: string,
+  isCurrent: () => boolean,
+): Promise<
+  | {
+      title: string
+      titleState: 'generated'
+      expectedTitleState: 'placeholder'
+    }
+  | undefined
+> {
+  const chat = await indexedDBStorage.getChat(chatId)
+  if (!isCurrent() || chat?.titleState !== 'placeholder') return
+
+  const firstUserMessage = chat.messages.find(
+    (message) => message.role === 'user',
+  )
+  if (!firstUserMessage || firstUserMessage.turnId !== turnId) return
+
+  const content = getTitleContent(firstUserMessage)
+  const title = await generateTitle([{ role: 'user', content }])
+  if (!isCurrent() || title === 'Untitled') return
+  return {
+    title,
+    titleState: 'generated',
+    expectedTitleState: 'placeholder',
+  }
+}
+
+function waitForRecoveryRetry(
+  attempt: number,
+  signal: AbortSignal,
+): Promise<void> {
+  const delay = Math.min(
+    RECOVERY_RETRY_BASE_DELAY_MS * 2 ** attempt,
+    RECOVERY_RETRY_MAX_DELAY_MS,
+  )
+  return new Promise((resolve, reject) => {
+    const onAbort = () => {
+      window.clearTimeout(timer)
+      reject(signal.reason ?? new DOMException('Aborted', 'AbortError'))
+    }
+    const timer = window.setTimeout(() => {
+      signal.removeEventListener('abort', onAbort)
+      resolve()
+    }, delay)
+    signal.addEventListener('abort', onAbort, { once: true })
+  })
+}
+
+function recoveryTokenFromPayload(
+  payload: string | { exportedSecret: string; requestEnc: string },
+): SessionRecoveryToken {
+  return deserializeSessionRecoveryToken(
+    typeof payload === 'string' ? payload : JSON.stringify(payload),
+  )
+}
+
+function candidateCEKs(): Uint8Array[] {
+  const candidates: Uint8Array[] = [encryptionService.getKeyBytesOrThrow()]
+  for (const alternative of encryptionService.getStoredAlternatives()) {
+    const bytes = encryptionService.getAlternativeKeyBytes(alternative)
+    if (bytes) candidates.push(bytes)
+  }
+  return candidates
+}
+
+async function openEnvelope(
+  userId: string,
+  chatId: string,
+  envelope: PendingRecoveryEnvelope,
+  now?: number,
+) {
+  if (isLocalRecoveryEnvelope(envelope)) {
+    return {
+      cek: null,
+      payload: {
+        sessionId: envelope.sessionId,
+        recoveryToken: envelope.recoveryToken,
+      },
+      usesPrimary: true,
+    }
+  }
+  let lastError: unknown
+  const candidates = candidateCEKs()
+  for (let index = 0; index < candidates.length; index++) {
+    const cek = candidates[index]
+    try {
+      const payload = await decryptRecoveryEnvelope({
+        cek,
+        userId,
+        chatId,
+        envelope,
+        now,
+      })
+      return { cek, payload, usesPrimary: index === 0 }
+    } catch (error) {
+      lastError = error
+    }
+  }
+  throw lastError ?? new Error('Unable to decrypt chat recovery envelope')
+}
+
+function isSyncedRecoveryEnvelope(
+  envelope: PendingRecoveryEnvelope,
+): envelope is SyncedRecoveryEnvelope {
+  return !isLocalRecoveryEnvelope(envelope)
+}
+
+async function deleteRecoveryQuietly(sessionId: string): Promise<void> {
+  try {
+    await deleteChatRecovery(sessionId)
+  } catch (error) {
+    logError('Failed to delete encrypted response recovery session', error, {
+      component: 'chat-recovery',
+      action: 'deleteRecovery',
+    })
+  }
+}
+
+export function startChatRecoveryAttempt(
+  chatId: string,
+  turnId: string,
+  sessionId: string,
+): void {
+  activeRecoveries.set(sessionId, {
+    chatId,
+    turnId,
+    sessionId,
+    generation: recoveryGeneration,
+  })
+}
+
+export async function persistChatRecoveryToken(args: {
+  userId: string
+  chatId: string
+  turnId: string
+  sessionId: string
+  token: SessionRecoveryToken
+}): Promise<void> {
+  const key = turnKey(args.chatId, args.turnId)
+  const active = activeRecoveries.get(args.sessionId)
+  const isCurrentAttempt = () =>
+    active?.generation === recoveryGeneration &&
+    active.chatId === args.chatId &&
+    active.turnId === args.turnId &&
+    activeRecoveries.get(args.sessionId) === active
+  if (!active || !isCurrentAttempt() || cancelledTurns.has(key)) {
+    await deleteRecoveryQuietly(args.sessionId)
+    throw new DOMException('Aborted', 'AbortError')
+  }
+
+  const recoveryToken = serializeSessionRecoveryToken(args.token)
+  const chat = await indexedDBStorage.getChat(args.chatId)
+  if (!chat) {
+    await deleteRecoveryQuietly(args.sessionId)
+    throw new Error('Chat recovery could not find the target chat')
+  }
+  const localOnly = chat.isLocalOnly || !isCloudSyncEnabled()
+  const now = new Date()
+  const envelope: PendingRecoveryEnvelope = localOnly
+    ? {
+        v: 1,
+        storage: 'local',
+        turnId: args.turnId,
+        createdAt: now.toISOString(),
+        expiresAt: new Date(
+          now.getTime() + RECOVERY_ENVELOPE_EXPIRY_MS,
+        ).toISOString(),
+        sessionId: args.sessionId,
+        recoveryToken,
+      }
+    : await encryptRecoveryEnvelope({
+        cek: encryptionService.getKeyBytesOrThrow(),
+        userId: args.userId,
+        chatId: args.chatId,
+        turnId: args.turnId,
+        sessionId: args.sessionId,
+        recoveryToken,
+      })
+  if (!isCurrentAttempt()) {
+    await deleteRecoveryQuietly(args.sessionId)
+    throw new DOMException('Aborted', 'AbortError')
+  }
+  await addPendingRecovery(args.chatId, envelope)
+
+  if (!isCurrentAttempt()) {
+    try {
+      await removePendingRecovery(args.chatId, envelope)
+    } finally {
+      await deleteRecoveryQuietly(args.sessionId)
+    }
+    throw new DOMException('Aborted', 'AbortError')
+  }
+  active.envelope = envelope
+  if (cancelledTurns.has(key)) {
+    await Promise.all([
+      removePendingRecovery(args.chatId, envelope, isCurrentAttempt),
+      deleteRecoveryQuietly(args.sessionId),
+    ])
+    throw new DOMException('Aborted', 'AbortError')
+  }
+}
+
+export async function abandonChatRecoveryAttempt(
+  sessionId: string,
+): Promise<void> {
+  const active = activeRecoveries.get(sessionId)
+  activeRecoveries.delete(sessionId)
+  try {
+    if (active) {
+      const isCurrent = () => active.generation === recoveryGeneration
+      if (isCurrent() && active.envelope) {
+        await removePendingRecovery(active.chatId, active.envelope, isCurrent)
+      }
+    }
+  } finally {
+    await deleteRecoveryQuietly(sessionId)
+  }
+}
+
+export async function completeLiveChatRecovery(args: {
+  chatId: string
+  turnId: string
+  assistantMessage: Message
+  chatPatch?: Parameters<typeof completePendingRecovery>[3]
+}): Promise<void> {
+  const active = [...activeRecoveries.values()].find(
+    (candidate) =>
+      candidate.chatId === args.chatId && candidate.turnId === args.turnId,
+  )
+  const isCurrent = () =>
+    active?.generation === recoveryGeneration &&
+    activeRecoveries.get(active.sessionId) === active
+  if (!active?.envelope || !isCurrent()) {
+    throw new DOMException('Aborted', 'AbortError')
+  }
+  await completePendingRecovery(
+    args.chatId,
+    active.envelope,
+    args.assistantMessage,
+    args.chatPatch,
+    isCurrent,
+  )
+  activeRecoveries.delete(active.sessionId)
+  await deleteRecoveryQuietly(active.sessionId)
+}
+
+export async function cancelChatRecovery(chatId: string): Promise<void> {
+  const active = [...activeRecoveries.values()].filter(
+    (candidate) => candidate.chatId === chatId,
+  )
+  const scanned = [...scannedRecoveries.values()].filter(
+    (candidate) => candidate.chatId === chatId,
+  )
+  for (const recovery of active) {
+    cancelledTurns.add(turnKey(recovery.chatId, recovery.turnId))
+    activeRecoveries.delete(recovery.sessionId)
+  }
+  for (const recovery of scanned) {
+    cancelledTurns.add(turnKey(recovery.chatId, recovery.turnId))
+    scannedRecoveries.delete(recovery.sessionId)
+    recovery.controller.abort()
+    setChatRecoveryActive(recovery.chatId, recovery.turnId, false)
+  }
+  const recoveries = [...active, ...scanned]
+  try {
+    await Promise.all(
+      recoveries.map((recovery) => {
+        const isCurrent = () => recovery.generation === recoveryGeneration
+        return isCurrent() && recovery.envelope
+          ? removePendingRecovery(recovery.chatId, recovery.envelope, isCurrent)
+          : undefined
+      }),
+    )
+  } finally {
+    await Promise.all(
+      recoveries.map((recovery) => deleteRecoveryQuietly(recovery.sessionId)),
+    )
+  }
+}
+
+export function releaseActiveChatRecovery(chatId: string): void {
+  for (const recovery of activeRecoveries.values()) {
+    if (recovery.chatId === chatId) {
+      activeRecoveries.delete(recovery.sessionId)
+    }
+  }
+}
+
+async function processEnvelope(
+  userId: string,
+  chatId: string,
+  envelope: PendingRecoveryEnvelope,
+  generation: number,
+  signal: AbortSignal,
+): Promise<void> {
+  const key = turnKey(chatId, envelope.turnId)
+  const isCurrent = () =>
+    generation === recoveryScanGeneration &&
+    !signal.aborted &&
+    !cancelledTurns.has(key)
+  if (!isCurrent()) return
+  if (
+    [...activeRecoveries.values()].some(
+      (active) => active.chatId === chatId && active.turnId === envelope.turnId,
+    )
+  ) {
+    return
+  }
+
+  if (Date.now() >= Date.parse(envelope.expiresAt)) {
+    let sessionId: string | undefined
+    try {
+      const opened = await openEnvelope(
+        userId,
+        chatId,
+        envelope,
+        Date.parse(envelope.expiresAt) - 1,
+      )
+      if (!isCurrent()) return
+      sessionId = opened.payload.sessionId
+    } catch (error) {
+      logError('Failed to clean up expired chat recovery session', error, {
+        component: 'chat-recovery',
+        action: 'cleanupExpiredRecovery',
+        metadata: { chatId },
+      })
+    }
+    if (!isCurrent()) return
+    try {
+      await removePendingRecovery(chatId, envelope, isCurrent, signal)
+    } finally {
+      if (sessionId) {
+        await deleteRecoveryQuietly(sessionId)
+      }
+    }
+    return
+  }
+
+  const opened = await openEnvelope(userId, chatId, envelope)
+  if (!isCurrent()) return
+  if (!opened.usesPrimary && isSyncedRecoveryEnvelope(envelope)) {
+    const rewrapped = await rewrapRecoveryEnvelope({
+      envelope,
+      userId,
+      chatId,
+      oldCek: opened.cek as Uint8Array,
+      newCek: encryptionService.getKeyBytesOrThrow(),
+    })
+    if (!isCurrent()) return
+    const rewrappedChat = await replacePendingRecovery(
+      chatId,
+      envelope,
+      rewrapped,
+      isCurrent,
+      signal,
+    )
+    if (!isCurrent()) return
+    if (
+      !rewrappedChat.pendingRecoveries?.some((candidate) =>
+        samePendingRecoveryEnvelope(candidate, rewrapped),
+      )
+    ) {
+      return
+    }
+    envelope = rewrapped
+  }
+  const payload = opened.payload
+  const initialStatus = await getChatRecoveryStatus(payload.sessionId)
+  if (!isCurrent()) return
+  const replacedRecoveryDeletions: Promise<void>[] = []
+  for (const [sessionId, retained] of scannedRecoveries) {
+    if (retained.chatId !== chatId || retained.turnId !== envelope.turnId) {
+      continue
+    }
+    if (
+      sessionId === payload.sessionId &&
+      (initialStatus.state === 'processing' ||
+        initialStatus.state === 'complete')
+    ) {
+      if (!retained.controller.signal.aborted) {
+        return
+      }
+      scannedRecoveries.delete(sessionId)
+      continue
+    }
+    scannedRecoveries.delete(sessionId)
+    retained.controller.abort()
+    setChatRecoveryActive(retained.chatId, retained.turnId, false)
+    if (sessionId !== payload.sessionId) {
+      replacedRecoveryDeletions.push(deleteRecoveryQuietly(sessionId))
+    }
+  }
+  if (initialStatus.state === 'failed') {
+    try {
+      await removePendingRecovery(chatId, envelope, isCurrent, signal)
+    } finally {
+      await Promise.all([
+        deleteRecoveryQuietly(payload.sessionId),
+        ...replacedRecoveryDeletions,
+      ])
+    }
+    return
+  }
+  if (initialStatus.state === 'missing') {
+    try {
+      await removePendingRecovery(chatId, envelope, isCurrent, signal)
+    } finally {
+      await Promise.all(replacedRecoveryDeletions)
+    }
+    return
+  }
+
+  const recoveryController = new AbortController()
+  const abortRecovery = () => recoveryController.abort(signal.reason)
+  const scannedRecovery: ScannedRecovery = {
+    chatId,
+    turnId: envelope.turnId,
+    sessionId: payload.sessionId,
+    generation: recoveryGeneration,
+    envelope,
+    controller: recoveryController,
+  }
+  signal.addEventListener('abort', abortRecovery, { once: true })
+  scannedRecoveries.set(payload.sessionId, scannedRecovery)
+  setChatRecoveryActive(chatId, envelope.turnId, true)
+  const recoverySignal = recoveryController.signal
+  const isRecoveryCurrent = () =>
+    isCurrent() &&
+    !recoverySignal.aborted &&
+    scannedRecoveries.get(payload.sessionId) === scannedRecovery
+  let highestEncryptedBytes = 0
+  let highestPersistedBytes = initialStatus.persistedBytes
+  const markRecoveryProgress = () => {
+    if (scanInFlight?.controller.signal === signal) {
+      scanInFlight.lastProgressAt = Date.now()
+    }
+  }
+  const observePersistedBytes = (bytes: number) => {
+    if (bytes <= highestPersistedBytes) return
+    highestPersistedBytes = bytes
+    markRecoveryProgress()
+  }
+  const publishDraft = (message: Message): Message | undefined => {
+    if (!isRecoveryCurrent() || !hasVisibleRecoveryDraft(message)) {
+      return undefined
+    }
+    const draftMessage: Message = {
+      ...message,
+      role: 'assistant',
+      turnId: envelope.turnId,
+    }
+    setChatRecoveryDraft({
+      chatId,
+      turnId: envelope.turnId,
+      sessionId: payload.sessionId,
+      message: draftMessage,
+    })
+    return draftMessage
+  }
+  try {
+    const recoveryDraft = getChatRecoveryDraft(chatId, envelope.turnId)
+    let presentationCheckpoint =
+      recoveryDraft?.sessionId === payload.sessionId
+        ? recoveryDraft.message
+        : undefined
+    if (!presentationCheckpoint) {
+      const storedChat = await indexedDBStorage.getChat(chatId)
+      if (!isRecoveryCurrent()) return
+      presentationCheckpoint = (storedChat?.messages ?? []).find(
+        (message) =>
+          message.role === 'assistant' && message.turnId === envelope.turnId,
+      )
+    }
+    let streamAttempt = 0
+    while (isRecoveryCurrent()) {
+      const attempt = streamAttempt++
+      let consumedEncryptedBytes = 0
+      let measuredEncryptedBytes = false
+      let assistantMessage: Message
+      const attemptCheckpoint = presentationCheckpoint
+      let checkpointReached = !attemptCheckpoint
+      try {
+        const response = await fetchRecoveredChatResponse(
+          payload.sessionId,
+          recoveryTokenFromPayload(payload.recoveryToken),
+          recoverySignal,
+          (bytes) => {
+            measuredEncryptedBytes = true
+            consumedEncryptedBytes += bytes
+            if (consumedEncryptedBytes > highestEncryptedBytes) {
+              highestEncryptedBytes = consumedEncryptedBytes
+              markRecoveryProgress()
+            }
+          },
+        )
+        if (!isRecoveryCurrent()) return
+        if (!response.ok) {
+          await response.arrayBuffer()
+          if (!isRecoveryCurrent()) return
+          try {
+            await removePendingRecovery(
+              chatId,
+              envelope,
+              isRecoveryCurrent,
+              recoverySignal,
+            )
+          } finally {
+            await deleteRecoveryQuietly(payload.sessionId)
+          }
+          return
+        }
+        assistantMessage = await parseRichStreamingResponse(response, {
+          onUpdate: (message) => {
+            if (!isRecoveryCurrent()) return
+            if (!checkpointReached && attemptCheckpoint) {
+              checkpointReached = sameRecoveredResponse(
+                attemptCheckpoint,
+                message,
+              )
+              return
+            }
+            const published = publishDraft(message)
+            if (
+              published &&
+              (!presentationCheckpoint ||
+                !sameRecoveredResponse(presentationCheckpoint, published))
+            ) {
+              presentationCheckpoint = published
+              markRecoveryProgress()
+            }
+          },
+        })
+      } catch {
+        if (!isRecoveryCurrent()) return
+        const retryStatus = await getChatRecoveryStatus(payload.sessionId)
+        if (!isRecoveryCurrent()) return
+        observePersistedBytes(retryStatus.persistedBytes)
+        if (retryStatus.state === 'failed') {
+          try {
+            await removePendingRecovery(
+              chatId,
+              envelope,
+              isRecoveryCurrent,
+              recoverySignal,
+            )
+          } finally {
+            await deleteRecoveryQuietly(payload.sessionId)
+          }
+          return
+        }
+        if (retryStatus.state === 'missing') {
+          await removePendingRecovery(
+            chatId,
+            envelope,
+            isRecoveryCurrent,
+            recoverySignal,
+          )
+          return
+        }
+        await waitForRecoveryRetry(attempt, recoverySignal)
+        continue
+      }
+      if (!isRecoveryCurrent()) return
+      const terminalStatus = await getChatRecoveryStatus(payload.sessionId)
+      if (!isRecoveryCurrent()) return
+      observePersistedBytes(terminalStatus.persistedBytes)
+      if (terminalStatus.state === 'processing') {
+        await waitForRecoveryRetry(attempt, recoverySignal)
+        continue
+      }
+      if (terminalStatus.state === 'failed') {
+        try {
+          await removePendingRecovery(
+            chatId,
+            envelope,
+            isRecoveryCurrent,
+            recoverySignal,
+          )
+        } finally {
+          await deleteRecoveryQuietly(payload.sessionId)
+        }
+        return
+      }
+      if (terminalStatus.state === 'missing') {
+        await removePendingRecovery(
+          chatId,
+          envelope,
+          isRecoveryCurrent,
+          recoverySignal,
+        )
+        return
+      }
+      if (
+        measuredEncryptedBytes &&
+        consumedEncryptedBytes < terminalStatus.persistedBytes
+      ) {
+        await waitForRecoveryRetry(attempt, recoverySignal)
+        continue
+      }
+      const titlePatch = await recoveredTitlePatch(
+        chatId,
+        envelope.turnId,
+        isRecoveryCurrent,
+      )
+      if (!isRecoveryCurrent()) return
+      await completePendingRecovery(
+        chatId,
+        envelope,
+        {
+          ...assistantMessage,
+          turnId: envelope.turnId,
+        },
+        titlePatch,
+        isRecoveryCurrent,
+        recoverySignal,
+      )
+      if (scannedRecoveries.get(payload.sessionId) === scannedRecovery) {
+        scannedRecoveries.delete(payload.sessionId)
+        setChatRecoveryActive(chatId, envelope.turnId, false)
+      }
+      await deleteRecoveryQuietly(payload.sessionId)
+      return
+    }
+  } finally {
+    signal.removeEventListener('abort', abortRecovery)
+    if (
+      scannedRecoveries.get(payload.sessionId) === scannedRecovery &&
+      isCurrent()
+    ) {
+      scannedRecoveries.delete(payload.sessionId)
+      setChatRecoveryActive(chatId, envelope.turnId, false)
+    }
+    await Promise.all(replacedRecoveryDeletions)
+  }
+}
+
+export function scanPendingChatRecoveries(
+  userId: string,
+  refreshPending = false,
+): Promise<void> {
+  if (
+    scanInFlight?.userId === userId &&
+    Date.now() - scanInFlight.lastProgressAt < RECOVERY_SCAN_MAX_AGE_MS
+  ) {
+    if (refreshPending) {
+      queuedScanUserId = userId
+    }
+    return scanInFlight.promise
+  }
+  queuedScanUserId = null
+  const generation = ++recoveryScanGeneration
+  scanInFlight?.controller.abort()
+  const controller = new AbortController()
+  const promise = (async () => {
+    try {
+      const chats = await indexedDBStorage.getAllChats()
+      if (generation !== recoveryScanGeneration) return
+      const pending = chats.flatMap((chat) =>
+        (chat.pendingRecoveries ?? []).map((envelope) => ({
+          chatId: chat.id,
+          envelope,
+        })),
+      )
+      const pendingTurnKeys = new Set(
+        pending.map((candidate) =>
+          turnKey(candidate.chatId, candidate.envelope.turnId),
+        ),
+      )
+      const orphanedRecoveryDeletions: Promise<void>[] = []
+      for (const [sessionId, retained] of scannedRecoveries) {
+        if (pendingTurnKeys.has(turnKey(retained.chatId, retained.turnId))) {
+          continue
+        }
+        scannedRecoveries.delete(sessionId)
+        retained.controller.abort()
+        setChatRecoveryActive(retained.chatId, retained.turnId, false)
+        orphanedRecoveryDeletions.push(deleteRecoveryQuietly(sessionId))
+      }
+      pruneChatRecoveryDrafts(pendingTurnKeys)
+      let nextIndex = 0
+      const worker = async () => {
+        while (
+          generation === recoveryScanGeneration &&
+          nextIndex < pending.length
+        ) {
+          const candidate = pending[nextIndex++]
+          try {
+            await processEnvelope(
+              userId,
+              candidate.chatId,
+              candidate.envelope,
+              generation,
+              controller.signal,
+            )
+          } catch (error) {
+            if (generation !== recoveryScanGeneration) return
+            if (
+              cancelledTurns.has(
+                turnKey(candidate.chatId, candidate.envelope.turnId),
+              ) ||
+              (error instanceof DOMException && error.name === 'AbortError')
+            ) {
+              continue
+            }
+            if (error instanceof ChatRecoveryError && !error.retryable) {
+              if (error.state === 'failed' || error.state === 'missing') {
+                await removePendingRecovery(
+                  candidate.chatId,
+                  candidate.envelope,
+                  () => generation === recoveryScanGeneration,
+                  controller.signal,
+                )
+              }
+              continue
+            }
+            logError('Failed to recover encrypted chat response', error, {
+              component: 'chat-recovery',
+              action: 'scan',
+              metadata: { chatId: candidate.chatId },
+            })
+          }
+        }
+      }
+      await Promise.all([
+        ...Array.from(
+          { length: Math.min(RECOVERY_SCAN_CONCURRENCY, pending.length) },
+          worker,
+        ),
+        ...orphanedRecoveryDeletions,
+      ])
+    } finally {
+      if (generation === recoveryScanGeneration) {
+        await retryDeferredAlternativesFinalization()
+      }
+    }
+  })()
+  scanInFlight = {
+    userId,
+    promise,
+    lastProgressAt: Date.now(),
+    controller,
+  }
+  const clear = () => {
+    if (scanInFlight?.promise === promise) {
+      scanInFlight = null
+      if (queuedScanUserId === userId) {
+        queuedScanUserId = null
+        void scanPendingChatRecoveries(userId, true)
+      }
+    }
+  }
+  void promise.then(clear, clear)
+  return promise
+}
+
+export function resetChatRecoveryState(): void {
+  recoveryGeneration += 1
+  recoveryScanGeneration += 1
+  scanInFlight?.controller.abort()
+  for (const recovery of scannedRecoveries.values()) {
+    recovery.controller.abort()
+  }
+  activeRecoveries.clear()
+  scannedRecoveries.clear()
+  cancelledTurns.clear()
+  clearChatRecoveryDrafts()
+  clearActiveChatRecoveries()
+  scanInFlight = null
+  queuedScanUserId = null
+  resetChatRecoverySyncState()
+}

--- a/src/services/inference/inference-client.ts
+++ b/src/services/inference/inference-client.ts
@@ -12,9 +12,20 @@ import type { BaseModel } from '@/config/models'
 import { AUTO_MODEL_OPTIONS_FIELD, AUTO_REQUEST_MODEL } from '@/config/models'
 import { shouldRetryTestFail } from '@/utils/dev-simulator'
 import { logError, logInfo } from '@/utils/error-handling'
-import { APIConnectionError, APIUserAbortError } from 'openai'
+import {
+  APIConnectionError,
+  APIUserAbortError,
+  AuthenticationError,
+} from 'openai'
+import type { SessionRecoveryToken } from 'tinfoil'
 import { ChatQueryBuilder } from './chat-query-builder'
-import { getTinfoilClient } from './tinfoil-client'
+import {
+  createRecoverableTinfoilClient,
+  createRecoverableTinfoilTransport,
+  getTinfoilClient,
+  resetTinfoilClient,
+  type RecoverableTinfoilTransport,
+} from './tinfoil-client'
 
 const CHAT_COMPLETIONS_ENDPOINT = '/v1/chat/completions'
 
@@ -120,6 +131,25 @@ function delay(ms: number): Promise<void> {
 // Statuses the OpenAI SDK itself treats as retryable (client shouldRetry):
 // request timeout, lock timeout, and rate limit. 5xx is handled as a range.
 const RETRYABLE_HTTP_STATUSES = new Set([408, 409, 429])
+const RECOVERY_SESSION_ID_BYTES = 16
+
+export function generateRecoverySessionId(): string {
+  const bytes = crypto.getRandomValues(
+    new Uint8Array(RECOVERY_SESSION_ID_BYTES),
+  )
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join(
+    '',
+  )
+}
+
+export interface ChatRecoveryCallbacks {
+  onAttemptStarted: (sessionId: string) => void
+  onTokenCaptured: (
+    sessionId: string,
+    token: SessionRecoveryToken,
+  ) => Promise<void>
+  onAttemptAbandoned: (sessionId: string) => Promise<void>
+}
 
 // Typed classification only — never inspect error message strings, which
 // vary across browsers, SDK versions, and locales.
@@ -188,6 +218,7 @@ export interface SendChatStreamParams {
   codeExecutionEncryptionKey?: string
   /** Per-chat hex token authenticating the code-exec container. */
   codeExecutionContainerAuthToken?: string
+  recovery?: ChatRecoveryCallbacks
 }
 
 export async function sendChatStream(
@@ -210,6 +241,7 @@ export async function sendChatStream(
     codeExecutionAccessToken,
     codeExecutionEncryptionKey,
     codeExecutionContainerAuthToken,
+    recovery,
   } = params
 
   const genUITools = genUIEnabled ? buildGenUIToolSchemas() : []
@@ -346,8 +378,10 @@ export async function sendChatStream(
 
   let lastError: unknown = null
   const maxRetries = CONSTANTS.MESSAGE_SEND_MAX_RETRIES
+  let recoverableTransport: RecoverableTinfoilTransport | null = null
 
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    let recoverySessionId: string | null = null
     if (signal.aborted) {
       throw new DOMException('Aborted', 'AbortError')
     }
@@ -421,7 +455,21 @@ export async function sendChatStream(
         }
       }
 
-      const client = await getTinfoilClient()
+      let client
+      if (recovery) {
+        recoverableTransport ??= await createRecoverableTinfoilTransport()
+        recoverySessionId = generateRecoverySessionId()
+        recovery.onAttemptStarted(recoverySessionId)
+        const recoverable = await createRecoverableTinfoilClient(
+          recoverableTransport,
+          recoverySessionId,
+          (token) =>
+            recovery.onTokenCaptured(recoverySessionId as string, token),
+        )
+        client = recoverable.client
+      } else {
+        client = await getTinfoilClient()
+      }
 
       const stream: any = await (client.chat.completions.create as Function)(
         requestBody,
@@ -456,6 +504,17 @@ export async function sendChatStream(
         headers: { 'Content-Type': 'text/event-stream' },
       })
     } catch (err: unknown) {
+      if (recoverySessionId && recovery) {
+        try {
+          await recovery.onAttemptAbandoned(recoverySessionId)
+        } catch (cleanupError) {
+          logError('Failed to abandon chat recovery attempt', cleanupError, {
+            component: 'inference-client',
+            action: 'sendChatStream.recoveryCleanup',
+            metadata: { sessionId: recoverySessionId },
+          })
+        }
+      }
       lastError = err
       const anyErr = err as any
 
@@ -469,7 +528,15 @@ export async function sendChatStream(
         throw err
       }
 
-      if (attempt < maxRetries && isRetryableError(err)) {
+      const refreshAuthentication =
+        recovery && err instanceof AuthenticationError
+      if (refreshAuthentication) {
+        resetTinfoilClient()
+      }
+      if (
+        attempt < maxRetries &&
+        (refreshAuthentication || isRetryableError(err))
+      ) {
         const backoffDelay =
           CONSTANTS.MESSAGE_SEND_RETRY_DELAY_MS * Math.pow(2, attempt)
 

--- a/src/services/inference/tinfoil-client.ts
+++ b/src/services/inference/tinfoil-client.ts
@@ -10,6 +10,7 @@ import OpenAI from 'openai'
 import {
   AuthenticationError,
   SecureClient,
+  type SessionRecoveryToken,
   type VerificationDocument,
 } from 'tinfoil'
 import { authTokenManager } from '../auth'
@@ -445,6 +446,81 @@ export async function getSecureFetch(): Promise<typeof fetch> {
     return fetch
   }
   return secureClient.fetch
+}
+
+export interface RecoverableTinfoilClient {
+  client: OpenAI
+  baseURL: string
+}
+
+export interface RecoverableTinfoilTransport {
+  secureClient: SecureClient
+  baseURL: string
+}
+
+export function isChatRecoveryAvailable(): boolean {
+  return !IS_DEV
+}
+
+function controlplaneBaseURL(): string {
+  const configured =
+    API_BASE_URL ||
+    (typeof window !== 'undefined' ? window.location.origin : null)
+  if (!configured) {
+    throw new Error('Controlplane base URL is unavailable')
+  }
+  const parsed = new URL(configured)
+  if (parsed.protocol !== 'https:' || !parsed.hostname) {
+    throw new Error('Controlplane base URL must use HTTPS')
+  }
+  return configured
+}
+
+export async function createRecoverableTinfoilTransport(): Promise<RecoverableTinfoilTransport> {
+  if (IS_DEV) {
+    throw new Error('Chat recovery is unavailable in local development')
+  }
+  const baseURL = new URL('/v1/', controlplaneBaseURL()).toString()
+  const dedicatedSecureClient = new SecureClient({ baseURL })
+  await dedicatedSecureClient.ready()
+  return { secureClient: dedicatedSecureClient, baseURL }
+}
+
+export async function createRecoverableTinfoilClient(
+  transport: RecoverableTinfoilTransport,
+  sessionId: string,
+  onTokenCaptured: (token: SessionRecoveryToken) => Promise<void>,
+): Promise<RecoverableTinfoilClient> {
+  if (IS_DEV) {
+    throw new Error('Chat recovery is unavailable in local development')
+  }
+
+  const sessionToken = await fetchSessionToken()
+  const recoverableFetch: typeof fetch = async (input, init) => {
+    const response = await transport.secureClient.fetch(input, init)
+    const token = await transport.secureClient.getSessionRecoveryToken()
+    await onTokenCaptured(token)
+    return response
+  }
+
+  return {
+    baseURL: transport.baseURL,
+    client: new OpenAI({
+      apiKey: sessionToken,
+      baseURL: transport.baseURL,
+      dangerouslyAllowBrowser: true,
+      maxRetries: 0,
+      defaultHeaders: {
+        [TINFOIL_EVENTS_HEADER]: `${TINFOIL_EVENTS_VALUE_WEB_SEARCH},${TINFOIL_EVENTS_VALUE_CODE_EXECUTION}`,
+        'X-Session-Id': sessionId,
+      },
+      fetch: recoverableFetch,
+    }),
+  }
+}
+
+export function getRecoveryBaseURL(): string {
+  return controlplaneBaseURL()
 }
 
 /**

--- a/src/services/inference/title.ts
+++ b/src/services/inference/title.ts
@@ -1,6 +1,25 @@
 import { CONSTANTS } from '@/components/chat/constants'
+import type { Message } from '@/components/chat/types'
 import { logError } from '@/utils/error-handling'
 import { summarize } from './summary-client'
+
+export function getTitleContent(
+  message: Pick<Message, 'content' | 'attachments'>,
+): string {
+  return (
+    message.content?.trim() ||
+    (message.attachments
+      ?.map(
+        (attachment) =>
+          attachment.textContent?.trim() ||
+          attachment.description?.trim() ||
+          attachment.fileName.trim(),
+      )
+      .filter(Boolean)
+      .join('\n') ??
+      '')
+  )
+}
 
 export async function generateTitle(
   messages: Array<{ role: string; content: string }>,

--- a/src/services/storage/chat-events.ts
+++ b/src/services/storage/chat-events.ts
@@ -1,6 +1,7 @@
 import { logError } from '@/utils/error-handling'
 
-export type ChatChangeReason = 'save' | 'delete' | 'sync' | 'pagination'
+export type ChatChangeReason =
+  'save' | 'delete' | 'sync' | 'pagination' | 'recovery'
 
 export interface ChatIdChange {
   from: string

--- a/src/services/storage/chat-storage.ts
+++ b/src/services/storage/chat-storage.ts
@@ -120,6 +120,15 @@ export class ChatStorageService {
     return await this.saveChat(chat, false)
   }
 
+  async saveChatAndWaitForSync(chat: Chat): Promise<Chat> {
+    const saved = await this.saveChat(chat, true)
+    if (saved.isBlankChat) {
+      return saved
+    }
+    await cloudSync.backupChatAndWait(saved.id)
+    return (await this.getChat(saved.id)) ?? saved
+  }
+
   async getChat(id: string): Promise<Chat | null> {
     await this.initialize()
 

--- a/src/services/storage/indexed-db.ts
+++ b/src/services/storage/indexed-db.ts
@@ -68,10 +68,12 @@ export function chatContentFingerprint(chat: {
   title?: string
   projectId?: string
   messages?: any[]
+  pendingRecoveries?: any[]
 }): string {
   const messages = (chat.messages || []).map((m) => ({
     role: m.role,
     content: m.content,
+    turnId: m.turnId,
     thoughts: m.thoughts,
     isThinking: m.isThinking,
     thinkingDuration: m.thinkingDuration,
@@ -111,6 +113,7 @@ export function chatContentFingerprint(chat: {
     title: chat.title ?? '',
     projectId: chat.projectId ?? null,
     messages,
+    pendingRecoveries: chat.pendingRecoveries ?? [],
   })
 }
 
@@ -249,6 +252,64 @@ export class IndexedDBStorage {
     )
   }
 
+  async mutateChat(
+    chatId: string,
+    mutation: (chat: StoredChat) => {
+      chat: StoredChat
+      changed: boolean
+    },
+  ): Promise<StoredChat | null> {
+    return this.enqueueSave('mutateChat', async () => {
+      const db = await this.ensureDB()
+      return new Promise<StoredChat | null>((resolve, reject) => {
+        const transaction = db.transaction([CHATS_STORE], 'readwrite')
+        const store = transaction.objectStore(CHATS_STORE)
+        let output: StoredChat | null = null
+
+        transaction.oncomplete = () => resolve(output)
+        transaction.onerror = () => reject(new Error('Failed to mutate chat'))
+        transaction.onabort = () =>
+          reject(new Error('Chat mutation transaction aborted'))
+
+        const request = store.get(chatId)
+        request.onerror = () => reject(new Error('Failed to read chat'))
+        request.onsuccess = () => {
+          const current = request.result as StoredChat | undefined
+          if (!current) return
+
+          const result = mutation(current)
+          if (!result.changed) {
+            output = result.chat
+            return
+          }
+
+          const clock = nextClock(current.clock)
+          output = {
+            ...result.chat,
+            messages: result.chat.messages.map((message) => ({
+              ...message,
+              timestamp:
+                message.timestamp instanceof Date
+                  ? message.timestamp.toISOString()
+                  : message.timestamp,
+            })) as any,
+            lastAccessedAt: Date.now(),
+            clock: clock.v,
+            writer: clock.w,
+            locallyModified: computeLocallyModified({
+              isFailedDecryption: current.decryptionFailed === true,
+              existingChat: current,
+              hasContentChanges: true,
+              callerValue: result.chat.locallyModified,
+            }),
+            version: 1,
+          }
+          store.put(output)
+        }
+      })
+    })
+  }
+
   private async saveChatInternal(
     chat: Chat,
     options: {
@@ -324,11 +385,13 @@ export class IndexedDBStorage {
               title: existingChat.title,
               projectId: existingChat.projectId,
               messages: existingChat.messages,
+              pendingRecoveries: existingChat.pendingRecoveries,
             }) !==
             chatContentFingerprint({
               title: chat.title,
               projectId: (chat as StoredChat).projectId,
               messages: messagesForStorage,
+              pendingRecoveries: (chat as StoredChat).pendingRecoveries,
             })
           : false
 
@@ -627,6 +690,76 @@ export class IndexedDBStorage {
       }
 
       request.onerror = () => reject(new Error('Failed to count chats'))
+    })
+  }
+
+  async hasPendingChatRecoveries(): Promise<boolean> {
+    await this.saveQueue.catch(() => {})
+    const db = await this.ensureDB()
+
+    return new Promise((resolve, reject) => {
+      const transaction = db.transaction([CHATS_STORE], 'readonly')
+      const store = transaction.objectStore(CHATS_STORE)
+      const request = store.openCursor()
+
+      request.onsuccess = (event) => {
+        const cursor = (event.target as IDBRequest<IDBCursorWithValue | null>)
+          .result
+        if (!cursor) {
+          resolve(false)
+          return
+        }
+        const chat = cursor.value as StoredChat
+        if ((chat.pendingRecoveries?.length ?? 0) > 0) {
+          resolve(true)
+          return
+        }
+        cursor.continue()
+      }
+
+      request.onerror = () =>
+        reject(new Error('Failed to inspect pending chat recoveries'))
+    })
+  }
+
+  async isChatHistoryAuthoritative(
+    expectedCloudVersions: ReadonlyMap<string, number>,
+  ): Promise<boolean> {
+    await this.saveQueue.catch(() => {})
+    const db = await this.ensureDB()
+
+    return new Promise((resolve, reject) => {
+      const transaction = db.transaction([CHATS_STORE], 'readonly')
+      const store = transaction.objectStore(CHATS_STORE)
+      const request = store.openCursor()
+      const missingCloudVersions = new Map(expectedCloudVersions)
+
+      request.onsuccess = (event) => {
+        const cursor = (event.target as IDBRequest<IDBCursorWithValue | null>)
+          .result
+        if (!cursor) {
+          resolve(missingCloudVersions.size === 0)
+          return
+        }
+        const chat = cursor.value as StoredChat
+        if (!chat.isLocalOnly) {
+          const expectedVersion = missingCloudVersions.get(chat.id)
+          if (
+            chat.locallyModified ||
+            chat.decryptionFailed ||
+            expectedVersion === undefined ||
+            chat.syncVersion !== expectedVersion
+          ) {
+            resolve(false)
+            return
+          }
+          missingCloudVersions.delete(chat.id)
+        }
+        cursor.continue()
+      }
+
+      request.onerror = () =>
+        reject(new Error('Failed to verify local chat history'))
     })
   }
 

--- a/src/types/chat-recovery.ts
+++ b/src/types/chat-recovery.ts
@@ -1,0 +1,58 @@
+export const RECOVERY_ENVELOPE_EXPIRY_MS = 7 * 24 * 60 * 60 * 1000
+export const MAX_PENDING_RECOVERIES_PER_CHAT = 8
+export const MAX_RECOVERY_ID_LENGTH = 256
+export const MAX_RECOVERY_CIPHERTEXT_BYTES = 4096
+
+export type SyncedRecoveryEnvelope = {
+  v: 1
+  storage?: never
+  turnId: string
+  keyId: string
+  createdAt: string
+  expiresAt: string
+  nonce: string
+  ciphertext: string
+}
+
+export type LocalRecoveryEnvelope = {
+  v: 1
+  storage: 'local'
+  turnId: string
+  createdAt: string
+  expiresAt: string
+  sessionId: string
+  recoveryToken: string
+}
+
+export type PendingRecoveryEnvelope =
+  SyncedRecoveryEnvelope | LocalRecoveryEnvelope
+
+export function isLocalRecoveryEnvelope(
+  envelope: PendingRecoveryEnvelope,
+): envelope is LocalRecoveryEnvelope {
+  return envelope.storage === 'local'
+}
+
+export function samePendingRecoveryEnvelope(
+  left: PendingRecoveryEnvelope,
+  right: PendingRecoveryEnvelope,
+): boolean {
+  if (left.v !== right.v || left.turnId !== right.turnId) return false
+  if (isLocalRecoveryEnvelope(left) || isLocalRecoveryEnvelope(right)) {
+    return (
+      isLocalRecoveryEnvelope(left) &&
+      isLocalRecoveryEnvelope(right) &&
+      left.createdAt === right.createdAt &&
+      left.expiresAt === right.expiresAt &&
+      left.sessionId === right.sessionId &&
+      left.recoveryToken === right.recoveryToken
+    )
+  }
+  return (
+    left.keyId === right.keyId &&
+    left.createdAt === right.createdAt &&
+    left.expiresAt === right.expiresAt &&
+    left.nonce === right.nonce &&
+    left.ciphertext === right.ciphertext
+  )
+}

--- a/src/utils/chat-recovery-envelope.ts
+++ b/src/utils/chat-recovery-envelope.ts
@@ -1,0 +1,111 @@
+import {
+  MAX_RECOVERY_CIPHERTEXT_BYTES,
+  MAX_RECOVERY_ID_LENGTH,
+  RECOVERY_ENVELOPE_EXPIRY_MS,
+  type SyncedRecoveryEnvelope,
+} from '@/types/chat-recovery'
+import { base64ToUint8Array } from './binary-codec'
+
+const AES_GCM_TAG_BYTES = 16
+const NONCE_BYTES = 12
+const NONCE_BASE64_LENGTH = 16
+const MAX_RECOVERY_CIPHERTEXT_BASE64_LENGTH =
+  Math.ceil(MAX_RECOVERY_CIPHERTEXT_BYTES / 3) * 4
+const RECOVERY_TIMESTAMP_PATTERN =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/
+
+export function requireRecoveryId(value: string, name: string): void {
+  if (
+    typeof value !== 'string' ||
+    value.length === 0 ||
+    value.trim().length === 0 ||
+    value.length > MAX_RECOVERY_ID_LENGTH
+  ) {
+    throw new Error(
+      `chat recovery: ${name} must be between 1 and ${MAX_RECOVERY_ID_LENGTH} characters`,
+    )
+  }
+}
+
+export function requireRecoveryLowercaseHex(
+  value: string,
+  length: number,
+  name: string,
+): void {
+  if (
+    typeof value !== 'string' ||
+    value.length !== length ||
+    !/^[0-9a-f]+$/.test(value)
+  ) {
+    throw new Error(
+      `chat recovery: ${name} must be ${length} lowercase hexadecimal characters`,
+    )
+  }
+}
+
+function requireTimestamp(value: string, name: string): number {
+  if (typeof value !== 'string' || !RECOVERY_TIMESTAMP_PATTERN.test(value)) {
+    throw new Error(`chat recovery: ${name} must be a timestamp`)
+  }
+  const timestamp = Date.parse(value)
+  if (!Number.isFinite(timestamp)) {
+    throw new Error(`chat recovery: ${name} must be a valid timestamp`)
+  }
+  return timestamp
+}
+
+export function decodeRecoveryBase64(
+  value: string,
+  name: string,
+  maxEncodedLength = MAX_RECOVERY_CIPHERTEXT_BASE64_LENGTH,
+): Uint8Array {
+  if (
+    typeof value !== 'string' ||
+    value.length === 0 ||
+    value.length > maxEncodedLength ||
+    !/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(
+      value,
+    )
+  ) {
+    throw new Error(`chat recovery: ${name} must be base64`)
+  }
+
+  try {
+    return base64ToUint8Array(value)
+  } catch {
+    throw new Error(`chat recovery: ${name} must be base64`)
+  }
+}
+
+export function validateRecoveryEnvelope(
+  envelope: SyncedRecoveryEnvelope,
+): void {
+  if (typeof envelope !== 'object' || envelope === null || envelope.v !== 1) {
+    throw new Error('chat recovery: envelope version must be 1')
+  }
+  requireRecoveryId(envelope.turnId, 'turnId')
+  requireRecoveryLowercaseHex(envelope.keyId, 32, 'keyId')
+
+  const createdAt = requireTimestamp(envelope.createdAt, 'createdAt')
+  const expiresAt = requireTimestamp(envelope.expiresAt, 'expiresAt')
+  const lifetime = expiresAt - createdAt
+  if (lifetime <= 0 || lifetime > RECOVERY_ENVELOPE_EXPIRY_MS) {
+    throw new Error('chat recovery: envelope lifetime is invalid')
+  }
+
+  const nonce = decodeRecoveryBase64(
+    envelope.nonce,
+    'nonce',
+    NONCE_BASE64_LENGTH,
+  )
+  if (nonce.length !== NONCE_BYTES) {
+    throw new Error(`chat recovery: nonce must decode to ${NONCE_BYTES} bytes`)
+  }
+  const ciphertext = decodeRecoveryBase64(envelope.ciphertext, 'ciphertext')
+  if (
+    ciphertext.length <= AES_GCM_TAG_BYTES ||
+    ciphertext.length > MAX_RECOVERY_CIPHERTEXT_BYTES
+  ) {
+    throw new Error('chat recovery: ciphertext length is invalid')
+  }
+}

--- a/src/utils/dev-simulator.ts
+++ b/src/utils/dev-simulator.ts
@@ -543,6 +543,7 @@ export async function* simulateStream(
   }
 
   // Send done signal
+  yield 'data: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}\n\n'
   yield 'data: [DONE]\n\n'
 }
 

--- a/src/utils/signout-cleanup.ts
+++ b/src/utils/signout-cleanup.ts
@@ -11,6 +11,7 @@ import { profileSync } from '@/services/cloud/profile-sync'
 import { invalidateProfileSyncGeneration } from '@/services/cloud/profile-sync-coordinator'
 import { resetSyncHealth } from '@/services/cloud/sync-health'
 import { encryptionService } from '@/services/encryption/encryption-service'
+import { resetChatRecoveryState } from '@/services/inference/chat-recovery'
 import { resetTinfoilClient } from '@/services/inference/tinfoil-client'
 import { projectEvents } from '@/services/project/project-events'
 import { deletedChatsTracker } from '@/services/storage/deleted-chats-tracker'
@@ -69,6 +70,7 @@ async function clearAllUserData(options: ClearUserDataOptions): Promise<void> {
 
   // Reset tinfoil client to clear cached API key
   resetTinfoilClient()
+  resetChatRecoveryState()
 
   // Drop the verified sync-enclave SecureClient so the next signed-in
   // user re-runs attestation from scratch.

--- a/tests/components/chat/chat-input-streaming.test.tsx
+++ b/tests/components/chat/chat-input-streaming.test.tsx
@@ -1,0 +1,48 @@
+import { ChatInput } from '@/components/chat/chat-input'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { createRef } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/components/project', () => ({
+  ProjectModeBanner: () => null,
+  useProject: () => ({
+    isProjectMode: false,
+    activeProject: null,
+    loadingProject: false,
+  }),
+}))
+
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}))
+
+vi.mock('@/components/chat/hooks/use-chat-font', () => ({
+  CHAT_FONT_CLASSES: { default: '' },
+  useChatFont: () => 'default',
+}))
+
+describe('ChatInput streaming action', () => {
+  it('shows Stop while a recovered response is streaming', () => {
+    const cancelGeneration = vi.fn()
+    render(
+      <ChatInput
+        input=""
+        setInput={vi.fn()}
+        handleSubmit={vi.fn()}
+        loadingState="streaming"
+        cancelGeneration={cancelGeneration}
+        inputRef={createRef<HTMLTextAreaElement>()}
+        handleInputFocus={vi.fn()}
+        inputMinHeight="40px"
+        isDarkMode
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Stop generation' }))
+
+    expect(cancelGeneration).toHaveBeenCalledOnce()
+    expect(
+      screen.queryByRole('button', { name: 'Send' }),
+    ).not.toBeInTheDocument()
+  })
+})

--- a/tests/components/chat/chat-messages-recovery.test.tsx
+++ b/tests/components/chat/chat-messages-recovery.test.tsx
@@ -1,0 +1,270 @@
+import { ChatMessages } from '@/components/chat/chat-messages'
+import { render, screen, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/config/models', () => ({
+  findSelectableModel: (_id: string, models: unknown[]) => models[0],
+}))
+
+vi.mock('@/components/chat/renderers/client', () => ({
+  getRendererRegistry: () => ({
+    getMessageRenderer: () => ({
+      render: ({
+        message,
+        isStreaming,
+        isLastMessage,
+        hideActions,
+      }: {
+        message: { role: string; turnId?: string; content?: string }
+        isStreaming?: boolean
+        isLastMessage?: boolean
+        hideActions?: boolean
+      }) => (
+        <div
+          data-testid={`message-${message.turnId}`}
+          data-streaming={isStreaming}
+          data-last={isLastMessage}
+          data-actions-hidden={hideActions}
+        >
+          {message.role}: {message.content}
+        </div>
+      ),
+    }),
+  }),
+}))
+
+vi.mock('@/components/chat/hooks/use-chat-font', () => ({
+  CHAT_FONT_CLASSES: { default: '' },
+  useChatFont: () => 'default',
+}))
+
+vi.mock('@/hooks/use-chat-print', () => ({
+  useChatPrint: () => undefined,
+}))
+
+vi.mock('@/utils/token-estimation', () => ({
+  findContextStartIndex: () => 0,
+  getContextTokenBudget: () => 1000,
+}))
+
+vi.mock('@/components/chat/PrintableChat', () => ({
+  PrintableChat: () => null,
+}))
+
+const recovery = {
+  v: 1 as const,
+  turnId: 'turn-1',
+  keyId: '0'.repeat(32),
+  createdAt: '2026-07-21T00:00:00.000Z',
+  expiresAt: '2026-07-22T00:00:00.000Z',
+  nonce: 'nonce',
+  ciphertext: 'ciphertext',
+}
+
+const messages = [
+  {
+    role: 'user' as const,
+    turnId: 'turn-1',
+    content: 'Question',
+    timestamp: new Date('2026-07-21T00:00:00.000Z'),
+  },
+]
+
+const baseProps = {
+  messages,
+  pendingRecoveries: [recovery],
+  isDarkMode: false,
+  chatId: 'chat-1',
+  models: [{ id: 'model-1', contextWindow: 1000 }] as any,
+  selectedModel: 'model-1',
+}
+
+describe('ChatMessages recovery indicator', () => {
+  it('renders the recovery widget immediately after its user turn', async () => {
+    render(<ChatMessages {...baseProps} />)
+
+    const userMessage = await screen.findByTestId('message-turn-1')
+    const indicator = screen.getByRole('status', {
+      name: /Recovering stream/,
+    })
+
+    expect(userMessage.nextElementSibling).toBe(indicator)
+    expect(screen.getByText('Recovering stream...')).toBeInTheDocument()
+    expect(
+      screen.queryByText('Catching up to the live response'),
+    ).not.toBeInTheDocument()
+    expect(indicator).toHaveClass('-mt-6')
+    expect(indicator.firstElementChild).not.toHaveClass('border')
+    expect(indicator.firstElementChild).not.toHaveClass('bg-surface-chat')
+  })
+
+  it('hides the widget for the actively streaming turn', async () => {
+    render(
+      <ChatMessages {...baseProps} isWaitingForResponse isStreamingResponse />,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('message-turn-1')).toBeInTheDocument()
+    })
+    expect(
+      screen.queryByRole('status', { name: /Recovering stream/ }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('ignores an active recovery after its pending envelope is removed', () => {
+    render(
+      <ChatMessages
+        {...baseProps}
+        pendingRecoveries={[]}
+        activeRecoveryTurnIds={['turn-1']}
+      />,
+    )
+
+    expect(screen.getByRole('log')).toHaveAttribute('aria-busy', 'false')
+    expect(
+      screen.queryByRole('status', { name: /Recovering stream/ }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('replaces the recovery widget with a progressive draft', async () => {
+    render(
+      <ChatMessages
+        {...baseProps}
+        recoveryDrafts={[
+          {
+            turnId: 'turn-1',
+            message: {
+              role: 'assistant',
+              turnId: 'turn-1',
+              content: 'Partial answer',
+              timestamp: new Date('2026-07-21T00:00:01.000Z'),
+            },
+          },
+        ]}
+      />,
+    )
+
+    const renderedMessages = await screen.findAllByTestId('message-turn-1')
+    expect(renderedMessages).toHaveLength(2)
+    expect(renderedMessages[0].nextElementSibling).toBe(renderedMessages[1])
+    expect(renderedMessages[1]).toHaveAttribute('data-streaming', 'true')
+    expect(renderedMessages[1]).toHaveAttribute('data-last', 'true')
+    expect(screen.getByText('assistant: Partial answer')).toBeInTheDocument()
+    expect(
+      screen.queryByRole('status', { name: /Recovering stream/ }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('renders the progressive draft while the recovered turn is active', async () => {
+    render(
+      <ChatMessages
+        {...baseProps}
+        isStreamingResponse
+        activeRecoveryTurnIds={['turn-1']}
+        recoveryDrafts={[
+          {
+            turnId: 'turn-1',
+            message: {
+              role: 'assistant',
+              turnId: 'turn-1',
+              content: 'Live recovered answer',
+              timestamp: new Date('2026-07-21T00:00:01.000Z'),
+            },
+          },
+        ]}
+      />,
+    )
+
+    expect(
+      await screen.findByText('assistant: Live recovered answer'),
+    ).toBeInTheDocument()
+  })
+
+  it('streams replayed events without a separate catch-up state', async () => {
+    render(
+      <ChatMessages
+        {...baseProps}
+        isStreamingResponse
+        activeRecoveryTurnIds={['turn-1']}
+        recoveryDrafts={[
+          {
+            turnId: 'turn-1',
+            message: {
+              role: 'assistant',
+              turnId: 'turn-1',
+              content: 'Recovered so far',
+              timestamp: new Date('2026-07-21T00:00:01.000Z'),
+            },
+          },
+        ]}
+      />,
+    )
+
+    const assistant = (await screen.findAllByTestId('message-turn-1'))[1]
+    expect(assistant).toHaveAttribute('data-streaming', 'true')
+    expect(assistant).toHaveAttribute('data-actions-hidden', 'false')
+    expect(
+      screen.queryByRole('status', { name: /Recovering stream/ }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('substitutes a progressive draft for a persisted partial response', async () => {
+    render(
+      <ChatMessages
+        {...baseProps}
+        messages={[
+          ...messages,
+          {
+            role: 'assistant',
+            turnId: 'turn-1',
+            content: 'Persisted partial',
+            timestamp: new Date('2026-07-21T00:00:01.000Z'),
+          },
+        ]}
+        recoveryDrafts={[
+          {
+            turnId: 'turn-1',
+            message: {
+              role: 'assistant',
+              turnId: 'turn-1',
+              content: 'New streamed partial',
+              timestamp: new Date('2026-07-21T00:00:02.000Z'),
+            },
+          },
+        ]}
+      />,
+    )
+
+    expect(await screen.findAllByTestId('message-turn-1')).toHaveLength(2)
+    expect(
+      screen.getByText('assistant: New streamed partial'),
+    ).toBeInTheDocument()
+    expect(screen.queryByText(/Persisted partial/)).not.toBeInTheDocument()
+    expect(screen.getAllByTestId('message-turn-1')[1]).toHaveAttribute(
+      'data-last',
+      'true',
+    )
+  })
+
+  it('keeps recovery status visible beside a persisted partial', async () => {
+    render(
+      <ChatMessages
+        {...baseProps}
+        messages={[
+          ...messages,
+          {
+            role: 'assistant',
+            turnId: 'turn-1',
+            content: 'Persisted partial',
+            timestamp: new Date('2026-07-21T00:00:01.000Z'),
+          },
+        ]}
+      />,
+    )
+
+    const assistant = screen.getAllByTestId('message-turn-1')[1]
+    expect(assistant.nextElementSibling).toBe(
+      screen.getByRole('status', { name: /Recovering stream/ }),
+    )
+  })
+})

--- a/tests/components/chat/streaming/rich-response-parser.test.ts
+++ b/tests/components/chat/streaming/rich-response-parser.test.ts
@@ -1,0 +1,353 @@
+import { parseRichStreamingResponse } from '@/components/chat/hooks/streaming'
+import { describe, expect, it } from 'vitest'
+
+function sseResponse(events: unknown[]): Response {
+  const body = [
+    ...events,
+    { choices: [{ index: 0, delta: {}, finish_reason: 'stop' }] },
+  ]
+    .map((event) => `data: ${JSON.stringify(event)}\n\n`)
+    .join('')
+  return new Response(`${body}data: [DONE]\n\n`, {
+    headers: { 'Content-Type': 'text/event-stream' },
+  })
+}
+
+describe('parseRichStreamingResponse', () => {
+  it('rejects a stream without an authenticated completion marker', async () => {
+    const response = new Response(
+      'data: {"choices":[{"delta":{"content":"partial"}}]}\n\ndata: [DONE]\n\n',
+    )
+
+    await expect(parseRichStreamingResponse(response)).rejects.toThrow(
+      'Chat response ended before its completion marker',
+    )
+  })
+
+  it('accepts a completion marker without relying on the SSE sentinel', async () => {
+    const response = new Response(
+      'data: {"choices":[{"delta":{"content":"complete"}}]}\n\n' +
+        'data: {"choices":[{"index":0,"delta":{},"finish_reason":"length"}]}\n\n',
+    )
+
+    await expect(parseRichStreamingResponse(response)).resolves.toMatchObject({
+      content: 'complete',
+    })
+  })
+
+  it('reconstructs reasoning, content, citations, and tool calls', async () => {
+    const message = await parseRichStreamingResponse(
+      sseResponse([
+        {
+          choices: [{ delta: { reasoning_content: 'Check sources. ' } }],
+        },
+        {
+          choices: [
+            {
+              delta: {
+                content: 'Final answer.',
+                annotations: [
+                  {
+                    type: 'url_citation',
+                    url_citation: {
+                      title: 'Example',
+                      url: 'https://example.com',
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+        {
+          choices: [
+            {
+              delta: {
+                tool_calls: [
+                  {
+                    index: 0,
+                    id: 'call-1',
+                    function: { name: 'render_card', arguments: '{"x":' },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+        {
+          choices: [
+            {
+              delta: {
+                tool_calls: [
+                  {
+                    index: 0,
+                    function: { arguments: '1}' },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ]),
+    )
+
+    expect(message.content).toBe('Final answer.')
+    expect(message.thoughts).toBe('Check sources.')
+    expect(message.thinkingDuration).toBeUndefined()
+    expect(message.annotations).toEqual([
+      {
+        type: 'url_citation',
+        url_citation: {
+          title: 'Example',
+          url: 'https://example.com',
+        },
+      },
+    ])
+    expect(message.toolCalls).toEqual([
+      { id: 'call-1', name: 'render_card', arguments: '{"x":1}' },
+    ])
+    expect(message.timeline?.map((block) => block.type)).toEqual([
+      'thinking',
+      'content',
+      'tool_call',
+    ])
+  })
+
+  it('preserves the query from a terminal-only web search event', async () => {
+    const message = await parseRichStreamingResponse(
+      sseResponse([
+        {
+          type: 'web_search_call',
+          id: 'search-1',
+          status: 'completed',
+          action: { query: 'actual query' },
+        },
+      ]),
+    )
+
+    expect(message.webSearch).toMatchObject({
+      query: 'actual query',
+      status: 'completed',
+    })
+  })
+
+  it('keeps separate terminal-only web searches distinct', async () => {
+    const message = await parseRichStreamingResponse(
+      sseResponse([
+        {
+          type: 'web_search_call',
+          id: 'search-1',
+          status: 'completed',
+          action: { query: 'first query' },
+        },
+        {
+          type: 'web_search_call',
+          id: 'search-2',
+          status: 'completed',
+          action: { query: 'second query' },
+        },
+      ]),
+    )
+
+    expect(
+      message.timeline
+        ?.filter((block) => block.type === 'web_search')
+        .map((block) => block.state.query),
+    ).toEqual(['first query', 'second query'])
+  })
+
+  it('matches interleaved web-search completions by event ID', async () => {
+    const message = await parseRichStreamingResponse(
+      sseResponse([
+        {
+          type: 'web_search_call',
+          id: 'search-1',
+          status: 'in_progress',
+          action: { query: 'first query' },
+        },
+        {
+          type: 'web_search_call',
+          id: 'search-2',
+          status: 'in_progress',
+          action: { query: 'second query' },
+        },
+        {
+          type: 'web_search_call',
+          id: 'search-1',
+          status: 'completed',
+        },
+      ]),
+    )
+
+    expect(
+      message.timeline
+        ?.filter((block) => block.type === 'web_search')
+        .map((block) => block.state),
+    ).toEqual([
+      expect.objectContaining({ query: 'first query', status: 'completed' }),
+      expect.objectContaining({ query: 'second query', status: 'searching' }),
+    ])
+  })
+
+  it('updates a blocked web search by event ID', async () => {
+    const message = await parseRichStreamingResponse(
+      sseResponse([
+        {
+          type: 'web_search_call',
+          id: 'search-1',
+          status: 'in_progress',
+          action: { query: 'blocked query' },
+        },
+        {
+          type: 'web_search_call',
+          id: 'search-1',
+          status: 'blocked',
+          reason: 'policy',
+        },
+      ]),
+    )
+
+    expect(
+      message.timeline?.filter((block) => block.type === 'web_search'),
+    ).toEqual([
+      expect.objectContaining({
+        state: {
+          query: 'blocked query',
+          status: 'blocked',
+          reason: 'policy',
+        },
+      }),
+    ])
+  })
+
+  it('matches an id-less blocked search by query', async () => {
+    const message = await parseRichStreamingResponse(
+      sseResponse([
+        {
+          type: 'web_search_call',
+          status: 'in_progress',
+          action: { query: 'first query' },
+        },
+        {
+          type: 'web_search_call',
+          status: 'in_progress',
+          action: { query: 'second query' },
+        },
+        {
+          type: 'web_search_call',
+          status: 'blocked',
+          action: { query: 'first query' },
+          reason: 'policy',
+        },
+      ]),
+    )
+
+    expect(
+      message.timeline
+        ?.filter((block) => block.type === 'web_search')
+        .map((block) => block.state),
+    ).toEqual([
+      {
+        query: 'first query',
+        status: 'blocked',
+        reason: 'policy',
+      },
+      {
+        query: 'second query',
+        status: 'searching',
+      },
+    ])
+  })
+
+  it('matches an identified terminal event to an id-less search start', async () => {
+    const message = await parseRichStreamingResponse(
+      sseResponse([
+        {
+          type: 'web_search_call',
+          status: 'in_progress',
+          action: { query: 'mixed identity query' },
+        },
+        {
+          type: 'web_search_call',
+          id: 'search-1',
+          status: 'completed',
+          action: { query: 'mixed identity query' },
+        },
+      ]),
+    )
+
+    expect(
+      message.timeline?.filter((block) => block.type === 'web_search'),
+    ).toEqual([
+      expect.objectContaining({
+        state: expect.objectContaining({
+          query: 'mixed identity query',
+          status: 'completed',
+        }),
+      }),
+    ])
+  })
+
+  it('does not match an identified terminal event to concurrent id-less searches', async () => {
+    const message = await parseRichStreamingResponse(
+      sseResponse([
+        {
+          type: 'web_search_call',
+          status: 'in_progress',
+          action: { query: 'first query' },
+        },
+        {
+          type: 'web_search_call',
+          status: 'in_progress',
+          action: { query: 'second query' },
+        },
+        {
+          type: 'web_search_call',
+          id: 'search-1',
+          status: 'completed',
+        },
+      ]),
+    )
+
+    expect(
+      message.timeline
+        ?.filter((block) => block.type === 'web_search')
+        .map((block) => block.state),
+    ).toEqual([
+      expect.objectContaining({ query: 'first query', status: 'searching' }),
+      expect.objectContaining({ query: 'second query', status: 'searching' }),
+      expect.objectContaining({ status: 'completed' }),
+    ])
+  })
+
+  it('ends thinking callbacks when the response stream fails', async () => {
+    const encoder = new TextEncoder()
+    let emitted = false
+    const response = new Response(
+      new ReadableStream({
+        pull(controller) {
+          if (!emitted) {
+            emitted = true
+            controller.enqueue(
+              encoder.encode(
+                `data: ${JSON.stringify({
+                  choices: [{ delta: { reasoning_content: 'thinking' } }],
+                })}\n\n`,
+              ),
+            )
+            return
+          }
+          controller.error(new Error('stream failed'))
+        },
+      }),
+    )
+    const thinkingChanges: boolean[] = []
+
+    await expect(
+      parseRichStreamingResponse(response, {
+        onThinkingChange: (thinking) => thinkingChanges.push(thinking),
+      }),
+    ).rejects.toThrow('stream failed')
+    expect(thinkingChanges).toEqual([true, false])
+  })
+})

--- a/tests/components/chat/use-chat-messaging.cancel-generation.test.tsx
+++ b/tests/components/chat/use-chat-messaging.cancel-generation.test.tsx
@@ -1,5 +1,10 @@
 import { useChatMessaging } from '@/components/chat/hooks/use-chat-messaging'
 import type { Chat } from '@/components/chat/types'
+import {
+  clearActiveChatRecoveries,
+  setChatRecoveryActive,
+} from '@/services/inference/chat-recovery-drafts'
+import { chatEvents } from '@/services/storage/chat-events'
 import { act, renderHook } from '@testing-library/react'
 import {
   type Dispatch,
@@ -15,11 +20,20 @@ const resetStatusMock = vi.fn()
 const moveStatusMock = vi.fn()
 const registerControllerMock = vi.fn()
 const clearControllerMock = vi.fn()
+const streamStatuses: Record<string, object> = {}
+const { authState, cloudSyncState, scanPendingChatRecoveriesMock } = vi.hoisted(
+  () => ({
+    authState: {
+      isSignedIn: false,
+      userId: undefined as string | undefined,
+    },
+    cloudSyncState: { enabled: true },
+    scanPendingChatRecoveriesMock: vi.fn(),
+  }),
+)
 
 vi.mock('@clerk/nextjs', () => ({
-  useAuth: () => ({
-    isSignedIn: false,
-  }),
+  useAuth: () => authState,
 }))
 
 vi.mock('@/components/project', () => ({
@@ -36,6 +50,30 @@ vi.mock('@/services/cloud/streaming-tracker', () => ({
   },
 }))
 
+vi.mock('@/services/inference/tinfoil-client', async () => {
+  const actual = await vi.importActual<
+    typeof import('@/services/inference/tinfoil-client')
+  >('@/services/inference/tinfoil-client')
+  return {
+    ...actual,
+    isChatRecoveryAvailable: () => true,
+  }
+})
+
+vi.mock('@/utils/cloud-sync-settings', () => ({
+  isCloudSyncEnabled: () => cloudSyncState.enabled,
+}))
+
+vi.mock('@/services/inference/chat-recovery', () => ({
+  abandonChatRecoveryAttempt: vi.fn(),
+  cancelChatRecovery: vi.fn(async () => undefined),
+  completeLiveChatRecovery: vi.fn(),
+  persistChatRecoveryToken: vi.fn(),
+  releaseActiveChatRecovery: vi.fn(),
+  scanPendingChatRecoveries: scanPendingChatRecoveriesMock,
+  startChatRecoveryAttempt: vi.fn(),
+}))
+
 vi.mock('@/components/chat/hooks/use-chat-streams', async () => {
   const actual = await vi.importActual<
     typeof import('@/components/chat/hooks/use-chat-streams')
@@ -44,7 +82,7 @@ vi.mock('@/components/chat/hooks/use-chat-streams', async () => {
   return {
     ...actual,
     useChatStreams: () => ({
-      statusByChat: {},
+      statusByChat: streamStatuses,
       patchStatus: patchStatusMock,
       resetStatus: resetStatusMock,
       moveStatus: moveStatusMock,
@@ -104,6 +142,13 @@ function useChatMessagingHarness({
 describe('useChatMessaging cancelGeneration', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    clearActiveChatRecoveries()
+    authState.isSignedIn = false
+    authState.userId = undefined
+    cloudSyncState.enabled = true
+    for (const chatId of Object.keys(streamStatuses)) {
+      delete streamStatuses[chatId]
+    }
   })
 
   it('targets the latest rendered chat during a chat switch', () => {
@@ -135,5 +180,200 @@ describe('useChatMessaging cancelGeneration', () => {
         isStreaming: false,
       }),
     )
+  })
+
+  it('exposes a resumed recovery as an active stream', () => {
+    const chat = createChat('chat-a')
+    streamStatuses['chat-a'] = {
+      loadingState: 'streaming',
+      retryInfo: null,
+      isThinking: false,
+      isWaitingForResponse: false,
+      isStreaming: true,
+      streamError: null,
+    }
+    const { result } = renderHook(useChatMessagingHarness, {
+      initialProps: {
+        currentChat: chat,
+        triggerCancelOnLayout: false,
+      },
+    })
+
+    act(() => {
+      setChatRecoveryActive('chat-a', 'turn-1', true)
+    })
+
+    expect(result.current.loadingState).toBe('loading')
+    expect(result.current.isStreaming).toBe(true)
+  })
+
+  it('does not start a new prompt while recovery is active', async () => {
+    const chat = createChat('chat-a')
+    const { result } = renderHook(useChatMessagingHarness, {
+      initialProps: {
+        currentChat: chat,
+        triggerCancelOnLayout: false,
+      },
+    })
+    act(() => {
+      setChatRecoveryActive('chat-a', 'turn-1', true)
+    })
+    resetStatusMock.mockClear()
+    registerControllerMock.mockClear()
+
+    await act(async () => {
+      await result.current.handleQuery('Another prompt')
+    })
+
+    expect(resetStatusMock).not.toHaveBeenCalled()
+    expect(registerControllerMock).not.toHaveBeenCalled()
+  })
+
+  it('keeps the Stop action active whenever the chat is streaming', () => {
+    const chat = createChat('chat-a')
+    streamStatuses['chat-a'] = {
+      loadingState: 'idle',
+      retryInfo: null,
+      isThinking: false,
+      isWaitingForResponse: false,
+      isStreaming: true,
+      streamError: null,
+    }
+
+    const { result } = renderHook(useChatMessagingHarness, {
+      initialProps: {
+        currentChat: chat,
+        triggerCancelOnLayout: false,
+      },
+    })
+
+    expect(result.current.loadingState).toBe('loading')
+    expect(result.current.isStreaming).toBe(true)
+  })
+
+  it('rescans pending recoveries when cloud sync downloads a chat', () => {
+    authState.isSignedIn = true
+    authState.userId = 'user-1'
+    const chat = createChat('chat-a')
+
+    const { unmount } = renderHook(() =>
+      useChatMessaging({
+        systemPrompt: '',
+        rules: '',
+        storeHistory: true,
+        models: [],
+        selectedModel: 'test-model',
+        chats: [chat],
+        currentChat: chat,
+        setChats: noopSetChats,
+        setCurrentChat: noopSetCurrentChat,
+        messagesEndRef,
+      }),
+    )
+    scanPendingChatRecoveriesMock.mockClear()
+
+    act(() => {
+      chatEvents.emit({ reason: 'sync', ids: ['chat-a'] })
+    })
+
+    expect(scanPendingChatRecoveriesMock).toHaveBeenCalledWith('user-1', false)
+    unmount()
+  })
+
+  it('rescans pending recoveries when the encryption key becomes available', () => {
+    authState.isSignedIn = true
+    authState.userId = 'user-1'
+    const chat = createChat('chat-a')
+    const { unmount } = renderHook(() =>
+      useChatMessaging({
+        systemPrompt: '',
+        rules: '',
+        storeHistory: true,
+        models: [],
+        selectedModel: 'test-model',
+        chats: [chat],
+        currentChat: chat,
+        setChats: noopSetChats,
+        setCurrentChat: noopSetCurrentChat,
+        messagesEndRef,
+      }),
+    )
+    scanPendingChatRecoveriesMock.mockClear()
+
+    act(() => {
+      window.dispatchEvent(new Event('encryptionKeyChanged'))
+    })
+
+    expect(scanPendingChatRecoveriesMock).toHaveBeenCalledWith('user-1', true)
+    unmount()
+  })
+
+  it('scans IndexedDB recoveries when cloud sync is disabled', () => {
+    authState.isSignedIn = true
+    authState.userId = 'user-1'
+    cloudSyncState.enabled = false
+    const chat = { ...createChat('chat-a'), isLocalOnly: true }
+
+    const { unmount } = renderHook(() =>
+      useChatMessaging({
+        systemPrompt: '',
+        rules: '',
+        storeHistory: true,
+        models: [],
+        selectedModel: 'test-model',
+        chats: [chat],
+        currentChat: chat,
+        setChats: noopSetChats,
+        setCurrentChat: noopSetCurrentChat,
+        messagesEndRef,
+      }),
+    )
+
+    expect(scanPendingChatRecoveriesMock).toHaveBeenCalledWith('user-1', false)
+    unmount()
+  })
+
+  it('scans a recovery loaded after the initial page scan', () => {
+    authState.isSignedIn = true
+    authState.userId = 'user-1'
+    const chat = createChat('chat-a')
+    const { rerender } = renderHook(
+      ({ currentChat }: { currentChat: Chat }) =>
+        useChatMessaging({
+          systemPrompt: '',
+          rules: '',
+          storeHistory: true,
+          models: [],
+          selectedModel: 'test-model',
+          chats: [currentChat],
+          currentChat,
+          setChats: noopSetChats,
+          setCurrentChat: noopSetCurrentChat,
+          messagesEndRef,
+        }),
+      {
+        initialProps: { currentChat: chat },
+      },
+    )
+    scanPendingChatRecoveriesMock.mockClear()
+
+    rerender({
+      currentChat: {
+        ...chat,
+        pendingRecoveries: [
+          {
+            v: 1,
+            storage: 'local',
+            turnId: 'turn-1',
+            createdAt: new Date().toISOString(),
+            expiresAt: new Date(Date.now() + 60_000).toISOString(),
+            sessionId: '0123456789abcdef0123456789abcdef',
+            recoveryToken: 'token',
+          },
+        ],
+      },
+    })
+
+    expect(scanPendingChatRecoveriesMock).toHaveBeenCalledWith('user-1', true)
   })
 })

--- a/tests/components/chat/use-chat-storage.reloadChats.test.tsx
+++ b/tests/components/chat/use-chat-storage.reloadChats.test.tsx
@@ -1,7 +1,22 @@
 import { useChatStorage } from '@/components/chat/hooks/use-chat-storage'
+import type { PendingRecoveryEnvelope } from '@/components/chat/types'
 import { chatEvents } from '@/services/storage/chat-events'
 import { act, renderHook, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  mockLoadChats,
+  mockIsStreaming,
+  mockDownloadChat,
+  mockLoadChatImages,
+  mockApplyRemoteChat,
+} = vi.hoisted(() => ({
+  mockLoadChats: vi.fn(),
+  mockIsStreaming: vi.fn(),
+  mockDownloadChat: vi.fn(),
+  mockLoadChatImages: vi.fn(),
+  mockApplyRemoteChat: vi.fn(),
+}))
 
 vi.mock('@clerk/nextjs', () => ({
   useAuth: () => ({
@@ -17,13 +32,51 @@ vi.mock('@/components/chat/hooks/chat-operations', async () => {
   >('@/components/chat/hooks/chat-operations')
   return {
     ...actual,
-    loadChats: vi.fn(async () => []),
+    loadChats: mockLoadChats,
   }
 })
+
+vi.mock('@/services/cloud/streaming-tracker', () => ({
+  streamingTracker: {
+    isStreaming: mockIsStreaming,
+  },
+}))
+
+vi.mock('@/services/cloud/cloud-storage', () => ({
+  cloudStorage: {
+    downloadChat: mockDownloadChat,
+    loadChatImages: mockLoadChatImages,
+  },
+}))
+
+vi.mock('@/services/storage/indexed-db', () => ({
+  indexedDBStorage: {
+    applyRemoteChatIfFresh: mockApplyRemoteChat,
+  },
+}))
+
+function createMockRecovery(
+  overrides: Partial<PendingRecoveryEnvelope> = {},
+): PendingRecoveryEnvelope {
+  return {
+    v: 1,
+    turnId: 'turn-1',
+    keyId: '0'.repeat(32),
+    createdAt: '2026-07-21T00:00:00.000Z',
+    expiresAt: '2026-07-22T00:00:00.000Z',
+    nonce: 'nonce',
+    ciphertext: 'ciphertext',
+    ...overrides,
+  }
+}
 
 describe('useChatStorage.reloadChats', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockLoadChats.mockResolvedValue([])
+    mockIsStreaming.mockReturnValue(false)
+    mockLoadChatImages.mockResolvedValue(new Map())
+    mockApplyRemoteChat.mockResolvedValue({ applied: true })
   })
 
   it('keeps a routed local new chat selected after loading storage', async () => {
@@ -142,5 +195,380 @@ describe('useChatStorage.reloadChats', () => {
     })
 
     expect(result.current.currentChat.id).toBe('server-def')
+  })
+
+  it('refreshes pending recoveries for the selected chat after sync', async () => {
+    const { result } = renderHook(() =>
+      useChatStorage({
+        storeHistory: true,
+      }),
+    )
+
+    await waitFor(() => {
+      expect(result.current.isInitialLoad).toBe(false)
+    })
+
+    const current = {
+      id: 'chat-1',
+      title: 'Recovery chat',
+      messages: [
+        {
+          role: 'user' as const,
+          content: 'Question',
+          turnId: 'turn-1',
+          timestamp: new Date(),
+        },
+      ],
+      createdAt: new Date(),
+      isBlankChat: false,
+      isLocalOnly: false,
+    }
+    const recovery = createMockRecovery()
+
+    await act(async () => {
+      result.current.setCurrentChat(current as any)
+    })
+    mockLoadChats.mockResolvedValue([
+      { ...current, pendingRecoveries: [recovery] },
+    ])
+
+    act(() => {
+      chatEvents.emit({ reason: 'sync', ids: ['chat-1'] })
+    })
+    await waitFor(() => {
+      expect(result.current.currentChat.pendingRecoveries).toEqual([recovery])
+    })
+  })
+
+  it('refreshes pending recoveries while the selected chat is switching', async () => {
+    const current = {
+      id: 'chat-1',
+      title: 'Recovery chat',
+      messages: [
+        {
+          role: 'user' as const,
+          content: 'Question',
+          turnId: 'turn-1',
+          timestamp: new Date(),
+        },
+      ],
+      createdAt: new Date(),
+      isBlankChat: false,
+      isLocalOnly: false,
+    }
+    const recovery = createMockRecovery()
+    const { result } = renderHook(() =>
+      useChatStorage({
+        storeHistory: true,
+      }),
+    )
+    await waitFor(() => {
+      expect(result.current.isInitialLoad).toBe(false)
+    })
+
+    await act(async () => {
+      await result.current.switchChat(current as any)
+    })
+    mockLoadChats.mockResolvedValue([
+      { ...current, pendingRecoveries: [recovery] },
+    ])
+    act(() => {
+      chatEvents.emit({ reason: 'sync', ids: ['chat-1'] })
+    })
+
+    await waitFor(() => {
+      expect(result.current.currentChat.pendingRecoveries).toEqual([recovery])
+    })
+  })
+
+  it('does not let an older sync reload clear recovery progress', async () => {
+    const current = {
+      id: 'chat-1',
+      title: 'Recovery chat',
+      messages: [
+        {
+          role: 'user' as const,
+          content: 'Question',
+          turnId: 'turn-1',
+          timestamp: new Date(),
+        },
+      ],
+      createdAt: new Date(),
+      isBlankChat: false,
+      isLocalOnly: false,
+    }
+    const recovery = createMockRecovery()
+    const { result } = renderHook(() =>
+      useChatStorage({
+        storeHistory: true,
+      }),
+    )
+    await waitFor(() => {
+      expect(result.current.isInitialLoad).toBe(false)
+    })
+
+    let finishOlderReload: ((chats: any[]) => void) | undefined
+    mockLoadChats
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          finishOlderReload = resolve
+        }),
+      )
+      .mockResolvedValueOnce([{ ...current, pendingRecoveries: [recovery] }])
+    await act(async () => {
+      result.current.setCurrentChat(current as any)
+    })
+    act(() => {
+      chatEvents.emit({ reason: 'sync', ids: ['chat-1'] })
+      chatEvents.emit({ reason: 'recovery', ids: ['chat-1'] })
+    })
+
+    await waitFor(() => {
+      expect(result.current.currentChat.pendingRecoveries).toEqual([recovery])
+    })
+    finishOlderReload?.([current])
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(result.current.currentChat.pendingRecoveries).toEqual([recovery])
+    expect(
+      result.current.chats.find((chat) => chat.id === 'chat-1')
+        ?.pendingRecoveries,
+    ).toEqual([recovery])
+  })
+
+  it('preserves pending recoveries when loading a chat from a URL', async () => {
+    const recovery = createMockRecovery()
+    mockDownloadChat.mockResolvedValue({
+      id: 'chat-1',
+      title: 'Recovery chat',
+      messages: [
+        {
+          role: 'user',
+          content: 'Question',
+          turnId: 'turn-1',
+          timestamp: new Date(),
+        },
+      ],
+      pendingRecoveries: [recovery],
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      lastAccessedAt: Date.now(),
+    })
+
+    const { result } = renderHook(() =>
+      useChatStorage({
+        storeHistory: true,
+        initialChatId: 'chat-1',
+      }),
+    )
+
+    await waitFor(() => {
+      expect(result.current.currentChat.id).toBe('chat-1')
+    })
+    expect(result.current.currentChat.pendingRecoveries).toEqual([recovery])
+    expect(mockApplyRemoteChat).toHaveBeenCalledWith({
+      chat: expect.objectContaining({
+        id: 'chat-1',
+        pendingRecoveries: [recovery],
+      }),
+      syncVersion: 1,
+      expectedLocalUpdatedAt: null,
+    })
+  })
+
+  it('keeps recovery updates when a sync reload supersedes them', async () => {
+    const { result } = renderHook(() =>
+      useChatStorage({
+        storeHistory: true,
+      }),
+    )
+
+    await waitFor(() => {
+      expect(result.current.isInitialLoad).toBe(false)
+    })
+
+    const userMessage = {
+      role: 'user' as const,
+      content: 'Question',
+      turnId: 'turn-1',
+      timestamp: new Date(),
+    }
+    const current = {
+      id: 'chat-1',
+      title: 'Recovery chat',
+      messages: [userMessage],
+      createdAt: new Date(),
+      isBlankChat: false,
+      isLocalOnly: false,
+    }
+    const recovery = createMockRecovery()
+    let finishOlderReload: ((chats: any[]) => void) | undefined
+    mockLoadChats
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          finishOlderReload = resolve
+        }),
+      )
+      .mockResolvedValueOnce([
+        {
+          ...current,
+          messages: [
+            userMessage,
+            {
+              role: 'assistant',
+              content: 'Recovered answer',
+              turnId: 'turn-1',
+              timestamp: new Date(),
+            },
+          ],
+        },
+      ])
+
+    await act(async () => {
+      result.current.setCurrentChat(current as any)
+    })
+    act(() => {
+      chatEvents.emit({ reason: 'recovery', ids: ['chat-1'] })
+      chatEvents.emit({ reason: 'sync', ids: ['chat-1'] })
+    })
+    await waitFor(() => {
+      expect(result.current.currentChat.messages).toHaveLength(2)
+    })
+
+    finishOlderReload?.([{ ...current, pendingRecoveries: [recovery] }])
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(result.current.currentChat.messages).toHaveLength(2)
+    expect(result.current.currentChat.pendingRecoveries).toBeUndefined()
+  })
+
+  it('adopts a recovered response delivered by a plain sync', async () => {
+    const recovery = createMockRecovery()
+    const userMessage = {
+      role: 'user' as const,
+      content: 'Question',
+      turnId: 'turn-1',
+      timestamp: new Date(),
+    }
+    const current = {
+      id: 'chat-1',
+      title: 'Recovery chat',
+      messages: [
+        userMessage,
+        {
+          role: 'assistant' as const,
+          content: 'Partial',
+          turnId: 'turn-1',
+          timestamp: new Date(),
+        },
+      ],
+      pendingRecoveries: [recovery],
+      createdAt: new Date(),
+      isBlankChat: false,
+      isLocalOnly: false,
+    }
+    mockLoadChats.mockResolvedValue([
+      {
+        ...current,
+        messages: [
+          userMessage,
+          {
+            role: 'assistant',
+            content: 'Recovered answer',
+            turnId: 'turn-1',
+            timestamp: new Date(),
+          },
+        ],
+        pendingRecoveries: undefined,
+      },
+    ])
+    const { result } = renderHook(() =>
+      useChatStorage({
+        storeHistory: true,
+      }),
+    )
+    await waitFor(() => {
+      expect(result.current.isInitialLoad).toBe(false)
+    })
+    await act(async () => {
+      result.current.setCurrentChat(current as any)
+    })
+
+    act(() => {
+      chatEvents.emit({ reason: 'sync', ids: ['chat-1'] })
+    })
+
+    await waitFor(() => {
+      expect(result.current.currentChat.messages[1].content).toBe(
+        'Recovered answer',
+      )
+    })
+    expect(result.current.currentChat.pendingRecoveries).toBeUndefined()
+  })
+
+  it('keeps a partial response when sync only removes its recovery', async () => {
+    const recovery = createMockRecovery()
+    const currentTimestamp = new Date('2026-07-21T00:00:00.000Z')
+    const current = {
+      id: 'chat-1',
+      title: 'Recovery chat',
+      messages: [
+        {
+          role: 'user' as const,
+          content: 'Question',
+          turnId: 'turn-1',
+          timestamp: new Date(),
+        },
+        {
+          role: 'assistant' as const,
+          content: 'Partial',
+          turnId: 'turn-1',
+          timestamp: currentTimestamp,
+        },
+      ],
+      pendingRecoveries: [recovery],
+      createdAt: new Date(),
+      isBlankChat: false,
+      isLocalOnly: false,
+    }
+    mockLoadChats.mockResolvedValue([
+      {
+        ...current,
+        messages: [
+          current.messages[0],
+          {
+            ...current.messages[1],
+            timestamp: new Date('2026-07-21T00:01:00.000Z'),
+          },
+        ],
+        pendingRecoveries: undefined,
+      },
+    ])
+    const { result } = renderHook(() =>
+      useChatStorage({
+        storeHistory: true,
+      }),
+    )
+    await waitFor(() => {
+      expect(result.current.isInitialLoad).toBe(false)
+    })
+    await act(async () => {
+      result.current.setCurrentChat(current as any)
+    })
+
+    act(() => {
+      chatEvents.emit({ reason: 'sync', ids: ['chat-1'] })
+    })
+
+    await waitFor(() => {
+      expect(result.current.currentChat.pendingRecoveries).toBeUndefined()
+    })
+    expect(result.current.currentChat.messages[1].timestamp).toBe(
+      currentTimestamp,
+    )
   })
 })

--- a/tests/components/chat/use-message-queue.concurrency.test.tsx
+++ b/tests/components/chat/use-message-queue.concurrency.test.tsx
@@ -307,6 +307,47 @@ describe('useMessageQueue concurrency', () => {
     )
   })
 
+  it('holds a queued message while recovery is active', async () => {
+    const handleQuery = vi.fn(() => Promise.resolve())
+    let recoveryActive = true
+
+    const { result, rerender } = renderHook(
+      ({ dispatchBlocked }) =>
+        useMessageQueue({
+          chatId: 'A',
+          loadingState: 'idle' as LoadingState,
+          handleQuery,
+          isRateLimited: () => false,
+          isDispatchBlocked: () => recoveryActive,
+          dispatchBlocked,
+        }),
+      { initialProps: { dispatchBlocked: true } },
+    )
+
+    act(() => {
+      result.current.submit({ text: 'q1' })
+    })
+    await flushMicrotasks()
+
+    expect(handleQuery).not.toHaveBeenCalled()
+    expect(
+      result.current.queuedMessages.map((message) => message.text),
+    ).toEqual(['q1'])
+
+    recoveryActive = false
+    rerender({ dispatchBlocked: false })
+    await flushMicrotasks()
+
+    expect(handleQuery).toHaveBeenCalledTimes(1)
+    expect(handleQuery).toHaveBeenLastCalledWith(
+      'q1',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+    )
+  })
+
   it('removes a specific queued message from the active chat', async () => {
     const handleQuery = vi.fn(() => new Promise<void>(() => {}))
 

--- a/tests/services/cloud/chat-codec.test.ts
+++ b/tests/services/cloud/chat-codec.test.ts
@@ -72,6 +72,33 @@ describe('Chat Codec - processRemoteChat', () => {
       expect(result.chat.syncVersion).toBe(5)
     })
 
+    it('does not trust a plaintext clock without a server row version', async () => {
+      const result = await processRemoteChat({
+        ...baseRemoteChat,
+        plaintext: basePlaintext({
+          clock: 7,
+          writer: 'device-a',
+          clockVersion: 5,
+        }),
+      })
+
+      expect(result.chat.clockVersion).toBeUndefined()
+    })
+
+    it('preserves a clock version when the server row is versioned', async () => {
+      const result = await processRemoteChat({
+        ...baseRemoteChat,
+        syncVersion: 5,
+        plaintext: basePlaintext({
+          clock: 7,
+          writer: 'device-a',
+          clockVersion: 5,
+        }),
+      })
+
+      expect(result.chat.clockVersion).toBe(5)
+    })
+
     it('uses remote ID over plaintext ID', async () => {
       const result = await processRemoteChat({
         ...baseRemoteChat,

--- a/tests/services/cloud/chat-recovery-schema.test.ts
+++ b/tests/services/cloud/chat-recovery-schema.test.ts
@@ -1,0 +1,74 @@
+import { RemoteChatPlaintextSchema } from '@/services/cloud/schemas'
+import { MAX_RECOVERY_CIPHERTEXT_BYTES } from '@/types/chat-recovery'
+import { uint8ArrayToBase64 } from '@/utils/binary-codec'
+import { describe, expect, it } from 'vitest'
+
+function envelope(ciphertextBytes: number) {
+  return {
+    v: 1,
+    turnId: 'turn-1',
+    keyId: '00'.repeat(16),
+    createdAt: '2026-07-20T00:00:00.000Z',
+    expiresAt: '2026-07-21T00:00:00.000Z',
+    nonce: uint8ArrayToBase64(new Uint8Array(12)),
+    ciphertext: uint8ArrayToBase64(new Uint8Array(ciphertextBytes)),
+  }
+}
+
+function chatWithEnvelope(recovery: ReturnType<typeof envelope>) {
+  return {
+    messages: [],
+    pendingRecoveries: [recovery],
+  }
+}
+
+describe('remote chat recovery schema', () => {
+  it('accepts ciphertext within the authenticated payload bounds', () => {
+    expect(
+      RemoteChatPlaintextSchema.safeParse(chatWithEnvelope(envelope(17)))
+        .success,
+    ).toBe(true)
+  })
+
+  it('rejects ciphertext that contains only an authentication tag', () => {
+    expect(
+      RemoteChatPlaintextSchema.safeParse(chatWithEnvelope(envelope(16)))
+        .success,
+    ).toBe(false)
+  })
+
+  it('rejects ciphertext larger than the decoded byte limit', () => {
+    expect(
+      RemoteChatPlaintextSchema.safeParse(
+        chatWithEnvelope(envelope(MAX_RECOVERY_CIPHERTEXT_BYTES + 1)),
+      ).success,
+    ).toBe(false)
+  })
+
+  it('rejects multiple recovery envelopes for the same turn', () => {
+    const recovery = envelope(17)
+
+    expect(
+      RemoteChatPlaintextSchema.safeParse({
+        messages: [],
+        pendingRecoveries: [
+          recovery,
+          { ...recovery, ciphertext: uint8ArrayToBase64(new Uint8Array(18)) },
+        ],
+      }).success,
+    ).toBe(false)
+  })
+
+  it('rejects the device-local recovery discriminator', () => {
+    expect(
+      RemoteChatPlaintextSchema.safeParse(
+        chatWithEnvelope({
+          ...envelope(17),
+          storage: 'local',
+          sessionId: '0123456789abcdef0123456789abcdef',
+          recoveryToken: 'local-token',
+        }),
+      ).success,
+    ).toBe(false)
+  })
+})

--- a/tests/services/cloud/cloud-storage.test.ts
+++ b/tests/services/cloud/cloud-storage.test.ts
@@ -139,6 +139,35 @@ describe('CloudStorageService auth readiness', () => {
     expect(pushArg.metadata).toMatchObject({ restoreDeleted: true })
   })
 
+  it('never uploads device-local recovery tokens', async () => {
+    const service = new CloudStorageService()
+    await service.uploadChat({
+      id: 'chat-1',
+      title: 'Local chat',
+      messages: [{ role: 'user', content: 'hi' }],
+      pendingRecoveries: [
+        {
+          v: 1,
+          storage: 'local',
+          turnId: 'turn-1',
+          createdAt: '2026-01-01T00:00:00.000Z',
+          expiresAt: '2026-01-02T00:00:00.000Z',
+          sessionId: '0123456789abcdef0123456789abcdef',
+          recoveryToken: 'sensitive-local-token',
+        },
+      ],
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+      lastAccessedAt: 0,
+    } as any)
+
+    const plaintext = JSON.parse(
+      new TextDecoder().decode(mockEnclavePush.mock.calls[0][0].plaintext),
+    )
+    expect(plaintext.pendingRecoveries).toBeUndefined()
+    expect(JSON.stringify(plaintext)).not.toContain('sensitive-local-token')
+  })
+
   it('reuses stable attachment idempotency keys across upload retries', async () => {
     const service = new CloudStorageService()
     const chat = {

--- a/tests/services/cloud/cloud-sync.test.ts
+++ b/tests/services/cloud/cloud-sync.test.ts
@@ -9,6 +9,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mockGetAllChats = vi.fn()
 const mockGetCloudChatCount = vi.fn()
+const mockIsChatHistoryAuthoritative = vi.fn()
 const mockGetUnsyncedChats = vi.fn()
 const mockGetChat = vi.fn()
 const mockSaveChat = vi.fn()
@@ -35,6 +36,10 @@ const mockEncryptionInitialize = vi.fn()
 const mockGetKey = vi.fn()
 const mockRunLegacyBlobMigration = vi.fn()
 const mockFinalizeAlternatives = vi.fn()
+const mockHasDeferredAlternativesFinalization = vi.fn()
+const mockNeedsRecoveryHistorySync = vi.fn()
+const mockMarkRecoveryHistoryReady = vi.fn()
+const mockResetAlternativesFinalizationState = vi.fn()
 const mockRunLegacyChatEviction = vi.fn()
 const mockKeyCurrent = vi.fn()
 const mockPrimaryKeyIdHex = vi.fn()
@@ -70,6 +75,8 @@ vi.mock('@/services/storage/indexed-db', () => ({
   indexedDBStorage: {
     getAllChats: (...args: any[]) => mockGetAllChats(...args),
     getCloudChatCount: (...args: any[]) => mockGetCloudChatCount(...args),
+    isChatHistoryAuthoritative: (...args: any[]) =>
+      mockIsChatHistoryAuthoritative(...args),
     getUnsyncedChats: (...args: any[]) => mockGetUnsyncedChats(...args),
     saveChat: (...args: any[]) => mockSaveChat(...args),
     saveExistingChat: (...args: any[]) => mockSaveExistingChat(...args),
@@ -183,6 +190,13 @@ vi.mock('@/services/cloud/legacy-blob-migration', () => ({
     mockRunLegacyBlobMigration(...args),
   finalizeAlternativesIfMigrated: (...args: any[]) =>
     mockFinalizeAlternatives(...args),
+  hasDeferredAlternativesFinalization: () =>
+    mockHasDeferredAlternativesFinalization(),
+  needsRecoveryHistorySync: () => mockNeedsRecoveryHistorySync(),
+  markRecoveryHistoryReady: (...args: any[]) =>
+    mockMarkRecoveryHistoryReady(...args),
+  resetAlternativesFinalizationState: (...args: any[]) =>
+    mockResetAlternativesFinalizationState(...args),
 }))
 
 vi.mock('@/services/cloud/legacy-chat-eviction', () => ({
@@ -204,6 +218,7 @@ describe('CloudSyncService', () => {
     mockResetSyncMetadataForAllChats.mockResolvedValue(undefined)
     mockDeleteChat.mockResolvedValue(undefined)
     mockGetKey.mockReturnValue(null)
+    mockIsChatHistoryAuthoritative.mockResolvedValue(true)
     mockKeyCurrent.mockResolvedValue({ key_id: null })
     mockPrimaryKeyIdHex.mockResolvedValue(null)
     mockRegisterKey.mockResolvedValue({ key_id: 'kid-local' })
@@ -226,6 +241,9 @@ describe('CloudSyncService', () => {
       fullyMigrated: true,
     })
     mockFinalizeAlternatives.mockReturnValue(true)
+    mockHasDeferredAlternativesFinalization.mockReturnValue(false)
+    mockNeedsRecoveryHistorySync.mockReturnValue(false)
+    mockMarkRecoveryHistoryReady.mockResolvedValue(undefined)
     mockRunLegacyChatEviction.mockResolvedValue(undefined)
     mockIsAuthenticated.mockResolvedValue(true)
     mockUploadChat.mockResolvedValue({ syncVersion: null, rewrites: [] })
@@ -427,6 +445,109 @@ describe('CloudSyncService', () => {
       await Promise.resolve()
 
       expect(mockUploadChat).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('backupChatAndWait', () => {
+    const localChat = {
+      id: 'required-1',
+      title: 'Required upload',
+      messages: [{ role: 'user', content: 'question' }],
+      createdAt: '2026-07-20T00:00:00.000Z',
+      updatedAt: '2026-07-20T00:01:00.000Z',
+      isBlankChat: false,
+      isLocalOnly: false,
+      locallyModified: true,
+      syncVersion: 1,
+    }
+
+    it('rejects when the required upload fails terminally', async () => {
+      mockGetChat.mockResolvedValue(localChat)
+      mockUploadChat.mockRejectedValue(
+        new SyncEnclaveError('forbidden', 403, 'FORBIDDEN'),
+      )
+
+      await expect(
+        new CloudSyncService().backupChatAndWait(localChat.id),
+      ).rejects.toThrow('forbidden')
+    })
+
+    it('surfaces a sync conflict on the required upload instead of retrying', async () => {
+      mockGetChat.mockResolvedValue(localChat)
+      mockUploadChat.mockRejectedValue(
+        new SyncEnclaveError('conflict', 409, 'SYNC_CONFLICT'),
+      )
+
+      await expect(
+        new CloudSyncService().backupChatAndWait(localChat.id),
+      ).rejects.toThrow('conflict')
+      expect(mockRebaseSyncVersion).not.toHaveBeenCalled()
+    })
+
+    it('does not upload again when a queued upload already synchronized the chat', async () => {
+      let readCount = 0
+      mockGetChat.mockImplementation(async () =>
+        ++readCount >= 4
+          ? { ...localChat, locallyModified: false, syncedAt: Date.now() }
+          : localChat,
+      )
+      let finishUpload: (() => void) | undefined
+      mockUploadChat.mockReturnValue(
+        new Promise((resolve) => {
+          finishUpload = () => resolve({ syncVersion: 2, rewrites: [] })
+        }),
+      )
+      const service = new CloudSyncService()
+
+      const queuedUpload = service.backupChat(localChat.id)
+      await vi.waitFor(() => expect(mockUploadChat).toHaveBeenCalledOnce())
+      const requiredUpload = service.backupChatAndWait(localChat.id)
+      finishUpload?.()
+      await requiredUpload
+      await queuedUpload
+
+      expect(mockUploadChat).toHaveBeenCalledOnce()
+    })
+
+    it('rejects when a queued conflict replaced the required revision', async () => {
+      let readCount = 0
+      mockGetChat.mockImplementation(async () =>
+        ++readCount >= 4
+          ? {
+              ...localChat,
+              updatedAt: '2026-07-20T00:02:00.000Z',
+              locallyModified: false,
+              syncedAt: Date.now(),
+            }
+          : localChat,
+      )
+      let finishUpload: (() => void) | undefined
+      mockUploadChat.mockReturnValue(
+        new Promise((resolve) => {
+          finishUpload = () => resolve({ syncVersion: 2, rewrites: [] })
+        }),
+      )
+      const service = new CloudSyncService()
+      const queuedUpload = service.backupChat(localChat.id)
+      await vi.waitFor(() => expect(mockUploadChat).toHaveBeenCalledOnce())
+      const requiredUpload = service.backupChatAndWait(localChat.id)
+      finishUpload?.()
+
+      await expect(requiredUpload).rejects.toThrow(
+        'Chat changed on another device before synchronization',
+      )
+      await queuedUpload
+    })
+
+    it('uploads a clean chat when no queued upload established cloud state', async () => {
+      mockGetChat.mockResolvedValue({
+        ...localChat,
+        locallyModified: false,
+      })
+
+      await new CloudSyncService().backupChatAndWait(localChat.id)
+
+      expect(mockUploadChat).toHaveBeenCalledOnce()
     })
   })
 
@@ -658,6 +779,86 @@ describe('CloudSyncService', () => {
     })
   })
 
+  describe('smartSync recovery history finalization', () => {
+    it('deep-syncs every remote chat before marking history ready', async () => {
+      mockNeedsRecoveryHistorySync.mockReturnValue(true)
+      mockGetUnsyncedChats.mockResolvedValue([])
+      mockGetAllChats.mockResolvedValue([])
+      mockGetChatSyncStatus.mockResolvedValue({
+        count: 2,
+        lastUpdated: '2026-07-20T00:00:00.000Z',
+      })
+      mockListChats
+        .mockResolvedValueOnce({
+          conversations: [{ id: 'chat-1', syncVersion: 4 }],
+          hasMore: true,
+          nextContinuationToken: 'next',
+        })
+        .mockResolvedValueOnce({
+          conversations: [{ id: 'chat-2', syncVersion: 5 }],
+          hasMore: false,
+        })
+
+      await new CloudSyncService().smartSync()
+
+      expect(mockListChats).toHaveBeenCalledTimes(2)
+      expect(mockIsChatHistoryAuthoritative).toHaveBeenCalledWith(
+        new Map([
+          ['chat-1', 4],
+          ['chat-2', 5],
+        ]),
+      )
+      expect(mockMarkRecoveryHistoryReady).toHaveBeenCalledOnce()
+    })
+
+    it('does not mark history ready when the remote snapshot changes', async () => {
+      mockNeedsRecoveryHistorySync.mockReturnValue(true)
+      mockGetUnsyncedChats.mockResolvedValue([])
+      mockGetAllChats.mockResolvedValue([])
+      mockGetChatSyncStatus
+        .mockResolvedValueOnce({
+          count: 1,
+          lastUpdated: '2026-07-20T00:00:00.000Z',
+        })
+        .mockResolvedValueOnce({
+          count: 1,
+          lastUpdated: '2026-07-20T00:01:00.000Z',
+        })
+      mockListChats.mockResolvedValue({
+        conversations: [{ id: 'chat-1', syncVersion: 4 }],
+        hasMore: false,
+      })
+
+      await new CloudSyncService().smartSync()
+
+      expect(mockIsChatHistoryAuthoritative).not.toHaveBeenCalled()
+      expect(mockMarkRecoveryHistoryReady).not.toHaveBeenCalled()
+    })
+
+    it('does not mark recovery history ready after an account reset', async () => {
+      let resolveAuthoritative: ((value: boolean) => void) | undefined
+      mockNeedsRecoveryHistorySync.mockReturnValue(true)
+      mockGetUnsyncedChats.mockResolvedValue([])
+      mockGetAllChats.mockResolvedValue([])
+      mockIsChatHistoryAuthoritative.mockReturnValue(
+        new Promise<boolean>((resolve) => {
+          resolveAuthoritative = resolve
+        }),
+      )
+      const service = new CloudSyncService()
+      const sync = service.smartSync()
+      await vi.waitFor(() =>
+        expect(mockIsChatHistoryAuthoritative).toHaveBeenCalled(),
+      )
+
+      service.resetForAccountChange()
+      resolveAuthoritative?.(true)
+      await sync
+
+      expect(mockMarkRecoveryHistoryReady).not.toHaveBeenCalled()
+    })
+  })
+
   describe('syncAllChats', () => {
     it('runs the deletion reconciliation pass even without cached sync status', async () => {
       mockGetUnsyncedChats.mockResolvedValue([])
@@ -754,6 +955,7 @@ describe('CloudSyncService', () => {
     })
 
     it('fetches only the first page for a default (non-deep) full sync', async () => {
+      mockNeedsRecoveryHistorySync.mockReturnValue(true)
       mockGetUnsyncedChats.mockResolvedValue([])
       mockGetAllChats.mockResolvedValue([])
       mockListChats.mockResolvedValue({
@@ -769,6 +971,7 @@ describe('CloudSyncService', () => {
       expect(
         mockListChats.mock.calls[0]?.[0]?.continuationToken,
       ).toBeUndefined()
+      expect(mockIsChatHistoryAuthoritative).not.toHaveBeenCalled()
     })
 
     it('pages through every remote chat when a deep sync is requested', async () => {
@@ -1162,6 +1365,7 @@ describe('CloudSyncService', () => {
 
   describe('syncProjectChats', () => {
     it('retries listing project chats before succeeding', async () => {
+      mockNeedsRecoveryHistorySync.mockReturnValue(true)
       mockGetAllChats.mockResolvedValue([])
       mockListProjectChats
         .mockRejectedValueOnce(new Error('temporary auth failure'))
@@ -1175,6 +1379,7 @@ describe('CloudSyncService', () => {
 
       expect(mockListProjectChats).toHaveBeenCalledTimes(2)
       expect(result).toEqual({ uploaded: 0, downloaded: 0, errors: [] })
+      expect(mockIsChatHistoryAuthoritative).not.toHaveBeenCalled()
     })
   })
 

--- a/tests/services/cloud/legacy-blob-migration.test.ts
+++ b/tests/services/cloud/legacy-blob-migration.test.ts
@@ -28,6 +28,7 @@ vi.mock('@/services/cloud/cek-encoding', () => ({
 
 const mockClearFallbackKeys = vi.fn()
 const mockGetFallbackKeyCount = vi.fn<() => number>()
+const mockHasPendingChatRecoveries = vi.fn()
 
 vi.mock('@/services/encryption/encryption-service', () => ({
   encryptionService: {
@@ -36,8 +37,17 @@ vi.mock('@/services/encryption/encryption-service', () => ({
   },
 }))
 
+vi.mock('@/services/storage/indexed-db', () => ({
+  indexedDBStorage: {
+    hasPendingChatRecoveries: () => mockHasPendingChatRecoveries(),
+  },
+}))
+
 import {
   finalizeAlternativesIfMigrated,
+  hasDeferredAlternativesFinalization,
+  markRecoveryHistoryReady,
+  resetAlternativesFinalizationState,
   runLegacyBlobMigration,
   runLegacyBlobMigrationAndFinalize,
   type MigrationReport,
@@ -69,6 +79,9 @@ describe('runLegacyBlobMigration', () => {
     mockClearFallbackKeys.mockReset()
     mockGetFallbackKeyCount.mockReset()
     mockGetFallbackKeyCount.mockReturnValue(0)
+    mockHasPendingChatRecoveries.mockReset()
+    mockHasPendingChatRecoveries.mockResolvedValue(false)
+    resetAlternativesFinalizationState()
     mockRequirePrimaryKeyB64.mockReturnValue('PRIMARY_B64')
     mockPullKeys.mockReturnValue([{ key: 'PRIMARY_B64' }, { key: 'ALT_B64' }])
   })
@@ -252,29 +265,83 @@ describe('finalizeAlternativesIfMigrated', () => {
     mockClearFallbackKeys.mockReset()
     mockGetFallbackKeyCount.mockReset()
     mockGetFallbackKeyCount.mockReturnValue(0)
+    mockHasPendingChatRecoveries.mockReset()
+    mockHasPendingChatRecoveries.mockResolvedValue(false)
+    resetAlternativesFinalizationState()
   })
 
-  it('is a no-op when migration is not fully complete', () => {
-    const ran = finalizeAlternativesIfMigrated(
+  it('is a no-op when migration is not fully complete', async () => {
+    const ran = await finalizeAlternativesIfMigrated(
       buildReport({ fullyMigrated: false, totalRemaining: 5 }),
     )
     expect(ran).toBe(false)
     expect(mockClearFallbackKeys).not.toHaveBeenCalled()
   })
 
-  it('clears fallback keys when fullyMigrated is true', () => {
+  it('clears fallback keys when fullyMigrated is true', async () => {
     mockGetFallbackKeyCount.mockReturnValue(3)
-    const ran = finalizeAlternativesIfMigrated(
-      buildReport({ totalMigrated: 12 }),
-    )
-    expect(ran).toBe(true)
+    expect(
+      await finalizeAlternativesIfMigrated(buildReport({ totalMigrated: 12 })),
+    ).toBe(false)
+    await markRecoveryHistoryReady()
     expect(mockClearFallbackKeys).toHaveBeenCalledOnce()
   })
 
-  it('is idempotent — still returns true when no fallbacks remain', () => {
+  it('keeps fallback keys while recovery envelopes still need them', async () => {
+    mockHasPendingChatRecoveries.mockResolvedValue(true)
+    expect(await finalizeAlternativesIfMigrated(buildReport())).toBe(false)
+    await markRecoveryHistoryReady()
+    expect(mockClearFallbackKeys).not.toHaveBeenCalled()
+  })
+
+  it('clears fallback keys after deferred history readiness', async () => {
     mockGetFallbackKeyCount.mockReturnValue(0)
-    expect(finalizeAlternativesIfMigrated(buildReport())).toBe(true)
+    await finalizeAlternativesIfMigrated(buildReport())
+    await markRecoveryHistoryReady()
     expect(mockClearFallbackKeys).toHaveBeenCalledOnce()
+  })
+
+  it('retries deferred cleanup after recovery history is fully ingested', async () => {
+    expect(await finalizeAlternativesIfMigrated(buildReport())).toBe(false)
+    expect(mockClearFallbackKeys).not.toHaveBeenCalled()
+
+    await markRecoveryHistoryReady()
+
+    expect(mockClearFallbackKeys).toHaveBeenCalledOnce()
+  })
+
+  it('preserves history readiness reported before migration completes', async () => {
+    await markRecoveryHistoryReady()
+
+    expect(await finalizeAlternativesIfMigrated(buildReport())).toBe(true)
+    expect(mockClearFallbackKeys).toHaveBeenCalledOnce()
+  })
+
+  it('keeps repeated finalization of the same report idempotent', async () => {
+    const report = buildReport()
+    expect(await finalizeAlternativesIfMigrated(report)).toBe(false)
+    await markRecoveryHistoryReady()
+
+    expect(await finalizeAlternativesIfMigrated(report)).toBe(true)
+    expect(mockClearFallbackKeys).toHaveBeenCalledOnce()
+    expect(hasDeferredAlternativesFinalization()).toBe(false)
+  })
+
+  it('does not clear fallback keys after finalization state resets', async () => {
+    let resolvePending: ((value: boolean) => void) | undefined
+    await finalizeAlternativesIfMigrated(buildReport())
+    mockHasPendingChatRecoveries.mockReturnValueOnce(
+      new Promise<boolean>((resolve) => {
+        resolvePending = resolve
+      }),
+    )
+
+    const readiness = markRecoveryHistoryReady()
+    resetAlternativesFinalizationState()
+    resolvePending?.(false)
+    await readiness
+
+    expect(mockClearFallbackKeys).not.toHaveBeenCalled()
   })
 })
 
@@ -286,6 +353,9 @@ describe('runLegacyBlobMigrationAndFinalize', () => {
     mockClearFallbackKeys.mockReset()
     mockGetFallbackKeyCount.mockReset()
     mockGetFallbackKeyCount.mockReturnValue(0)
+    mockHasPendingChatRecoveries.mockReset()
+    mockHasPendingChatRecoveries.mockResolvedValue(false)
+    resetAlternativesFinalizationState()
     mockRequirePrimaryKeyB64.mockReturnValue('PRIMARY_B64')
     mockPullKeys.mockReturnValue([{ key: 'PRIMARY_B64' }])
   })
@@ -294,6 +364,8 @@ describe('runLegacyBlobMigrationAndFinalize', () => {
     mockMigrateAll.mockResolvedValue(emptyEnclaveReport())
     const report = await runLegacyBlobMigrationAndFinalize()
     expect(report.fullyMigrated).toBe(true)
+    expect(mockClearFallbackKeys).not.toHaveBeenCalled()
+    await markRecoveryHistoryReady()
     expect(mockClearFallbackKeys).toHaveBeenCalledOnce()
   })
 

--- a/tests/services/cloud/sync-predicates.test.ts
+++ b/tests/services/cloud/sync-predicates.test.ts
@@ -15,6 +15,7 @@ import {
   remoteWins,
   remoteWinsLastWrite,
   shouldIngestRemoteChat,
+  trustedChatClock,
 } from '@/services/cloud/sync-predicates'
 import type { StoredChat } from '@/services/storage/indexed-db'
 import { describe, expect, it } from 'vitest'
@@ -348,6 +349,46 @@ describe('Sync Predicates', () => {
       }
 
       expect(isUploadableChat(blankCloudChat)).toBe(false)
+    })
+  })
+
+  describe('trustedChatClock', () => {
+    it('accepts a version-bound positive safe clock', () => {
+      expect(
+        trustedChatClock({
+          clock: 4,
+          writer: 'writer-a',
+          clockVersion: 3,
+          syncVersion: 3,
+        }),
+      ).toEqual({ v: 4, w: 'writer-a' })
+    })
+
+    it.each([Number.NaN, Infinity, -1, 1.5, Number.MAX_SAFE_INTEGER + 1])(
+      'rejects malformed clock value %s',
+      (clock) => {
+        expect(
+          trustedChatClock({
+            clock,
+            writer: 'writer-a',
+            clockVersion: 3,
+            syncVersion: 3,
+          }),
+        ).toBeUndefined()
+      },
+    )
+
+    it('rejects an empty writer identifier', () => {
+      for (const writer of ['', '   ']) {
+        expect(
+          trustedChatClock({
+            clock: 4,
+            writer,
+            clockVersion: 3,
+            syncVersion: 3,
+          }),
+        ).toBeUndefined()
+      }
     })
   })
 })

--- a/tests/services/cloud/upload-coalescer.test.ts
+++ b/tests/services/cloud/upload-coalescer.test.ts
@@ -191,6 +191,24 @@ describe('UploadCoalescer', () => {
   })
 
   describe('Coalescing behavior', () => {
+    it('waits for an existing upload without scheduling another write', async () => {
+      let resolveUpload: (() => void) | undefined
+      const uploadFn = vi.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveUpload = resolve
+          }),
+      )
+      const coalescer = new UploadCoalescer(uploadFn)
+      coalescer.enqueue('chat-1')
+
+      const ensured = coalescer.ensureUploadAndWait('chat-1')
+      resolveUpload?.()
+      await ensured
+
+      expect(uploadFn).toHaveBeenCalledOnce()
+    })
+
     it('coalesces rapid enqueues for the same chat', async () => {
       let resolveUpload: () => void
       const uploadPromise = new Promise<void>((resolve) => {

--- a/tests/services/inference/chat-recovery-client.test.ts
+++ b/tests/services/inference/chat-recovery-client.test.ts
@@ -1,0 +1,183 @@
+import {
+  deleteChatRecovery,
+  fetchRecoveredChatResponse,
+  getChatRecoveryState,
+} from '@/services/inference/chat-recovery-client'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const decryptResponseWithToken = vi.fn()
+
+vi.mock('tinfoil', () => ({
+  decryptResponseWithToken: (...args: unknown[]) =>
+    decryptResponseWithToken(...args),
+}))
+
+vi.mock('@/services/inference/tinfoil-client', () => ({
+  getRecoveryBaseURL: vi.fn(() => 'https://api.example'),
+}))
+
+const SESSION_ID = '0123456789abcdef0123456789abcdef'
+
+describe('chat recovery client', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    decryptResponseWithToken.mockReset()
+  })
+
+  it('reads complete recovery status without sending credentials', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ status: 'complete', bytes: 128 }), {
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+
+    await expect(getChatRecoveryState(SESSION_ID)).resolves.toBe('complete')
+    expect(fetchMock).toHaveBeenCalledWith(
+      `https://api.example/recovery/${SESSION_ID}/status`,
+      expect.objectContaining({
+        credentials: 'omit',
+        referrerPolicy: 'no-referrer',
+      }),
+    )
+  })
+
+  it('preserves the underlying recovery transport error', async () => {
+    const networkError = new TypeError('network unavailable')
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(networkError)
+
+    await expect(getChatRecoveryState(SESSION_ID)).rejects.toMatchObject({
+      cause: networkError,
+      retryable: true,
+    })
+  })
+
+  it('rejects a null recovery status response with a typed error', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('null', {
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+
+    await expect(getChatRecoveryState(SESSION_ID)).rejects.toMatchObject({
+      name: 'ChatRecoveryError',
+      retryable: false,
+    })
+  })
+
+  it('rejects recovery status without a persisted byte count', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ status: 'processing' }), {
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+
+    await expect(getChatRecoveryState(SESSION_ID)).rejects.toMatchObject({
+      name: 'ChatRecoveryError',
+      retryable: false,
+    })
+  })
+
+  it('decrypts the recovered encrypted response with the EHBP token', async () => {
+    const encrypted = new Response('encrypted')
+    const decrypted = new Response('decrypted')
+    const token = {
+      exportedSecret: new Uint8Array(32),
+      requestEnc: new Uint8Array(32),
+    }
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(encrypted)
+    decryptResponseWithToken.mockResolvedValue(decrypted)
+
+    await expect(fetchRecoveredChatResponse(SESSION_ID, token)).resolves.toBe(
+      decrypted,
+    )
+    expect(decryptResponseWithToken).toHaveBeenCalledWith(encrypted, token)
+  })
+
+  it('decrypts an authenticated upstream conflict response', async () => {
+    const encrypted = new Response('encrypted conflict', {
+      status: 409,
+      headers: { 'Ehbp-Response-Nonce': 'nonce' },
+    })
+    const decrypted = new Response('decrypted conflict', { status: 409 })
+    const token = {
+      exportedSecret: new Uint8Array(32),
+      requestEnc: new Uint8Array(32),
+    }
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(encrypted)
+    decryptResponseWithToken.mockResolvedValue(decrypted)
+
+    await expect(fetchRecoveredChatResponse(SESSION_ID, token)).resolves.toBe(
+      decrypted,
+    )
+    expect(decryptResponseWithToken).toHaveBeenCalledWith(encrypted, token)
+  })
+
+  it('keeps a recovery stream tied to its scan signal', async () => {
+    const encrypted = new Response('encrypted')
+    const decrypted = new Response('decrypted')
+    const token = {
+      exportedSecret: new Uint8Array(32),
+      requestEnc: new Uint8Array(32),
+    }
+    const controller = new AbortController()
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(encrypted)
+    decryptResponseWithToken.mockResolvedValue(decrypted)
+
+    await fetchRecoveredChatResponse(SESSION_ID, token, controller.signal)
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `https://api.example/recovery/${SESSION_ID}`,
+      expect.objectContaining({ signal: controller.signal }),
+    )
+  })
+
+  it('counts encrypted bytes without splitting the replay stream', async () => {
+    const encryptedBytes = new TextEncoder().encode('replay-and-live')
+    const encryptedProgress = vi.fn()
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(encryptedBytes),
+    )
+    decryptResponseWithToken.mockImplementation(async (response: Response) => {
+      expect(new Uint8Array(await response.arrayBuffer())).toEqual(
+        encryptedBytes,
+      )
+      return new Response('decrypted')
+    })
+
+    await fetchRecoveredChatResponse(
+      SESSION_ID,
+      {
+        exportedSecret: new Uint8Array(32),
+        requestEnc: new Uint8Array(32),
+      },
+      undefined,
+      encryptedProgress,
+    )
+
+    expect(encryptedProgress).toHaveBeenCalledWith(encryptedBytes.byteLength)
+  })
+
+  it.each([
+    [404, 'missing'],
+    [410, 'failed'],
+  ])('treats a %s recovery response as terminal', async (status, state) => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(null, { status }),
+    )
+
+    await expect(
+      fetchRecoveredChatResponse(SESSION_ID, {
+        exportedSecret: new Uint8Array(32),
+        requestEnc: new Uint8Array(32),
+      }),
+    ).rejects.toMatchObject({ state, retryable: false })
+  })
+
+  it('treats deletion of an already-missing session as success', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(null, { status: 404 }),
+    )
+
+    await expect(deleteChatRecovery(SESSION_ID)).resolves.toBeUndefined()
+  })
+})

--- a/tests/services/inference/chat-recovery-crypto.test.ts
+++ b/tests/services/inference/chat-recovery-crypto.test.ts
@@ -1,0 +1,221 @@
+import { RemoteChatPlaintextSchema } from '@/services/cloud/schemas'
+import {
+  decryptRecoveryEnvelope,
+  encryptRecoveryEnvelope,
+  rewrapRecoveryEnvelope,
+  validateRecoveryEnvelope,
+  type RecoveryTokenFields,
+} from '@/services/inference/chat-recovery-crypto'
+import { uint8ArrayToBase64 } from '@/utils/binary-codec'
+import { describe, expect, it } from 'vitest'
+
+const USER_ID = 'user_123'
+const CHAT_ID = 'chat_123'
+const TURN_ID = 'turn_123'
+const SESSION_ID = '0123456789abcdef0123456789abcdef'
+const NOW = Date.parse('2026-07-20T12:00:00.000Z')
+const TOKEN: RecoveryTokenFields = {
+  exportedSecret: 'a'.repeat(64),
+  requestEnc: 'b'.repeat(64),
+}
+
+function cek(fill: number): Uint8Array {
+  return new Uint8Array(32).fill(fill)
+}
+
+async function envelope() {
+  return encryptRecoveryEnvelope({
+    cek: cek(1),
+    userId: USER_ID,
+    chatId: CHAT_ID,
+    turnId: TURN_ID,
+    sessionId: SESSION_ID,
+    recoveryToken: TOKEN,
+    now: NOW,
+  })
+}
+
+describe('chat recovery envelope crypto', () => {
+  it('round-trips a recovery payload', async () => {
+    const encrypted = await envelope()
+
+    await expect(
+      decryptRecoveryEnvelope({
+        cek: cek(1),
+        userId: USER_ID,
+        chatId: CHAT_ID,
+        envelope: encrypted,
+        now: NOW,
+      }),
+    ).resolves.toEqual({
+      sessionId: SESSION_ID,
+      recoveryToken: TOKEN,
+    })
+  })
+
+  it('round-trips an SDK-serialized recovery token', async () => {
+    const recoveryToken = JSON.stringify(TOKEN)
+    const encrypted = await encryptRecoveryEnvelope({
+      cek: cek(1),
+      userId: USER_ID,
+      chatId: CHAT_ID,
+      turnId: TURN_ID,
+      sessionId: SESSION_ID,
+      recoveryToken,
+      now: NOW,
+    })
+
+    await expect(
+      decryptRecoveryEnvelope({
+        cek: cek(1),
+        userId: USER_ID,
+        chatId: CHAT_ID,
+        envelope: encrypted,
+        now: NOW,
+      }),
+    ).resolves.toEqual({ sessionId: SESSION_ID, recoveryToken })
+  })
+
+  it('rejects the wrong CEK and AAD', async () => {
+    const encrypted = await envelope()
+
+    await expect(
+      decryptRecoveryEnvelope({
+        cek: cek(2),
+        userId: USER_ID,
+        chatId: CHAT_ID,
+        envelope: encrypted,
+        now: NOW,
+      }),
+    ).rejects.toThrow()
+    await expect(
+      decryptRecoveryEnvelope({
+        cek: cek(1),
+        userId: 'another-user',
+        chatId: CHAT_ID,
+        envelope: encrypted,
+        now: NOW,
+      }),
+    ).rejects.toThrow()
+  })
+
+  it('rejects ciphertext and authenticated metadata tampering', async () => {
+    const encrypted = await envelope()
+    const ciphertext = Uint8Array.from(atob(encrypted.ciphertext), (value) =>
+      value.charCodeAt(0),
+    )
+    ciphertext[0] ^= 1
+
+    await expect(
+      decryptRecoveryEnvelope({
+        cek: cek(1),
+        userId: USER_ID,
+        chatId: CHAT_ID,
+        envelope: {
+          ...encrypted,
+          ciphertext: uint8ArrayToBase64(ciphertext),
+        },
+        now: NOW,
+      }),
+    ).rejects.toThrow()
+    await expect(
+      decryptRecoveryEnvelope({
+        cek: cek(1),
+        userId: USER_ID,
+        chatId: CHAT_ID,
+        envelope: { ...encrypted, turnId: 'tampered-turn' },
+        now: NOW,
+      }),
+    ).rejects.toThrow()
+  })
+
+  it('rejects expired and malformed envelopes and payload inputs', async () => {
+    const encrypted = await envelope()
+
+    await expect(
+      decryptRecoveryEnvelope({
+        cek: cek(1),
+        userId: USER_ID,
+        chatId: CHAT_ID,
+        envelope: encrypted,
+        now: Date.parse(encrypted.expiresAt),
+      }),
+    ).rejects.toThrow('expired')
+
+    expect(() =>
+      validateRecoveryEnvelope({ ...encrypted, nonce: 'not-base64' }),
+    ).toThrow()
+    await expect(
+      encryptRecoveryEnvelope({
+        cek: cek(1),
+        userId: USER_ID,
+        chatId: CHAT_ID,
+        turnId: TURN_ID,
+        sessionId: SESSION_ID.toUpperCase(),
+        recoveryToken: TOKEN,
+        now: NOW,
+      }),
+    ).rejects.toThrow('sessionId')
+    await expect(
+      encryptRecoveryEnvelope({
+        cek: cek(1),
+        userId: USER_ID,
+        chatId: CHAT_ID,
+        turnId: TURN_ID,
+        sessionId: SESSION_ID,
+        recoveryToken: { ...TOKEN, requestEnc: 'ab' },
+        now: NOW,
+      }),
+    ).rejects.toThrow('requestEnc')
+  })
+
+  it('rewraps under a new CEK without changing recovery metadata', async () => {
+    const encrypted = await envelope()
+    const rewrapped = await rewrapRecoveryEnvelope({
+      envelope: encrypted,
+      userId: USER_ID,
+      chatId: CHAT_ID,
+      oldCek: cek(1),
+      newCek: cek(2),
+      now: NOW,
+    })
+
+    expect(rewrapped.keyId).not.toBe(encrypted.keyId)
+    expect(rewrapped.createdAt).toBe(encrypted.createdAt)
+    expect(rewrapped.expiresAt).toBe(encrypted.expiresAt)
+    await expect(
+      decryptRecoveryEnvelope({
+        cek: cek(2),
+        userId: USER_ID,
+        chatId: CHAT_ID,
+        envelope: rewrapped,
+        now: NOW,
+      }),
+    ).resolves.toEqual({
+      sessionId: SESSION_ID,
+      recoveryToken: TOKEN,
+    })
+  })
+
+  it('validates turn IDs and pending recoveries in remote chat plaintext', async () => {
+    const encrypted = await envelope()
+    expect(
+      RemoteChatPlaintextSchema.safeParse({
+        messages: [{ role: 'user', content: 'hello', turnId: TURN_ID }],
+        pendingRecoveries: [encrypted],
+      }).success,
+    ).toBe(true)
+    expect(
+      RemoteChatPlaintextSchema.safeParse({
+        messages: [{ role: 'user', content: 'hello', turnId: '' }],
+        pendingRecoveries: [encrypted],
+      }).success,
+    ).toBe(false)
+    expect(
+      RemoteChatPlaintextSchema.safeParse({
+        messages: [],
+        pendingRecoveries: [{ ...encrypted, keyId: 'invalid' }],
+      }).success,
+    ).toBe(false)
+  })
+})

--- a/tests/services/inference/chat-recovery-drafts.test.ts
+++ b/tests/services/inference/chat-recovery-drafts.test.ts
@@ -1,0 +1,82 @@
+import {
+  clearActiveChatRecoveries,
+  clearChatRecoveryDraft,
+  clearChatRecoveryDrafts,
+  getActiveChatRecoverySnapshot,
+  getChatRecoveryDraftSnapshot,
+  isChatRecoveryActive,
+  pruneChatRecoveryDrafts,
+  setChatRecoveryActive,
+  setChatRecoveryDraft,
+  subscribeChatRecoveryDrafts,
+} from '@/services/inference/chat-recovery-drafts'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const message = (content: string) => ({
+  role: 'assistant' as const,
+  content,
+  timestamp: new Date('2026-07-21T00:00:00.000Z'),
+})
+
+describe('chat recovery drafts', () => {
+  beforeEach(() => {
+    clearChatRecoveryDrafts()
+    clearActiveChatRecoveries()
+  })
+
+  it('replaces reconnect snapshots without letting an old session clear them', () => {
+    const listener = vi.fn()
+    const unsubscribe = subscribeChatRecoveryDrafts(listener)
+    setChatRecoveryDraft({
+      chatId: 'chat-1',
+      turnId: 'turn-1',
+      sessionId: 'session-1',
+      message: message('First replay'),
+    })
+    setChatRecoveryDraft({
+      chatId: 'chat-1',
+      turnId: 'turn-1',
+      sessionId: 'session-2',
+      message: message('Reconnected replay'),
+    })
+
+    clearChatRecoveryDraft('session-1')
+
+    expect(getChatRecoveryDraftSnapshot()).toEqual([
+      expect.objectContaining({
+        sessionId: 'session-2',
+        message: expect.objectContaining({ content: 'Reconnected replay' }),
+      }),
+    ])
+    expect(listener).toHaveBeenCalledTimes(2)
+    unsubscribe()
+  })
+
+  it('prunes drafts whose pending turn no longer exists', () => {
+    setChatRecoveryDraft({
+      chatId: 'chat-1',
+      turnId: 'turn-1',
+      sessionId: 'session-1',
+      message: message('Partial'),
+    })
+
+    pruneChatRecoveryDrafts(new Set())
+
+    expect(getChatRecoveryDraftSnapshot()).toEqual([])
+  })
+
+  it('publishes active resumed recoveries', () => {
+    const listener = vi.fn()
+    const unsubscribe = subscribeChatRecoveryDrafts(listener)
+
+    setChatRecoveryActive('chat-1', 'turn-1', true)
+    expect(isChatRecoveryActive('chat-1')).toBe(true)
+    expect(getActiveChatRecoverySnapshot()).toEqual(['chat-1\u0000turn-1'])
+
+    setChatRecoveryActive('chat-1', 'turn-1', false)
+    expect(isChatRecoveryActive('chat-1')).toBe(false)
+    expect(getActiveChatRecoverySnapshot()).toEqual([])
+    expect(listener).toHaveBeenCalledTimes(2)
+    unsubscribe()
+  })
+})

--- a/tests/services/inference/chat-recovery-sync.test.ts
+++ b/tests/services/inference/chat-recovery-sync.test.ts
@@ -1,6 +1,10 @@
-import type { Message, PendingRecoveryEnvelope } from '@/components/chat/types'
+import type { Message } from '@/components/chat/types'
 import type { StoredChat } from '@/services/storage/indexed-db'
 import { SyncEnclaveError } from '@/services/sync-enclave/sync-enclave-client'
+import {
+  MAX_PENDING_RECOVERIES_PER_CHAT,
+  type PendingRecoveryEnvelope,
+} from '@/types/chat-recovery'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 let remoteChat: StoredChat
@@ -161,18 +165,23 @@ describe('chat recovery sync mutations', () => {
     expect(localChat?.pendingRecoveries).toEqual(result.pendingRecoveries)
   })
 
-  it('prunes expired recoveries before enforcing the pending limit', async () => {
-    remoteChat.pendingRecoveries = Array.from({ length: 8 }, (_, index) => ({
-      ...envelope(`expired-${index}`),
-      expiresAt: new Date(Date.now() - 60_000).toISOString(),
-    }))
+  it('keeps expired recoveries for scanner cleanup', async () => {
+    remoteChat.pendingRecoveries = Array.from(
+      { length: MAX_PENDING_RECOVERIES_PER_CHAT - 1 },
+      (_, index) => ({
+        ...envelope(`expired-${index}`),
+        expiresAt: new Date(Date.now() - 60_000).toISOString(),
+      }),
+    )
     localChat = structuredClone(remoteChat)
 
     const result = await addPendingRecovery(remoteChat.id, envelope('turn-1'))
 
-    expect(result.pendingRecoveries?.map((item) => item.turnId)).toEqual([
-      'turn-1',
-    ])
+    expect(result.pendingRecoveries).toHaveLength(
+      MAX_PENDING_RECOVERIES_PER_CHAT,
+    )
+    expect(result.pendingRecoveries?.[0].turnId).toBe('expired-0')
+    expect(result.pendingRecoveries?.at(-1)?.turnId).toBe('turn-1')
   })
 
   it('keeps recovery state local when cloud sync is disabled', async () => {

--- a/tests/services/inference/chat-recovery-sync.test.ts
+++ b/tests/services/inference/chat-recovery-sync.test.ts
@@ -1,0 +1,534 @@
+import type { Message, PendingRecoveryEnvelope } from '@/components/chat/types'
+import type { StoredChat } from '@/services/storage/indexed-db'
+import { SyncEnclaveError } from '@/services/sync-enclave/sync-enclave-client'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+let remoteChat: StoredChat
+let localChat: StoredChat | undefined
+let uploadAttempts = 0
+let conflictOnce = false
+let applyFailures = 0
+let cloudSyncEnabled = true
+const downloadChat = vi.fn(async () => structuredClone(remoteChat))
+const uploadChat = vi.fn(async (chat: StoredChat) => {
+  uploadAttempts += 1
+  if (conflictOnce) {
+    conflictOnce = false
+    throw new SyncEnclaveError('conflict', 409, 'SYNC_CONFLICT')
+  }
+  remoteChat = {
+    ...structuredClone(chat),
+    syncVersion: uploadAttempts + 1,
+  }
+  return remoteChat
+})
+const getChat = vi.fn(async () => structuredClone(localChat))
+const applyRemoteChatIfFresh = vi.fn(async ({ chat }: { chat: StoredChat }) => {
+  if (applyFailures > 0) {
+    applyFailures -= 1
+    return { applied: false }
+  }
+  localChat = structuredClone(chat)
+  return { applied: true }
+})
+const mutateChat = vi.fn(
+  async (
+    _chatId: string,
+    mutation: (chat: StoredChat) => {
+      chat: StoredChat
+      changed: boolean
+    },
+  ) => {
+    if (!localChat) return null
+    const result = mutation(structuredClone(localChat))
+    if (result.changed) {
+      localChat = structuredClone(result.chat)
+    }
+    return structuredClone(result.chat)
+  },
+)
+
+vi.mock('@/services/cloud/cloud-storage', () => ({
+  cloudStorage: {
+    downloadChat: (chatId: string) => downloadChat(chatId),
+    uploadChat: (chat: StoredChat) => uploadChat(chat),
+  },
+}))
+
+vi.mock('@/services/storage/indexed-db', () => ({
+  indexedDBStorage: {
+    getChat: (chatId: string) => getChat(chatId),
+    mutateChat: (
+      chatId: string,
+      mutation: (chat: StoredChat) => {
+        chat: StoredChat
+        changed: boolean
+      },
+    ) => mutateChat(chatId, mutation),
+    applyRemoteChatIfFresh: (args: { chat: StoredChat }) =>
+      applyRemoteChatIfFresh(args),
+  },
+}))
+
+vi.mock('@/utils/cloud-sync-settings', () => ({
+  isCloudSyncEnabled: () => cloudSyncEnabled,
+}))
+
+vi.mock('@/services/cloud/edit-clock', () => ({
+  nextClock: vi.fn(() => ({ v: 42, w: 'writer' })),
+}))
+
+vi.mock('@/services/storage/chat-events', () => ({
+  chatEvents: { emit: vi.fn() },
+}))
+
+vi.mock('@/services/sync-enclave/sync-api', () => ({
+  newIdempotencyKey: vi.fn(() => 'idempotency-key'),
+}))
+
+import {
+  addPendingRecovery,
+  completePendingRecovery,
+  removePendingRecovery,
+  replacePendingRecovery,
+  resetChatRecoverySyncState,
+} from '@/services/inference/chat-recovery-sync'
+
+function message(
+  role: Message['role'],
+  content: string,
+  turnId?: string,
+): Message {
+  return { role, content, turnId, timestamp: new Date().toISOString() }
+}
+
+function envelope(turnId: string): PendingRecoveryEnvelope {
+  return {
+    v: 1,
+    sessionId: '0123456789abcdef0123456789abcdef',
+    turnId,
+    keyId: 'key-id',
+    createdAt: new Date().toISOString(),
+    expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    nonce: 'AAAAAAAAAAAAAAAA',
+    ciphertext: 'AAAAAAAAAAAAAAAAAAAAAAAA',
+  }
+}
+
+function currentEnvelope(turnId: string): PendingRecoveryEnvelope {
+  return (
+    localChat?.pendingRecoveries?.find(
+      (candidate) => candidate.turnId === turnId,
+    ) ??
+    remoteChat.pendingRecoveries?.find(
+      (candidate) => candidate.turnId === turnId,
+    ) ??
+    envelope(turnId)
+  )
+}
+
+describe('chat recovery sync mutations', () => {
+  beforeEach(() => {
+    resetChatRecoverySyncState()
+    uploadAttempts = 0
+    conflictOnce = false
+    applyFailures = 0
+    cloudSyncEnabled = true
+    downloadChat.mockClear()
+    uploadChat.mockClear()
+    getChat.mockClear()
+    applyRemoteChatIfFresh.mockClear()
+    mutateChat.mockClear()
+    remoteChat = {
+      id: 'chat-id',
+      title: 'Chat',
+      model: 'model',
+      messages: [message('user', 'Question', 'turn-1')],
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      syncVersion: 1,
+    }
+    localChat = structuredClone(remoteChat)
+  })
+
+  it('retries a conflict and synchronizes the encrypted envelope', async () => {
+    conflictOnce = true
+
+    const result = await addPendingRecovery(remoteChat.id, envelope('turn-1'))
+
+    expect(uploadAttempts).toBe(2)
+    expect(result.pendingRecoveries).toHaveLength(1)
+    expect(localChat?.pendingRecoveries).toEqual(result.pendingRecoveries)
+  })
+
+  it('prunes expired recoveries before enforcing the pending limit', async () => {
+    remoteChat.pendingRecoveries = Array.from({ length: 8 }, (_, index) => ({
+      ...envelope(`expired-${index}`),
+      expiresAt: new Date(Date.now() - 60_000).toISOString(),
+    }))
+    localChat = structuredClone(remoteChat)
+
+    const result = await addPendingRecovery(remoteChat.id, envelope('turn-1'))
+
+    expect(result.pendingRecoveries?.map((item) => item.turnId)).toEqual([
+      'turn-1',
+    ])
+  })
+
+  it('keeps recovery state local when cloud sync is disabled', async () => {
+    cloudSyncEnabled = false
+
+    await addPendingRecovery(remoteChat.id, envelope('turn-1'))
+    await completePendingRecovery(
+      remoteChat.id,
+      currentEnvelope('turn-1'),
+      message('assistant', 'Recovered answer', 'turn-1'),
+    )
+
+    expect(downloadChat).not.toHaveBeenCalled()
+    expect(uploadChat).not.toHaveBeenCalled()
+    expect(mutateChat).toHaveBeenCalledTimes(2)
+    expect(localChat?.messages.map((item) => item.content)).toEqual([
+      'Question',
+      'Recovered answer',
+    ])
+    expect(localChat?.pendingRecoveries).toBeUndefined()
+  })
+
+  it('finishes a local recovery after cloud sync is enabled', async () => {
+    localChat = {
+      ...localChat!,
+      isLocalOnly: false,
+      pendingRecoveries: [
+        {
+          v: 1,
+          storage: 'local',
+          turnId: 'turn-1',
+          createdAt: new Date().toISOString(),
+          expiresAt: new Date(Date.now() + 60_000).toISOString(),
+          sessionId: '0123456789abcdef0123456789abcdef',
+          recoveryToken: 'local-token',
+        },
+      ],
+    }
+
+    await completePendingRecovery(
+      remoteChat.id,
+      currentEnvelope('turn-1'),
+      message('assistant', 'Recovered answer', 'turn-1'),
+    )
+
+    expect(downloadChat).not.toHaveBeenCalled()
+    expect(uploadChat).not.toHaveBeenCalled()
+    expect(localChat?.messages[1].content).toBe('Recovered answer')
+    expect(localChat?.pendingRecoveries).toBeUndefined()
+  })
+
+  it('preserves a newer unsynced local edit while adding recovery state', async () => {
+    remoteChat.updatedAt = '2026-01-01T00:00:00.000Z'
+    localChat = {
+      ...structuredClone(remoteChat),
+      title: 'Locally renamed',
+      updatedAt: '2026-01-01T00:01:00.000Z',
+      locallyModified: true,
+    }
+
+    await addPendingRecovery(remoteChat.id, envelope('turn-1'))
+
+    expect(remoteChat.title).toBe('Locally renamed')
+    expect(remoteChat.pendingRecoveries).toHaveLength(1)
+  })
+
+  it('merges a recovered response once after its user turn', async () => {
+    remoteChat.messages.push(message('user', 'Later question', 'turn-2'))
+    remoteChat.pendingRecoveries = [envelope('turn-1')]
+    localChat = structuredClone(remoteChat)
+    const assistant = message('assistant', 'Recovered answer', 'turn-1')
+
+    const expected = currentEnvelope('turn-1')
+    await completePendingRecovery(remoteChat.id, expected, assistant)
+    await completePendingRecovery(remoteChat.id, expected, assistant)
+
+    expect(remoteChat.messages.map((item) => item.content)).toEqual([
+      'Question',
+      'Recovered answer',
+      'Later question',
+    ])
+    expect(remoteChat.pendingRecoveries).toBeUndefined()
+  })
+
+  it('retries when a concurrent local edit rejects the first local apply', async () => {
+    remoteChat.pendingRecoveries = [envelope('turn-1')]
+    localChat = structuredClone(remoteChat)
+    applyFailures = 1
+
+    await completePendingRecovery(
+      remoteChat.id,
+      currentEnvelope('turn-1'),
+      message('assistant', 'Recovered answer', 'turn-1'),
+    )
+
+    expect(localChat?.messages.map((item) => item.content)).toEqual([
+      'Question',
+      'Recovered answer',
+    ])
+    expect(localChat?.pendingRecoveries).toBeUndefined()
+  })
+
+  it('replaces an interrupted partial message with the recovered response', async () => {
+    remoteChat.messages.push({
+      ...message('assistant', '', 'turn-1'),
+      thoughts: 'Drafting an outline',
+      isThinking: true,
+    })
+    remoteChat.pendingRecoveries = [envelope('turn-1')]
+    localChat = structuredClone(remoteChat)
+
+    await completePendingRecovery(
+      remoteChat.id,
+      currentEnvelope('turn-1'),
+      message('assistant', 'Recovered answer', 'turn-1'),
+    )
+
+    expect(remoteChat.messages).toHaveLength(2)
+    expect(remoteChat.messages[1].content).toBe('Recovered answer')
+    expect(remoteChat.messages[1].isThinking).toBeUndefined()
+    expect(remoteChat.pendingRecoveries).toBeUndefined()
+  })
+
+  it('updates recovered search reasoning when response content is unchanged', async () => {
+    remoteChat.messages.push({
+      ...message('assistant', 'Recovered answer', 'turn-1'),
+      searchReasoning: 'Partial search context',
+    })
+    remoteChat.pendingRecoveries = [envelope('turn-1')]
+    localChat = structuredClone(remoteChat)
+
+    await completePendingRecovery(remoteChat.id, currentEnvelope('turn-1'), {
+      ...message('assistant', 'Recovered answer', 'turn-1'),
+      searchReasoning: 'Complete search context',
+    })
+
+    expect(remoteChat.messages[1].searchReasoning).toBe(
+      'Complete search context',
+    )
+    expect(remoteChat.pendingRecoveries).toBeUndefined()
+  })
+
+  it('appends the recovered response when the user turn has not synced', async () => {
+    remoteChat.messages = [message('user', 'Question', 'other-turn')]
+    remoteChat.pendingRecoveries = [envelope('turn-1')]
+    localChat = structuredClone(remoteChat)
+
+    await completePendingRecovery(
+      remoteChat.id,
+      currentEnvelope('turn-1'),
+      message('assistant', 'Recovered answer', 'turn-1'),
+    )
+
+    expect(remoteChat.messages.map((item) => item.content)).toEqual([
+      'Question',
+      'Recovered answer',
+    ])
+    expect(remoteChat.pendingRecoveries).toBeUndefined()
+  })
+
+  it('does not restore a response after another device cancels the turn', async () => {
+    const assistant = message('assistant', 'Late recovered answer', 'turn-1')
+
+    await completePendingRecovery(
+      remoteChat.id,
+      currentEnvelope('turn-1'),
+      assistant,
+    )
+
+    expect(remoteChat.messages).toHaveLength(1)
+    expect(uploadAttempts).toBe(0)
+  })
+
+  it('does not complete or remove a replacement recovery', async () => {
+    const replaced = envelope('turn-1')
+    const replacement = {
+      ...envelope('turn-1'),
+      sessionId: 'abcdef0123456789abcdef0123456789',
+      ciphertext: 'BBBBBBBBBBBBBBBBBBBBBBBB',
+    }
+    remoteChat.pendingRecoveries = [replacement]
+    localChat = structuredClone(remoteChat)
+
+    await completePendingRecovery(
+      remoteChat.id,
+      replaced,
+      message('assistant', 'Stale answer', 'turn-1'),
+    )
+    await removePendingRecovery(remoteChat.id, replaced)
+
+    expect(remoteChat.messages).toHaveLength(1)
+    expect(remoteChat.pendingRecoveries).toEqual([replacement])
+    expect(uploadAttempts).toBe(0)
+  })
+
+  it('persists a live metadata patch after concurrent completion', async () => {
+    const assistant = message('assistant', 'Recovered answer', 'turn-1')
+    remoteChat.messages.push(assistant)
+    localChat = structuredClone(remoteChat)
+
+    await completePendingRecovery(
+      remoteChat.id,
+      currentEnvelope('turn-1'),
+      assistant,
+      {
+        title: 'Generated title',
+        model: 'new-model',
+      },
+    )
+
+    expect(remoteChat.title).toBe('Generated title')
+    expect(remoteChat.model).toBe('new-model')
+    expect(uploadAttempts).toBe(1)
+  })
+
+  it('does not replace a title changed while recovery was finishing', async () => {
+    const assistant = message('assistant', 'Recovered answer', 'turn-1')
+    remoteChat.messages.push(assistant)
+    remoteChat.title = 'Renamed chat'
+    remoteChat.titleState = 'manual'
+    localChat = structuredClone(remoteChat)
+
+    await completePendingRecovery(
+      remoteChat.id,
+      currentEnvelope('turn-1'),
+      assistant,
+      {
+        title: 'Generated title',
+        titleState: 'generated',
+        expectedTitleState: 'placeholder',
+        model: 'new-model',
+      },
+    )
+
+    expect(remoteChat.title).toBe('Renamed chat')
+    expect(remoteChat.titleState).toBe('manual')
+    expect(remoteChat.model).toBe('new-model')
+  })
+
+  it('does not reintroduce an envelope removed by another device', async () => {
+    await replacePendingRecovery(remoteChat.id, envelope('turn-1'), {
+      ...envelope('turn-1'),
+      keyId: 'abcdefabcdefabcdefabcdefabcdefab',
+    })
+
+    expect(remoteChat.pendingRecoveries).toBeUndefined()
+    expect(uploadAttempts).toBe(0)
+  })
+
+  it('releases queued mutations when a stalled mutation is aborted', async () => {
+    remoteChat.pendingRecoveries = [envelope('turn-1')]
+    localChat = structuredClone(remoteChat)
+    const controller = new AbortController()
+    let finishStalledUpload: ((chat: StoredChat) => void) | undefined
+    let markStalledUploadSettled: (() => void) | undefined
+    const stalledUploadSettled = new Promise<void>((resolve) => {
+      markStalledUploadSettled = resolve
+    })
+    uploadChat.mockImplementationOnce((chat: StoredChat) =>
+      new Promise<StoredChat>((resolve) => {
+        finishStalledUpload = resolve
+      }).then((uploaded) => {
+        uploadAttempts += 1
+        markStalledUploadSettled?.()
+        return uploaded
+      }),
+    )
+
+    const stalled = completePendingRecovery(
+      remoteChat.id,
+      currentEnvelope('turn-1'),
+      message('assistant', 'Stale answer', 'turn-1'),
+      undefined,
+      undefined,
+      controller.signal,
+    )
+    await vi.waitFor(() => expect(uploadChat).toHaveBeenCalledTimes(1))
+
+    const replacement = completePendingRecovery(
+      remoteChat.id,
+      currentEnvelope('turn-1'),
+      message('assistant', 'Recovered answer', 'turn-1'),
+    )
+    expect(uploadChat).toHaveBeenCalledTimes(1)
+
+    controller.abort()
+    await expect(stalled).rejects.toMatchObject({ name: 'AbortError' })
+    await replacement
+
+    expect(uploadChat).toHaveBeenCalledTimes(2)
+    expect(applyRemoteChatIfFresh).toHaveBeenCalledTimes(1)
+    expect(localChat?.messages[1].content).toBe('Recovered answer')
+
+    const staleUploadResult = {
+      ...structuredClone(remoteChat),
+      messages: [
+        remoteChat.messages[0],
+        message('assistant', 'Stale answer', 'turn-1'),
+      ],
+      syncVersion: 2,
+    }
+    finishStalledUpload?.(staleUploadResult)
+    await stalledUploadSettled
+    await Promise.resolve()
+
+    expect(applyRemoteChatIfFresh).toHaveBeenCalledTimes(1)
+    expect(localChat?.messages[1].content).toBe('Recovered answer')
+  })
+
+  it('does not execute an aborted mutation that is waiting in the queue', async () => {
+    remoteChat.pendingRecoveries = [envelope('turn-1')]
+    localChat = structuredClone(remoteChat)
+    let finishFirstUpload: (() => void) | undefined
+    uploadChat.mockImplementationOnce((chat: StoredChat) => {
+      const uploadedChat = structuredClone(chat)
+      return new Promise<StoredChat>((resolve) => {
+        finishFirstUpload = () => {
+          uploadAttempts += 1
+          remoteChat = {
+            ...uploadedChat,
+            syncVersion: 2,
+          }
+          resolve(remoteChat)
+        }
+      })
+    })
+
+    const first = completePendingRecovery(
+      remoteChat.id,
+      currentEnvelope('turn-1'),
+      message('assistant', 'Recovered answer', 'turn-1'),
+    )
+    await vi.waitFor(() => expect(uploadChat).toHaveBeenCalledTimes(1))
+
+    const controller = new AbortController()
+    const aborted = replacePendingRecovery(
+      remoteChat.id,
+      envelope('turn-1'),
+      { ...envelope('turn-1'), keyId: 'replacement-key' },
+      undefined,
+      controller.signal,
+    )
+    const following = addPendingRecovery(remoteChat.id, envelope('turn-2'))
+
+    controller.abort()
+    await expect(aborted).rejects.toMatchObject({ name: 'AbortError' })
+    expect(downloadChat).toHaveBeenCalledTimes(1)
+
+    finishFirstUpload?.()
+    await first
+    const result = await following
+
+    expect(uploadChat).toHaveBeenCalledTimes(2)
+    expect(downloadChat).toHaveBeenCalledTimes(2)
+    expect(result.pendingRecoveries?.map((pending) => pending.turnId)).toEqual([
+      'turn-2',
+    ])
+  })
+})

--- a/tests/services/inference/chat-recovery.test.ts
+++ b/tests/services/inference/chat-recovery.test.ts
@@ -1,0 +1,1559 @@
+import type { PendingRecoveryEnvelope } from '@/components/chat/types'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const decryptRecoveryEnvelope = vi.fn()
+const encryptRecoveryEnvelope = vi.fn()
+const rewrapRecoveryEnvelope = vi.fn()
+const deleteChatRecovery = vi.fn()
+const fetchRecoveredChatResponse = vi.fn()
+const getChatRecoveryState = vi.fn()
+const addPendingRecovery = vi.fn()
+const completePendingRecovery = vi.fn()
+const removePendingRecovery = vi.fn()
+const replacePendingRecovery = vi.fn()
+const resetChatRecoverySyncState = vi.fn()
+const clearChatRecoveryDrafts = vi.fn()
+const clearActiveChatRecoveries = vi.fn()
+const getChatRecoveryDraft = vi.fn()
+const pruneChatRecoveryDrafts = vi.fn()
+const setChatRecoveryActive = vi.fn()
+const setChatRecoveryDraft = vi.fn()
+const retryDeferredAlternativesFinalization = vi.fn()
+const parseRichStreamingResponse = vi.fn()
+const generateTitle = vi.fn()
+const getAllChats = vi.fn()
+const getChat = vi.fn()
+let storedAlternatives: string[] = []
+let cloudSyncEnabled = true
+
+vi.mock('@/services/inference/chat-recovery-crypto', () => ({
+  decryptRecoveryEnvelope: (...args: unknown[]) =>
+    decryptRecoveryEnvelope(...args),
+  encryptRecoveryEnvelope: (...args: unknown[]) =>
+    encryptRecoveryEnvelope(...args),
+  rewrapRecoveryEnvelope: (...args: unknown[]) =>
+    rewrapRecoveryEnvelope(...args),
+}))
+
+vi.mock('@/services/inference/chat-recovery-client', () => ({
+  ChatRecoveryError: class ChatRecoveryError extends Error {
+    constructor(
+      message: string,
+      public readonly state?: string,
+      public readonly retryable = false,
+    ) {
+      super(message)
+    }
+  },
+  deleteChatRecovery: (...args: unknown[]) => deleteChatRecovery(...args),
+  fetchRecoveredChatResponse: (...args: unknown[]) =>
+    fetchRecoveredChatResponse(...args),
+  getChatRecoveryStatus: async (...args: unknown[]) => ({
+    state: await getChatRecoveryState(...args),
+    persistedBytes: 128,
+  }),
+}))
+
+vi.mock('@/services/inference/chat-recovery-sync', () => ({
+  addPendingRecovery: (...args: unknown[]) => addPendingRecovery(...args),
+  completePendingRecovery: (...args: unknown[]) =>
+    completePendingRecovery(...args),
+  removePendingRecovery: (...args: unknown[]) => removePendingRecovery(...args),
+  replacePendingRecovery: (...args: unknown[]) =>
+    replacePendingRecovery(...args),
+  resetChatRecoverySyncState: () => resetChatRecoverySyncState(),
+  sameRecoveredResponse: (
+    existing: { content?: string },
+    recovered: { content?: string },
+  ) => existing.content === recovered.content,
+}))
+
+vi.mock('@/services/inference/chat-recovery-drafts', () => ({
+  clearActiveChatRecoveries: () => clearActiveChatRecoveries(),
+  clearChatRecoveryDrafts: () => clearChatRecoveryDrafts(),
+  getChatRecoveryDraft: (...args: unknown[]) => getChatRecoveryDraft(...args),
+  pruneChatRecoveryDrafts: (...args: unknown[]) =>
+    pruneChatRecoveryDrafts(...args),
+  setChatRecoveryActive: (...args: unknown[]) => setChatRecoveryActive(...args),
+  setChatRecoveryDraft: (...args: unknown[]) => setChatRecoveryDraft(...args),
+}))
+
+vi.mock('@/services/cloud/legacy-blob-migration', () => ({
+  retryDeferredAlternativesFinalization: () =>
+    retryDeferredAlternativesFinalization(),
+}))
+
+vi.mock('@/components/chat/hooks/streaming', () => ({
+  parseRichStreamingResponse: (...args: unknown[]) =>
+    parseRichStreamingResponse(...args),
+}))
+
+vi.mock('@/services/inference/title', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/services/inference/title')>()),
+  generateTitle: (...args: unknown[]) => generateTitle(...args),
+}))
+
+vi.mock('@/services/encryption/encryption-service', () => ({
+  encryptionService: {
+    getKeyBytesOrThrow: () => new Uint8Array(32),
+    getStoredAlternatives: () => storedAlternatives,
+    getAlternativeKeyBytes: () => new Uint8Array(32).fill(1),
+  },
+}))
+
+vi.mock('@/services/storage/indexed-db', () => ({
+  indexedDBStorage: {
+    getAllChats: () => getAllChats(),
+    getChat: (...args: unknown[]) => getChat(...args),
+  },
+}))
+
+vi.mock('@/utils/cloud-sync-settings', () => ({
+  isCloudSyncEnabled: () => cloudSyncEnabled,
+}))
+
+vi.mock('@/utils/error-handling', () => ({
+  logError: vi.fn(),
+}))
+
+import {
+  abandonChatRecoveryAttempt,
+  cancelChatRecovery,
+  persistChatRecoveryToken,
+  resetChatRecoveryState,
+  scanPendingChatRecoveries,
+  startChatRecoveryAttempt,
+} from '@/services/inference/chat-recovery'
+
+const SESSION_ID = '0123456789abcdef0123456789abcdef'
+const RECOVERY_SCAN_MAX_AGE_MS = 120_000
+const envelope: PendingRecoveryEnvelope = {
+  v: 1,
+  turnId: 'turn-1',
+  keyId: '0123456789abcdef0123456789abcdef',
+  createdAt: new Date().toISOString(),
+  expiresAt: new Date(Date.now() + 60_000).toISOString(),
+  nonce: 'AAAAAAAAAAAAAAAA',
+  ciphertext: 'AAAAAAAAAAAAAAAAAAAAAAAA',
+}
+
+async function persistActiveRecovery(): Promise<void> {
+  encryptRecoveryEnvelope.mockResolvedValueOnce(envelope)
+  startChatRecoveryAttempt('chat-1', 'turn-1', SESSION_ID)
+  await persistChatRecoveryToken({
+    userId: 'user-1',
+    chatId: 'chat-1',
+    turnId: 'turn-1',
+    sessionId: SESSION_ID,
+    token: {
+      exportedSecret: new Uint8Array(32),
+      requestEnc: new Uint8Array(32),
+    },
+  })
+}
+
+describe('chat recovery lifecycle', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getChatRecoveryDraft.mockReset()
+    resetChatRecoveryState()
+    storedAlternatives = []
+    cloudSyncEnabled = true
+    getChat.mockResolvedValue({ id: 'chat-1', isLocalOnly: false })
+    generateTitle.mockResolvedValue('Untitled')
+    deleteChatRecovery.mockResolvedValue(undefined)
+    removePendingRecovery.mockResolvedValue(undefined)
+    addPendingRecovery.mockResolvedValue(undefined)
+    completePendingRecovery.mockResolvedValue(undefined)
+    replacePendingRecovery.mockResolvedValue(undefined)
+    retryDeferredAlternativesFinalization.mockResolvedValue(undefined)
+  })
+
+  it('suppresses a token that arrives after explicit cancellation', async () => {
+    startChatRecoveryAttempt('chat-1', 'turn-1', SESSION_ID)
+    const cancellation = cancelChatRecovery('chat-1')
+
+    await expect(
+      persistChatRecoveryToken({
+        userId: 'user-1',
+        chatId: 'chat-1',
+        turnId: 'turn-1',
+        sessionId: SESSION_ID,
+        token: {
+          exportedSecret: new Uint8Array(32),
+          requestEnc: new Uint8Array(32),
+        },
+      }),
+    ).rejects.toMatchObject({ name: 'AbortError' })
+    await cancellation
+
+    expect(encryptRecoveryEnvelope).not.toHaveBeenCalled()
+    expect(addPendingRecovery).not.toHaveBeenCalled()
+    expect(deleteChatRecovery).toHaveBeenCalledWith(SESSION_ID)
+  })
+
+  it('stores a local recovery token without a cloud encryption key', async () => {
+    cloudSyncEnabled = false
+    getChat.mockResolvedValue({ id: 'chat-1', isLocalOnly: true })
+    startChatRecoveryAttempt('chat-1', 'turn-1', SESSION_ID)
+
+    await persistChatRecoveryToken({
+      userId: 'user-1',
+      chatId: 'chat-1',
+      turnId: 'turn-1',
+      sessionId: SESSION_ID,
+      token: {
+        exportedSecret: new Uint8Array(32),
+        requestEnc: new Uint8Array(32),
+      },
+    })
+
+    expect(encryptRecoveryEnvelope).not.toHaveBeenCalled()
+    expect(addPendingRecovery).toHaveBeenCalledWith(
+      'chat-1',
+      expect.objectContaining({
+        storage: 'local',
+        sessionId: SESSION_ID,
+        turnId: 'turn-1',
+        recoveryToken: expect.any(String),
+      }),
+    )
+  })
+
+  it('streams a processing session and persists only after completion', async () => {
+    getAllChats.mockResolvedValue([
+      { id: 'chat-1', pendingRecoveries: [envelope] },
+    ])
+    decryptRecoveryEnvelope.mockResolvedValue({
+      sessionId: SESSION_ID,
+      recoveryToken: JSON.stringify({
+        exportedSecret: '00'.repeat(32),
+        requestEnc: '11'.repeat(32),
+      }),
+    })
+    getChatRecoveryState
+      .mockResolvedValueOnce('processing')
+      .mockResolvedValueOnce('complete')
+    fetchRecoveredChatResponse.mockResolvedValue(new Response('stream'))
+    parseRichStreamingResponse.mockImplementation(
+      async (
+        _response: Response,
+        options: { onUpdate: (message: object) => void },
+      ) => {
+        options.onUpdate({
+          role: 'assistant',
+          content: '',
+          timestamp: new Date().toISOString(),
+        })
+        options.onUpdate({
+          role: 'assistant',
+          content: 'Recover',
+          timestamp: new Date().toISOString(),
+        })
+        expect(completePendingRecovery).not.toHaveBeenCalled()
+        return {
+          role: 'assistant',
+          content: 'Recovered',
+          timestamp: new Date().toISOString(),
+        }
+      },
+    )
+
+    await scanPendingChatRecoveries('user-1')
+
+    expect(fetchRecoveredChatResponse).toHaveBeenCalledWith(
+      SESSION_ID,
+      expect.any(Object),
+      expect.any(AbortSignal),
+      expect.any(Function),
+    )
+    expect(setChatRecoveryDraft).toHaveBeenCalledWith({
+      chatId: 'chat-1',
+      turnId: 'turn-1',
+      sessionId: SESSION_ID,
+      message: expect.objectContaining({
+        role: 'assistant',
+        content: 'Recover',
+        turnId: 'turn-1',
+      }),
+    })
+    expect(setChatRecoveryDraft).toHaveBeenCalledTimes(1)
+
+    expect(completePendingRecovery).toHaveBeenCalledWith(
+      'chat-1',
+      expect.objectContaining({ turnId: 'turn-1' }),
+      expect.objectContaining({
+        role: 'assistant',
+        content: 'Recovered',
+        turnId: 'turn-1',
+      }),
+      undefined,
+      expect.any(Function),
+      expect.any(AbortSignal),
+    )
+    expect(deleteChatRecovery).toHaveBeenCalledWith(SESSION_ID)
+  })
+
+  it('generates a title when the first response is recovered', async () => {
+    getAllChats.mockResolvedValue([
+      { id: 'chat-1', pendingRecoveries: [envelope] },
+    ])
+    getChat.mockResolvedValue({
+      id: 'chat-1',
+      title: 'Untitled',
+      titleState: 'placeholder',
+      messages: [
+        {
+          role: 'user',
+          turnId: 'turn-1',
+          content: '',
+          attachments: [
+            {
+              fileName: 'recovery.txt',
+              textContent: '   ',
+              description: 'How does encrypted recovery work?',
+            },
+          ],
+        },
+      ],
+    })
+    decryptRecoveryEnvelope.mockResolvedValue({
+      sessionId: SESSION_ID,
+      recoveryToken: JSON.stringify({
+        exportedSecret: '00'.repeat(32),
+        requestEnc: '11'.repeat(32),
+      }),
+    })
+    getChatRecoveryState
+      .mockResolvedValueOnce('processing')
+      .mockResolvedValueOnce('complete')
+    fetchRecoveredChatResponse.mockResolvedValue(new Response('stream'))
+    parseRichStreamingResponse.mockResolvedValue({
+      role: 'assistant',
+      content: 'Recovered',
+      timestamp: new Date().toISOString(),
+    })
+    generateTitle.mockResolvedValue('Encrypted recovery')
+
+    await scanPendingChatRecoveries('user-1')
+
+    expect(generateTitle).toHaveBeenCalledWith([
+      { role: 'user', content: 'How does encrypted recovery work?' },
+    ])
+    expect(completePendingRecovery).toHaveBeenCalledWith(
+      'chat-1',
+      expect.objectContaining({ turnId: 'turn-1' }),
+      expect.objectContaining({ content: 'Recovered' }),
+      {
+        title: 'Encrypted recovery',
+        titleState: 'generated',
+        expectedTitleState: 'placeholder',
+      },
+      expect.any(Function),
+      expect.any(AbortSignal),
+    )
+  })
+
+  it('releases recovery activity before deleting the completed session', async () => {
+    getAllChats.mockResolvedValue([
+      { id: 'chat-1', pendingRecoveries: [envelope] },
+    ])
+    decryptRecoveryEnvelope.mockResolvedValue({
+      sessionId: SESSION_ID,
+      recoveryToken: JSON.stringify({
+        exportedSecret: '00'.repeat(32),
+        requestEnc: '11'.repeat(32),
+      }),
+    })
+    getChatRecoveryState
+      .mockResolvedValueOnce('processing')
+      .mockResolvedValueOnce('complete')
+    fetchRecoveredChatResponse.mockResolvedValue(new Response('stream'))
+    parseRichStreamingResponse.mockResolvedValue({
+      role: 'assistant',
+      content: 'Recovered',
+      timestamp: new Date().toISOString(),
+    })
+    let finishDeletion: (() => void) | undefined
+    deleteChatRecovery.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          finishDeletion = resolve
+        }),
+    )
+
+    const scan = scanPendingChatRecoveries('user-1')
+    await vi.waitFor(() => {
+      expect(completePendingRecovery).toHaveBeenCalled()
+      expect(setChatRecoveryActive).toHaveBeenLastCalledWith(
+        'chat-1',
+        'turn-1',
+        false,
+      )
+    })
+
+    finishDeletion?.()
+    await scan
+  })
+
+  it('ignores a stream update after recovery cancellation', async () => {
+    getAllChats.mockResolvedValue([
+      { id: 'chat-1', pendingRecoveries: [envelope] },
+    ])
+    decryptRecoveryEnvelope.mockResolvedValue({
+      sessionId: SESSION_ID,
+      recoveryToken: JSON.stringify({
+        exportedSecret: '00'.repeat(32),
+        requestEnc: '11'.repeat(32),
+      }),
+    })
+    getChatRecoveryState.mockResolvedValue('processing')
+    let recoverySignal: AbortSignal | undefined
+    let publishUpdate: ((message: object) => void) | undefined
+    fetchRecoveredChatResponse.mockImplementation(
+      async (_sessionId: string, _token: unknown, signal: AbortSignal) => {
+        recoverySignal = signal
+        return new Response('stream')
+      },
+    )
+    parseRichStreamingResponse.mockImplementation(
+      (_response: Response, options: { onUpdate: (message: object) => void }) =>
+        new Promise((_resolve, reject) => {
+          publishUpdate = options.onUpdate
+          const rejectAbort = () =>
+            reject(new DOMException('Aborted', 'AbortError'))
+          if (recoverySignal?.aborted) {
+            rejectAbort()
+          } else {
+            recoverySignal?.addEventListener('abort', rejectAbort, {
+              once: true,
+            })
+          }
+        }),
+    )
+
+    const scan = scanPendingChatRecoveries('user-1')
+    await vi.waitFor(() => expect(publishUpdate).toBeTypeOf('function'))
+    await cancelChatRecovery('chat-1')
+
+    publishUpdate?.({
+      role: 'assistant',
+      content: 'Stale replay',
+      timestamp: new Date().toISOString(),
+    })
+
+    expect(setChatRecoveryDraft).not.toHaveBeenCalled()
+    await scan
+  })
+
+  it('publishes the recovered replay from its first visible update', async () => {
+    getAllChats.mockResolvedValue([
+      { id: 'chat-1', pendingRecoveries: [envelope] },
+    ])
+    decryptRecoveryEnvelope.mockResolvedValue({
+      sessionId: SESSION_ID,
+      recoveryToken: JSON.stringify({
+        exportedSecret: '00'.repeat(32),
+        requestEnc: '11'.repeat(32),
+      }),
+    })
+    getChatRecoveryState
+      .mockResolvedValueOnce('processing')
+      .mockResolvedValueOnce('complete')
+    fetchRecoveredChatResponse.mockResolvedValue(new Response('stream'))
+    parseRichStreamingResponse.mockImplementation(
+      async (
+        _response: Response,
+        options: { onUpdate: (message: object) => void },
+      ) => {
+        options.onUpdate({
+          role: 'assistant',
+          content: 'Recovered so far',
+          timestamp: new Date().toISOString(),
+        })
+        expect(setChatRecoveryDraft).toHaveBeenCalledWith(
+          expect.objectContaining({
+            chatId: 'chat-1',
+            turnId: 'turn-1',
+            message: expect.objectContaining({
+              content: 'Recovered so far',
+            }),
+          }),
+        )
+        return {
+          role: 'assistant',
+          content: 'Recovered so far',
+          timestamp: new Date().toISOString(),
+        }
+      },
+    )
+
+    await scanPendingChatRecoveries('user-1')
+
+    expect(setChatRecoveryDraft).toHaveBeenCalledTimes(1)
+  })
+
+  it('releases recovery activity when checkpoint loading fails', async () => {
+    getAllChats.mockResolvedValue([
+      { id: 'chat-1', pendingRecoveries: [envelope] },
+    ])
+    getChat.mockRejectedValueOnce(new Error('IndexedDB unavailable'))
+    decryptRecoveryEnvelope.mockResolvedValue({
+      sessionId: SESSION_ID,
+      recoveryToken: JSON.stringify({
+        exportedSecret: '00'.repeat(32),
+        requestEnc: '11'.repeat(32),
+      }),
+    })
+    getChatRecoveryState.mockResolvedValue('processing')
+
+    await scanPendingChatRecoveries('user-1')
+
+    expect(fetchRecoveredChatResponse).not.toHaveBeenCalled()
+    expect(setChatRecoveryActive.mock.calls).toEqual([
+      ['chat-1', 'turn-1', true],
+      ['chat-1', 'turn-1', false],
+    ])
+  })
+
+  it('preserves the partial response when recovery returns an upstream error', async () => {
+    getAllChats.mockResolvedValue([
+      { id: 'chat-1', pendingRecoveries: [envelope] },
+    ])
+    decryptRecoveryEnvelope.mockResolvedValue({
+      sessionId: SESSION_ID,
+      recoveryToken: JSON.stringify({
+        exportedSecret: '00'.repeat(32),
+        requestEnc: '11'.repeat(32),
+      }),
+    })
+    getChatRecoveryState.mockResolvedValue('processing')
+    fetchRecoveredChatResponse.mockResolvedValue(
+      new Response('{"error":"conflict"}', { status: 409 }),
+    )
+
+    await scanPendingChatRecoveries('user-1')
+
+    expect(parseRichStreamingResponse).not.toHaveBeenCalled()
+    expect(completePendingRecovery).not.toHaveBeenCalled()
+    expect(removePendingRecovery).toHaveBeenCalledWith(
+      'chat-1',
+      expect.objectContaining({ turnId: 'turn-1' }),
+      expect.any(Function),
+      expect.any(AbortSignal),
+    )
+    expect(deleteChatRecovery).toHaveBeenCalledWith(SESSION_ID)
+  })
+
+  it('keeps recovery active through repeated processing reconnects', async () => {
+    getAllChats.mockResolvedValue([
+      { id: 'chat-1', pendingRecoveries: [envelope] },
+    ])
+    decryptRecoveryEnvelope.mockResolvedValue({
+      sessionId: SESSION_ID,
+      recoveryToken: JSON.stringify({
+        exportedSecret: '00'.repeat(32),
+        requestEnc: '11'.repeat(32),
+      }),
+    })
+    getChatRecoveryState
+      .mockResolvedValueOnce('processing')
+      .mockResolvedValueOnce('processing')
+      .mockResolvedValueOnce('processing')
+      .mockResolvedValueOnce('processing')
+      .mockResolvedValueOnce('complete')
+    fetchRecoveredChatResponse.mockResolvedValue(new Response('stream'))
+    parseRichStreamingResponse.mockImplementation(
+      async (
+        _response: Response,
+        options: { onUpdate: (message: object) => void },
+      ) => {
+        const message = {
+          role: 'assistant',
+          content: 'Partial',
+          timestamp: new Date().toISOString(),
+        }
+        options.onUpdate(message)
+        return message
+      },
+    )
+
+    await scanPendingChatRecoveries('user-1')
+
+    expect(setChatRecoveryDraft).toHaveBeenCalled()
+    expect(fetchRecoveredChatResponse).toHaveBeenCalledTimes(4)
+    expect(completePendingRecovery).toHaveBeenCalledWith(
+      'chat-1',
+      expect.objectContaining({ turnId: 'turn-1' }),
+      expect.objectContaining({ content: 'Partial' }),
+      undefined,
+      expect.any(Function),
+      expect.any(AbortSignal),
+    )
+    expect(deleteChatRecovery).toHaveBeenCalledWith(SESSION_ID)
+    expect(setChatRecoveryActive.mock.calls).toEqual([
+      ['chat-1', 'turn-1', true],
+      ['chat-1', 'turn-1', false],
+    ])
+  })
+
+  it('keeps streaming when a recovered response ends while processing', async () => {
+    getAllChats.mockResolvedValue([
+      { id: 'chat-1', pendingRecoveries: [envelope] },
+    ])
+    decryptRecoveryEnvelope.mockResolvedValue({
+      sessionId: SESSION_ID,
+      recoveryToken: JSON.stringify({
+        exportedSecret: '00'.repeat(32),
+        requestEnc: '11'.repeat(32),
+      }),
+    })
+    getChatRecoveryState
+      .mockResolvedValueOnce('processing')
+      .mockResolvedValueOnce('processing')
+      .mockResolvedValueOnce('complete')
+    fetchRecoveredChatResponse
+      .mockResolvedValueOnce(new Response('partial'))
+      .mockResolvedValueOnce(new Response('complete'))
+    parseRichStreamingResponse
+      .mockResolvedValueOnce({
+        role: 'assistant',
+        content: 'Partial',
+        timestamp: new Date().toISOString(),
+      })
+      .mockResolvedValueOnce({
+        role: 'assistant',
+        content: 'Complete',
+        timestamp: new Date().toISOString(),
+      })
+
+    await scanPendingChatRecoveries('user-1')
+
+    expect(fetchRecoveredChatResponse).toHaveBeenCalledTimes(2)
+    expect(completePendingRecovery).toHaveBeenCalledWith(
+      'chat-1',
+      expect.objectContaining({ turnId: 'turn-1' }),
+      expect.objectContaining({ content: 'Complete' }),
+      undefined,
+      expect.any(Function),
+      expect.any(AbortSignal),
+    )
+    expect(setChatRecoveryActive.mock.calls).toEqual([
+      ['chat-1', 'turn-1', true],
+      ['chat-1', 'turn-1', false],
+    ])
+  })
+
+  it('reconnects when a recovered response transport terminates', async () => {
+    getAllChats.mockResolvedValue([
+      { id: 'chat-1', pendingRecoveries: [envelope] },
+    ])
+    decryptRecoveryEnvelope.mockResolvedValue({
+      sessionId: SESSION_ID,
+      recoveryToken: JSON.stringify({
+        exportedSecret: '00'.repeat(32),
+        requestEnc: '11'.repeat(32),
+      }),
+    })
+    getChatRecoveryState
+      .mockResolvedValueOnce('processing')
+      .mockResolvedValueOnce('processing')
+      .mockResolvedValueOnce('complete')
+    fetchRecoveredChatResponse.mockResolvedValue(new Response('stream'))
+    parseRichStreamingResponse
+      .mockRejectedValueOnce(new TypeError('terminated'))
+      .mockResolvedValueOnce({
+        role: 'assistant',
+        content: 'Complete',
+        timestamp: new Date().toISOString(),
+      })
+
+    await scanPendingChatRecoveries('user-1')
+
+    expect(fetchRecoveredChatResponse).toHaveBeenCalledTimes(2)
+    expect(fetchRecoveredChatResponse.mock.calls[1]).toEqual([
+      SESSION_ID,
+      expect.any(Object),
+      expect.any(AbortSignal),
+      expect.any(Function),
+    ])
+    expect(completePendingRecovery).toHaveBeenCalledWith(
+      'chat-1',
+      expect.objectContaining({ turnId: 'turn-1' }),
+      expect.objectContaining({ content: 'Complete' }),
+      undefined,
+      expect.any(Function),
+      expect.any(AbortSignal),
+    )
+    expect(setChatRecoveryActive.mock.calls).toEqual([
+      ['chat-1', 'turn-1', true],
+      ['chat-1', 'turn-1', false],
+    ])
+  })
+
+  it('replays from zero when a completed response is truncated', async () => {
+    getAllChats.mockResolvedValue([
+      { id: 'chat-1', pendingRecoveries: [envelope] },
+    ])
+    decryptRecoveryEnvelope.mockResolvedValue({
+      sessionId: SESSION_ID,
+      recoveryToken: JSON.stringify({
+        exportedSecret: '00'.repeat(32),
+        requestEnc: '11'.repeat(32),
+      }),
+    })
+    getChatRecoveryState
+      .mockResolvedValueOnce('processing')
+      .mockResolvedValueOnce('complete')
+      .mockResolvedValueOnce('complete')
+    fetchRecoveredChatResponse
+      .mockImplementationOnce(
+        async (
+          _sessionId: string,
+          _token: unknown,
+          _signal: AbortSignal,
+          onEncryptedBytes: (bytes: number) => void,
+        ) => {
+          onEncryptedBytes(64)
+          return new Response('partial')
+        },
+      )
+      .mockImplementationOnce(
+        async (
+          _sessionId: string,
+          _token: unknown,
+          _signal: AbortSignal,
+          onEncryptedBytes: (bytes: number) => void,
+        ) => {
+          onEncryptedBytes(128)
+          return new Response('complete')
+        },
+      )
+    parseRichStreamingResponse
+      .mockResolvedValueOnce({
+        role: 'assistant',
+        content: 'Partial',
+        timestamp: new Date().toISOString(),
+      })
+      .mockResolvedValueOnce({
+        role: 'assistant',
+        content: 'Complete',
+        timestamp: new Date().toISOString(),
+      })
+
+    await scanPendingChatRecoveries('user-1')
+
+    expect(fetchRecoveredChatResponse).toHaveBeenCalledTimes(2)
+    expect(fetchRecoveredChatResponse.mock.calls[1]).toEqual([
+      SESSION_ID,
+      expect.any(Object),
+      expect.any(AbortSignal),
+      expect.any(Function),
+    ])
+    expect(completePendingRecovery).toHaveBeenCalledWith(
+      'chat-1',
+      expect.objectContaining({ turnId: 'turn-1' }),
+      expect.objectContaining({ content: 'Complete' }),
+      undefined,
+      expect.any(Function),
+      expect.any(AbortSignal),
+    )
+  })
+
+  it('does not regress the visible draft while replaying after reconnect', async () => {
+    getAllChats.mockResolvedValue([
+      { id: 'chat-1', pendingRecoveries: [envelope] },
+    ])
+    decryptRecoveryEnvelope.mockResolvedValue({
+      sessionId: SESSION_ID,
+      recoveryToken: JSON.stringify({
+        exportedSecret: '00'.repeat(32),
+        requestEnc: '11'.repeat(32),
+      }),
+    })
+    getChatRecoveryDraft.mockReturnValue({
+      chatId: 'chat-1',
+      turnId: 'turn-1',
+      sessionId: SESSION_ID,
+      message: {
+        role: 'assistant',
+        content: 'Already shown',
+        timestamp: new Date().toISOString(),
+      },
+    })
+    getChatRecoveryState
+      .mockResolvedValueOnce('processing')
+      .mockResolvedValueOnce('processing')
+      .mockResolvedValueOnce('complete')
+    fetchRecoveredChatResponse.mockResolvedValue(new Response('stream'))
+    parseRichStreamingResponse
+      .mockImplementationOnce(
+        async (
+          _response: Response,
+          options: { onUpdate: (message: object) => void },
+        ) => {
+          options.onUpdate({
+            role: 'assistant',
+            content: 'Old prefix',
+            timestamp: new Date().toISOString(),
+          })
+          throw new TypeError('terminated')
+        },
+      )
+      .mockImplementationOnce(
+        async (
+          _response: Response,
+          options: { onUpdate: (message: object) => void },
+        ) => {
+          options.onUpdate({
+            role: 'assistant',
+            content: 'Old prefix',
+            timestamp: new Date().toISOString(),
+          })
+          options.onUpdate({
+            role: 'assistant',
+            content: 'Already shown',
+            timestamp: new Date().toISOString(),
+          })
+          options.onUpdate({
+            role: 'assistant',
+            content: 'Newest',
+            timestamp: new Date().toISOString(),
+          })
+          return {
+            role: 'assistant',
+            content: 'Newest',
+            timestamp: new Date().toISOString(),
+          }
+        },
+      )
+
+    await scanPendingChatRecoveries('user-1')
+
+    expect(fetchRecoveredChatResponse).toHaveBeenCalledTimes(2)
+    expect(setChatRecoveryDraft).toHaveBeenCalledTimes(1)
+    expect(setChatRecoveryDraft).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.objectContaining({ content: 'Newest' }),
+      }),
+    )
+  })
+
+  it('ignores a presentation checkpoint from a replaced session', async () => {
+    getAllChats.mockResolvedValue([
+      { id: 'chat-1', pendingRecoveries: [envelope] },
+    ])
+    decryptRecoveryEnvelope.mockResolvedValue({
+      sessionId: SESSION_ID,
+      recoveryToken: JSON.stringify({
+        exportedSecret: '00'.repeat(32),
+        requestEnc: '11'.repeat(32),
+      }),
+    })
+    getChatRecoveryDraft.mockReturnValue({
+      chatId: 'chat-1',
+      turnId: 'turn-1',
+      sessionId: 'fedcba9876543210fedcba9876543210',
+      message: {
+        role: 'assistant',
+        content: 'Output from replaced session',
+        timestamp: new Date().toISOString(),
+      },
+    })
+    getChatRecoveryState
+      .mockResolvedValueOnce('processing')
+      .mockResolvedValueOnce('complete')
+    fetchRecoveredChatResponse.mockResolvedValue(new Response('stream'))
+    parseRichStreamingResponse.mockImplementation(
+      async (
+        _response: Response,
+        options: { onUpdate: (message: object) => void },
+      ) => {
+        const message = {
+          role: 'assistant',
+          content: 'New session output',
+          timestamp: new Date().toISOString(),
+        }
+        options.onUpdate(message)
+        return message
+      },
+    )
+
+    await scanPendingChatRecoveries('user-1')
+
+    expect(setChatRecoveryDraft).toHaveBeenCalledTimes(1)
+    expect(setChatRecoveryDraft).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: SESSION_ID,
+        message: expect.objectContaining({ content: 'New session output' }),
+      }),
+    )
+  })
+
+  it('keeps a persisted partial visible until replay catches up', async () => {
+    getAllChats.mockResolvedValue([
+      { id: 'chat-1', pendingRecoveries: [envelope] },
+    ])
+    getChat.mockResolvedValue({
+      id: 'chat-1',
+      isLocalOnly: false,
+      messages: [
+        {
+          role: 'assistant',
+          turnId: 'turn-1',
+          content: 'Already persisted',
+          timestamp: new Date().toISOString(),
+        },
+      ],
+    })
+    decryptRecoveryEnvelope.mockResolvedValue({
+      sessionId: SESSION_ID,
+      recoveryToken: JSON.stringify({
+        exportedSecret: '00'.repeat(32),
+        requestEnc: '11'.repeat(32),
+      }),
+    })
+    getChatRecoveryState
+      .mockResolvedValueOnce('processing')
+      .mockResolvedValueOnce('complete')
+    fetchRecoveredChatResponse.mockResolvedValue(new Response('stream'))
+    parseRichStreamingResponse.mockImplementation(
+      async (
+        _response: Response,
+        options: { onUpdate: (message: object) => void },
+      ) => {
+        options.onUpdate({
+          role: 'assistant',
+          content: 'Old prefix',
+          timestamp: new Date().toISOString(),
+        })
+        options.onUpdate({
+          role: 'assistant',
+          content: 'Already persisted',
+          timestamp: new Date().toISOString(),
+        })
+        options.onUpdate({
+          role: 'assistant',
+          content: 'New streamed content',
+          timestamp: new Date().toISOString(),
+        })
+        return {
+          role: 'assistant',
+          content: 'New streamed content',
+          timestamp: new Date().toISOString(),
+        }
+      },
+    )
+
+    await scanPendingChatRecoveries('user-1')
+
+    expect(setChatRecoveryDraft).toHaveBeenCalledTimes(1)
+    expect(setChatRecoveryDraft).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.objectContaining({ content: 'New streamed content' }),
+      }),
+    )
+  })
+
+  it('reuses an in-flight recovery scan instead of restarting its stream', async () => {
+    getAllChats.mockResolvedValue([
+      { id: 'chat-1', pendingRecoveries: [envelope] },
+    ])
+    decryptRecoveryEnvelope.mockResolvedValue({
+      sessionId: SESSION_ID,
+      recoveryToken: JSON.stringify({
+        exportedSecret: '00'.repeat(32),
+        requestEnc: '11'.repeat(32),
+      }),
+    })
+    getChatRecoveryState.mockResolvedValue('processing')
+    let recoverySignal: AbortSignal | undefined
+    fetchRecoveredChatResponse.mockImplementation(
+      async (_sessionId: string, _token: unknown, signal: AbortSignal) => {
+        recoverySignal = signal
+        return new Response('stream')
+      },
+    )
+    parseRichStreamingResponse.mockImplementation(
+      () =>
+        new Promise((_resolve, reject) => {
+          recoverySignal?.addEventListener(
+            'abort',
+            () => reject(new DOMException('Aborted', 'AbortError')),
+            { once: true },
+          )
+        }),
+    )
+
+    const firstScan = scanPendingChatRecoveries('user-1')
+    await vi.waitFor(() =>
+      expect(fetchRecoveredChatResponse).toHaveBeenCalledTimes(1),
+    )
+    const repeatedScan = scanPendingChatRecoveries('user-1')
+
+    expect(repeatedScan).toBe(firstScan)
+    expect(fetchRecoveredChatResponse).toHaveBeenCalledTimes(1)
+
+    await cancelChatRecovery('chat-1')
+    await firstScan
+  })
+
+  it('queues refreshed discovery without restarting the active stream', async () => {
+    getAllChats
+      .mockResolvedValueOnce([{ id: 'chat-1', pendingRecoveries: [envelope] }])
+      .mockResolvedValueOnce([])
+    decryptRecoveryEnvelope.mockResolvedValue({
+      sessionId: SESSION_ID,
+      recoveryToken: JSON.stringify({
+        exportedSecret: '00'.repeat(32),
+        requestEnc: '11'.repeat(32),
+      }),
+    })
+    getChatRecoveryState
+      .mockResolvedValueOnce('processing')
+      .mockResolvedValueOnce('complete')
+    fetchRecoveredChatResponse.mockResolvedValue(new Response('stream'))
+    let finishStream: ((message: object) => void) | undefined
+    parseRichStreamingResponse.mockReturnValueOnce(
+      new Promise((resolve) => {
+        finishStream = resolve
+      }),
+    )
+
+    const activeScan = scanPendingChatRecoveries('user-1')
+    await vi.waitFor(() =>
+      expect(fetchRecoveredChatResponse).toHaveBeenCalledTimes(1),
+    )
+    const refresh = scanPendingChatRecoveries('user-1', true)
+
+    expect(refresh).toBe(activeScan)
+    expect(fetchRecoveredChatResponse).toHaveBeenCalledTimes(1)
+
+    finishStream?.({
+      role: 'assistant',
+      content: 'Complete',
+      timestamp: new Date().toISOString(),
+    })
+    await activeScan
+    await vi.waitFor(() => expect(getAllChats).toHaveBeenCalledTimes(2))
+  })
+
+  it('cancels a recovery stream resumed by a scan', async () => {
+    getAllChats.mockResolvedValue([
+      { id: 'chat-1', pendingRecoveries: [envelope] },
+    ])
+    decryptRecoveryEnvelope.mockResolvedValue({
+      sessionId: SESSION_ID,
+      recoveryToken: JSON.stringify({
+        exportedSecret: '00'.repeat(32),
+        requestEnc: '11'.repeat(32),
+      }),
+    })
+    getChatRecoveryState.mockResolvedValue('processing')
+    let recoverySignal: AbortSignal | undefined
+    fetchRecoveredChatResponse.mockImplementation(
+      async (_sessionId: string, _token: unknown, signal: AbortSignal) => {
+        recoverySignal = signal
+        return new Response('stream')
+      },
+    )
+    parseRichStreamingResponse.mockImplementation(
+      () =>
+        new Promise((_resolve, reject) => {
+          const rejectAbort = () =>
+            reject(new DOMException('Aborted', 'AbortError'))
+          if (recoverySignal?.aborted) {
+            rejectAbort()
+          } else {
+            recoverySignal?.addEventListener('abort', rejectAbort, {
+              once: true,
+            })
+          }
+        }),
+    )
+    let finishRemoval: (() => void) | undefined
+    removePendingRecovery.mockImplementationOnce(
+      (_chatId: string, _turnId: string, isCurrent: () => boolean) =>
+        new Promise<void>((resolve) => {
+          finishRemoval = () => {
+            expect(isCurrent()).toBe(true)
+            resolve()
+          }
+        }),
+    )
+
+    const scan = scanPendingChatRecoveries('user-1')
+    await vi.waitFor(() => {
+      expect(setChatRecoveryActive).toHaveBeenCalledWith(
+        'chat-1',
+        'turn-1',
+        true,
+      )
+    })
+
+    const cancellation = cancelChatRecovery('chat-1')
+    await vi.waitFor(() => expect(removePendingRecovery).toHaveBeenCalled())
+    await scanPendingChatRecoveries('user-1', true)
+    finishRemoval?.()
+    await cancellation
+    await scan
+
+    expect(recoverySignal?.aborted).toBe(true)
+    expect(setChatRecoveryActive).toHaveBeenCalledWith(
+      'chat-1',
+      'turn-1',
+      false,
+    )
+    expect(removePendingRecovery).toHaveBeenCalledWith(
+      'chat-1',
+      expect.objectContaining({ turnId: 'turn-1' }),
+      expect.any(Function),
+    )
+    expect(deleteChatRecovery).toHaveBeenCalledWith(SESSION_ID)
+  })
+
+  it('replays a completed response through progressive drafts', async () => {
+    getAllChats.mockResolvedValue([
+      { id: 'chat-1', pendingRecoveries: [envelope] },
+    ])
+    decryptRecoveryEnvelope.mockResolvedValue({
+      sessionId: SESSION_ID,
+      recoveryToken: JSON.stringify({
+        exportedSecret: '00'.repeat(32),
+        requestEnc: '11'.repeat(32),
+      }),
+    })
+    getChatRecoveryState.mockResolvedValue('complete')
+    fetchRecoveredChatResponse.mockResolvedValue(new Response('stream'))
+    parseRichStreamingResponse.mockImplementation(
+      async (
+        _response: Response,
+        options: { onUpdate: (message: object) => void },
+      ) => {
+        options.onUpdate({
+          role: 'assistant',
+          content: 'Replay prefix',
+          timestamp: new Date().toISOString(),
+        })
+        return {
+          role: 'assistant',
+          content: 'Recovered',
+          timestamp: new Date().toISOString(),
+        }
+      },
+    )
+
+    await scanPendingChatRecoveries('user-1')
+
+    expect(setChatRecoveryDraft).toHaveBeenCalledWith(
+      expect.objectContaining({
+        chatId: 'chat-1',
+        turnId: 'turn-1',
+        message: expect.objectContaining({ content: 'Replay prefix' }),
+      }),
+    )
+    expect(completePendingRecovery).toHaveBeenCalled()
+    expect(deleteChatRecovery).toHaveBeenCalledWith(SESSION_ID)
+  })
+
+  it('recovers a device-local token directly from IndexedDB', async () => {
+    getAllChats.mockResolvedValue([
+      {
+        id: 'chat-1',
+        isLocalOnly: true,
+        pendingRecoveries: [
+          {
+            v: 1,
+            storage: 'local',
+            turnId: 'turn-1',
+            createdAt: new Date().toISOString(),
+            expiresAt: new Date(Date.now() + 60_000).toISOString(),
+            sessionId: SESSION_ID,
+            recoveryToken: JSON.stringify({
+              exportedSecret: '00'.repeat(32),
+              requestEnc: '11'.repeat(32),
+            }),
+          },
+        ],
+      },
+    ])
+    getChatRecoveryState.mockResolvedValue('complete')
+    fetchRecoveredChatResponse.mockResolvedValue(new Response('stream'))
+    parseRichStreamingResponse.mockResolvedValue({
+      role: 'assistant',
+      content: 'Recovered locally',
+      timestamp: new Date().toISOString(),
+    })
+
+    await scanPendingChatRecoveries('user-1')
+
+    expect(decryptRecoveryEnvelope).not.toHaveBeenCalled()
+    expect(fetchRecoveredChatResponse).toHaveBeenCalledWith(
+      SESSION_ID,
+      expect.any(Object),
+      expect.any(AbortSignal),
+      expect.any(Function),
+    )
+    expect(completePendingRecovery).toHaveBeenCalled()
+    expect(deleteChatRecovery).toHaveBeenCalledWith(SESSION_ID)
+  })
+
+  it('stops an old account scan when recovery state is reset', async () => {
+    let resolveChats: ((chats: unknown[]) => void) | undefined
+    getAllChats.mockReturnValueOnce(
+      new Promise<unknown[]>((resolve) => {
+        resolveChats = resolve
+      }),
+    )
+    const oldScan = scanPendingChatRecoveries('old-user')
+
+    resetChatRecoveryState()
+    resolveChats?.([{ id: 'chat-1', pendingRecoveries: [envelope] }])
+    await oldScan
+
+    expect(decryptRecoveryEnvelope).not.toHaveBeenCalled()
+    getAllChats.mockResolvedValueOnce([])
+    await expect(scanPendingChatRecoveries('new-user')).resolves.toBeUndefined()
+  })
+
+  it('aborts an aged scan before starting its replacement', async () => {
+    let now = 1_000
+    const dateNow = vi.spyOn(Date, 'now').mockImplementation(() => now)
+    getAllChats.mockResolvedValue([
+      { id: 'chat-1', pendingRecoveries: [envelope] },
+    ])
+    decryptRecoveryEnvelope.mockResolvedValue({
+      sessionId: SESSION_ID,
+      recoveryToken: JSON.stringify({
+        exportedSecret: '00'.repeat(32),
+        requestEnc: '11'.repeat(32),
+      }),
+    })
+    getChatRecoveryState.mockResolvedValue('complete')
+    fetchRecoveredChatResponse.mockResolvedValue(new Response('stream'))
+    parseRichStreamingResponse.mockResolvedValue({
+      role: 'assistant',
+      content: 'Recovered',
+      timestamp: new Date().toISOString(),
+    })
+    let firstSignal: AbortSignal | undefined
+    completePendingRecovery.mockImplementationOnce((...args: unknown[]) => {
+      firstSignal = args[5] as AbortSignal
+      return new Promise<void>((_resolve, reject) => {
+        firstSignal?.addEventListener(
+          'abort',
+          () => reject(new DOMException('Aborted', 'AbortError')),
+          { once: true },
+        )
+      })
+    })
+
+    const oldScan = scanPendingChatRecoveries('user-1')
+    await vi.waitFor(() =>
+      expect(completePendingRecovery).toHaveBeenCalledTimes(1),
+    )
+
+    now += RECOVERY_SCAN_MAX_AGE_MS
+    const replacement = scanPendingChatRecoveries('user-1')
+
+    await expect(replacement).resolves.toBeUndefined()
+    await expect(oldScan).resolves.toBeUndefined()
+    expect(firstSignal?.aborted).toBe(true)
+    expect(completePendingRecovery).toHaveBeenCalledTimes(2)
+    expect(completePendingRecovery.mock.calls[1][5]).toBeInstanceOf(AbortSignal)
+    expect(completePendingRecovery.mock.calls[1][5].aborted).toBe(false)
+    expect(setChatRecoveryActive.mock.calls).toEqual([
+      ['chat-1', 'turn-1', true],
+      ['chat-1', 'turn-1', true],
+      ['chat-1', 'turn-1', false],
+    ])
+    dateNow.mockRestore()
+  })
+
+  it('replaces reconnects that report no forward progress', async () => {
+    let now = 1_000
+    const dateNow = vi.spyOn(Date, 'now').mockImplementation(() => now)
+    getAllChats.mockResolvedValue([
+      { id: 'chat-1', pendingRecoveries: [envelope] },
+    ])
+    decryptRecoveryEnvelope.mockResolvedValue({
+      sessionId: SESSION_ID,
+      recoveryToken: JSON.stringify({
+        exportedSecret: '00'.repeat(32),
+        requestEnc: '11'.repeat(32),
+      }),
+    })
+    getChatRecoveryState.mockResolvedValue('processing')
+    fetchRecoveredChatResponse.mockResolvedValue(new Response('stream'))
+    parseRichStreamingResponse.mockResolvedValue({
+      role: 'assistant',
+      content: '',
+      timestamp: new Date().toISOString(),
+    })
+
+    const oldScan = scanPendingChatRecoveries('user-1')
+    await vi.waitFor(() =>
+      expect(fetchRecoveredChatResponse).toHaveBeenCalledTimes(1),
+    )
+    now = 50_000
+    await vi.waitFor(() =>
+      expect(fetchRecoveredChatResponse).toHaveBeenCalledTimes(2),
+    )
+
+    now = 1_000 + RECOVERY_SCAN_MAX_AGE_MS
+    const replacement = scanPendingChatRecoveries('user-1')
+
+    expect(replacement).not.toBe(oldScan)
+    await vi.waitFor(() =>
+      expect(fetchRecoveredChatResponse).toHaveBeenCalledTimes(3),
+    )
+    expect(
+      (fetchRecoveredChatResponse.mock.calls[0][2] as AbortSignal).aborted,
+    ).toBe(true)
+    expect(setChatRecoveryActive.mock.calls).toEqual([
+      ['chat-1', 'turn-1', true],
+      ['chat-1', 'turn-1', true],
+    ])
+
+    await cancelChatRecovery('chat-1')
+    await replacement
+    await oldScan
+    dateNow.mockRestore()
+  })
+
+  it('retains stale recovery ownership when replacement discovery fails', async () => {
+    let now = 1_000
+    const dateNow = vi.spyOn(Date, 'now').mockImplementation(() => now)
+    getAllChats
+      .mockResolvedValueOnce([{ id: 'chat-1', pendingRecoveries: [envelope] }])
+      .mockRejectedValueOnce(new Error('IndexedDB unavailable'))
+      .mockResolvedValueOnce([])
+    decryptRecoveryEnvelope.mockResolvedValue({
+      sessionId: SESSION_ID,
+      recoveryToken: JSON.stringify({
+        exportedSecret: '00'.repeat(32),
+        requestEnc: '11'.repeat(32),
+      }),
+    })
+    getChatRecoveryState.mockResolvedValue('processing')
+    fetchRecoveredChatResponse.mockResolvedValue(new Response('stream'))
+    let recoverySignal: AbortSignal | undefined
+    parseRichStreamingResponse.mockImplementation(
+      () =>
+        new Promise((_resolve, reject) => {
+          recoverySignal?.addEventListener(
+            'abort',
+            () => reject(new DOMException('Aborted', 'AbortError')),
+            { once: true },
+          )
+        }),
+    )
+    fetchRecoveredChatResponse.mockImplementation(
+      async (_sessionId: string, _token: unknown, signal: AbortSignal) => {
+        recoverySignal = signal
+        return new Response('stream')
+      },
+    )
+
+    const oldScan = scanPendingChatRecoveries('user-1')
+    await vi.waitFor(() =>
+      expect(fetchRecoveredChatResponse).toHaveBeenCalledTimes(1),
+    )
+    now += RECOVERY_SCAN_MAX_AGE_MS
+
+    await expect(scanPendingChatRecoveries('user-1')).rejects.toThrow(
+      'IndexedDB unavailable',
+    )
+    await oldScan
+    expect(setChatRecoveryActive).not.toHaveBeenCalledWith(
+      'chat-1',
+      'turn-1',
+      false,
+    )
+
+    await scanPendingChatRecoveries('user-1')
+    expect(setChatRecoveryActive).toHaveBeenCalledWith(
+      'chat-1',
+      'turn-1',
+      false,
+    )
+    fetchRecoveredChatResponse.mockReset()
+    parseRichStreamingResponse.mockReset()
+    dateNow.mockRestore()
+  })
+
+  it('does not invalidate a live attempt when a recovery scan starts', async () => {
+    getAllChats.mockResolvedValue([])
+    encryptRecoveryEnvelope.mockResolvedValue(envelope)
+    startChatRecoveryAttempt('chat-1', 'turn-1', SESSION_ID)
+
+    await scanPendingChatRecoveries('user-1')
+    await persistChatRecoveryToken({
+      userId: 'user-1',
+      chatId: 'chat-1',
+      turnId: 'turn-1',
+      sessionId: SESSION_ID,
+      token: {
+        exportedSecret: new Uint8Array(32),
+        requestEnc: new Uint8Array(32),
+      },
+    })
+
+    expect(addPendingRecovery).toHaveBeenCalledWith('chat-1', envelope)
+  })
+
+  it('rejects token persistence after the account generation changes', async () => {
+    let finishEncryption: ((value: PendingRecoveryEnvelope) => void) | undefined
+    encryptRecoveryEnvelope.mockReturnValueOnce(
+      new Promise<PendingRecoveryEnvelope>((resolve) => {
+        finishEncryption = resolve
+      }),
+    )
+    startChatRecoveryAttempt('chat-1', 'turn-1', SESSION_ID)
+    const persistence = persistChatRecoveryToken({
+      userId: 'user-1',
+      chatId: 'chat-1',
+      turnId: 'turn-1',
+      sessionId: SESSION_ID,
+      token: {
+        exportedSecret: new Uint8Array(32),
+        requestEnc: new Uint8Array(32),
+      },
+    })
+
+    resetChatRecoveryState()
+    finishEncryption?.(envelope)
+
+    await expect(persistence).rejects.toMatchObject({ name: 'AbortError' })
+    expect(addPendingRecovery).not.toHaveBeenCalled()
+    expect(deleteChatRecovery).toHaveBeenCalledWith(SESSION_ID)
+  })
+
+  it('lets an in-flight abandonment reject stale account cleanup', async () => {
+    let rejectRemoval: ((error: Error) => void) | undefined
+    removePendingRecovery.mockReturnValueOnce(
+      new Promise<void>((_resolve, reject) => {
+        rejectRemoval = reject
+      }),
+    )
+    await persistActiveRecovery()
+
+    const abandonment = abandonChatRecoveryAttempt(SESSION_ID)
+    await vi.waitFor(() =>
+      expect(removePendingRecovery).toHaveBeenCalledWith(
+        'chat-1',
+        expect.objectContaining({ turnId: 'turn-1' }),
+        expect.any(Function),
+      ),
+    )
+    const isCurrent = removePendingRecovery.mock.calls[0][2]
+    resetChatRecoveryState()
+    expect(isCurrent()).toBe(false)
+    rejectRemoval?.(new DOMException('Aborted', 'AbortError'))
+    await expect(abandonment).rejects.toMatchObject({ name: 'AbortError' })
+
+    expect(deleteChatRecovery).toHaveBeenCalledWith(SESSION_ID)
+  })
+
+  it('lets an in-flight cancellation reject stale account cleanup', async () => {
+    let rejectRemoval: ((error: Error) => void) | undefined
+    removePendingRecovery.mockReturnValueOnce(
+      new Promise<void>((_resolve, reject) => {
+        rejectRemoval = reject
+      }),
+    )
+    await persistActiveRecovery()
+
+    const cancellation = cancelChatRecovery('chat-1')
+    await vi.waitFor(() =>
+      expect(removePendingRecovery).toHaveBeenCalledWith(
+        'chat-1',
+        expect.objectContaining({ turnId: 'turn-1' }),
+        expect.any(Function),
+      ),
+    )
+    const isCurrent = removePendingRecovery.mock.calls[0][2]
+    resetChatRecoveryState()
+    expect(isCurrent()).toBe(false)
+    rejectRemoval?.(new DOMException('Aborted', 'AbortError'))
+    await expect(cancellation).rejects.toMatchObject({ name: 'AbortError' })
+
+    expect(deleteChatRecovery).toHaveBeenCalledWith(SESSION_ID)
+  })
+
+  it('removes a failed envelope before deleting its server session', async () => {
+    getAllChats.mockResolvedValue([
+      { id: 'chat-1', pendingRecoveries: [envelope] },
+    ])
+    decryptRecoveryEnvelope.mockResolvedValue({
+      sessionId: SESSION_ID,
+      recoveryToken: JSON.stringify({
+        exportedSecret: '00'.repeat(32),
+        requestEnc: '11'.repeat(32),
+      }),
+    })
+    getChatRecoveryState.mockResolvedValue('failed')
+    let finishRemoval: (() => void) | undefined
+    removePendingRecovery.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        finishRemoval = resolve
+      }),
+    )
+
+    const scan = scanPendingChatRecoveries('user-1')
+    await vi.waitFor(() =>
+      expect(removePendingRecovery).toHaveBeenCalledWith(
+        'chat-1',
+        expect.objectContaining({ turnId: 'turn-1' }),
+        expect.any(Function),
+        expect.any(AbortSignal),
+      ),
+    )
+    expect(deleteChatRecovery).not.toHaveBeenCalled()
+
+    finishRemoval?.()
+    await scan
+
+    expect(deleteChatRecovery).toHaveBeenCalledWith(SESSION_ID)
+  })
+
+  it('rewraps an envelope opened with a historical CEK', async () => {
+    storedAlternatives = ['historical-key']
+    getAllChats.mockResolvedValue([
+      { id: 'chat-1', pendingRecoveries: [envelope] },
+    ])
+    decryptRecoveryEnvelope
+      .mockRejectedValueOnce(new Error('wrong key'))
+      .mockResolvedValueOnce({
+        sessionId: SESSION_ID,
+        recoveryToken: JSON.stringify({
+          exportedSecret: '00'.repeat(32),
+          requestEnc: '11'.repeat(32),
+        }),
+      })
+    const rewrapped = {
+      ...envelope,
+      keyId: 'abcdefabcdefabcdefabcdefabcdefab',
+    }
+    rewrapRecoveryEnvelope.mockResolvedValue(rewrapped)
+    replacePendingRecovery.mockResolvedValue({
+      pendingRecoveries: [rewrapped],
+    })
+    getChatRecoveryState
+      .mockResolvedValueOnce('processing')
+      .mockResolvedValueOnce('failed')
+
+    await scanPendingChatRecoveries('user-1')
+
+    expect(rewrapRecoveryEnvelope).toHaveBeenCalled()
+    expect(replacePendingRecovery).toHaveBeenCalledWith(
+      'chat-1',
+      envelope,
+      expect.objectContaining({
+        keyId: 'abcdefabcdefabcdefabcdefabcdefab',
+      }),
+      expect.any(Function),
+      expect.any(AbortSignal),
+    )
+  })
+})

--- a/tests/services/inference/inference-client-recovery.test.ts
+++ b/tests/services/inference/inference-client-recovery.test.ts
@@ -1,0 +1,128 @@
+import type { BaseModel } from '@/config/models'
+import { AuthenticationError } from 'openai'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const createCompletion = vi.fn()
+const createRecoverableTransport = vi.fn()
+const createRecoverableClient = vi.fn()
+const resetTinfoilClient = vi.fn()
+
+vi.mock('@/components/chat/constants', async () => {
+  const actual = await vi.importActual<
+    typeof import('@/components/chat/constants')
+  >('@/components/chat/constants')
+  return {
+    ...actual,
+    CONSTANTS: {
+      ...actual.CONSTANTS,
+      MESSAGE_SEND_MAX_RETRIES: 2,
+      MESSAGE_SEND_RETRY_DELAY_MS: 0,
+    },
+  }
+})
+
+vi.mock('@/services/inference/tinfoil-client', () => ({
+  createRecoverableTinfoilTransport: () => createRecoverableTransport(),
+  createRecoverableTinfoilClient: (...args: unknown[]) =>
+    createRecoverableClient(...args),
+  getTinfoilClient: vi.fn(),
+  resetTinfoilClient: () => resetTinfoilClient(),
+}))
+
+import { sendChatStream } from '@/services/inference/inference-client'
+
+const model: BaseModel = {
+  modelName: 'gpt-oss-120b',
+  image: '',
+  name: 'Test',
+  nameShort: 'Test',
+  description: 'Test model',
+  type: 'chat',
+}
+
+function successfulStream() {
+  return {
+    async *[Symbol.asyncIterator]() {
+      yield { choices: [{ delta: { content: 'answer' } }] }
+    },
+  }
+}
+
+function recoveryCallbacks() {
+  return {
+    onAttemptStarted: vi.fn(),
+    onTokenCaptured: vi.fn(async () => undefined),
+    onAttemptAbandoned: vi.fn(async () => undefined),
+  }
+}
+
+function send(recovery = recoveryCallbacks()) {
+  return {
+    promise: sendChatStream({
+      model,
+      systemPrompt: '',
+      updatedMessages: [
+        {
+          role: 'user',
+          content: 'question',
+          timestamp: new Date(),
+        },
+      ],
+      signal: new AbortController().signal,
+      genUIEnabled: false,
+      recovery,
+    }),
+    recovery,
+  }
+}
+
+describe('recoverable inference retries', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    createRecoverableTransport.mockResolvedValue({ transport: true })
+    createRecoverableClient.mockResolvedValue({
+      client: {
+        chat: {
+          completions: {
+            create: (...args: unknown[]) => createCompletion(...args),
+          },
+        },
+      },
+    })
+  })
+
+  it('reuses attestation and preserves retries when cleanup fails', async () => {
+    createCompletion
+      .mockRejectedValueOnce(new TypeError('network unavailable'))
+      .mockResolvedValueOnce(successfulStream())
+    const recovery = recoveryCallbacks()
+    recovery.onAttemptAbandoned.mockRejectedValueOnce(
+      new Error('cleanup unavailable'),
+    )
+
+    await expect(send(recovery).promise).resolves.toBeInstanceOf(Response)
+
+    expect(createRecoverableTransport).toHaveBeenCalledOnce()
+    expect(createRecoverableClient).toHaveBeenCalledTimes(2)
+    expect(createCompletion).toHaveBeenCalledTimes(2)
+  })
+
+  it('refreshes authentication for a recoverable request', async () => {
+    createCompletion
+      .mockRejectedValueOnce(
+        new AuthenticationError(
+          401,
+          { error: { message: 'expired' }, type: 'auth_error' },
+          'expired',
+          new Headers(),
+        ),
+      )
+      .mockResolvedValueOnce(successfulStream())
+
+    await expect(send().promise).resolves.toBeInstanceOf(Response)
+
+    expect(resetTinfoilClient).toHaveBeenCalledOnce()
+    expect(createRecoverableTransport).toHaveBeenCalledOnce()
+    expect(createRecoverableClient).toHaveBeenCalledTimes(2)
+  })
+})

--- a/tests/services/inference/inference-client-retry.test.ts
+++ b/tests/services/inference/inference-client-retry.test.ts
@@ -6,7 +6,10 @@ import {
 } from 'openai'
 import { describe, expect, it } from 'vitest'
 
-import { isRetryableError } from '@/services/inference/inference-client'
+import {
+  generateRecoverySessionId,
+  isRetryableError,
+} from '@/services/inference/inference-client'
 
 function statusError(status: number) {
   return APIError.generate(status, undefined, undefined, new Headers())
@@ -43,5 +46,16 @@ describe('isRetryableError', () => {
     // A bare Error carrying a transport-sounding message is not enough
     expect(isRetryableError(new Error('Connection error.'))).toBe(false)
     expect(isRetryableError(undefined)).toBe(false)
+  })
+
+  it('generates fresh 128-bit recovery capabilities', () => {
+    const sessionIds = new Set(
+      Array.from({ length: 100 }, () => generateRecoverySessionId()),
+    )
+
+    expect(sessionIds.size).toBe(100)
+    for (const sessionId of sessionIds) {
+      expect(sessionId).toMatch(/^[0-9a-f]{32}$/)
+    }
   })
 })

--- a/tests/services/inference/tinfoil-client.test.ts
+++ b/tests/services/inference/tinfoil-client.test.ts
@@ -1,0 +1,14 @@
+import { getRecoveryBaseURL } from '@/services/inference/tinfoil-client'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/config', () => ({
+  API_BASE_URL: 'http://api.example',
+}))
+
+describe('tinfoil recovery transport', () => {
+  it('rejects an insecure controlplane URL', () => {
+    expect(() => getRecoveryBaseURL()).toThrow(
+      'Controlplane base URL must use HTTPS',
+    )
+  })
+})

--- a/tests/services/storage/chat-storage-pending-save.test.ts
+++ b/tests/services/storage/chat-storage-pending-save.test.ts
@@ -5,6 +5,7 @@ const saveChatSpy = vi.fn(async (chat: unknown) => chat)
 const getChatSpy = vi.fn(async () => null as unknown)
 const getAllChatsSpy = vi.fn(async () => [] as unknown[])
 const backupChatSpy = vi.fn(async () => {})
+const backupChatAndWaitSpy = vi.fn(async () => {})
 
 vi.mock('@/services/storage/indexed-db', () => ({
   indexedDBStorage: {
@@ -15,7 +16,10 @@ vi.mock('@/services/storage/indexed-db', () => ({
   },
 }))
 vi.mock('@/services/cloud/cloud-sync', () => ({
-  cloudSync: { backupChat: (...args: unknown[]) => backupChatSpy(...args) },
+  cloudSync: {
+    backupChat: (...args: unknown[]) => backupChatSpy(...args),
+    backupChatAndWait: (...args: unknown[]) => backupChatAndWaitSpy(...args),
+  },
 }))
 vi.mock('@/services/cloud/cloud-storage', () => ({ cloudStorage: {} }))
 vi.mock('@/services/cloud/streaming-tracker', () => ({
@@ -98,5 +102,20 @@ describe('chatStorage pendingSave is not persisted', () => {
     const chats = await chatStorage.getAllChatsWithSyncStatus()
 
     expect('pendingSave' in chats[0]).toBe(false)
+  })
+
+  it('propagates a required cloud upload failure', async () => {
+    backupChatAndWaitSpy.mockRejectedValueOnce(new Error('upload failed'))
+
+    await expect(
+      chatStorage.saveChatAndWaitForSync(makeChat()),
+    ).rejects.toThrow('upload failed')
+  })
+
+  it('does not require a cloud upload for a blank chat', async () => {
+    const blank = makeChat({ isBlankChat: true })
+
+    await expect(chatStorage.saveChatAndWaitForSync(blank)).resolves.toBe(blank)
+    expect(backupChatAndWaitSpy).not.toHaveBeenCalled()
   })
 })

--- a/tests/services/storage/indexed-db-content-fingerprint.test.ts
+++ b/tests/services/storage/indexed-db-content-fingerprint.test.ts
@@ -68,6 +68,50 @@ describe('chatContentFingerprint', () => {
     expect(fp1).not.toBe(fp2)
   })
 
+  it('changes when message turnId changes', () => {
+    const message = {
+      role: 'user',
+      content: 'hello',
+      timestamp: '2024-01-01T00:00:00Z',
+    }
+    const fp1 = chatContentFingerprint({
+      title: 'T',
+      messages: [{ ...message, turnId: 'turn-1' }],
+    })
+    const fp2 = chatContentFingerprint({
+      title: 'T',
+      messages: [{ ...message, turnId: 'turn-2' }],
+    })
+
+    expect(fp1).not.toBe(fp2)
+  })
+
+  it('changes when only pending recovery envelopes change', () => {
+    const recovery = {
+      v: 1,
+      turnId: 'turn-1',
+      keyId: 'a'.repeat(32),
+      createdAt: '2026-07-20T00:00:00.000Z',
+      expiresAt: '2026-07-27T00:00:00.000Z',
+      nonce: 'AAAAAAAAAAAAAAAA',
+      ciphertext: 'AAAAAAAAAAAAAAAAAAAAAA==',
+    }
+    const fp1 = chatContentFingerprint({
+      title: 'T',
+      messages: [],
+      pendingRecoveries: [recovery],
+    })
+    const fp2 = chatContentFingerprint({
+      title: 'T',
+      messages: [],
+      pendingRecoveries: [
+        { ...recovery, ciphertext: 'AQAAAAAAAAAAAAAAAAAAAA==' },
+      ],
+    })
+
+    expect(fp1).not.toBe(fp2)
+  })
+
   it('does not depend on full documentContent string (hashes it)', () => {
     const fp1 = chatContentFingerprint({
       title: 'T',


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Recover interrupted chat responses across devices and for local chats using encrypted recovery tokens with live auto-restore. Adds a recoverable streaming transport with strict completion markers, a rich response parser, and a UI that catches up, resumes live, keeps Stop active, queues prompts, and persists across reloads/devices.

- New Features
  - Encrypted recovery envelopes: AES-GCM + HKDF, 7-day expiry, rewrap on CEK rotation, up to 8 per chat, strict schema validation (ciphertext/nonce bounds, keyId/turnId formats, ISO timestamps, and local token/session length).
  - Streaming integration: recoverable `tinfoil` transport with 128-bit session IDs; rich streaming parser rebuilds reasoning, citations, tool calls, and web search (ID-based updates), and requires an authenticated completion marker; recovered replies stream live; callbacks to start/persist/abandon/release.
  - Background scanning: polls every 10s and on reconnect, merges recovered replies by `turnId`, then cleans server/local state; single-owner scan with stalled-scan reclamation to avoid collisions.
  - Chat UI: recovery progress with explicit phases (“Catching up” → live); `ChatMessages` renders placeholders keyed by `turnId`; hides assistant actions during recovery.
  - Data model and sync: added `Message.turnId` and `Chat.pendingRecoveries`; content fingerprint includes both; conflict-safe mutations with a server-version-bound trusted chat clock; new `chatStorage.saveChatAndWaitForSync`; upload coalescer can `ensureUploadAndWait`.
  - Safety and ops: production-only recovery; HTTPS-enforced recovery base URL validation; strict session ID validation; validate local envelope bounds; sign-out resets recovery state; alternatives finalization deferred until recovery history is ready, then retried.
  - Update `tinfoil` to `^1.1.12`.
  - Local-only recovery for unsynced chats: device-local envelopes (session ID + token) persist across reloads and never upload.

- Bug Fixes
  - Preserve and update web search blocks during recovery.
  - Ensure interrupted recoveries stay active, converge, resume from current progress, and stay in sync across reloads/devices; show progress for chats loaded from sync or after refresh; show recovered responses from other devices without a reload.
  - Keep recovered responses streaming after reloads; keep recovery checks running after hung/timeout requests; reclaim stalled scans; retry incomplete replays; prevent stalls by advancing progress monotonically.
  - Prevent stale partial replies from overwriting recovered ones; avoid resetting the current chat during in-flight streams.
  - Respect disabled chat history; keep Stop active while recovered replies stream; block prompts during recovery; hold and release queued prompts when recovery finishes.
  - Replay recovered responses from the beginning before switching to live to avoid truncation; align recovery status indicator and tighten spacing.
  - Title recovered conversations using recovered content (and attachments), and handle attachment titles consistently so recovered chats aren’t left untitled.
  - Reject incomplete chat responses that end without an authenticated completion marker.
  - Keep replacement recoveries intact during rotation/replay.
  - Tighten encrypted transport lifecycle (HTTPS-only recovery base URL validation; reset secure clients on sign-out).
  - Keep expired recovery envelopes available until cleanup to ensure they are removed reliably.

<sup>Written for commit f63af6cbf32700167b6cfc9711667117b696b416. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/438?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

