### PR TITLE
Fix UI nits

### DIFF
--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -3349,7 +3349,9 @@ export function ChatInterface({
                 style={
                   {
                     paddingBottom:
-                      inputAreaHeight + CONSTANTS.CHAT_INPUT_BOTTOM_GAP_PX,
+                      inputAreaHeight > 0
+                        ? inputAreaHeight + CONSTANTS.CHAT_INPUT_BOTTOM_GAP_PX
+                        : 0,
                     '--input-area-height': `${inputAreaHeight}px`,
                   } as React.CSSProperties
                 }

--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -4418,7 +4418,14 @@ ${encryptionKey.replace('key_', '')}
                               </div>
                             </div>
                             <div className="text-sm text-content-muted">
-                              {billingLoading ? '...' : '→'}
+                              {billingLoading ? (
+                                '...'
+                              ) : (
+                                <ArrowTopRightOnSquareIcon
+                                  className="h-4 w-4"
+                                  aria-hidden="true"
+                                />
+                              )}
                             </div>
                           </button>
                         )}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the stray bottom gap on the welcome screen by only applying bottom padding when inputAreaHeight > 0. Updated the Billing button to use a consistent external-link icon instead of the text arrow.

<sup>Written for commit 538dfb4d6bad71dda3e34a2597a3d9e9f4dac335. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/440?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

