### PR TITLE
fix: remember the web search toggle per chat

### DIFF
--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -1080,8 +1080,15 @@ export function ChatInterface({
       webSearchEnabled: next,
     }
     setCurrentChat(updatedChat)
+    // Blank chats share an empty id (one per storage mode), so also match
+    // the mode to avoid rewriting the other blank entry.
     setChats((prev) =>
-      prev.map((c) => (c.id === currentChat.id ? updatedChat : c)),
+      prev.map((c) =>
+        c.id === currentChat.id &&
+        (!currentChat.isBlankChat || c.isLocalOnly === currentChat.isLocalOnly)
+          ? updatedChat
+          : c,
+      ),
     )
     const storeHistory = isSignedIn || !isCloudSyncEnabled()
     if (!updatedChat.isTemporary && !updatedChat.isBlankChat && storeHistory) {

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -469,7 +469,9 @@ export function ChatInterface({
   const [artifactPreview, setArtifactPreview] =
     useState<ArtifactPreviewSidebarDetail | null>(null)
 
-  // State for web search toggle (persisted in localStorage)
+  // Global web search default (persisted in localStorage). Serves as the
+  // fallback for chats without a per-chat preference; the toolbar toggle
+  // writes a per-chat override instead of mutating this value.
   const [webSearchEnabled, setWebSearchEnabled] = useState(() => {
     if (typeof window === 'undefined') return true
     const saved = localStorage.getItem(SETTINGS_WEB_SEARCH_ENABLED)
@@ -481,7 +483,6 @@ export function ChatInterface({
     const saved = localStorage.getItem(SETTINGS_WEB_SEARCH_AVAILABLE)
     return saved === null ? true : saved === 'true'
   })
-  const effectiveWebSearchEnabled = webSearchAvailable && webSearchEnabled
 
   // State for code execution toggle (persisted in localStorage, defaults to off)
   const [codeExecutionEnabled, setCodeExecutionEnabled] = useState(() => {
@@ -772,7 +773,8 @@ export function ChatInterface({
     thinkingEnabled,
     initialChatId,
     isLocalChatUrl,
-    webSearchEnabled: effectiveWebSearchEnabled,
+    webSearchEnabled,
+    webSearchAvailable,
     // Feature flag gates key derivation in useExecSnapshot; the toggle
     // gates request plumbing. Both layers must be on to use code-exec.
     canUseCodeExecution,
@@ -782,6 +784,11 @@ export function ChatInterface({
   })
 
   const isTemporaryMode = currentChat?.isTemporary === true
+
+  // Per-chat web search preference wins; chats that never touched the
+  // toggle fall back to the global default.
+  const effectiveWebSearchEnabled =
+    webSearchAvailable && (currentChat?.webSearchEnabled ?? webSearchEnabled)
 
   const currentChatRef = useRef<Chat | null>(null)
   useEffect(() => {
@@ -1063,16 +1070,29 @@ export function ChatInterface({
   }, [webSearchEnabled])
 
   const handleWebSearchToggle = useCallback(() => {
-    setWebSearchEnabled((prev) => {
-      const next = !prev
-      window.dispatchEvent(
-        new CustomEvent('webSearchEnabledChanged', {
-          detail: { enabled: next },
-        }),
-      )
-      return next
-    })
-  }, [])
+    if (!currentChat) {
+      setWebSearchEnabled((prev) => !prev)
+      return
+    }
+    const next = !(currentChat.webSearchEnabled ?? webSearchEnabled)
+    const updatedChat: Chat = {
+      ...currentChat,
+      webSearchEnabled: next,
+    }
+    setCurrentChat(updatedChat)
+    setChats((prev) =>
+      prev.map((c) => (c.id === currentChat.id ? updatedChat : c)),
+    )
+    const storeHistory = isSignedIn || !isCloudSyncEnabled()
+    if (!updatedChat.isTemporary && !updatedChat.isBlankChat && storeHistory) {
+      chatStorage.saveChat(updatedChat).catch((err) => {
+        logError('Failed to persist web search preference', err, {
+          component: 'ChatInterface',
+          metadata: { chatId: updatedChat.id, webSearchEnabled: next },
+        })
+      })
+    }
+  }, [currentChat, webSearchEnabled, setCurrentChat, setChats, isSignedIn])
 
   // Persist code execution toggle to localStorage
   useEffect(() => {
@@ -1786,6 +1806,7 @@ export function ChatInterface({
       isBlankChat: true,
       isTemporary: true,
       presetId: currentChat?.presetId,
+      webSearchEnabled: currentChat?.webSearchEnabled,
     }
     setCurrentChat(tempChat)
   }, [chats, createNewChat, currentChat, isSignedIn, setChats, setCurrentChat])

--- a/src/components/chat/hooks/chat-persistence.ts
+++ b/src/components/chat/hooks/chat-persistence.ts
@@ -21,11 +21,16 @@ interface CreateUpdateChatWithHistoryCheckParams {
   // a streamed update should also be reflected into `currentChat`. With
   // concurrent streams this is independent of which chat is streaming.
   viewedChatIdRef: React.MutableRefObject<string>
+  // Live mirror of the chats state. Streamed updates spread a send-time
+  // chat snapshot, so per-chat preferences toggled mid-stream must be
+  // re-read from here or they would be reverted by the next flush.
+  chatsRef: React.MutableRefObject<Chat[]>
 }
 
 export function createUpdateChatWithHistoryCheck({
   storeHistory,
   viewedChatIdRef,
+  chatsRef,
 }: CreateUpdateChatWithHistoryCheckParams) {
   return function updateChatWithHistoryCheck(
     setChats: React.Dispatch<React.SetStateAction<Chat[]>>,
@@ -41,11 +46,17 @@ export function createUpdateChatWithHistoryCheck({
     // Only update messages and set isBlankChat based on message count
     // Keep all other properties from chatSnapshot (including title, isLocalOnly, etc.)
     // IMPORTANT: Preserve title from current state to avoid race with early title generation
+    const liveChat = chatsRef.current.find((c) => c.id === chatId)
     const updatedChat: Chat = {
       ...chatSnapshot,
       id: chatId,
       messages: newMessages,
       isBlankChat: newMessages.length === 0,
+      // Same rationale as title: the web search toggle can flip while this
+      // chat is streaming, so the live value wins over the snapshot.
+      webSearchEnabled: liveChat
+        ? liveChat.webSearchEnabled
+        : chatSnapshot.webSearchEnabled,
     }
 
     setChats((prevChats) => {

--- a/src/components/chat/hooks/use-chat-messaging.ts
+++ b/src/components/chat/hooks/use-chat-messaging.ts
@@ -165,6 +165,11 @@ export function useChatMessaging({
   const viewedChatIdRef = useRef<string>(currentChat?.id || '')
   viewedChatIdRef.current = currentChat?.id || ''
 
+  // Live mirror of the chats state so the persistence helper can re-read
+  // per-chat preferences that changed after a stream's snapshot was taken.
+  const chatsRef = useRef<Chat[]>(chats)
+  chatsRef.current = chats
+
   const dismissStreamError = useCallback(() => {
     patchStatus(viewedChatIdRef.current, { streamError: null })
   }, [patchStatus])
@@ -178,6 +183,7 @@ export function useChatMessaging({
       createUpdateChatWithHistoryCheck({
         storeHistory,
         viewedChatIdRef,
+        chatsRef,
       }),
     [storeHistory],
   )

--- a/src/components/chat/hooks/use-chat-messaging.ts
+++ b/src/components/chat/hooks/use-chat-messaging.ts
@@ -63,7 +63,9 @@ interface UseChatMessagingProps {
   scrollToBottom?: () => void
   reasoningEffort?: ReasoningEffort
   thinkingEnabled?: boolean
+  // Global default; the chat's own webSearchEnabled field overrides it.
   webSearchEnabled?: boolean
+  webSearchAvailable?: boolean
   codeExecutionEnabled?: boolean
   piiCheckEnabled?: boolean
   genUIEnabled?: boolean
@@ -115,6 +117,7 @@ export function useChatMessaging({
   reasoningEffort,
   thinkingEnabled,
   webSearchEnabled,
+  webSearchAvailable,
   codeExecutionEnabled,
   piiCheckEnabled,
   genUIEnabled,
@@ -615,8 +618,13 @@ export function useChatMessaging({
         const preferMultimodal = updatedMessages.some(
           (m) => getMessageImages(m).length > 0,
         )
+        const chatWebSearchEnabled =
+          (webSearchAvailable ?? true) &&
+          (updatedChat.webSearchEnabled ?? webSearchEnabled ?? true)
         const preferToolCalling = Boolean(
-          webSearchEnabled || codeExecutionEnabled || (genUIEnabled ?? true),
+          chatWebSearchEnabled ||
+          codeExecutionEnabled ||
+          (genUIEnabled ?? true),
         )
         const { model, autoCandidates } = resolveModelSelection(
           selectedModel,
@@ -666,7 +674,7 @@ export function useChatMessaging({
           signal: controller.signal,
           reasoningEffort,
           thinkingEnabled,
-          webSearchEnabled,
+          webSearchEnabled: chatWebSearchEnabled,
           codeExecutionEnabled,
           piiCheckEnabled,
           genUIEnabled: genUIEnabled ?? true,
@@ -909,6 +917,7 @@ export function useChatMessaging({
       isProjectMode,
       activeProject,
       webSearchEnabled,
+      webSearchAvailable,
       codeExecutionEnabled,
       piiCheckEnabled,
       genUIEnabled,

--- a/src/components/chat/hooks/use-chat-state.ts
+++ b/src/components/chat/hooks/use-chat-state.ts
@@ -98,6 +98,7 @@ export function useChatState({
   initialChatId,
   isLocalChatUrl = false,
   webSearchEnabled,
+  webSearchAvailable,
   canUseCodeExecution = false,
   codeExecutionEnabled,
   piiCheckEnabled,
@@ -112,7 +113,9 @@ export function useChatState({
   thinkingEnabled?: boolean
   initialChatId?: string | null
   isLocalChatUrl?: boolean
+  // Global default; each chat's own webSearchEnabled field overrides it.
   webSearchEnabled?: boolean
+  webSearchAvailable?: boolean
   // Feature flag: when false, useExecSnapshot stays a no-op and no
   // key material is derived. Distinct from `codeExecutionEnabled`,
   // which is the user-facing toggle.
@@ -247,6 +250,7 @@ export function useChatState({
     reasoningEffort,
     thinkingEnabled,
     webSearchEnabled,
+    webSearchAvailable,
     // code-exec requires encryptionKey for snapshots
     codeExecutionEnabled:
       codeExecutionEnabled && codeExecutionEncryptionKey != null,

--- a/src/components/chat/hooks/use-chat-storage.ts
+++ b/src/components/chat/hooks/use-chat-storage.ts
@@ -245,8 +245,12 @@ export function useChatStorage({
               ? blankChat
               : { ...blankChat, webSearchEnabled: undefined }
           if (freshBlank !== blankChat) {
+            // Blank chats share an empty id, so match by mode to avoid
+            // touching the other mode's blank entry.
             setChats((prev) =>
-              prev.map((c) => (c.id === blankChat.id ? freshBlank : c)),
+              prev.map((c) =>
+                c.isBlankChat && c.isLocalOnly === isLocalOnly ? freshBlank : c,
+              ),
             )
           }
           setCurrentChat(freshBlank)

--- a/src/components/chat/hooks/use-chat-storage.ts
+++ b/src/components/chat/hooks/use-chat-storage.ts
@@ -238,7 +238,18 @@ export function useChatStorage({
       if (blankChat) {
         // Always switch when from user action, or when we're on a different blank chat
         if (fromUserAction || currentChat.isBlankChat) {
-          setCurrentChat(blankChat)
+          // A reused blank represents a fresh chat, so drop any per-chat
+          // web search override left behind by an earlier visit.
+          const freshBlank =
+            blankChat.webSearchEnabled === undefined
+              ? blankChat
+              : { ...blankChat, webSearchEnabled: undefined }
+          if (freshBlank !== blankChat) {
+            setChats((prev) =>
+              prev.map((c) => (c.id === blankChat.id ? freshBlank : c)),
+            )
+          }
+          setCurrentChat(freshBlank)
         }
       } else {
         // Create a new blank chat if it doesn't exist (shouldn't normally happen)

--- a/src/components/chat/types.ts
+++ b/src/components/chat/types.ts
@@ -189,6 +189,10 @@ export type Chat = {
   // is active and the model used for new messages. Falls back to the first
   // available model when unset or no longer available.
   model?: string
+  // Per-chat web search preference. When unset, falls back to the global
+  // default. Persisted with the chat and synced across devices (the iOS
+  // app reads/writes the same field).
+  webSearchEnabled?: boolean
   // For code execution.
   codeExecutionAccessToken?: string
 }
@@ -216,11 +220,7 @@ export type LabelType = 'verify' | 'model' | 'info' | 'reasoning' | null
 
 // Document processing types
 export type DocumentProcessingStatus =
-  | 'idle'
-  | 'uploading'
-  | 'processing'
-  | 'complete'
-  | 'error'
+  'idle' | 'uploading' | 'processing' | 'complete' | 'error'
 
 export interface DocumentMetadata {
   filename?: string

--- a/src/services/cloud/schemas.ts
+++ b/src/services/cloud/schemas.ts
@@ -37,6 +37,7 @@ export const RemoteChatPlaintextSchema = z
     createdAt: z.union([z.string(), z.number()]).optional(),
     updatedAt: z.union([z.string(), z.number()]).optional(),
     model: z.string().optional(),
+    webSearchEnabled: z.boolean().optional(),
     isLocalOnly: z.boolean().optional(),
     isBlankChat: z.boolean().optional(),
     syncVersion: z.number().optional(),


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Remembers the web search toggle per chat so each conversation keeps its own setting. Falls back to the global default and syncs across devices.

- **Bug Fixes**
  - Added per-chat `webSearchEnabled` on `Chat` and in cloud schema to persist and sync the preference.
  - Toolbar toggle now writes the chat’s preference; with no active chat, it updates the global default in localStorage (used only when no override).
  - Effective value = `webSearchAvailable` AND (chat override if set, else global default); used for tool-calling and request options.
  - Reusing a blank chat clears any old override; temporary chats inherit the current chat’s preference.
  - Streaming updates no longer revert a changed toggle by reading live chat state during flushes.

<sup>Written for commit 4af2a97257a9a470bd438b69607f5e5e1fa3ec5c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/441?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

