### PR TITLE
Refactor: extract passkey kit as standalone package 

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -33,6 +33,9 @@ const nextConfig = {
   // Optimize production builds
   productionBrowserSourceMaps: false,
 
+  // Local packages ship TypeScript source; let Next compile them.
+  transpilePackages: ['@tinfoilsh/passkey-kit'],
+
   // Tree-shake large icon and utility packages.
   experimental: {
     optimizePackageImports: ['react-icons', 'lucide-react', '@heroicons/react'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@radix-ui/react-toast": "^1.2.7",
         "@radix-ui/react-tooltip": "^1.2.0",
         "@tailwindcss/typography": "^0.5.16",
+        "@tinfoilsh/passkey-kit": "file:packages/passkey-kit",
         "@tinfoilsh/tinfoil-icons": "^2.0.4",
         "autoprefixer": "^10.4.21",
         "boring-avatars": "^2.0.4",
@@ -3348,6 +3349,10 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@tinfoilsh/passkey-kit": {
+      "resolved": "packages/passkey-kit",
+      "link": true
     },
     "node_modules/@tinfoilsh/tinfoil-icons": {
       "version": "2.0.4",
@@ -15228,6 +15233,14 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "packages/passkey-kit": {
+      "name": "@tinfoilsh/passkey-kit",
+      "version": "0.1.0",
+      "license": "GPL-3.0",
+      "devDependencies": {
+        "typescript": "^5"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@radix-ui/react-toast": "^1.2.7",
     "@radix-ui/react-tooltip": "^1.2.0",
     "@tailwindcss/typography": "^0.5.16",
+    "@tinfoilsh/passkey-kit": "file:packages/passkey-kit",
     "@tinfoilsh/tinfoil-icons": "^2.0.4",
     "autoprefixer": "^10.4.21",
     "boring-avatars": "^2.0.4",

--- a/packages/passkey-kit/README.md
+++ b/packages/passkey-kit/README.md
@@ -1,0 +1,59 @@
+# @tinfoilsh/passkey-kit
+
+Browser SDK for passkey-based key protection. It wraps the WebAuthn PRF
+extension into a small, typed API:
+
+- Device support detection (`isPrfSupported`)
+- Passkey ceremonies (create / authenticate with the PRF extension)
+- KEK derivation from PRF output (HKDF-SHA-256)
+- CEK wrap/unwrap under the KEK (AES-256-GCM)
+- Device-local state (PRF output cache, this device's credential id) via a
+  pluggable storage adapter
+
+## Usage
+
+```ts
+import { createPasskeyKit } from '@tinfoilsh/passkey-kit'
+
+const kit = createPasskeyKit({
+  rpId: 'example.com',
+  rpName: 'Example App',
+})
+
+// Enroll: create a passkey and wrap the user's 32-byte CEK under it.
+// `wrappedCek` is safe to persist server-side; `prfResult` is cached
+// locally through the storage adapter automatically.
+const enrolled = await kit.enroll({
+  user: { id: userId, name: email, displayName },
+  cek, // Uint8Array(32)
+})
+if (enrolled) {
+  await api.saveBundle(enrolled.wrappedCek)
+}
+
+// Unlock: prompt for a passkey and recover the CEK from the matching bundle.
+const unlocked = await kit.unlock(bundlesFromServer)
+if (unlocked) {
+  useCek(unlocked.cek)
+}
+
+// Re-wrap without a biometric prompt using the cached PRF output.
+const rewrapped = await kit.rewrapWithCachedPrf(newCek)
+```
+
+Lower-level building blocks (`createPasskey`, `authenticate`, `deriveKek`,
+`wrapCek`, `unwrapCek`, `deriveKeyId`) are exported for flows that need
+finer control.
+
+## Conventions
+
+- High-level ceremony methods return `null` when the user cancels; they
+  throw `PrfNotSupportedError` when the authenticator lacks PRF support and
+  `PasskeyTimeoutError` when the provider hangs. Branch on `instanceof`,
+  never on message strings.
+- `prfSaltInput` and `hkdfInfo` default to the Tinfoil v1 protocol
+  constants so wrapped CEKs interoperate across Tinfoil clients. Override
+  both to establish a new protocol domain.
+- The default storage adapter is best-effort `localStorage`; pass
+  `storage: null` to disable local persistence, or supply your own
+  `StorageAdapter`.

--- a/packages/passkey-kit/README.md
+++ b/packages/passkey-kit/README.md
@@ -13,19 +13,22 @@ extension into a small, typed API:
 ## Usage
 
 ```ts
-import { createPasskeyKit } from '@tinfoilsh/passkey-kit'
+import { createPasskeyKit, generateCek } from '@tinfoilsh/passkey-kit'
 
 const kit = createPasskeyKit({
   rpId: 'example.com',
   rpName: 'Example App',
 })
 
+// Bring your own 32-byte CEK, or generate a fresh one.
+const cek = generateCek()
+
 // Enroll: create a passkey and wrap the user's 32-byte CEK under it.
 // `wrappedCek` is safe to persist server-side; `prfResult` is cached
 // locally through the storage adapter automatically.
 const enrolled = await kit.enroll({
   user: { id: userId, name: email, displayName },
-  cek, // Uint8Array(32)
+  cek,
 })
 if (enrolled) {
   await api.saveBundle(enrolled.wrappedCek)
@@ -37,13 +40,17 @@ if (unlocked) {
   useCek(unlocked.cek)
 }
 
+// Silent unlock via the cached PRF output (no biometric prompt).
+// Returns null when nothing usable is cached — fall back to unlock().
+const silent = await kit.unlockWithCachedPrf(bundlesFromServer)
+
 // Re-wrap without a biometric prompt using the cached PRF output.
 const rewrapped = await kit.rewrapWithCachedPrf(newCek)
 ```
 
 Lower-level building blocks (`createPasskey`, `authenticate`, `deriveKek`,
-`wrapCek`, `unwrapCek`, `deriveKeyId`) are exported for flows that need
-finer control.
+`generateCek`, `isValidCek`, `wrapCek`, `unwrapCek`, `deriveKeyId`) are
+exported for flows that need finer control.
 
 ## Conventions
 
@@ -57,6 +64,8 @@ finer control.
 - The default storage adapter is best-effort `localStorage`; pass
   `storage: null` to disable local persistence, or supply your own
   `StorageAdapter`.
+- Error messages default to brand-neutral text; pass `errorMessages` to
+  brand or localize them without affecting the error classes.
 
 ## Security
 

--- a/packages/passkey-kit/README.md
+++ b/packages/passkey-kit/README.md
@@ -57,3 +57,13 @@ finer control.
 - The default storage adapter is best-effort `localStorage`; pass
   `storage: null` to disable local persistence, or supply your own
   `StorageAdapter`.
+
+## Security
+
+The cached PRF output is raw key material: anyone who can read it can
+re-derive the KEK and unwrap the CEK. The default adapter stores it in
+`localStorage` as plaintext, which is only as strong as the origin's
+script-injection defenses. Hosts that need at-rest protection should
+supply a `StorageAdapter` with their own encryption, or set
+`storage: null` to keep nothing on device and re-prompt biometrics
+instead.

--- a/packages/passkey-kit/package.json
+++ b/packages/passkey-kit/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@tinfoilsh/passkey-kit",
+  "version": "0.1.0",
+  "description": "WebAuthn PRF passkey SDK: device support detection, passkey ceremonies, and CEK wrapping under a passkey-derived KEK.",
+  "license": "GPL-3.0",
+  "type": "module",
+  "sideEffects": false,
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "prepublishOnly": "npm run build"
+  },
+  "publishConfig": {
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    }
+  },
+  "devDependencies": {
+    "typescript": "^5"
+  }
+}

--- a/packages/passkey-kit/src/codec.ts
+++ b/packages/passkey-kit/src/codec.ts
@@ -1,0 +1,71 @@
+/** Dependency-free binary codecs shared across the SDK. */
+
+export function bytesToHex(bytes: Uint8Array): string {
+  let out = ''
+  for (let i = 0; i < bytes.length; i++) {
+    out += bytes[i].toString(16).padStart(2, '0')
+  }
+  return out
+}
+
+export function hexToBytes(hex: string): Uint8Array {
+  if (hex.length % 2 !== 0) {
+    throw new Error('passkey-kit: odd-length hex input')
+  }
+  if (!/^[0-9a-fA-F]*$/.test(hex)) {
+    throw new Error('passkey-kit: invalid hex character')
+  }
+  const out = new Uint8Array(hex.length / 2)
+  for (let i = 0; i < out.length; i++) {
+    out[i] = parseInt(hex.substring(i * 2, i * 2 + 2), 16)
+  }
+  return out
+}
+
+export function bytesToBase64(bytes: Uint8Array): string {
+  const CHUNK_SIZE = 0x8000
+  const chunks: string[] = []
+  for (let i = 0; i < bytes.length; i += CHUNK_SIZE) {
+    const chunk = bytes.subarray(i, i + CHUNK_SIZE)
+    chunks.push(String.fromCharCode.apply(null, Array.from(chunk)))
+  }
+  return btoa(chunks.join(''))
+}
+
+export function base64ToBytes(base64: string): Uint8Array {
+  const binary = atob(base64)
+  const bytes = new Uint8Array(binary.length)
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i)
+  }
+  return bytes
+}
+
+export function bytesToBase64Url(bytes: Uint8Array): string {
+  return bytesToBase64(bytes)
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '')
+}
+
+export function base64UrlToBytes(base64url: string): Uint8Array {
+  const base64 = base64url.replace(/-/g, '+').replace(/_/g, '/')
+  const padded = base64 + '='.repeat((4 - (base64.length % 4)) % 4)
+  return base64ToBytes(padded)
+}
+
+/** Convert a BufferSource (ArrayBuffer or view) to a standalone ArrayBuffer copy. */
+export function bufferSourceToArrayBuffer(source: BufferSource): ArrayBuffer {
+  if (source instanceof ArrayBuffer) {
+    return source
+  }
+  return source.buffer.slice(
+    source.byteOffset,
+    source.byteOffset + source.byteLength,
+  ) as ArrayBuffer
+}
+
+/** Normalize a string (UTF-8 encoded) or byte input to bytes. */
+export function toBytes(input: string | Uint8Array): Uint8Array {
+  return typeof input === 'string' ? new TextEncoder().encode(input) : input
+}

--- a/packages/passkey-kit/src/codec.ts
+++ b/packages/passkey-kit/src/codec.ts
@@ -57,7 +57,7 @@ export function base64UrlToBytes(base64url: string): Uint8Array {
 /** Convert a BufferSource (ArrayBuffer or view) to a standalone ArrayBuffer copy. */
 export function bufferSourceToArrayBuffer(source: BufferSource): ArrayBuffer {
   if (source instanceof ArrayBuffer) {
-    return source
+    return source.slice(0)
   }
   return source.buffer.slice(
     source.byteOffset,

--- a/packages/passkey-kit/src/crypto.ts
+++ b/packages/passkey-kit/src/crypto.ts
@@ -1,0 +1,143 @@
+/**
+ * Pure WebCrypto primitives: PRF output → KEK derivation (HKDF-SHA-256)
+ * and CEK wrap/unwrap under that KEK (AES-256-GCM).
+ *
+ * References:
+ * - W3C WebAuthn Level 3, §10.1.4 (PRF extension): https://w3c.github.io/webauthn/#prf-extension
+ * - RFC 5869 (HKDF): https://tools.ietf.org/html/rfc5869
+ */
+
+import { bytesToHex, hexToBytes, toBytes } from './codec'
+import { PasskeyKitError } from './errors'
+import type { WrappedCek } from './types'
+
+export const CEK_BYTES = 32
+const AES_GCM_IV_BYTES = 12
+const DEFAULT_KEY_ID_BYTES = 16
+
+/**
+ * Derive an AES-256-GCM Key Encryption Key (KEK) from PRF output using HKDF.
+ *
+ * Raw PRF output is treated as Input Keying Material (IKM), not used
+ * directly as a key. HKDF with a purpose-binding info string produces the
+ * final non-extractable CryptoKey. An empty HKDF salt is used, which is
+ * fine for high-entropy IKM (RFC 5869 §3.1).
+ */
+export async function deriveKeyEncryptionKey(
+  prfOutput: ArrayBuffer | Uint8Array,
+  hkdfInfo: string | Uint8Array,
+): Promise<CryptoKey> {
+  const masterKey = await crypto.subtle.importKey(
+    'raw',
+    prfOutput as BufferSource,
+    'HKDF',
+    false, // non-extractable
+    ['deriveKey'],
+  )
+
+  return crypto.subtle.deriveKey(
+    {
+      name: 'HKDF',
+      hash: 'SHA-256',
+      salt: new Uint8Array(),
+      info: toBytes(hkdfInfo) as BufferSource,
+    },
+    masterKey,
+    { name: 'AES-GCM', length: 256 },
+    false, // non-extractable
+    ['encrypt', 'decrypt'],
+  )
+}
+
+/**
+ * Wrap a raw 32-byte CEK under a passkey-derived KEK using AES-256-GCM
+ * with a fresh random IV. The returned hex fields are safe to persist
+ * server-side; only the matching passkey can recover the CEK.
+ */
+export async function wrapCek(opts: {
+  credentialId: string
+  kek: CryptoKey
+  cek: Uint8Array
+}): Promise<WrappedCek> {
+  if (opts.cek.length !== CEK_BYTES) {
+    throw new PasskeyKitError(
+      `passkey-kit: CEK must be ${CEK_BYTES} bytes, got ${opts.cek.length}`,
+    )
+  }
+  const iv = crypto.getRandomValues(new Uint8Array(AES_GCM_IV_BYTES))
+  const ciphertext = await crypto.subtle.encrypt(
+    { name: 'AES-GCM', iv: iv as BufferSource },
+    opts.kek,
+    opts.cek as BufferSource,
+  )
+  return {
+    credentialId: opts.credentialId,
+    kekIvHex: bytesToHex(iv),
+    wrappedKeyHex: bytesToHex(new Uint8Array(ciphertext)),
+  }
+}
+
+/**
+ * Inverse of {@link wrapCek}: recover the raw CEK bytes given the same KEK.
+ * Throws on tamper (GCM auth failure) or any shape mismatch.
+ */
+export async function unwrapCek(
+  kek: CryptoKey,
+  wrapped: Pick<WrappedCek, 'kekIvHex' | 'wrappedKeyHex'>,
+): Promise<Uint8Array> {
+  if (!wrapped.kekIvHex || !wrapped.wrappedKeyHex) {
+    throw new PasskeyKitError('passkey-kit: missing iv or wrapped key')
+  }
+  const iv = hexToBytes(wrapped.kekIvHex)
+  if (iv.length !== AES_GCM_IV_BYTES) {
+    throw new PasskeyKitError('passkey-kit: iv length mismatch')
+  }
+  const ciphertext = hexToBytes(wrapped.wrappedKeyHex)
+  const plaintext = await crypto.subtle.decrypt(
+    { name: 'AES-GCM', iv: iv as BufferSource },
+    kek,
+    ciphertext as BufferSource,
+  )
+  const cek = new Uint8Array(plaintext)
+  if (cek.length !== CEK_BYTES) {
+    throw new PasskeyKitError(
+      `passkey-kit: unwrapped CEK has wrong length ${cek.length}`,
+    )
+  }
+  return cek
+}
+
+/**
+ * Derive a stable public identifier for a CEK via HKDF-SHA-256 with an
+ * empty salt and a caller-supplied info string. The result identifies the
+ * key without revealing it (one-way derivation).
+ */
+export async function deriveKeyId(
+  cek: Uint8Array,
+  opts: { info: string | Uint8Array; lengthBytes?: number },
+): Promise<Uint8Array> {
+  if (cek.length !== CEK_BYTES) {
+    throw new PasskeyKitError(
+      `passkey-kit: CEK must be ${CEK_BYTES} bytes, got ${cek.length}`,
+    )
+  }
+  const lengthBytes = opts.lengthBytes ?? DEFAULT_KEY_ID_BYTES
+  const ikm = await crypto.subtle.importKey(
+    'raw',
+    cek as BufferSource,
+    'HKDF',
+    false,
+    ['deriveBits'],
+  )
+  const bits = await crypto.subtle.deriveBits(
+    {
+      name: 'HKDF',
+      hash: 'SHA-256',
+      salt: new Uint8Array(0) as BufferSource,
+      info: toBytes(opts.info) as BufferSource,
+    },
+    ikm,
+    lengthBytes * 8,
+  )
+  return new Uint8Array(bits)
+}

--- a/packages/passkey-kit/src/crypto.ts
+++ b/packages/passkey-kit/src/crypto.ts
@@ -9,6 +9,7 @@
 
 import { bytesToHex, hexToBytes, toBytes } from './codec'
 import { PasskeyKitError } from './errors'
+import { TINFOIL_HKDF_INFO_V1 } from './protocol'
 import type { WrappedCek } from './types'
 
 export const CEK_BYTES = 32
@@ -22,10 +23,13 @@ const DEFAULT_KEY_ID_BYTES = 16
  * directly as a key. HKDF with a purpose-binding info string produces the
  * final non-extractable CryptoKey. An empty HKDF salt is used, which is
  * fine for high-entropy IKM (RFC 5869 §3.1).
+ *
+ * `hkdfInfo` defaults to the Tinfoil v1 protocol constant so standalone
+ * callers derive the same interoperable KEK as a default-configured kit.
  */
 export async function deriveKeyEncryptionKey(
   prfOutput: ArrayBuffer | Uint8Array,
-  hkdfInfo: string | Uint8Array,
+  hkdfInfo: string | Uint8Array = TINFOIL_HKDF_INFO_V1,
 ): Promise<CryptoKey> {
   const masterKey = await crypto.subtle.importKey(
     'raw',

--- a/packages/passkey-kit/src/crypto.ts
+++ b/packages/passkey-kit/src/crypto.ts
@@ -16,6 +16,20 @@ export const CEK_BYTES = 32
 const AES_GCM_IV_BYTES = 12
 const DEFAULT_KEY_ID_BYTES = 16
 
+/** Generate a fresh random 32-byte CEK suitable for {@link wrapCek}. */
+export function generateCek(): Uint8Array {
+  return crypto.getRandomValues(new Uint8Array(CEK_BYTES))
+}
+
+/**
+ * Type guard for a well-formed CEK: a Uint8Array of exactly
+ * {@link CEK_BYTES} bytes. Useful for validating deserialized input
+ * before wrapping.
+ */
+export function isValidCek(cek: unknown): cek is Uint8Array {
+  return cek instanceof Uint8Array && cek.length === CEK_BYTES
+}
+
 /**
  * Derive an AES-256-GCM Key Encryption Key (KEK) from PRF output using HKDF.
  *

--- a/packages/passkey-kit/src/errors.ts
+++ b/packages/passkey-kit/src/errors.ts
@@ -1,0 +1,38 @@
+/**
+ * Typed errors thrown by the SDK. Callers should branch on `instanceof`
+ * (never on message strings) to drive recovery flows.
+ */
+
+/** Base class for every error the SDK throws on its own behalf. */
+export class PasskeyKitError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'PasskeyKitError'
+  }
+}
+
+/**
+ * The authenticator created a credential but does not support the WebAuthn
+ * PRF extension, so no key material can be derived from it.
+ */
+export class PrfNotSupportedError extends PasskeyKitError {
+  constructor(
+    message = "Your passkey provider doesn't support the security features required by Tinfoil. Try using iCloud Keychain, Chrome's built-in passkey manager, or the Passwords app in your device settings.",
+  ) {
+    super(message)
+    this.name = 'PrfNotSupportedError'
+  }
+}
+
+/**
+ * The passkey provider never resolved the WebAuthn promise within the
+ * SDK's hard timeout (some password-manager browser extensions hang).
+ */
+export class PasskeyTimeoutError extends PasskeyKitError {
+  constructor(
+    message = "Your passkey provider took too long to respond. This can happen with some browser extension password managers. Try using iCloud Keychain, Chrome's built-in passkey manager, or the Passwords app in your device settings.",
+  ) {
+    super(message)
+    this.name = 'PasskeyTimeoutError'
+  }
+}

--- a/packages/passkey-kit/src/errors.ts
+++ b/packages/passkey-kit/src/errors.ts
@@ -20,7 +20,7 @@ const PROVIDER_SUGGESTION =
  */
 export class PrfNotSupportedError extends PasskeyKitError {
   constructor(
-    message = `Your passkey provider doesn't support the security features required by Tinfoil. ${PROVIDER_SUGGESTION}`,
+    message = `Your passkey provider doesn't support the security features required by this app. ${PROVIDER_SUGGESTION}`,
   ) {
     super(message)
     this.name = 'PrfNotSupportedError'

--- a/packages/passkey-kit/src/errors.ts
+++ b/packages/passkey-kit/src/errors.ts
@@ -11,13 +11,16 @@ export class PasskeyKitError extends Error {
   }
 }
 
+const PROVIDER_SUGGESTION =
+  "Try using iCloud Keychain, Chrome's built-in passkey manager, or the Passwords app in your device settings."
+
 /**
  * The authenticator created a credential but does not support the WebAuthn
  * PRF extension, so no key material can be derived from it.
  */
 export class PrfNotSupportedError extends PasskeyKitError {
   constructor(
-    message = "Your passkey provider doesn't support the security features required by Tinfoil. Try using iCloud Keychain, Chrome's built-in passkey manager, or the Passwords app in your device settings.",
+    message = `Your passkey provider doesn't support the security features required by Tinfoil. ${PROVIDER_SUGGESTION}`,
   ) {
     super(message)
     this.name = 'PrfNotSupportedError'
@@ -30,7 +33,7 @@ export class PrfNotSupportedError extends PasskeyKitError {
  */
 export class PasskeyTimeoutError extends PasskeyKitError {
   constructor(
-    message = "Your passkey provider took too long to respond. This can happen with some browser extension password managers. Try using iCloud Keychain, Chrome's built-in passkey manager, or the Passwords app in your device settings.",
+    message = `Your passkey provider took too long to respond. This can happen with some browser extension password managers. ${PROVIDER_SUGGESTION}`,
   ) {
     super(message)
     this.name = 'PasskeyTimeoutError'

--- a/packages/passkey-kit/src/index.ts
+++ b/packages/passkey-kit/src/index.ts
@@ -11,6 +11,8 @@ export {
   CEK_BYTES,
   deriveKeyEncryptionKey,
   deriveKeyId,
+  generateCek,
+  isValidCek,
   unwrapCek,
   wrapCek,
 } from './crypto'

--- a/packages/passkey-kit/src/index.ts
+++ b/packages/passkey-kit/src/index.ts
@@ -1,0 +1,39 @@
+export {
+  base64ToBytes,
+  base64UrlToBytes,
+  bufferSourceToArrayBuffer,
+  bytesToBase64,
+  bytesToBase64Url,
+  bytesToHex,
+  hexToBytes,
+} from './codec'
+export {
+  CEK_BYTES,
+  deriveKeyEncryptionKey,
+  deriveKeyId,
+  unwrapCek,
+  wrapCek,
+} from './crypto'
+export {
+  PasskeyKitError,
+  PasskeyTimeoutError,
+  PrfNotSupportedError,
+} from './errors'
+export { createPasskeyKit } from './kit'
+export type { PasskeyKit } from './kit'
+export {
+  browserLocalStorageAdapter,
+  createMemoryStorageAdapter,
+} from './storage'
+export type { StorageAdapter } from './storage'
+export { detectPrfSupport } from './support'
+export type {
+  EnrollResult,
+  PasskeyKitConfig,
+  PasskeyKitLogger,
+  PasskeyKitStorageKeys,
+  PasskeyUser,
+  PrfPasskeyResult,
+  UnlockResult,
+  WrappedCek,
+} from './types'

--- a/packages/passkey-kit/src/index.ts
+++ b/packages/passkey-kit/src/index.ts
@@ -21,6 +21,7 @@ export {
 } from './errors'
 export { createPasskeyKit } from './kit'
 export type { PasskeyKit } from './kit'
+export { TINFOIL_HKDF_INFO_V1, TINFOIL_PRF_SALT_INPUT_V1 } from './protocol'
 export {
   browserLocalStorageAdapter,
   createMemoryStorageAdapter,

--- a/packages/passkey-kit/src/index.ts
+++ b/packages/passkey-kit/src/index.ts
@@ -31,6 +31,7 @@ export { detectPrfSupport } from './support'
 export type {
   EnrollResult,
   PasskeyKitConfig,
+  PasskeyKitErrorMessages,
   PasskeyKitLogger,
   PasskeyKitStorageKeys,
   PasskeyUser,

--- a/packages/passkey-kit/src/kit.ts
+++ b/packages/passkey-kit/src/kit.ts
@@ -77,6 +77,13 @@ export interface PasskeyKit {
   /** Authenticate against the given wrapped CEKs and unwrap the matching one. */
   unlock(wrappedCeks: WrappedCek[]): Promise<UnlockResult | null>
   /**
+   * Unwrap the wrapped CEK matching the cached PRF output without a
+   * biometric prompt. Returns null when nothing is cached, no wrapped CEK
+   * matches the cached credential, or the cached output fails to unwrap;
+   * fall back to `unlock()` in that case.
+   */
+  unlockWithCachedPrf(wrappedCeks: WrappedCek[]): Promise<UnlockResult | null>
+  /**
    * Re-wrap a CEK using the cached PRF output (no biometric prompt).
    * Returns null when nothing is cached.
    */
@@ -266,6 +273,28 @@ export function createPasskeyKit(config: PasskeyKitConfig): PasskeyKit {
       const kek = await deriveKek(prfResult.prfOutput)
       const cek = await unwrapCek(kek, match)
       return { credentialId: prfResult.credentialId, cek }
+    },
+
+    async unlockWithCachedPrf(
+      wrappedCeks: WrappedCek[],
+    ): Promise<UnlockResult | null> {
+      const cached = getCachedPrfResult()
+      if (!cached) return null
+      const match = wrappedCeks.find(
+        (w) => w.credentialId === cached.credentialId,
+      )
+      if (!match) return null
+      try {
+        const kek = await deriveKek(cached.prfOutput)
+        const cek = await unwrapCek(kek, match)
+        return { credentialId: cached.credentialId, cek }
+      } catch (error) {
+        logger.error?.('failed to unwrap CEK with cached PRF output', error, {
+          action: 'unlockWithCachedPrf',
+          credentialId: cached.credentialId,
+        })
+        return null
+      }
     },
 
     async rewrapWithCachedPrf(cek: Uint8Array): Promise<WrappedCek | null> {

--- a/packages/passkey-kit/src/kit.ts
+++ b/packages/passkey-kit/src/kit.ts
@@ -191,6 +191,7 @@ export function createPasskeyKit(config: PasskeyKitConfig): PasskeyKit {
     prfSalt,
     webauthnTimeoutMs: config.webauthnTimeoutMs ?? DEFAULT_WEBAUTHN_TIMEOUT_MS,
     stuckTimeoutMs: config.stuckTimeoutMs ?? DEFAULT_STUCK_TIMEOUT_MS,
+    errorMessages: config.errorMessages,
     logger,
     onPrfResult,
   }

--- a/packages/passkey-kit/src/kit.ts
+++ b/packages/passkey-kit/src/kit.ts
@@ -11,6 +11,7 @@ import {
   unwrapCek,
   wrapCek,
 } from './crypto'
+import { TINFOIL_HKDF_INFO_V1, TINFOIL_PRF_SALT_INPUT_V1 } from './protocol'
 import { browserLocalStorageAdapter, type StorageAdapter } from './storage'
 import { detectPrfSupport } from './support'
 import type {
@@ -27,12 +28,6 @@ import {
   createPrfPasskey,
   type CeremonyContext,
 } from './webauthn'
-
-// Tinfoil v1 protocol constants. Kept as defaults so every Tinfoil client
-// wrapping the same CEK stays interoperable; override both for a new
-// protocol domain.
-const DEFAULT_PRF_SALT_INPUT = 'tinfoil-chat-key-encryption'
-const DEFAULT_HKDF_INFO = 'tinfoil-chat-kek-v1'
 
 const DEFAULT_STORAGE_KEYS: PasskeyKitStorageKeys = {
   prfResult: 'tinfoil-secret-passkey-prf-output',
@@ -119,11 +114,20 @@ export function createPasskeyKit(config: PasskeyKitConfig): PasskeyKit {
     ...DEFAULT_STORAGE_KEYS,
     ...config.storageKeys,
   }
+  // Byte inputs are snapshotted so later caller-side buffer reuse cannot
+  // silently change the PRF domain or KEK derivation between ceremonies.
   const prfSalt =
     typeof config.prfSaltInput === 'string' || config.prfSaltInput === undefined
-      ? new TextEncoder().encode(config.prfSaltInput ?? DEFAULT_PRF_SALT_INPUT)
-      : config.prfSaltInput
-  const hkdfInfo = config.hkdfInfo ?? DEFAULT_HKDF_INFO
+      ? new TextEncoder().encode(
+          config.prfSaltInput ?? TINFOIL_PRF_SALT_INPUT_V1,
+        )
+      : config.prfSaltInput.slice()
+  const hkdfInfo =
+    config.hkdfInfo === undefined
+      ? TINFOIL_HKDF_INFO_V1
+      : typeof config.hkdfInfo === 'string'
+        ? config.hkdfInfo
+        : config.hkdfInfo.slice()
 
   let prfSupportCache: boolean | null = null
 
@@ -157,7 +161,12 @@ export function createPasskeyKit(config: PasskeyKitConfig): PasskeyKit {
   ): void {
     cachePrfResult(result)
     if (credential.authenticatorAttachment === 'platform') {
-      setLocalCredentialId(result.credentialId)
+      try {
+        setLocalCredentialId(result.credentialId)
+      } catch {
+        // best-effort: a throwing custom adapter must not discard the
+        // ceremony result
+      }
     }
   }
 
@@ -197,10 +206,14 @@ export function createPasskeyKit(config: PasskeyKitConfig): PasskeyKit {
       return createPrfPasskey(ceremonyContext, user)
     },
 
-    authenticate(
+    async authenticate(
       credentialIds: string[],
       options: { throwOnCancel?: boolean } = {},
     ): Promise<PrfPasskeyResult | null> {
+      // An empty allowCredentials list would start a discoverable-passkey
+      // ceremony against ANY credential, breaking the "only the supplied
+      // ids" contract.
+      if (credentialIds.length === 0) return null
       return authenticatePrfPasskey(ceremonyContext, credentialIds, options)
     },
 

--- a/packages/passkey-kit/src/kit.ts
+++ b/packages/passkey-kit/src/kit.ts
@@ -144,6 +144,21 @@ export function createPasskeyKit(config: PasskeyKitConfig): PasskeyKit {
     }
   }
 
+  function getCachedPrfResult(): PrfPasskeyResult | null {
+    if (!storage) return null
+    try {
+      const raw = storage.getItem(storageKeys.prfResult)
+      if (!raw) return null
+      const entry = JSON.parse(raw) as PrfCacheEntry
+      return {
+        credentialId: entry.credentialId,
+        prfOutput: base64ToBytes(entry.prfOutput).buffer as ArrayBuffer,
+      }
+    } catch {
+      return null
+    }
+  }
+
   function setLocalCredentialId(credentialId: string): void {
     storage?.setItem(storageKeys.localCredentialId, credentialId)
   }
@@ -253,7 +268,7 @@ export function createPasskeyKit(config: PasskeyKitConfig): PasskeyKit {
     },
 
     async rewrapWithCachedPrf(cek: Uint8Array): Promise<WrappedCek | null> {
-      const cached = this.getCachedPrfResult()
+      const cached = getCachedPrfResult()
       if (!cached) return null
       return wrapWithPrfResult(cached, cek)
     },
@@ -268,20 +283,7 @@ export function createPasskeyKit(config: PasskeyKitConfig): PasskeyKit {
       return unwrapCek(kek, wrapped)
     },
 
-    getCachedPrfResult(): PrfPasskeyResult | null {
-      if (!storage) return null
-      try {
-        const raw = storage.getItem(storageKeys.prfResult)
-        if (!raw) return null
-        const entry = JSON.parse(raw) as PrfCacheEntry
-        return {
-          credentialId: entry.credentialId,
-          prfOutput: base64ToBytes(entry.prfOutput).buffer as ArrayBuffer,
-        }
-      } catch {
-        return null
-      }
-    },
+    getCachedPrfResult,
 
     clearCachedPrfResult(): void {
       storage?.removeItem(storageKeys.prfResult)

--- a/packages/passkey-kit/src/kit.ts
+++ b/packages/passkey-kit/src/kit.ts
@@ -1,0 +1,288 @@
+/**
+ * The main SDK entry point. `createPasskeyKit(config)` binds relying-party
+ * configuration, protocol constants, and local persistence into a single
+ * object exposing both high-level flows (enroll / unlock / rewrap) and the
+ * lower-level ceremony + crypto building blocks.
+ */
+
+import { base64ToBytes, bytesToBase64 } from './codec'
+import {
+  deriveKeyEncryptionKey as deriveKekFromPrf,
+  unwrapCek,
+  wrapCek,
+} from './crypto'
+import { browserLocalStorageAdapter, type StorageAdapter } from './storage'
+import { detectPrfSupport } from './support'
+import type {
+  EnrollResult,
+  PasskeyKitConfig,
+  PasskeyKitStorageKeys,
+  PasskeyUser,
+  PrfPasskeyResult,
+  UnlockResult,
+  WrappedCek,
+} from './types'
+import {
+  authenticatePrfPasskey,
+  createPrfPasskey,
+  type CeremonyContext,
+} from './webauthn'
+
+// Tinfoil v1 protocol constants. Kept as defaults so every Tinfoil client
+// wrapping the same CEK stays interoperable; override both for a new
+// protocol domain.
+const DEFAULT_PRF_SALT_INPUT = 'tinfoil-chat-key-encryption'
+const DEFAULT_HKDF_INFO = 'tinfoil-chat-kek-v1'
+
+const DEFAULT_STORAGE_KEYS: PasskeyKitStorageKeys = {
+  prfResult: 'tinfoil-secret-passkey-prf-output',
+  localCredentialId: 'tinfoil-local-passkey-credential-id',
+}
+
+const DEFAULT_WEBAUTHN_TIMEOUT_MS = 30_000
+
+// Internal hard timeout to guard against providers (e.g. some
+// password-manager browser extensions) that never resolve the
+// credentials.create/get promise. Kept tight so users aren't left staring
+// at an indefinite spinner; the WebAuthn flow itself should complete well
+// within this window once the provider actually prompts.
+const DEFAULT_STUCK_TIMEOUT_MS = 10_000
+
+interface PrfCacheEntry {
+  credentialId: string
+  prfOutput: string // base64-encoded
+}
+
+export interface PasskeyKit {
+  /** Optimistic device/browser PRF support check (cached per kit). */
+  isPrfSupported(): Promise<boolean>
+  resetPrfSupportCache(): void
+
+  /**
+   * Create a new PRF-capable passkey. Returns null when the user cancels;
+   * throws PrfNotSupportedError / PasskeyTimeoutError otherwise on failure.
+   */
+  createPasskey(user: PasskeyUser): Promise<PrfPasskeyResult | null>
+  /**
+   * Prompt for an assertion against any of the given credential ids and
+   * return the matched credential's PRF output. Null on cancel/failure.
+   */
+  authenticate(
+    credentialIds: string[],
+    options?: { throwOnCancel?: boolean },
+  ): Promise<PrfPasskeyResult | null>
+  /** Derive the AES-256-GCM KEK from a PRF output (HKDF-SHA-256). */
+  deriveKek(prfOutput: ArrayBuffer | Uint8Array): Promise<CryptoKey>
+
+  /** Create a passkey and wrap the given CEK under it in one flow. */
+  enroll(opts: {
+    user: PasskeyUser
+    cek: Uint8Array
+  }): Promise<EnrollResult | null>
+  /** Authenticate against the given wrapped CEKs and unwrap the matching one. */
+  unlock(wrappedCeks: WrappedCek[]): Promise<UnlockResult | null>
+  /**
+   * Re-wrap a CEK using the cached PRF output (no biometric prompt).
+   * Returns null when nothing is cached.
+   */
+  rewrapWithCachedPrf(cek: Uint8Array): Promise<WrappedCek | null>
+  /** Wrap a CEK under the KEK of an explicit PRF result. */
+  wrapWithPrfResult(
+    prfResult: PrfPasskeyResult,
+    cek: Uint8Array,
+  ): Promise<WrappedCek>
+  /** Unwrap a CEK with the KEK of an explicit PRF result. */
+  unwrapWithPrfResult(
+    prfResult: PrfPasskeyResult,
+    wrapped: Pick<WrappedCek, 'kekIvHex' | 'wrappedKeyHex'>,
+  ): Promise<Uint8Array>
+
+  /**
+   * Cached PRF result from local storage, if any. The PRF output is
+   * deterministic for a given passkey, so it can be reused to avoid
+   * re-prompting biometrics on key updates.
+   */
+  getCachedPrfResult(): PrfPasskeyResult | null
+  clearCachedPrfResult(): void
+  /** Credential id owned by this device (platform attachment), if known. */
+  getLocalCredentialId(): string | null
+  setLocalCredentialId(credentialId: string): void
+  /** Clear all device-local state (e.g. on sign-out). */
+  clearLocalState(): void
+}
+
+export function createPasskeyKit(config: PasskeyKitConfig): PasskeyKit {
+  const logger = config.logger ?? {}
+  const storage: StorageAdapter | null =
+    config.storage === undefined ? browserLocalStorageAdapter : config.storage
+  const storageKeys: PasskeyKitStorageKeys = {
+    ...DEFAULT_STORAGE_KEYS,
+    ...config.storageKeys,
+  }
+  const prfSalt =
+    typeof config.prfSaltInput === 'string' || config.prfSaltInput === undefined
+      ? new TextEncoder().encode(config.prfSaltInput ?? DEFAULT_PRF_SALT_INPUT)
+      : config.prfSaltInput
+  const hkdfInfo = config.hkdfInfo ?? DEFAULT_HKDF_INFO
+
+  let prfSupportCache: boolean | null = null
+
+  function cachePrfResult(result: PrfPasskeyResult): void {
+    if (!storage) return
+    const entry: PrfCacheEntry = {
+      credentialId: result.credentialId,
+      prfOutput: bytesToBase64(new Uint8Array(result.prfOutput)),
+    }
+    try {
+      storage.setItem(storageKeys.prfResult, JSON.stringify(entry))
+    } catch {
+      // best-effort
+    }
+  }
+
+  function setLocalCredentialId(credentialId: string): void {
+    storage?.setItem(storageKeys.localCredentialId, credentialId)
+  }
+
+  // Cross-device hybrid (QR-paired phone, etc.) reports
+  // `authenticatorAttachment === 'cross-platform'` on the resulting
+  // credential. Caching the cred id in that case would make this
+  // device look like it has its own passkey when in reality the user
+  // just borrowed another device's passkey for a one-shot unlock.
+  // Per WebAuthn L3 §5.2.1, we only treat `authenticatorAttachment`
+  // of `'platform'` as "this device truly owns this credential".
+  function onPrfResult(
+    result: PrfPasskeyResult,
+    credential: PublicKeyCredential,
+  ): void {
+    cachePrfResult(result)
+    if (credential.authenticatorAttachment === 'platform') {
+      setLocalCredentialId(result.credentialId)
+    }
+  }
+
+  const ceremonyContext: CeremonyContext = {
+    rpId: config.rpId,
+    rpName: config.rpName,
+    prfSalt,
+    webauthnTimeoutMs: config.webauthnTimeoutMs ?? DEFAULT_WEBAUTHN_TIMEOUT_MS,
+    stuckTimeoutMs: config.stuckTimeoutMs ?? DEFAULT_STUCK_TIMEOUT_MS,
+    logger,
+    onPrfResult,
+  }
+
+  const deriveKek = (prfOutput: ArrayBuffer | Uint8Array) =>
+    deriveKekFromPrf(prfOutput, hkdfInfo)
+
+  async function wrapWithPrfResult(
+    prfResult: PrfPasskeyResult,
+    cek: Uint8Array,
+  ): Promise<WrappedCek> {
+    const kek = await deriveKek(prfResult.prfOutput)
+    return wrapCek({ credentialId: prfResult.credentialId, kek, cek })
+  }
+
+  return {
+    async isPrfSupported(): Promise<boolean> {
+      if (prfSupportCache !== null) return prfSupportCache
+      prfSupportCache = await detectPrfSupport()
+      return prfSupportCache
+    },
+
+    resetPrfSupportCache(): void {
+      prfSupportCache = null
+    },
+
+    createPasskey(user: PasskeyUser): Promise<PrfPasskeyResult | null> {
+      return createPrfPasskey(ceremonyContext, user)
+    },
+
+    authenticate(
+      credentialIds: string[],
+      options: { throwOnCancel?: boolean } = {},
+    ): Promise<PrfPasskeyResult | null> {
+      return authenticatePrfPasskey(ceremonyContext, credentialIds, options)
+    },
+
+    deriveKek,
+
+    async enroll(opts: {
+      user: PasskeyUser
+      cek: Uint8Array
+    }): Promise<EnrollResult | null> {
+      const prfResult = await createPrfPasskey(ceremonyContext, opts.user)
+      if (!prfResult) return null
+      const wrappedCek = await wrapWithPrfResult(prfResult, opts.cek)
+      return { credentialId: prfResult.credentialId, wrappedCek, prfResult }
+    },
+
+    async unlock(wrappedCeks: WrappedCek[]): Promise<UnlockResult | null> {
+      if (wrappedCeks.length === 0) return null
+      const prfResult = await authenticatePrfPasskey(
+        ceremonyContext,
+        wrappedCeks.map((w) => w.credentialId),
+      )
+      if (!prfResult) return null
+      const match = wrappedCeks.find(
+        (w) => w.credentialId === prfResult.credentialId,
+      )
+      if (!match) {
+        logger.error?.(
+          'assertion matched a credential with no wrapped CEK',
+          undefined,
+          { action: 'unlock', credentialId: prfResult.credentialId },
+        )
+        return null
+      }
+      const kek = await deriveKek(prfResult.prfOutput)
+      const cek = await unwrapCek(kek, match)
+      return { credentialId: prfResult.credentialId, cek }
+    },
+
+    async rewrapWithCachedPrf(cek: Uint8Array): Promise<WrappedCek | null> {
+      const cached = this.getCachedPrfResult()
+      if (!cached) return null
+      return wrapWithPrfResult(cached, cek)
+    },
+
+    wrapWithPrfResult,
+
+    async unwrapWithPrfResult(
+      prfResult: PrfPasskeyResult,
+      wrapped: Pick<WrappedCek, 'kekIvHex' | 'wrappedKeyHex'>,
+    ): Promise<Uint8Array> {
+      const kek = await deriveKek(prfResult.prfOutput)
+      return unwrapCek(kek, wrapped)
+    },
+
+    getCachedPrfResult(): PrfPasskeyResult | null {
+      if (!storage) return null
+      try {
+        const raw = storage.getItem(storageKeys.prfResult)
+        if (!raw) return null
+        const entry = JSON.parse(raw) as PrfCacheEntry
+        return {
+          credentialId: entry.credentialId,
+          prfOutput: base64ToBytes(entry.prfOutput).buffer as ArrayBuffer,
+        }
+      } catch {
+        return null
+      }
+    },
+
+    clearCachedPrfResult(): void {
+      storage?.removeItem(storageKeys.prfResult)
+    },
+
+    getLocalCredentialId(): string | null {
+      return storage?.getItem(storageKeys.localCredentialId) ?? null
+    },
+
+    setLocalCredentialId,
+
+    clearLocalState(): void {
+      storage?.removeItem(storageKeys.prfResult)
+      storage?.removeItem(storageKeys.localCredentialId)
+    },
+  }
+}

--- a/packages/passkey-kit/src/protocol.ts
+++ b/packages/passkey-kit/src/protocol.ts
@@ -1,0 +1,12 @@
+/**
+ * Tinfoil v1 protocol constants. Every client wrapping the same CEK must
+ * use identical values: the PRF salt input and HKDF info string both feed
+ * the KEK derivation, so changing either changes every derived KEK.
+ * Override both to establish a new protocol domain.
+ */
+
+/** Input to the WebAuthn PRF `eval.first` salt. */
+export const TINFOIL_PRF_SALT_INPUT_V1 = 'tinfoil-chat-key-encryption'
+
+/** HKDF info string for domain separation when deriving the KEK. */
+export const TINFOIL_HKDF_INFO_V1 = 'tinfoil-chat-kek-v1'

--- a/packages/passkey-kit/src/storage.ts
+++ b/packages/passkey-kit/src/storage.ts
@@ -1,0 +1,59 @@
+/**
+ * Pluggable local persistence for the SDK's device-side state: the cached
+ * PRF output and the credential id this device owns. Adapters are
+ * synchronous by design (mirroring the Web Storage API) so callers can
+ * read cached state without awaiting.
+ */
+
+export interface StorageAdapter {
+  getItem(key: string): string | null
+  setItem(key: string, value: string): void
+  removeItem(key: string): void
+}
+
+/**
+ * Default adapter backed by `window.localStorage`. Every operation is
+ * best-effort: quota errors, privacy-mode failures, and SSR (no window)
+ * all degrade to no-ops so storage problems never interrupt a passkey
+ * ceremony.
+ */
+export const browserLocalStorageAdapter: StorageAdapter = {
+  getItem(key: string): string | null {
+    if (typeof localStorage === 'undefined') return null
+    try {
+      return localStorage.getItem(key)
+    } catch {
+      return null
+    }
+  },
+  setItem(key: string, value: string): void {
+    if (typeof localStorage === 'undefined') return
+    try {
+      localStorage.setItem(key, value)
+    } catch {
+      // best-effort
+    }
+  },
+  removeItem(key: string): void {
+    if (typeof localStorage === 'undefined') return
+    try {
+      localStorage.removeItem(key)
+    } catch {
+      // best-effort
+    }
+  },
+}
+
+/** In-memory adapter for tests and non-browser environments. */
+export function createMemoryStorageAdapter(): StorageAdapter {
+  const store = new Map<string, string>()
+  return {
+    getItem: (key) => store.get(key) ?? null,
+    setItem: (key, value) => {
+      store.set(key, value)
+    },
+    removeItem: (key) => {
+      store.delete(key)
+    },
+  }
+}

--- a/packages/passkey-kit/src/storage.ts
+++ b/packages/passkey-kit/src/storage.ts
@@ -3,6 +3,15 @@
  * PRF output and the credential id this device owns. Adapters are
  * synchronous by design (mirroring the Web Storage API) so callers can
  * read cached state without awaiting.
+ *
+ * SECURITY: the PRF output cached through an adapter is raw key material —
+ * anyone who can read it can re-derive the KEK and unwrap the CEK. The
+ * default `localStorage` adapter stores it in plaintext, which is only as
+ * strong as the origin's script-injection defenses (an XSS attacker could
+ * equally just run the ceremony or exfiltrate decrypted data). Hosts with
+ * stricter requirements should supply their own adapter with at-rest
+ * protection, or pass `storage: null` to disable caching and re-prompt
+ * biometrics instead.
  */
 
 export interface StorageAdapter {
@@ -13,30 +22,31 @@ export interface StorageAdapter {
 
 /**
  * Default adapter backed by `window.localStorage`. Every operation is
- * best-effort: quota errors, privacy-mode failures, and SSR (no window)
- * all degrade to no-ops so storage problems never interrupt a passkey
- * ceremony.
+ * best-effort: quota errors, privacy-mode failures, blocked-storage
+ * contexts (e.g. sandboxed frames, where even touching `localStorage`
+ * throws), and SSR (no window) all degrade to no-ops so storage problems
+ * never interrupt a passkey ceremony.
  */
 export const browserLocalStorageAdapter: StorageAdapter = {
   getItem(key: string): string | null {
-    if (typeof localStorage === 'undefined') return null
     try {
+      if (typeof localStorage === 'undefined') return null
       return localStorage.getItem(key)
     } catch {
       return null
     }
   },
   setItem(key: string, value: string): void {
-    if (typeof localStorage === 'undefined') return
     try {
+      if (typeof localStorage === 'undefined') return
       localStorage.setItem(key, value)
     } catch {
       // best-effort
     }
   },
   removeItem(key: string): void {
-    if (typeof localStorage === 'undefined') return
     try {
+      if (typeof localStorage === 'undefined') return
       localStorage.removeItem(key)
     } catch {
       // best-effort

--- a/packages/passkey-kit/src/support.ts
+++ b/packages/passkey-kit/src/support.ts
@@ -1,0 +1,61 @@
+/**
+ * PRF support detection.
+ *
+ * Checks whether the current browser/platform supports the WebAuthn PRF
+ * extension. This is an optimistic check — actual PRF support is only
+ * confirmed when a credential is created with prf.enabled: true in the
+ * response. If creation fails, callers should fall back to a manual flow.
+ *
+ * Detection strategy:
+ * 1. Check window.PublicKeyCredential exists (basic WebAuthn support)
+ * 2. Check isUserVerifyingPlatformAuthenticatorAvailable() (biometric/PIN authenticator present)
+ * 3. Optionally check getClientCapabilities() for explicit PRF support signal (new API, not universal)
+ */
+export async function detectPrfSupport(): Promise<boolean> {
+  if (typeof window === 'undefined') {
+    return false
+  }
+
+  if (!window.PublicKeyCredential) {
+    return false
+  }
+
+  // Check that a platform authenticator is available (Face ID, Touch ID, Windows Hello, etc.)
+  try {
+    const available =
+      await PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable()
+    if (!available) {
+      return false
+    }
+  } catch {
+    return false
+  }
+
+  // If getClientCapabilities is available, use it for a more precise check.
+  // This API is newer and may not be present in all browsers.
+  try {
+    if (typeof PublicKeyCredential.getClientCapabilities === 'function') {
+      const caps = await PublicKeyCredential.getClientCapabilities()
+      if (caps && typeof caps === 'object') {
+        // The shape of this API varies across browser versions.
+        // Chrome returns a map-like object; check for extension-prf or prf key.
+        const hasPrf =
+          (caps as Record<string, boolean>)['extension-prf'] === true ||
+          (caps as Record<string, boolean>)['prf'] === true
+        if (hasPrf) {
+          return true
+        }
+        // If getClientCapabilities is available but doesn't report PRF,
+        // that's a strong negative signal on platforms that implement it.
+        // However, since this API is still evolving, we don't treat absence
+        // as definitive — fall through to the optimistic path.
+      }
+    }
+  } catch {
+    // getClientCapabilities not available or threw — fall through
+  }
+
+  // Optimistic: platform authenticator is available, WebAuthn is supported.
+  // Actual PRF support will be confirmed during credential creation.
+  return true
+}

--- a/packages/passkey-kit/src/types.ts
+++ b/packages/passkey-kit/src/types.ts
@@ -17,6 +17,18 @@ export interface PasskeyKitStorageKeys {
   localCredentialId: string
 }
 
+/**
+ * Overrides for the messages on errors the SDK throws. Useful for branding
+ * or localization; the error classes themselves stay the same, so
+ * `instanceof` checks are unaffected.
+ */
+export interface PasskeyKitErrorMessages {
+  /** Message used for `PrfNotSupportedError`. */
+  prfNotSupported?: string
+  /** Message used for `PasskeyTimeoutError`. */
+  timeout?: string
+}
+
 export interface PasskeyKitConfig {
   /** WebAuthn relying party id (e.g. `example.com`, or `localhost` in dev). */
   rpId: string
@@ -47,6 +59,8 @@ export interface PasskeyKitConfig {
    * the WebAuthn promise. When exceeded, `PasskeyTimeoutError` is thrown.
    */
   stuckTimeoutMs?: number
+  /** Custom messages for the errors the SDK throws. */
+  errorMessages?: PasskeyKitErrorMessages
   logger?: PasskeyKitLogger
 }
 

--- a/packages/passkey-kit/src/types.ts
+++ b/packages/passkey-kit/src/types.ts
@@ -1,0 +1,99 @@
+import type { StorageAdapter } from './storage'
+
+/** Structured logging hooks; the SDK never writes to the console itself. */
+export interface PasskeyKitLogger {
+  info?(message: string, metadata?: Record<string, unknown>): void
+  error?(
+    message: string,
+    error?: unknown,
+    metadata?: Record<string, unknown>,
+  ): void
+}
+
+export interface PasskeyKitStorageKeys {
+  /** Key under which the cached PRF result is persisted. */
+  prfResult: string
+  /** Key under which this device's own credential id is persisted. */
+  localCredentialId: string
+}
+
+export interface PasskeyKitConfig {
+  /** WebAuthn relying party id (e.g. `example.com`, or `localhost` in dev). */
+  rpId: string
+  /** Human-readable relying party name shown in passkey prompts. */
+  rpName: string
+  /**
+   * Input to the PRF `eval.first` salt. Must stay stable across all clients
+   * of the same protocol: changing it changes every derived KEK.
+   * Defaults to the Tinfoil v1 protocol constant.
+   */
+  prfSaltInput?: string | Uint8Array
+  /**
+   * HKDF info string used for domain separation when deriving the KEK from
+   * the PRF output. Defaults to the Tinfoil v1 protocol constant.
+   */
+  hkdfInfo?: string | Uint8Array
+  /**
+   * Local persistence for the PRF cache and this device's credential id.
+   * Defaults to a best-effort `localStorage` adapter; pass `null` to
+   * disable local persistence entirely.
+   */
+  storage?: StorageAdapter | null
+  storageKeys?: Partial<PasskeyKitStorageKeys>
+  /** Timeout passed to the WebAuthn API (some browsers ignore this). */
+  webauthnTimeoutMs?: number
+  /**
+   * Hard client-side timeout guarding against providers that never resolve
+   * the WebAuthn promise. When exceeded, `PasskeyTimeoutError` is thrown.
+   */
+  stuckTimeoutMs?: number
+  logger?: PasskeyKitLogger
+}
+
+/** Identity attached to a newly created passkey. */
+export interface PasskeyUser {
+  /** Stable opaque user id (becomes the WebAuthn user handle). */
+  id: string
+  /** Account identifier shown in passkey pickers (usually an email). */
+  name: string
+  /** Friendly display name; falls back to `name` when omitted. */
+  displayName?: string
+}
+
+/** Result of a successful PRF ceremony (create or authenticate). */
+export interface PrfPasskeyResult {
+  /** base64url-encoded credential id. */
+  credentialId: string
+  /** Raw 32-byte PRF output; treat as secret key material. */
+  prfOutput: ArrayBuffer
+}
+
+/** A CEK wrapped under a passkey-derived KEK with AES-256-GCM. */
+export interface WrappedCek {
+  /** base64url-encoded credential id whose PRF output wraps this CEK. */
+  credentialId: string
+  /** 12-byte AES-GCM IV, hex-encoded. */
+  kekIvHex: string
+  /** Wrapped CEK ciphertext (including GCM tag), hex-encoded. */
+  wrappedKeyHex: string
+}
+
+/** Result of the high-level enroll flow: create passkey + wrap CEK. */
+export interface EnrollResult {
+  credentialId: string
+  /** Ciphertext safe to persist server-side. */
+  wrappedCek: WrappedCek
+  /**
+   * Device-local secret state (PRF output). Already persisted through the
+   * storage adapter when one is configured; returned so hosts with custom
+   * persistence can store it themselves.
+   */
+  prfResult: PrfPasskeyResult
+}
+
+/** Result of the high-level unlock flow: authenticate + unwrap CEK. */
+export interface UnlockResult {
+  credentialId: string
+  /** The recovered raw 32-byte CEK. */
+  cek: Uint8Array
+}

--- a/packages/passkey-kit/src/webauthn.ts
+++ b/packages/passkey-kit/src/webauthn.ts
@@ -10,7 +10,12 @@ import {
   bytesToBase64Url,
 } from './codec'
 import { PasskeyTimeoutError, PrfNotSupportedError } from './errors'
-import type { PasskeyKitLogger, PasskeyUser, PrfPasskeyResult } from './types'
+import type {
+  PasskeyKitErrorMessages,
+  PasskeyKitLogger,
+  PasskeyUser,
+  PrfPasskeyResult,
+} from './types'
 
 export interface CeremonyContext {
   rpId: string
@@ -20,6 +25,7 @@ export interface CeremonyContext {
   prfSalt: Uint8Array
   webauthnTimeoutMs: number
   stuckTimeoutMs: number
+  errorMessages?: PasskeyKitErrorMessages
   logger: PasskeyKitLogger
   /** Invoked after every successful PRF ceremony so the kit can cache state. */
   onPrfResult(result: PrfPasskeyResult, credential: PublicKeyCredential): void
@@ -27,7 +33,7 @@ export interface CeremonyContext {
 
 async function withStuckTimeout<T>(
   promise: Promise<T>,
-  stuckTimeoutMs: number,
+  ctx: CeremonyContext,
 ): Promise<T> {
   let timer: ReturnType<typeof setTimeout> | undefined
   try {
@@ -35,8 +41,8 @@ async function withStuckTimeout<T>(
       promise,
       new Promise<T>((_, reject) => {
         timer = setTimeout(
-          () => reject(new PasskeyTimeoutError()),
-          stuckTimeoutMs,
+          () => reject(new PasskeyTimeoutError(ctx.errorMessages?.timeout)),
+          ctx.stuckTimeoutMs,
         )
       }),
     ])
@@ -83,7 +89,7 @@ export async function createPrfPasskey(
           },
         },
       }),
-      ctx.stuckTimeoutMs,
+      ctx,
     )) as PublicKeyCredential | null
 
     if (!credential) {
@@ -97,7 +103,7 @@ export async function createPrfPasskey(
       ctx.logger.info?.('Authenticator does not support PRF', {
         action: 'createPrfPasskey',
       })
-      throw new PrfNotSupportedError()
+      throw new PrfNotSupportedError(ctx.errorMessages?.prfNotSupported)
     }
 
     const credentialId = bytesToBase64Url(new Uint8Array(credential.rawId))
@@ -131,7 +137,7 @@ export async function createPrfPasskey(
       // The provider claimed PRF support during creation but didn't deliver
       // a PRF output on the immediately-following assertion. Treat this as
       // a lack of real PRF support rather than a silent failure.
-      throw new PrfNotSupportedError()
+      throw new PrfNotSupportedError(ctx.errorMessages?.prfNotSupported)
     }
     return postCreateAuth
   } catch (error) {
@@ -187,7 +193,7 @@ export async function authenticatePrfPasskey(
           },
         },
       }),
-      ctx.stuckTimeoutMs,
+      ctx,
     )) as PublicKeyCredential | null
 
     if (!assertion) {

--- a/packages/passkey-kit/src/webauthn.ts
+++ b/packages/passkey-kit/src/webauthn.ts
@@ -1,0 +1,241 @@
+/**
+ * WebAuthn PRF ceremonies: credential creation and assertion with the PRF
+ * extension. Pure ceremony logic — persistence of the results is handled
+ * by the kit through the hooks on {@link CeremonyContext}.
+ */
+
+import {
+  base64UrlToBytes,
+  bufferSourceToArrayBuffer,
+  bytesToBase64Url,
+} from './codec'
+import { PasskeyTimeoutError, PrfNotSupportedError } from './errors'
+import type { PasskeyKitLogger, PasskeyUser, PrfPasskeyResult } from './types'
+
+export interface CeremonyContext {
+  rpId: string
+  rpName: string
+  /** Salt passed to PRF eval.first — the client internally computes
+   *  SHA-256("WebAuthn PRF" || 0x00 || salt). */
+  prfSalt: Uint8Array
+  webauthnTimeoutMs: number
+  stuckTimeoutMs: number
+  logger: PasskeyKitLogger
+  /** Invoked after every successful PRF ceremony so the kit can cache state. */
+  onPrfResult(result: PrfPasskeyResult, credential: PublicKeyCredential): void
+}
+
+async function withStuckTimeout<T>(
+  promise: Promise<T>,
+  stuckTimeoutMs: number,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_, reject) => {
+        timer = setTimeout(
+          () => reject(new PasskeyTimeoutError()),
+          stuckTimeoutMs,
+        )
+      }),
+    ])
+  } finally {
+    if (timer !== undefined) clearTimeout(timer)
+  }
+}
+
+/**
+ * Create a new PRF-capable passkey for the given user.
+ *
+ * Returns the credential ID and PRF output, or null if the user cancels.
+ * Throws {@link PrfNotSupportedError} when the authenticator cannot supply
+ * PRF output and {@link PasskeyTimeoutError} when the provider hangs.
+ */
+export async function createPrfPasskey(
+  ctx: CeremonyContext,
+  user: PasskeyUser,
+): Promise<PrfPasskeyResult | null> {
+  const userIdBytes = new TextEncoder().encode(user.id)
+
+  try {
+    const credential = (await withStuckTimeout(
+      navigator.credentials.create({
+        publicKey: {
+          challenge: crypto.getRandomValues(new Uint8Array(32)),
+          rp: { id: ctx.rpId, name: ctx.rpName },
+          user: {
+            id: userIdBytes,
+            name: user.name,
+            displayName: user.displayName || user.name,
+          },
+          pubKeyCredParams: [
+            { type: 'public-key', alg: -7 }, // ES256
+            { type: 'public-key', alg: -257 }, // RS256 (broader compat)
+          ],
+          authenticatorSelection: {
+            residentKey: 'preferred',
+            userVerification: 'required',
+          },
+          timeout: ctx.webauthnTimeoutMs,
+          extensions: {
+            prf: { eval: { first: ctx.prfSalt as BufferSource } },
+          },
+        },
+      }),
+      ctx.stuckTimeoutMs,
+    )) as PublicKeyCredential | null
+
+    if (!credential) {
+      return null
+    }
+
+    const extensionResults = credential.getClientExtensionResults()
+    const prfResults = extensionResults.prf
+
+    if (!prfResults?.enabled) {
+      ctx.logger.info?.('Authenticator does not support PRF', {
+        action: 'createPrfPasskey',
+      })
+      throw new PrfNotSupportedError()
+    }
+
+    const credentialId = bytesToBase64Url(new Uint8Array(credential.rawId))
+
+    // Some authenticators return PRF results during creation, others don't.
+    // "Not all authenticators support evaluating the PRFs during credential
+    // creation so outputs may, or may not, be provided."
+    // — https://w3c.github.io/webauthn/#prf-extension (eval description)
+    if (prfResults.results?.first) {
+      const result: PrfPasskeyResult = {
+        credentialId,
+        prfOutput: bufferSourceToArrayBuffer(prfResults.results.first),
+      }
+      ctx.onPrfResult(result, credential)
+      return result
+    }
+
+    // PRF enabled but no results during create — do an immediate get()
+    ctx.logger.info?.(
+      'PRF enabled but no results during creation, doing immediate auth',
+      { action: 'createPrfPasskey' },
+    )
+    // Pass throwOnCancel so a user-cancelled assertion surfaces as a
+    // DOMException we can handle below — otherwise a `null` return would
+    // be indistinguishable from "provider returned no PRF output" and we'd
+    // show the misleading "PRF not supported" error for a plain cancel.
+    const postCreateAuth = await authenticatePrfPasskey(ctx, [credentialId], {
+      throwOnCancel: true,
+    })
+    if (!postCreateAuth) {
+      // The provider claimed PRF support during creation but didn't deliver
+      // a PRF output on the immediately-following assertion. Treat this as
+      // a lack of real PRF support rather than a silent failure.
+      throw new PrfNotSupportedError()
+    }
+    return postCreateAuth
+  } catch (error) {
+    if (error instanceof PrfNotSupportedError) throw error
+    if (error instanceof PasskeyTimeoutError) throw error
+
+    // DOMException with name "NotAllowedError" means the user cancelled
+    if (error instanceof DOMException && error.name === 'NotAllowedError') {
+      ctx.logger.info?.('User cancelled passkey creation', {
+        action: 'createPrfPasskey',
+      })
+      return null
+    }
+
+    ctx.logger.error?.('Failed to create PRF passkey', error, {
+      action: 'createPrfPasskey',
+    })
+    return null
+  }
+}
+
+/**
+ * Authenticate with an existing PRF passkey to derive the PRF output.
+ *
+ * @param credentialIds - base64url-encoded credential IDs to allow. Pass all
+ *   known PRF credential IDs so the browser can select the right one.
+ * @returns The matched credential ID and PRF output, or null on failure/cancel.
+ */
+export async function authenticatePrfPasskey(
+  ctx: CeremonyContext,
+  credentialIds: string[],
+  options: { throwOnCancel?: boolean } = {},
+): Promise<PrfPasskeyResult | null> {
+  const { throwOnCancel = false } = options
+  const allowCredentials: PublicKeyCredentialDescriptor[] = credentialIds.map(
+    (id) => ({
+      id: base64UrlToBytes(id) as BufferSource,
+      type: 'public-key',
+    }),
+  )
+
+  try {
+    const assertion = (await withStuckTimeout(
+      navigator.credentials.get({
+        publicKey: {
+          challenge: crypto.getRandomValues(new Uint8Array(32)),
+          rpId: ctx.rpId,
+          allowCredentials,
+          userVerification: 'required',
+          timeout: ctx.webauthnTimeoutMs,
+          extensions: {
+            prf: { eval: { first: ctx.prfSalt as BufferSource } },
+          },
+        },
+      }),
+      ctx.stuckTimeoutMs,
+    )) as PublicKeyCredential | null
+
+    if (!assertion) {
+      ctx.logger.info?.('passkey assertion returned no credential', {
+        action: 'authenticatePrfPasskey',
+        allowedCredentials: credentialIds.length,
+      })
+      return null
+    }
+
+    const extensionResults = assertion.getClientExtensionResults()
+    const prfOutput = extensionResults.prf?.results?.first
+
+    if (!prfOutput) {
+      ctx.logger.error?.('PRF output missing from assertion', undefined, {
+        action: 'authenticatePrfPasskey',
+      })
+      return null
+    }
+
+    const result: PrfPasskeyResult = {
+      credentialId: bytesToBase64Url(new Uint8Array(assertion.rawId)),
+      prfOutput: bufferSourceToArrayBuffer(prfOutput),
+    }
+    ctx.onPrfResult(result, assertion)
+    return result
+  } catch (error) {
+    if (error instanceof PasskeyTimeoutError) throw error
+
+    if (error instanceof DOMException && error.name === 'NotAllowedError') {
+      // NotAllowedError covers both a user cancel and the case where the
+      // provider has no usable credential for any of the allowed ids
+      // (e.g. the passkey was created in a different browser/profile and
+      // never persisted on this device).
+      ctx.logger.info?.(
+        'passkey authentication not allowed (cancelled or no usable credential)',
+        {
+          action: 'authenticatePrfPasskey',
+          allowedCredentials: credentialIds.length,
+        },
+      )
+      if (throwOnCancel) throw error
+      return null
+    }
+
+    ctx.logger.error?.('Failed to authenticate with PRF passkey', error, {
+      action: 'authenticatePrfPasskey',
+    })
+    return null
+  }
+}

--- a/packages/passkey-kit/tests/codec.test.ts
+++ b/packages/passkey-kit/tests/codec.test.ts
@@ -40,4 +40,12 @@ describe('codec', () => {
     backing[2] = 99
     expect(copy[1]).toBe(3)
   })
+
+  it('copies raw ArrayBuffers instead of returning the original reference', () => {
+    const original = new Uint8Array([1, 2, 3]).buffer
+    const copy = bufferSourceToArrayBuffer(original)
+    expect(copy).not.toBe(original)
+    new Uint8Array(original)[0] = 99
+    expect(new Uint8Array(copy)[0]).toBe(1)
+  })
 })

--- a/packages/passkey-kit/tests/codec.test.ts
+++ b/packages/passkey-kit/tests/codec.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import {
+  base64ToBytes,
+  base64UrlToBytes,
+  bufferSourceToArrayBuffer,
+  bytesToBase64,
+  bytesToBase64Url,
+  bytesToHex,
+  hexToBytes,
+} from '../src/codec'
+
+describe('codec', () => {
+  it('round-trips bytes through hex', () => {
+    const bytes = crypto.getRandomValues(new Uint8Array(64))
+    expect(hexToBytes(bytesToHex(bytes))).toEqual(bytes)
+  })
+
+  it('rejects malformed hex', () => {
+    expect(() => hexToBytes('abc')).toThrow('odd-length')
+    expect(() => hexToBytes('zz')).toThrow('invalid hex')
+  })
+
+  it('round-trips bytes through base64', () => {
+    const bytes = new Uint8Array(100_000).map((_, i) => i % 256)
+    expect(base64ToBytes(bytesToBase64(bytes))).toEqual(bytes)
+  })
+
+  it('round-trips bytes through base64url without padding or unsafe chars', () => {
+    const bytes = crypto.getRandomValues(new Uint8Array(33))
+    const encoded = bytesToBase64Url(bytes)
+    expect(encoded).not.toMatch(/[+/=]/)
+    expect(base64UrlToBytes(encoded)).toEqual(bytes)
+  })
+
+  it('copies BufferSource views into standalone ArrayBuffers', () => {
+    const backing = new Uint8Array([1, 2, 3, 4, 5])
+    const view = backing.subarray(1, 4)
+    const copy = new Uint8Array(bufferSourceToArrayBuffer(view))
+    expect(copy).toEqual(new Uint8Array([2, 3, 4]))
+    backing[2] = 99
+    expect(copy[1]).toBe(3)
+  })
+})

--- a/packages/passkey-kit/tests/crypto.test.ts
+++ b/packages/passkey-kit/tests/crypto.test.ts
@@ -4,6 +4,8 @@ import {
   CEK_BYTES,
   deriveKeyEncryptionKey,
   deriveKeyId,
+  generateCek,
+  isValidCek,
   unwrapCek,
   wrapCek,
 } from '../src/crypto'
@@ -15,6 +17,28 @@ const HKDF_INFO = 'test-kek-v1'
 function randomPrfOutput(): ArrayBuffer {
   return crypto.getRandomValues(new Uint8Array(32)).buffer as ArrayBuffer
 }
+
+describe('generateCek / isValidCek', () => {
+  it('generates a valid CEK that wrap/unwrap accepts', async () => {
+    const cek = generateCek()
+    expect(isValidCek(cek)).toBe(true)
+    const kek = await deriveKeyEncryptionKey(randomPrfOutput(), HKDF_INFO)
+    const wrapped = await wrapCek({ credentialId: 'c', kek, cek })
+    expect(await unwrapCek(kek, wrapped)).toEqual(cek)
+  })
+
+  it('generates a distinct CEK per call', () => {
+    expect(generateCek()).not.toEqual(generateCek())
+  })
+
+  it('rejects wrong lengths and non-byte inputs', () => {
+    expect(isValidCek(new Uint8Array(CEK_BYTES - 1))).toBe(false)
+    expect(isValidCek(new Uint8Array(CEK_BYTES + 1))).toBe(false)
+    expect(isValidCek(Array.from(generateCek()))).toBe(false)
+    expect(isValidCek(generateCek().buffer)).toBe(false)
+    expect(isValidCek(null)).toBe(false)
+  })
+})
 
 describe('deriveKeyEncryptionKey', () => {
   it('derives a non-extractable AES-256-GCM key', async () => {

--- a/packages/passkey-kit/tests/crypto.test.ts
+++ b/packages/passkey-kit/tests/crypto.test.ts
@@ -8,6 +8,7 @@ import {
   wrapCek,
 } from '../src/crypto'
 import { PasskeyKitError } from '../src/errors'
+import { TINFOIL_HKDF_INFO_V1 } from '../src/protocol'
 
 const HKDF_INFO = 'test-kek-v1'
 
@@ -40,6 +41,18 @@ describe('deriveKeyEncryptionKey', () => {
     const kek2 = await deriveKeyEncryptionKey(prf.slice(), 'other-info')
     const wrapped = await wrapCek({ credentialId: 'c', kek: kek1, cek })
     await expect(unwrapCek(kek2, wrapped)).rejects.toThrow()
+  })
+
+  it('defaults hkdfInfo to the exported Tinfoil v1 constant', async () => {
+    const prf = crypto.getRandomValues(new Uint8Array(32))
+    const cek = crypto.getRandomValues(new Uint8Array(CEK_BYTES))
+    const defaulted = await deriveKeyEncryptionKey(prf.slice())
+    const explicit = await deriveKeyEncryptionKey(
+      prf.slice(),
+      TINFOIL_HKDF_INFO_V1,
+    )
+    const wrapped = await wrapCek({ credentialId: 'c', kek: defaulted, cek })
+    expect(await unwrapCek(explicit, wrapped)).toEqual(cek)
   })
 })
 

--- a/packages/passkey-kit/tests/crypto.test.ts
+++ b/packages/passkey-kit/tests/crypto.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest'
+import { bytesToHex } from '../src/codec'
+import {
+  CEK_BYTES,
+  deriveKeyEncryptionKey,
+  deriveKeyId,
+  unwrapCek,
+  wrapCek,
+} from '../src/crypto'
+import { PasskeyKitError } from '../src/errors'
+
+const HKDF_INFO = 'test-kek-v1'
+
+function randomPrfOutput(): ArrayBuffer {
+  return crypto.getRandomValues(new Uint8Array(32)).buffer as ArrayBuffer
+}
+
+describe('deriveKeyEncryptionKey', () => {
+  it('derives a non-extractable AES-256-GCM key', async () => {
+    const kek = await deriveKeyEncryptionKey(randomPrfOutput(), HKDF_INFO)
+    expect(kek.algorithm).toMatchObject({ name: 'AES-GCM', length: 256 })
+    expect(kek.extractable).toBe(false)
+    expect(kek.usages).toContain('encrypt')
+    expect(kek.usages).toContain('decrypt')
+  })
+
+  it('is deterministic for the same PRF output and info', async () => {
+    const prf = crypto.getRandomValues(new Uint8Array(32))
+    const cek = crypto.getRandomValues(new Uint8Array(CEK_BYTES))
+    const kek1 = await deriveKeyEncryptionKey(prf.slice(), HKDF_INFO)
+    const kek2 = await deriveKeyEncryptionKey(prf.slice(), HKDF_INFO)
+    const wrapped = await wrapCek({ credentialId: 'c', kek: kek1, cek })
+    expect(await unwrapCek(kek2, wrapped)).toEqual(cek)
+  })
+
+  it('domain-separates by hkdf info', async () => {
+    const prf = crypto.getRandomValues(new Uint8Array(32))
+    const cek = crypto.getRandomValues(new Uint8Array(CEK_BYTES))
+    const kek1 = await deriveKeyEncryptionKey(prf.slice(), HKDF_INFO)
+    const kek2 = await deriveKeyEncryptionKey(prf.slice(), 'other-info')
+    const wrapped = await wrapCek({ credentialId: 'c', kek: kek1, cek })
+    await expect(unwrapCek(kek2, wrapped)).rejects.toThrow()
+  })
+})
+
+describe('wrapCek / unwrapCek', () => {
+  it('round-trips a CEK', async () => {
+    const kek = await deriveKeyEncryptionKey(randomPrfOutput(), HKDF_INFO)
+    const cek = crypto.getRandomValues(new Uint8Array(CEK_BYTES))
+    const wrapped = await wrapCek({ credentialId: 'cred-1', kek, cek })
+    expect(wrapped.credentialId).toBe('cred-1')
+    expect(wrapped.kekIvHex).toMatch(/^[0-9a-f]{24}$/)
+    expect(await unwrapCek(kek, wrapped)).toEqual(cek)
+  })
+
+  it('uses a fresh IV per wrap', async () => {
+    const kek = await deriveKeyEncryptionKey(randomPrfOutput(), HKDF_INFO)
+    const cek = crypto.getRandomValues(new Uint8Array(CEK_BYTES))
+    const a = await wrapCek({ credentialId: 'c', kek, cek })
+    const b = await wrapCek({ credentialId: 'c', kek, cek })
+    expect(a.kekIvHex).not.toBe(b.kekIvHex)
+    expect(a.wrappedKeyHex).not.toBe(b.wrappedKeyHex)
+  })
+
+  it('rejects a CEK of the wrong length', async () => {
+    const kek = await deriveKeyEncryptionKey(randomPrfOutput(), HKDF_INFO)
+    await expect(
+      wrapCek({ credentialId: 'c', kek, cek: new Uint8Array(16) }),
+    ).rejects.toBeInstanceOf(PasskeyKitError)
+  })
+
+  it('rejects tampered ciphertext', async () => {
+    const kek = await deriveKeyEncryptionKey(randomPrfOutput(), HKDF_INFO)
+    const cek = crypto.getRandomValues(new Uint8Array(CEK_BYTES))
+    const wrapped = await wrapCek({ credentialId: 'c', kek, cek })
+    const firstByte = parseInt(wrapped.wrappedKeyHex.slice(0, 2), 16)
+    const flipped =
+      ((firstByte ^ 0xff).toString(16).padStart(2, '0') as string) +
+      wrapped.wrappedKeyHex.slice(2)
+    await expect(
+      unwrapCek(kek, { ...wrapped, wrappedKeyHex: flipped }),
+    ).rejects.toThrow()
+  })
+
+  it('rejects malformed inputs', async () => {
+    const kek = await deriveKeyEncryptionKey(randomPrfOutput(), HKDF_INFO)
+    await expect(
+      unwrapCek(kek, { kekIvHex: '', wrappedKeyHex: 'aa' }),
+    ).rejects.toBeInstanceOf(PasskeyKitError)
+    await expect(
+      unwrapCek(kek, { kekIvHex: 'aabb', wrappedKeyHex: 'aa' }),
+    ).rejects.toBeInstanceOf(PasskeyKitError)
+  })
+})
+
+describe('deriveKeyId', () => {
+  it('is deterministic and hex-encodable', async () => {
+    const cek = crypto.getRandomValues(new Uint8Array(CEK_BYTES))
+    const id1 = await deriveKeyId(cek, { info: 'key-id-v1' })
+    const id2 = await deriveKeyId(cek, { info: 'key-id-v1' })
+    expect(id1).toEqual(id2)
+    expect(bytesToHex(id1)).toMatch(/^[0-9a-f]{32}$/)
+  })
+
+  it('domain-separates by info and differs per CEK', async () => {
+    const cek = crypto.getRandomValues(new Uint8Array(CEK_BYTES))
+    const other = crypto.getRandomValues(new Uint8Array(CEK_BYTES))
+    const a = await deriveKeyId(cek, { info: 'key-id-v1' })
+    const b = await deriveKeyId(cek, { info: 'key-id-v2' })
+    const c = await deriveKeyId(other, { info: 'key-id-v1' })
+    expect(a).not.toEqual(b)
+    expect(a).not.toEqual(c)
+  })
+
+  it('supports custom output lengths and rejects bad CEKs', async () => {
+    const cek = crypto.getRandomValues(new Uint8Array(CEK_BYTES))
+    const id = await deriveKeyId(cek, { info: 'key-id-v1', lengthBytes: 32 })
+    expect(id.length).toBe(32)
+    await expect(
+      deriveKeyId(new Uint8Array(8), { info: 'key-id-v1' }),
+    ).rejects.toBeInstanceOf(PasskeyKitError)
+  })
+})

--- a/packages/passkey-kit/tests/kit.test.ts
+++ b/packages/passkey-kit/tests/kit.test.ts
@@ -288,6 +288,92 @@ describe('enroll and unlock', () => {
     await expect(kit.rewrapWithCachedPrf(cek)).resolves.toBeNull()
   })
 
+  it('unlocks with the cached PRF output without prompting', async () => {
+    const rawId = crypto.getRandomValues(new Uint8Array(16))
+      .buffer as ArrayBuffer
+    const prfFirst = crypto.getRandomValues(new Uint8Array(32))
+      .buffer as ArrayBuffer
+    const get = vi.fn()
+    installCredentialsMock({
+      create: vi.fn(async () =>
+        fakeCredential({
+          rawId,
+          prfEnabled: true,
+          prfFirst: prfFirst.slice(0),
+        }),
+      ),
+      get,
+    })
+
+    const cek = crypto.getRandomValues(new Uint8Array(CEK_BYTES))
+    const { kit } = makeKit()
+    const enrolled = await kit.enroll({
+      user: { id: 'u1', name: 'u@example.com' },
+      cek,
+    })
+
+    const unlocked = await kit.unlockWithCachedPrf([enrolled!.wrappedCek])
+    expect(unlocked?.credentialId).toBe(enrolled!.credentialId)
+    expect(unlocked?.cek).toEqual(cek)
+    expect(get).not.toHaveBeenCalled()
+  })
+
+  it('returns null from unlockWithCachedPrf when nothing is cached or nothing matches', async () => {
+    const { kit } = makeKit()
+    const stranger = {
+      credentialId: 'someone-else',
+      kekIvHex: '00'.repeat(12),
+      wrappedKeyHex: '00'.repeat(48),
+    }
+    await expect(kit.unlockWithCachedPrf([stranger])).resolves.toBeNull()
+
+    const rawId = crypto.getRandomValues(new Uint8Array(16))
+      .buffer as ArrayBuffer
+    const prfFirst = crypto.getRandomValues(new Uint8Array(32))
+      .buffer as ArrayBuffer
+    installCredentialsMock({
+      create: vi.fn(async () =>
+        fakeCredential({
+          rawId,
+          prfEnabled: true,
+          prfFirst: prfFirst.slice(0),
+        }),
+      ),
+    })
+    const cek = crypto.getRandomValues(new Uint8Array(CEK_BYTES))
+    await kit.enroll({ user: { id: 'u1', name: 'u@example.com' }, cek })
+    await expect(kit.unlockWithCachedPrf([stranger])).resolves.toBeNull()
+  })
+
+  it('returns null from unlockWithCachedPrf when the wrapped CEK is tampered', async () => {
+    const rawId = crypto.getRandomValues(new Uint8Array(16))
+      .buffer as ArrayBuffer
+    const prfFirst = crypto.getRandomValues(new Uint8Array(32))
+      .buffer as ArrayBuffer
+    installCredentialsMock({
+      create: vi.fn(async () =>
+        fakeCredential({
+          rawId,
+          prfEnabled: true,
+          prfFirst: prfFirst.slice(0),
+        }),
+      ),
+    })
+
+    const cek = crypto.getRandomValues(new Uint8Array(CEK_BYTES))
+    const { kit } = makeKit()
+    const enrolled = await kit.enroll({
+      user: { id: 'u1', name: 'u@example.com' },
+      cek,
+    })
+
+    const tampered = {
+      ...enrolled!.wrappedCek,
+      wrappedKeyHex: '00'.repeat(48),
+    }
+    await expect(kit.unlockWithCachedPrf([tampered])).resolves.toBeNull()
+  })
+
   it('rewraps with the cached PRF output when destructured off the kit', async () => {
     const rawId = crypto.getRandomValues(new Uint8Array(16))
       .buffer as ArrayBuffer

--- a/packages/passkey-kit/tests/kit.test.ts
+++ b/packages/passkey-kit/tests/kit.test.ts
@@ -137,6 +137,51 @@ describe('createPasskey', () => {
     ).rejects.toBeInstanceOf(PrfNotSupportedError)
   })
 
+  it('uses a brand-neutral default message and honors errorMessages overrides', async () => {
+    installCredentialsMock({
+      create: vi.fn(async () => fakeCredential({ prfEnabled: false })),
+    })
+
+    const { kit } = makeKit()
+    const defaultError = await kit
+      .createPasskey({ id: 'u1', name: 'u@example.com' })
+      .catch((error: unknown) => error as Error)
+    expect((defaultError as Error).message).toContain('this app')
+
+    const branded = createPasskeyKit({
+      rpId: 'example.com',
+      rpName: 'Example',
+      storage: createMemoryStorageAdapter(),
+      errorMessages: { prfNotSupported: 'Example App needs PRF support.' },
+    })
+    const brandedError = await branded
+      .createPasskey({ id: 'u1', name: 'u@example.com' })
+      .catch((error: unknown) => error as Error)
+    expect(brandedError).toBeInstanceOf(PrfNotSupportedError)
+    expect((brandedError as Error).message).toBe(
+      'Example App needs PRF support.',
+    )
+  })
+
+  it('honors the errorMessages timeout override when the provider hangs', async () => {
+    vi.useFakeTimers()
+    installCredentialsMock({ create: vi.fn(() => new Promise(() => {})) })
+
+    const kit = createPasskeyKit({
+      rpId: 'example.com',
+      rpName: 'Example',
+      storage: createMemoryStorageAdapter(),
+      errorMessages: { timeout: 'Example App timed out.' },
+    })
+    const promise = kit.createPasskey({ id: 'u1', name: 'u@example.com' })
+    promise.catch(() => {})
+    await vi.advanceTimersByTimeAsync(15_000)
+    await expect(promise).rejects.toMatchObject({
+      name: 'PasskeyTimeoutError',
+      message: 'Example App timed out.',
+    })
+  })
+
   it('returns null when the user cancels', async () => {
     installCredentialsMock({
       create: vi.fn(async () => {

--- a/packages/passkey-kit/tests/kit.test.ts
+++ b/packages/passkey-kit/tests/kit.test.ts
@@ -283,4 +283,37 @@ describe('local state', () => {
     expect(kit.getCachedPrfResult()).toBeNull()
     expect(kit.getLocalCredentialId()).toBeNull()
   })
+
+  it('does not discard the ceremony result when a custom adapter throws', async () => {
+    const prfFirst = crypto.getRandomValues(new Uint8Array(32))
+      .buffer as ArrayBuffer
+    installCredentialsMock({
+      create: vi.fn(async () =>
+        fakeCredential({ prfEnabled: true, prfFirst, attachment: 'platform' }),
+      ),
+    })
+
+    const kit = createPasskeyKit({
+      rpId: 'example.com',
+      rpName: 'Example',
+      storage: {
+        getItem: () => null,
+        setItem: () => {
+          throw new Error('storage is broken')
+        },
+        removeItem: () => {},
+      },
+    })
+    const result = await kit.createPasskey({ id: 'u1', name: 'u@example.com' })
+    expect(result).not.toBeNull()
+  })
+
+  it('authenticate([]) resolves null without opening a passkey prompt', async () => {
+    const get = vi.fn()
+    installCredentialsMock({ get })
+
+    const { kit } = makeKit()
+    await expect(kit.authenticate([])).resolves.toBeNull()
+    expect(get).not.toHaveBeenCalled()
+  })
 })

--- a/packages/passkey-kit/tests/kit.test.ts
+++ b/packages/passkey-kit/tests/kit.test.ts
@@ -1,0 +1,286 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { bytesToBase64Url } from '../src/codec'
+import { CEK_BYTES } from '../src/crypto'
+import { PasskeyTimeoutError, PrfNotSupportedError } from '../src/errors'
+import { createPasskeyKit } from '../src/kit'
+import { createMemoryStorageAdapter } from '../src/storage'
+
+const originalCredentials = navigator.credentials
+
+afterEach(() => {
+  vi.useRealTimers()
+  Object.defineProperty(navigator, 'credentials', {
+    value: originalCredentials,
+    writable: true,
+    configurable: true,
+  })
+})
+
+function installCredentialsMock(stub: {
+  create?: (...args: unknown[]) => unknown
+  get?: (...args: unknown[]) => unknown
+}): void {
+  Object.defineProperty(navigator, 'credentials', {
+    value: stub,
+    writable: true,
+    configurable: true,
+  })
+}
+
+function fakeCredential(options: {
+  rawId?: ArrayBuffer
+  prfEnabled?: boolean
+  prfFirst?: ArrayBuffer | null
+  attachment?: string | null
+}): PublicKeyCredential {
+  const rawId =
+    options.rawId ??
+    (crypto.getRandomValues(new Uint8Array(16)).buffer as ArrayBuffer)
+  return {
+    rawId,
+    authenticatorAttachment: options.attachment ?? null,
+    getClientExtensionResults: () => {
+      if (!options.prfEnabled && !options.prfFirst) return {}
+      const prf: { enabled?: boolean; results?: { first: ArrayBuffer } } = {}
+      if (options.prfEnabled) prf.enabled = true
+      if (options.prfFirst) prf.results = { first: options.prfFirst }
+      return { prf }
+    },
+  } as unknown as PublicKeyCredential
+}
+
+function makeKit(storage = createMemoryStorageAdapter()) {
+  return {
+    kit: createPasskeyKit({
+      rpId: 'example.com',
+      rpName: 'Example',
+      storage,
+    }),
+    storage,
+  }
+}
+
+describe('createPasskey', () => {
+  it('returns the PRF result and caches it when creation yields PRF output', async () => {
+    const prfFirst = crypto.getRandomValues(new Uint8Array(32))
+      .buffer as ArrayBuffer
+    const rawId = crypto.getRandomValues(new Uint8Array(16))
+      .buffer as ArrayBuffer
+    installCredentialsMock({
+      create: vi.fn(async () =>
+        fakeCredential({
+          rawId,
+          prfEnabled: true,
+          prfFirst,
+          attachment: 'platform',
+        }),
+      ),
+    })
+
+    const { kit } = makeKit()
+    const result = await kit.createPasskey({ id: 'u1', name: 'u@example.com' })
+
+    expect(result?.credentialId).toBe(bytesToBase64Url(new Uint8Array(rawId)))
+    expect(result?.prfOutput.byteLength).toBe(32)
+
+    const cached = kit.getCachedPrfResult()
+    expect(cached?.credentialId).toBe(result?.credentialId)
+    expect(new Uint8Array(cached!.prfOutput)).toEqual(new Uint8Array(prfFirst))
+    expect(kit.getLocalCredentialId()).toBe(result?.credentialId)
+  })
+
+  it('does not remember the credential id for cross-platform authenticators', async () => {
+    const prfFirst = crypto.getRandomValues(new Uint8Array(32))
+      .buffer as ArrayBuffer
+    installCredentialsMock({
+      create: vi.fn(async () =>
+        fakeCredential({
+          prfEnabled: true,
+          prfFirst,
+          attachment: 'cross-platform',
+        }),
+      ),
+    })
+
+    const { kit } = makeKit()
+    const result = await kit.createPasskey({ id: 'u1', name: 'u@example.com' })
+    expect(result).not.toBeNull()
+    expect(kit.getLocalCredentialId()).toBeNull()
+    expect(kit.getCachedPrfResult()).not.toBeNull()
+  })
+
+  it('falls back to an immediate assertion when creation reports PRF but no output', async () => {
+    const rawId = crypto.getRandomValues(new Uint8Array(16))
+      .buffer as ArrayBuffer
+    const prfFirst = crypto.getRandomValues(new Uint8Array(32))
+      .buffer as ArrayBuffer
+    installCredentialsMock({
+      create: vi.fn(async () =>
+        fakeCredential({ rawId, prfEnabled: true, prfFirst: null }),
+      ),
+      get: vi.fn(async () => fakeCredential({ rawId, prfFirst })),
+    })
+
+    const { kit } = makeKit()
+    const result = await kit.createPasskey({ id: 'u1', name: 'u@example.com' })
+    expect(result?.credentialId).toBe(bytesToBase64Url(new Uint8Array(rawId)))
+  })
+
+  it('throws PrfNotSupportedError when the authenticator lacks PRF', async () => {
+    installCredentialsMock({
+      create: vi.fn(async () => fakeCredential({ prfEnabled: false })),
+    })
+
+    const { kit } = makeKit()
+    await expect(
+      kit.createPasskey({ id: 'u1', name: 'u@example.com' }),
+    ).rejects.toBeInstanceOf(PrfNotSupportedError)
+  })
+
+  it('returns null when the user cancels', async () => {
+    installCredentialsMock({
+      create: vi.fn(async () => {
+        throw new DOMException('User cancelled', 'NotAllowedError')
+      }),
+    })
+
+    const { kit } = makeKit()
+    await expect(
+      kit.createPasskey({ id: 'u1', name: 'u@example.com' }),
+    ).resolves.toBeNull()
+  })
+
+  it('throws PasskeyTimeoutError when the provider hangs', async () => {
+    vi.useFakeTimers()
+    installCredentialsMock({ create: vi.fn(() => new Promise(() => {})) })
+
+    const { kit } = makeKit()
+    const promise = kit.createPasskey({ id: 'u1', name: 'u@example.com' })
+    promise.catch(() => {})
+    await vi.advanceTimersByTimeAsync(15_000)
+    await expect(promise).rejects.toBeInstanceOf(PasskeyTimeoutError)
+  })
+})
+
+describe('enroll and unlock', () => {
+  it('round-trips a CEK through enroll → unlock', async () => {
+    const rawId = crypto.getRandomValues(new Uint8Array(16))
+      .buffer as ArrayBuffer
+    const prfFirst = crypto.getRandomValues(new Uint8Array(32))
+      .buffer as ArrayBuffer
+    installCredentialsMock({
+      create: vi.fn(async () =>
+        fakeCredential({
+          rawId,
+          prfEnabled: true,
+          prfFirst: prfFirst.slice(0),
+        }),
+      ),
+      get: vi.fn(async () =>
+        fakeCredential({ rawId, prfFirst: prfFirst.slice(0) }),
+      ),
+    })
+
+    const cek = crypto.getRandomValues(new Uint8Array(CEK_BYTES))
+    const { kit } = makeKit()
+
+    const enrolled = await kit.enroll({
+      user: { id: 'u1', name: 'u@example.com' },
+      cek,
+    })
+    expect(enrolled).not.toBeNull()
+    expect(enrolled!.wrappedCek.credentialId).toBe(enrolled!.credentialId)
+
+    const unlocked = await kit.unlock([enrolled!.wrappedCek])
+    expect(unlocked?.credentialId).toBe(enrolled!.credentialId)
+    expect(unlocked?.cek).toEqual(cek)
+  })
+
+  it('returns null from unlock when there is nothing to unwrap', async () => {
+    const { kit } = makeKit()
+    await expect(kit.unlock([])).resolves.toBeNull()
+  })
+
+  it('rewraps with the cached PRF output without prompting', async () => {
+    const rawId = crypto.getRandomValues(new Uint8Array(16))
+      .buffer as ArrayBuffer
+    const prfFirst = crypto.getRandomValues(new Uint8Array(32))
+      .buffer as ArrayBuffer
+    const get = vi.fn(async () =>
+      fakeCredential({ rawId, prfFirst: prfFirst.slice(0) }),
+    )
+    installCredentialsMock({
+      create: vi.fn(async () =>
+        fakeCredential({
+          rawId,
+          prfEnabled: true,
+          prfFirst: prfFirst.slice(0),
+        }),
+      ),
+      get,
+    })
+
+    const cek = crypto.getRandomValues(new Uint8Array(CEK_BYTES))
+    const { kit } = makeKit()
+    const enrolled = await kit.enroll({
+      user: { id: 'u1', name: 'u@example.com' },
+      cek,
+    })
+
+    const newCek = crypto.getRandomValues(new Uint8Array(CEK_BYTES))
+    const rewrapped = await kit.rewrapWithCachedPrf(newCek)
+    expect(rewrapped).not.toBeNull()
+    expect(get).not.toHaveBeenCalled()
+
+    const unlocked = await kit.unlock([rewrapped!])
+    expect(unlocked?.cek).toEqual(newCek)
+    expect(enrolled!.credentialId).toBe(rewrapped!.credentialId)
+  })
+
+  it('returns null from rewrapWithCachedPrf when nothing is cached', async () => {
+    const { kit } = makeKit()
+    const cek = crypto.getRandomValues(new Uint8Array(CEK_BYTES))
+    await expect(kit.rewrapWithCachedPrf(cek)).resolves.toBeNull()
+  })
+})
+
+describe('local state', () => {
+  it('clearLocalState removes the PRF cache and local credential id', async () => {
+    const prfFirst = crypto.getRandomValues(new Uint8Array(32))
+      .buffer as ArrayBuffer
+    installCredentialsMock({
+      create: vi.fn(async () =>
+        fakeCredential({ prfEnabled: true, prfFirst, attachment: 'platform' }),
+      ),
+    })
+
+    const { kit } = makeKit()
+    await kit.createPasskey({ id: 'u1', name: 'u@example.com' })
+    expect(kit.getCachedPrfResult()).not.toBeNull()
+    expect(kit.getLocalCredentialId()).not.toBeNull()
+
+    kit.clearLocalState()
+    expect(kit.getCachedPrfResult()).toBeNull()
+    expect(kit.getLocalCredentialId()).toBeNull()
+  })
+
+  it('operates without persistence when storage is null', async () => {
+    const prfFirst = crypto.getRandomValues(new Uint8Array(32))
+      .buffer as ArrayBuffer
+    installCredentialsMock({
+      create: vi.fn(async () =>
+        fakeCredential({ prfEnabled: true, prfFirst, attachment: 'platform' }),
+      ),
+    })
+
+    const kit = createPasskeyKit({
+      rpId: 'example.com',
+      rpName: 'Example',
+      storage: null,
+    })
+    const result = await kit.createPasskey({ id: 'u1', name: 'u@example.com' })
+    expect(result).not.toBeNull()
+    expect(kit.getCachedPrfResult()).toBeNull()
+    expect(kit.getLocalCredentialId()).toBeNull()
+  })
+})

--- a/packages/passkey-kit/tests/kit.test.ts
+++ b/packages/passkey-kit/tests/kit.test.ts
@@ -242,6 +242,34 @@ describe('enroll and unlock', () => {
     const cek = crypto.getRandomValues(new Uint8Array(CEK_BYTES))
     await expect(kit.rewrapWithCachedPrf(cek)).resolves.toBeNull()
   })
+
+  it('rewraps with the cached PRF output when destructured off the kit', async () => {
+    const rawId = crypto.getRandomValues(new Uint8Array(16))
+      .buffer as ArrayBuffer
+    const prfFirst = crypto.getRandomValues(new Uint8Array(32))
+      .buffer as ArrayBuffer
+    installCredentialsMock({
+      create: vi.fn(async () =>
+        fakeCredential({
+          rawId,
+          prfEnabled: true,
+          prfFirst: prfFirst.slice(0),
+        }),
+      ),
+    })
+
+    const cek = crypto.getRandomValues(new Uint8Array(CEK_BYTES))
+    const { kit } = makeKit()
+    const enrolled = await kit.enroll({
+      user: { id: 'u1', name: 'u@example.com' },
+      cek,
+    })
+    expect(enrolled).not.toBeNull()
+
+    const { rewrapWithCachedPrf } = kit
+    const rewrapped = await rewrapWithCachedPrf(cek)
+    expect(rewrapped?.credentialId).toBe(enrolled!.credentialId)
+  })
 })
 
 describe('local state', () => {

--- a/packages/passkey-kit/tests/kit.test.ts
+++ b/packages/passkey-kit/tests/kit.test.ts
@@ -208,45 +208,11 @@ describe('createPasskey', () => {
 })
 
 describe('enroll and unlock', () => {
-  it('round-trips a CEK through enroll → unlock', async () => {
-    const rawId = crypto.getRandomValues(new Uint8Array(16))
-      .buffer as ArrayBuffer
-    const prfFirst = crypto.getRandomValues(new Uint8Array(32))
-      .buffer as ArrayBuffer
-    installCredentialsMock({
-      create: vi.fn(async () =>
-        fakeCredential({
-          rawId,
-          prfEnabled: true,
-          prfFirst: prfFirst.slice(0),
-        }),
-      ),
-      get: vi.fn(async () =>
-        fakeCredential({ rawId, prfFirst: prfFirst.slice(0) }),
-      ),
-    })
-
-    const cek = crypto.getRandomValues(new Uint8Array(CEK_BYTES))
-    const { kit } = makeKit()
-
-    const enrolled = await kit.enroll({
-      user: { id: 'u1', name: 'u@example.com' },
-      cek,
-    })
-    expect(enrolled).not.toBeNull()
-    expect(enrolled!.wrappedCek.credentialId).toBe(enrolled!.credentialId)
-
-    const unlocked = await kit.unlock([enrolled!.wrappedCek])
-    expect(unlocked?.credentialId).toBe(enrolled!.credentialId)
-    expect(unlocked?.cek).toEqual(cek)
-  })
-
-  it('returns null from unlock when there is nothing to unwrap', async () => {
-    const { kit } = makeKit()
-    await expect(kit.unlock([])).resolves.toBeNull()
-  })
-
-  it('rewraps with the cached PRF output without prompting', async () => {
+  /**
+   * Install a PRF-capable credentials mock and enroll a fresh CEK on a new
+   * kit. Returns the `get` spy so tests can assert whether a ceremony ran.
+   */
+  async function enrollWithMock() {
     const rawId = crypto.getRandomValues(new Uint8Array(16))
       .buffer as ArrayBuffer
     const prfFirst = crypto.getRandomValues(new Uint8Array(32))
@@ -271,6 +237,26 @@ describe('enroll and unlock', () => {
       user: { id: 'u1', name: 'u@example.com' },
       cek,
     })
+    expect(enrolled).not.toBeNull()
+    return { kit, cek, enrolled: enrolled!, get }
+  }
+
+  it('round-trips a CEK through enroll → unlock', async () => {
+    const { kit, cek, enrolled } = await enrollWithMock()
+    expect(enrolled.wrappedCek.credentialId).toBe(enrolled.credentialId)
+
+    const unlocked = await kit.unlock([enrolled.wrappedCek])
+    expect(unlocked?.credentialId).toBe(enrolled.credentialId)
+    expect(unlocked?.cek).toEqual(cek)
+  })
+
+  it('returns null from unlock when there is nothing to unwrap', async () => {
+    const { kit } = makeKit()
+    await expect(kit.unlock([])).resolves.toBeNull()
+  })
+
+  it('rewraps with the cached PRF output without prompting', async () => {
+    const { kit, enrolled, get } = await enrollWithMock()
 
     const newCek = crypto.getRandomValues(new Uint8Array(CEK_BYTES))
     const rewrapped = await kit.rewrapWithCachedPrf(newCek)
@@ -279,7 +265,7 @@ describe('enroll and unlock', () => {
 
     const unlocked = await kit.unlock([rewrapped!])
     expect(unlocked?.cek).toEqual(newCek)
-    expect(enrolled!.credentialId).toBe(rewrapped!.credentialId)
+    expect(enrolled.credentialId).toBe(rewrapped!.credentialId)
   })
 
   it('returns null from rewrapWithCachedPrf when nothing is cached', async () => {
@@ -289,117 +275,44 @@ describe('enroll and unlock', () => {
   })
 
   it('unlocks with the cached PRF output without prompting', async () => {
-    const rawId = crypto.getRandomValues(new Uint8Array(16))
-      .buffer as ArrayBuffer
-    const prfFirst = crypto.getRandomValues(new Uint8Array(32))
-      .buffer as ArrayBuffer
-    const get = vi.fn()
-    installCredentialsMock({
-      create: vi.fn(async () =>
-        fakeCredential({
-          rawId,
-          prfEnabled: true,
-          prfFirst: prfFirst.slice(0),
-        }),
-      ),
-      get,
-    })
+    const { kit, cek, enrolled, get } = await enrollWithMock()
 
-    const cek = crypto.getRandomValues(new Uint8Array(CEK_BYTES))
-    const { kit } = makeKit()
-    const enrolled = await kit.enroll({
-      user: { id: 'u1', name: 'u@example.com' },
-      cek,
-    })
-
-    const unlocked = await kit.unlockWithCachedPrf([enrolled!.wrappedCek])
-    expect(unlocked?.credentialId).toBe(enrolled!.credentialId)
+    const unlocked = await kit.unlockWithCachedPrf([enrolled.wrappedCek])
+    expect(unlocked?.credentialId).toBe(enrolled.credentialId)
     expect(unlocked?.cek).toEqual(cek)
     expect(get).not.toHaveBeenCalled()
   })
 
   it('returns null from unlockWithCachedPrf when nothing is cached or nothing matches', async () => {
-    const { kit } = makeKit()
     const stranger = {
       credentialId: 'someone-else',
       kekIvHex: '00'.repeat(12),
       wrappedKeyHex: '00'.repeat(48),
     }
-    await expect(kit.unlockWithCachedPrf([stranger])).resolves.toBeNull()
 
-    const rawId = crypto.getRandomValues(new Uint8Array(16))
-      .buffer as ArrayBuffer
-    const prfFirst = crypto.getRandomValues(new Uint8Array(32))
-      .buffer as ArrayBuffer
-    installCredentialsMock({
-      create: vi.fn(async () =>
-        fakeCredential({
-          rawId,
-          prfEnabled: true,
-          prfFirst: prfFirst.slice(0),
-        }),
-      ),
-    })
-    const cek = crypto.getRandomValues(new Uint8Array(CEK_BYTES))
-    await kit.enroll({ user: { id: 'u1', name: 'u@example.com' }, cek })
+    const { kit: emptyKit } = makeKit()
+    await expect(emptyKit.unlockWithCachedPrf([stranger])).resolves.toBeNull()
+
+    const { kit } = await enrollWithMock()
     await expect(kit.unlockWithCachedPrf([stranger])).resolves.toBeNull()
   })
 
   it('returns null from unlockWithCachedPrf when the wrapped CEK is tampered', async () => {
-    const rawId = crypto.getRandomValues(new Uint8Array(16))
-      .buffer as ArrayBuffer
-    const prfFirst = crypto.getRandomValues(new Uint8Array(32))
-      .buffer as ArrayBuffer
-    installCredentialsMock({
-      create: vi.fn(async () =>
-        fakeCredential({
-          rawId,
-          prfEnabled: true,
-          prfFirst: prfFirst.slice(0),
-        }),
-      ),
-    })
-
-    const cek = crypto.getRandomValues(new Uint8Array(CEK_BYTES))
-    const { kit } = makeKit()
-    const enrolled = await kit.enroll({
-      user: { id: 'u1', name: 'u@example.com' },
-      cek,
-    })
+    const { kit, enrolled } = await enrollWithMock()
 
     const tampered = {
-      ...enrolled!.wrappedCek,
+      ...enrolled.wrappedCek,
       wrappedKeyHex: '00'.repeat(48),
     }
     await expect(kit.unlockWithCachedPrf([tampered])).resolves.toBeNull()
   })
 
   it('rewraps with the cached PRF output when destructured off the kit', async () => {
-    const rawId = crypto.getRandomValues(new Uint8Array(16))
-      .buffer as ArrayBuffer
-    const prfFirst = crypto.getRandomValues(new Uint8Array(32))
-      .buffer as ArrayBuffer
-    installCredentialsMock({
-      create: vi.fn(async () =>
-        fakeCredential({
-          rawId,
-          prfEnabled: true,
-          prfFirst: prfFirst.slice(0),
-        }),
-      ),
-    })
-
-    const cek = crypto.getRandomValues(new Uint8Array(CEK_BYTES))
-    const { kit } = makeKit()
-    const enrolled = await kit.enroll({
-      user: { id: 'u1', name: 'u@example.com' },
-      cek,
-    })
-    expect(enrolled).not.toBeNull()
+    const { kit, cek, enrolled } = await enrollWithMock()
 
     const { rewrapWithCachedPrf } = kit
     const rewrapped = await rewrapWithCachedPrf(cek)
-    expect(rewrapped?.credentialId).toBe(enrolled!.credentialId)
+    expect(rewrapped?.credentialId).toBe(enrolled.credentialId)
   })
 })
 

--- a/packages/passkey-kit/tsconfig.build.json
+++ b/packages/passkey-kit/tsconfig.build.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/src/services/passkey/kit.ts
+++ b/src/services/passkey/kit.ts
@@ -1,0 +1,33 @@
+import {
+  LOCAL_PASSKEY_CREDENTIAL_ID,
+  SECRET_PASSKEY_PRF_OUTPUT,
+} from '@/constants/storage-keys'
+import { logError, logInfo } from '@/utils/error-handling'
+import { createPasskeyKit } from '@tinfoilsh/passkey-kit'
+
+const RP_ID =
+  typeof window !== 'undefined' && window.location.hostname === 'localhost'
+    ? 'localhost'
+    : 'tinfoil.sh'
+
+const RP_NAME = 'Tinfoil Chat'
+
+/**
+ * App-wide passkey SDK instance. PRF salt and HKDF info are left at the
+ * SDK's Tinfoil v1 protocol defaults so bundles stay interoperable with
+ * every other Tinfoil client.
+ */
+export const passkeyKit = createPasskeyKit({
+  rpId: RP_ID,
+  rpName: RP_NAME,
+  storageKeys: {
+    prfResult: SECRET_PASSKEY_PRF_OUTPUT,
+    localCredentialId: LOCAL_PASSKEY_CREDENTIAL_ID,
+  },
+  logger: {
+    info: (message, metadata) =>
+      logInfo(message, { component: 'PasskeyKit', metadata }),
+    error: (message, error, metadata) =>
+      logError(message, error, { component: 'PasskeyKit', metadata }),
+  },
+})

--- a/src/services/passkey/kit.ts
+++ b/src/services/passkey/kit.ts
@@ -24,6 +24,11 @@ export const passkeyKit = createPasskeyKit({
     prfResult: SECRET_PASSKEY_PRF_OUTPUT,
     localCredentialId: LOCAL_PASSKEY_CREDENTIAL_ID,
   },
+  errorMessages: {
+    prfNotSupported:
+      "Your passkey provider doesn't support the security features required by Tinfoil. " +
+      "Try using iCloud Keychain, Chrome's built-in passkey manager, or the Passwords app in your device settings.",
+  },
   logger: {
     info: (message, metadata) =>
       logInfo(message, { component: 'PasskeyKit', metadata }),

--- a/src/services/passkey/local-passkey-credential.ts
+++ b/src/services/passkey/local-passkey-credential.ts
@@ -1,20 +1,9 @@
-import { LOCAL_PASSKEY_CREDENTIAL_ID } from '@/constants/storage-keys'
+import { passkeyKit } from './kit'
 
 export function setLocalPasskeyCredentialId(credentialId: string): void {
-  if (typeof window === 'undefined') return
-  try {
-    localStorage.setItem(LOCAL_PASSKEY_CREDENTIAL_ID, credentialId)
-  } catch {
-    // best-effort: storage quota / privacy mode failures must never
-    // interrupt the passkey ceremony itself
-  }
+  passkeyKit.setLocalCredentialId(credentialId)
 }
 
 export function getLocalPasskeyCredentialId(): string | null {
-  if (typeof window === 'undefined') return null
-  try {
-    return localStorage.getItem(LOCAL_PASSKEY_CREDENTIAL_ID) || null
-  } catch {
-    return null
-  }
+  return passkeyKit.getLocalCredentialId()
 }

--- a/src/services/passkey/passkey-service.ts
+++ b/src/services/passkey/passkey-service.ts
@@ -1,152 +1,35 @@
 /**
- * Passkey Service — WebAuthn PRF Create/Authenticate + HKDF Key Derivation
+ * Passkey Service — thin app-side facade over @tinfoilsh/passkey-kit.
  *
- * Uses the WebAuthn PRF extension to derive deterministic 32-byte secrets from
- * a passkey's built-in pseudo-random function. These secrets are then processed
- * through HKDF-SHA256 to produce an AES-256-GCM Key Encryption Key (KEK).
- *
- * References:
- * - W3C WebAuthn Level 3, §10.1.4 (PRF extension): https://w3c.github.io/webauthn/#prf-extension
- * - RFC 5869 (HKDF): https://tools.ietf.org/html/rfc5869
+ * The WebAuthn PRF ceremonies, HKDF key derivation, and local caching all
+ * live in the SDK; this module preserves the historical export surface so
+ * hooks and flows keep importing the same names.
  */
 
-import { SECRET_PASSKEY_PRF_OUTPUT } from '@/constants/storage-keys'
-import {
-  base64ToUint8Array,
-  base64UrlToUint8Array,
-  bufferSourceToArrayBuffer,
-  uint8ArrayToBase64,
-  uint8ArrayToBase64Url,
-} from '@/utils/binary-codec'
-import { logError, logInfo } from '@/utils/error-handling'
+import type { PrfPasskeyResult } from '@tinfoilsh/passkey-kit'
+import { passkeyKit } from './kit'
 
-import { setLocalPasskeyCredentialId } from './local-passkey-credential'
-
-export class PrfNotSupportedError extends Error {
-  constructor() {
-    super(
-      "Your passkey provider doesn't support the security features required by Tinfoil. Try using iCloud Keychain, Chrome's built-in passkey manager, or the Passwords app in your device settings.",
-    )
-    this.name = 'PrfNotSupportedError'
-  }
-}
-
-export class PasskeyTimeoutError extends Error {
-  constructor() {
-    super(
-      "Your passkey provider took too long to respond. This can happen with some browser extension password managers. Try using iCloud Keychain, Chrome's built-in passkey manager, or the Passwords app in your device settings.",
-    )
-    this.name = 'PasskeyTimeoutError'
-  }
-}
-
-// Timeout passed to the WebAuthn API (some browsers ignore this).
-const WEBAUTHN_TIMEOUT_MS = 30_000
-
-// Internal hard timeout to guard against providers (e.g. some password-manager
-// browser extensions) that never resolve the credentials.create/get promise.
-// Kept tight so users aren't left staring at an indefinite spinner; the
-// WebAuthn flow itself should complete well within this window once the
-// provider actually prompts.
-const STUCK_WEBAUTHN_TIMEOUT_MS = 10_000
-
-async function withStuckTimeout<T>(promise: Promise<T>): Promise<T> {
-  let timer: ReturnType<typeof setTimeout> | undefined
-  try {
-    return await Promise.race([
-      promise,
-      new Promise<T>((_, reject) => {
-        timer = setTimeout(
-          () => reject(new PasskeyTimeoutError()),
-          STUCK_WEBAUTHN_TIMEOUT_MS,
-        )
-      }),
-    ])
-  } finally {
-    if (timer !== undefined) clearTimeout(timer)
-  }
-}
-
-// Salt passed to PRF eval.first — the client internally computes:
-// SHA-256("WebAuthn PRF" || 0x00 || PRF_EVAL_FIRST)
-const PRF_EVAL_FIRST = new TextEncoder().encode('tinfoil-chat-key-encryption')
-
-// HKDF info string for domain separation when deriving the KEK
-const HKDF_INFO = new TextEncoder().encode('tinfoil-chat-kek-v1')
-
-const RP_NAME = 'Tinfoil Chat'
-
-export interface PrfPasskeyResult {
-  credentialId: string
-  prfOutput: ArrayBuffer
-}
-
-interface PrfCacheEntry {
-  credentialId: string
-  prfOutput: string // base64-encoded
-}
-
-function cachePrfResult(result: PrfPasskeyResult): void {
-  try {
-    const entry: PrfCacheEntry = {
-      credentialId: result.credentialId,
-      prfOutput: uint8ArrayToBase64(new Uint8Array(result.prfOutput)),
-    }
-    localStorage.setItem(SECRET_PASSKEY_PRF_OUTPUT, JSON.stringify(entry))
-  } catch {
-    // best-effort
-  }
-}
-
-// Cross-device hybrid (QR-paired phone, etc.) reports
-// `authenticatorAttachment === 'cross-platform'` on the resulting
-// credential. Caching the cred id in that case would make this
-// device look like it has its own bundle when in reality the user
-// just borrowed another device's passkey for a one-shot unlock —
-// hiding the "Set Up Passkey on This Device" prompt forever.
-// Per WebAuthn L3 §5.2.1, we only treat `authenticatorAttachment`
-// of `'platform'` as "this device truly owns this credential".
-function rememberCredentialIfLocal(credential: PublicKeyCredential): void {
-  if (credential.authenticatorAttachment === 'platform') {
-    const credentialId = uint8ArrayToBase64Url(new Uint8Array(credential.rawId))
-    setLocalPasskeyCredentialId(credentialId)
-  }
-}
+export {
+  PasskeyTimeoutError,
+  PrfNotSupportedError,
+} from '@tinfoilsh/passkey-kit'
+export type { PrfPasskeyResult } from '@tinfoilsh/passkey-kit'
 
 /**
- * Get the cached PRF result from localStorage if available.
+ * Get the cached PRF result from local storage if available.
  * The PRF output is deterministic for a given passkey, so we can reuse it
  * to avoid re-prompting biometrics on key updates.
  */
 export function getCachedPrfResult(): PrfPasskeyResult | null {
-  try {
-    const raw = localStorage.getItem(SECRET_PASSKEY_PRF_OUTPUT)
-    if (!raw) return null
-    const entry = JSON.parse(raw) as PrfCacheEntry
-    return {
-      credentialId: entry.credentialId,
-      prfOutput: base64ToUint8Array(entry.prfOutput).buffer as ArrayBuffer,
-    }
-  } catch {
-    return null
-  }
+  return passkeyKit.getCachedPrfResult()
 }
 
 /**
  * Clear the cached PRF result (e.g., on sign-out).
  */
 export function clearCachedPrfResult(): void {
-  try {
-    localStorage.removeItem(SECRET_PASSKEY_PRF_OUTPUT)
-  } catch {
-    // best-effort
-  }
+  passkeyKit.clearCachedPrfResult()
 }
-
-const RP_ID =
-  typeof window !== 'undefined' && window.location.hostname === 'localhost'
-    ? 'localhost'
-    : 'tinfoil.sh'
 
 /**
  * Create a new PRF-capable passkey for the given user.
@@ -154,112 +37,16 @@ const RP_ID =
  * Returns the credential ID and PRF output, or null if PRF is not supported
  * by the authenticator or the user cancels.
  */
-export async function createPrfPasskey(
+export function createPrfPasskey(
   userId: string,
   userEmail: string,
   displayName: string,
 ): Promise<PrfPasskeyResult | null> {
-  const userIdBytes = new TextEncoder().encode(userId)
-
-  try {
-    const credential = (await withStuckTimeout(
-      navigator.credentials.create({
-        publicKey: {
-          challenge: crypto.getRandomValues(new Uint8Array(32)),
-          rp: { id: RP_ID, name: RP_NAME },
-          user: {
-            id: userIdBytes,
-            name: userEmail,
-            displayName: displayName || userEmail,
-          },
-          pubKeyCredParams: [
-            { type: 'public-key', alg: -7 }, // ES256
-            { type: 'public-key', alg: -257 }, // RS256 (broader compat)
-          ],
-          authenticatorSelection: {
-            residentKey: 'preferred',
-            userVerification: 'required',
-          },
-          timeout: WEBAUTHN_TIMEOUT_MS,
-          extensions: {
-            prf: { eval: { first: PRF_EVAL_FIRST } },
-          },
-        },
-      }),
-    )) as PublicKeyCredential | null
-
-    if (!credential) {
-      return null
-    }
-
-    const extensionResults = credential.getClientExtensionResults()
-    const prfResults = extensionResults.prf
-
-    if (!prfResults?.enabled) {
-      logInfo('Authenticator does not support PRF', {
-        component: 'PasskeyService',
-        action: 'createPrfPasskey',
-      })
-      throw new PrfNotSupportedError()
-    }
-
-    const credentialId = uint8ArrayToBase64Url(new Uint8Array(credential.rawId))
-
-    // Some authenticators return PRF results during creation, others don't.
-    // "Not all authenticators support evaluating the PRFs during credential
-    // creation so outputs may, or may not, be provided."
-    // — https://w3c.github.io/webauthn/#prf-extension (eval description)
-    if (prfResults.results?.first) {
-      const result = {
-        credentialId,
-        prfOutput: bufferSourceToArrayBuffer(prfResults.results.first),
-      }
-      cachePrfResult(result)
-      rememberCredentialIfLocal(credential)
-      return result
-    }
-
-    // PRF enabled but no results during create — do an immediate get()
-    logInfo(
-      'PRF enabled but no results during creation, doing immediate auth',
-      {
-        component: 'PasskeyService',
-        action: 'createPrfPasskey',
-      },
-    )
-    // Pass throwOnCancel so a user-cancelled assertion surfaces as a
-    // DOMException we can handle below — otherwise a `null` return would
-    // be indistinguishable from "provider returned no PRF output" and we'd
-    // show the misleading "PRF not supported" error for a plain cancel.
-    const postCreateAuth = await authenticatePrfPasskey([credentialId], {
-      throwOnCancel: true,
-    })
-    if (!postCreateAuth) {
-      // The provider claimed PRF support during creation but didn't deliver
-      // a PRF output on the immediately-following assertion. Treat this as
-      // a lack of real PRF support rather than a silent failure.
-      throw new PrfNotSupportedError()
-    }
-    return postCreateAuth
-  } catch (error) {
-    if (error instanceof PrfNotSupportedError) throw error
-    if (error instanceof PasskeyTimeoutError) throw error
-
-    // DOMException with name "NotAllowedError" means the user cancelled
-    if (error instanceof DOMException && error.name === 'NotAllowedError') {
-      logInfo('User cancelled passkey creation', {
-        component: 'PasskeyService',
-        action: 'createPrfPasskey',
-      })
-      return null
-    }
-
-    logError('Failed to create PRF passkey', error, {
-      component: 'PasskeyService',
-      action: 'createPrfPasskey',
-    })
-    return null
-  }
+  return passkeyKit.createPasskey({
+    id: userId,
+    name: userEmail,
+    displayName: displayName || userEmail,
+  })
 }
 
 /**
@@ -269,118 +56,18 @@ export async function createPrfPasskey(
  *   known PRF credential IDs so the browser can select the right one.
  * @returns The matched credential ID and PRF output, or null on failure/cancel.
  */
-export async function authenticatePrfPasskey(
+export function authenticatePrfPasskey(
   credentialIds: string[],
   options: { throwOnCancel?: boolean } = {},
 ): Promise<PrfPasskeyResult | null> {
-  const { throwOnCancel = false } = options
-  const allowCredentials: PublicKeyCredentialDescriptor[] = credentialIds.map(
-    (id) => ({
-      id: base64UrlToUint8Array(id),
-      type: 'public-key',
-    }),
-  )
-
-  try {
-    const assertion = (await withStuckTimeout(
-      navigator.credentials.get({
-        publicKey: {
-          challenge: crypto.getRandomValues(new Uint8Array(32)),
-          rpId: RP_ID,
-          allowCredentials,
-          userVerification: 'required',
-          timeout: WEBAUTHN_TIMEOUT_MS,
-          extensions: {
-            prf: { eval: { first: PRF_EVAL_FIRST } },
-          },
-        },
-      }),
-    )) as PublicKeyCredential | null
-
-    if (!assertion) {
-      logInfo('passkey assertion returned no credential', {
-        component: 'PasskeyService',
-        action: 'authenticatePrfPasskey',
-        metadata: { allowedCredentials: credentialIds.length },
-      })
-      return null
-    }
-
-    const extensionResults = assertion.getClientExtensionResults()
-    const prfOutput = extensionResults.prf?.results?.first
-
-    if (!prfOutput) {
-      logError('PRF output missing from assertion', undefined, {
-        component: 'PasskeyService',
-        action: 'authenticatePrfPasskey',
-      })
-      return null
-    }
-
-    const result = {
-      credentialId: uint8ArrayToBase64Url(new Uint8Array(assertion.rawId)),
-      prfOutput: bufferSourceToArrayBuffer(prfOutput),
-    }
-    cachePrfResult(result)
-    rememberCredentialIfLocal(assertion)
-    return result
-  } catch (error) {
-    if (error instanceof PasskeyTimeoutError) throw error
-
-    if (error instanceof DOMException && error.name === 'NotAllowedError') {
-      // NotAllowedError covers both a user cancel and the case where the
-      // provider has no usable credential for any of the allowed ids
-      // (e.g. the passkey was created in a different browser/profile and
-      // never persisted on this device).
-      logInfo(
-        'passkey authentication not allowed (cancelled or no usable credential)',
-        {
-          component: 'PasskeyService',
-          action: 'authenticatePrfPasskey',
-          metadata: { allowedCredentials: credentialIds.length },
-        },
-      )
-      if (throwOnCancel) throw error
-      return null
-    }
-
-    logError('Failed to authenticate with PRF passkey', error, {
-      component: 'PasskeyService',
-      action: 'authenticatePrfPasskey',
-    })
-    return null
-  }
+  return passkeyKit.authenticate(credentialIds, options)
 }
 
 /**
  * Derive an AES-256-GCM Key Encryption Key (KEK) from PRF output using HKDF.
- *
- * Raw PRF output is treated as Input Keying Material (IKM), not used directly as a key.
- * HKDF with a purpose-binding info string produces the final non-extractable CryptoKey.
  */
-export async function deriveKeyEncryptionKey(
+export function deriveKeyEncryptionKey(
   prfOutput: ArrayBuffer,
 ): Promise<CryptoKey> {
-  // Import PRF output as HKDF master key — non-extractable, derive-only
-  const masterKey = await crypto.subtle.importKey(
-    'raw',
-    prfOutput,
-    'HKDF',
-    false, // non-extractable
-    ['deriveKey'],
-  )
-
-  // Derive AES-256-GCM KEK with purpose-binding info string
-  return crypto.subtle.deriveKey(
-    {
-      name: 'HKDF',
-      hash: 'SHA-256',
-      salt: new Uint8Array(), // empty salt is fine for high-entropy IKM (RFC 5869 §3.1)
-      info: HKDF_INFO,
-    },
-    masterKey,
-    { name: 'AES-GCM', length: 256 },
-    false, // non-extractable
-    ['encrypt', 'decrypt'],
-  )
+  return passkeyKit.deriveKek(prfOutput)
 }

--- a/src/services/passkey/prf-support.ts
+++ b/src/services/passkey/prf-support.ts
@@ -1,84 +1,24 @@
 /**
- * PRF Support Detection
+ * PRF Support Detection — delegates to @tinfoilsh/passkey-kit.
  *
- * Checks whether the current browser/platform supports the WebAuthn PRF extension.
- * This is an optimistic check — actual PRF support is only confirmed when a credential
- * is created with prf.enabled: true in the response. If creation fails, callers should
- * fall back to the manual key flow.
- *
- * Detection strategy:
- * 1. Check window.PublicKeyCredential exists (basic WebAuthn support)
- * 2. Check isUserVerifyingPlatformAuthenticatorAvailable() (biometric/PIN authenticator present)
- * 3. Optionally check getClientCapabilities() for explicit PRF support signal (new API, not universal)
+ * This is an optimistic check — actual PRF support is only confirmed when a
+ * credential is created with prf.enabled: true in the response. If creation
+ * fails, callers should fall back to the manual key flow.
  */
 
-let cachedResult: boolean | null = null
+import { passkeyKit } from './kit'
 
 /**
  * Returns true if the browser/platform likely supports WebAuthn PRF.
  * Result is cached after the first call.
  */
-export async function isPrfSupported(): Promise<boolean> {
-  if (cachedResult !== null) {
-    return cachedResult
-  }
-
-  cachedResult = await detectPrfSupport()
-  return cachedResult
+export function isPrfSupported(): Promise<boolean> {
+  return passkeyKit.isPrfSupported()
 }
 
 /**
  * Clear the cached result. Useful for testing.
  */
 export function resetPrfSupportCache(): void {
-  cachedResult = null
-}
-
-async function detectPrfSupport(): Promise<boolean> {
-  if (typeof window === 'undefined') {
-    return false
-  }
-
-  if (!window.PublicKeyCredential) {
-    return false
-  }
-
-  // Check that a platform authenticator is available (Face ID, Touch ID, Windows Hello, etc.)
-  try {
-    const available =
-      await PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable()
-    if (!available) {
-      return false
-    }
-  } catch {
-    return false
-  }
-
-  // If getClientCapabilities is available, use it for a more precise check.
-  // This API is newer and may not be present in all browsers.
-  try {
-    if (typeof PublicKeyCredential.getClientCapabilities === 'function') {
-      const caps = await PublicKeyCredential.getClientCapabilities()
-      if (caps && typeof caps === 'object') {
-        // The shape of this API varies across browser versions.
-        // Chrome returns a map-like object; check for extension-prf or prf key.
-        const hasPrf =
-          (caps as Record<string, boolean>)['extension-prf'] === true ||
-          (caps as Record<string, boolean>)['prf'] === true
-        if (hasPrf) {
-          return true
-        }
-        // If getClientCapabilities is available but doesn't report PRF,
-        // that's a strong negative signal on platforms that implement it.
-        // However, since this API is still evolving, we don't treat absence
-        // as definitive — fall through to the optimistic path.
-      }
-    }
-  } catch {
-    // getClientCapabilities not available or threw — fall through
-  }
-
-  // Optimistic: platform authenticator is available, WebAuthn is supported.
-  // Actual PRF support will be confirmed during credential creation.
-  return true
+  passkeyKit.resetPrfSupportCache()
 }

--- a/src/services/sync-enclave/key-bundle.ts
+++ b/src/services/sync-enclave/key-bundle.ts
@@ -9,6 +9,14 @@
  * Phase 4 opportunistic migration.
  */
 
+import {
+  bytesToHex,
+  deriveKeyId,
+  hexToBytes,
+  unwrapCek,
+  wrapCek,
+} from '@tinfoilsh/passkey-kit'
+
 /**
  * Local-only descriptor for a wrapped CEK + the bookkeeping needed
  * to unwrap it later. This is NOT the on-wire shape — see
@@ -27,33 +35,8 @@ export interface BundleBody {
   info?: string
 }
 
-const AES_GCM_IV_BYTES = 12
-const CEK_BYTES = 32
-const KEY_ID_BYTES = 16
 const BUNDLE_INFO = 'tinfoil-chat-kek-v1'
 const KEY_ID_INFO = 'tinfoil-key-id-v1'
-
-function bytesToHex(bytes: Uint8Array): string {
-  let out = ''
-  for (let i = 0; i < bytes.length; i++) {
-    out += bytes[i].toString(16).padStart(2, '0')
-  }
-  return out
-}
-
-function hexToBytes(hex: string): Uint8Array {
-  if (hex.length % 2 !== 0) {
-    throw new Error('key-bundle: odd-length hex input')
-  }
-  if (!/^[0-9a-fA-F]*$/.test(hex)) {
-    throw new Error('key-bundle: invalid hex character')
-  }
-  const out = new Uint8Array(hex.length / 2)
-  for (let i = 0; i < out.length; i++) {
-    out[i] = parseInt(hex.substr(i * 2, 2), 16)
-  }
-  return out
-}
 
 /**
  * Wrap a raw 32-byte CEK under a passkey-PRF-derived KEK using
@@ -71,21 +54,15 @@ export async function wrapCekForCredential(opts: {
   cek: Uint8Array
   saltHex?: string
 }): Promise<BundleBody> {
-  if (opts.cek.length !== CEK_BYTES) {
-    throw new Error(
-      `key-bundle: CEK must be ${CEK_BYTES} bytes, got ${opts.cek.length}`,
-    )
-  }
-  const iv = crypto.getRandomValues(new Uint8Array(AES_GCM_IV_BYTES))
-  const ciphertext = await crypto.subtle.encrypt(
-    { name: 'AES-GCM', iv: iv as BufferSource },
-    opts.kek,
-    opts.cek as BufferSource,
-  )
-  return {
+  const wrapped = await wrapCek({
     credentialId: opts.credentialId,
-    kekIvHex: bytesToHex(iv),
-    wrappedKeyHex: bytesToHex(new Uint8Array(ciphertext)),
+    kek: opts.kek,
+    cek: opts.cek,
+  })
+  return {
+    credentialId: wrapped.credentialId,
+    kekIvHex: wrapped.kekIvHex,
+    wrappedKeyHex: wrapped.wrappedKeyHex,
     saltHex: opts.saltHex ?? '',
     info: BUNDLE_INFO,
   }
@@ -103,24 +80,7 @@ export async function unwrapCekFromBundle(
   const ivHex = 'kekIvHex' in bundle ? bundle.kekIvHex : bundle.kek_iv
   const ctHex =
     'wrappedKeyHex' in bundle ? bundle.wrappedKeyHex : bundle.wrapped_key
-  if (!ivHex || !ctHex) {
-    throw new Error('key-bundle: missing iv or wrapped_key')
-  }
-  const iv = hexToBytes(ivHex)
-  if (iv.length !== AES_GCM_IV_BYTES) {
-    throw new Error('key-bundle: iv length mismatch')
-  }
-  const ciphertext = hexToBytes(ctHex)
-  const plaintext = await crypto.subtle.decrypt(
-    { name: 'AES-GCM', iv: iv as BufferSource },
-    kek,
-    ciphertext as BufferSource,
-  )
-  const cek = new Uint8Array(plaintext)
-  if (cek.length !== CEK_BYTES) {
-    throw new Error(`key-bundle: unwrapped CEK has wrong length ${cek.length}`)
-  }
-  return cek
+  return unwrapCek(kek, { kekIvHex: ivHex, wrappedKeyHex: ctHex })
 }
 
 /**
@@ -177,28 +137,5 @@ export function cekBytesToHex(bytes: Uint8Array): string {
  * enclave's `crypto.DeriveKeyID` byte-for-byte.
  */
 export async function deriveKeyIdHex(cek: Uint8Array): Promise<string> {
-  if (cek.length !== CEK_BYTES) {
-    throw new Error(
-      `key-bundle: CEK must be ${CEK_BYTES} bytes, got ${cek.length}`,
-    )
-  }
-  const ikm = await crypto.subtle.importKey(
-    'raw',
-    cek as unknown as BufferSource,
-    'HKDF',
-    false,
-    ['deriveBits'],
-  )
-  const enc = new TextEncoder()
-  const bits = await crypto.subtle.deriveBits(
-    {
-      name: 'HKDF',
-      hash: 'SHA-256',
-      salt: new Uint8Array(0) as unknown as BufferSource,
-      info: enc.encode(KEY_ID_INFO) as unknown as BufferSource,
-    },
-    ikm,
-    KEY_ID_BYTES * 8,
-  )
-  return bytesToHex(new Uint8Array(bits))
+  return bytesToHex(await deriveKeyId(cek, { info: KEY_ID_INFO }))
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       reporter: ['text', 'html'],
-      include: ['src/**/*.ts', 'src/**/*.tsx'],
+      include: ['src/**/*.ts', 'src/**/*.tsx', 'packages/*/src/**/*.ts'],
       exclude: ['src/app/layout.tsx', 'src/app/page.tsx'],
     },
   },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,7 +7,11 @@ export default defineConfig({
     globals: true,
     typecheck: { tsconfig: './tsconfig.test.json' },
     setupFiles: ['./vitest.setup.ts'],
-    include: ['tests/**/*.test.ts', 'tests/**/*.test.tsx'],
+    include: [
+      'tests/**/*.test.ts',
+      'tests/**/*.test.tsx',
+      'packages/*/tests/**/*.test.ts',
+    ],
     exclude: ['tests/ui/**', 'tests/integration/**'],
     coverage: {
       provider: 'v8',


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Extracted the passkey logic into a reusable SDK, `@tinfoilsh/passkey-kit`, and refactored the app to consume it. Adds silent unlock and CEK generation helpers, plus customizable error messages.

- **New Features**
  - New package `@tinfoilsh/passkey-kit`: WebAuthn PRF create/auth flows, KEK derivation (HKDF-SHA-256), and CEK wrap/unwrap (AES-256-GCM).
  - High-level APIs: `enroll`, `unlock`, `unlockWithCachedPrf` (silent), `rewrapWithCachedPrf`; helpers like `generateCek`, `isValidCek`, and `deriveKeyId`.
  - PRF support detection, pluggable storage adapters, typed errors with a stuck-timeout guard, and configurable error messages.

- **Refactors**
  - App initializes a shared kit in `src/services/passkey/kit.ts` and delegates from passkey services (`passkey-service.ts`, `local-passkey-credential.ts`, `prf-support.ts`) and `sync-enclave/key-bundle.ts`.
  - Added `@tinfoilsh/passkey-kit` as a local workspace dep and set Next.js `transpilePackages` to compile it.
  - Fixed cached passkey rewrap to work when the method is called standalone (e.g., destructured from the kit).
  - Consolidated enrollment setup across passkey kit tests to reduce duplication.

<sup>Written for commit 8d73ee583832d22d30ac9ce74ff19d8da1d9b586. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/439?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

