### PR TITLE
fix: retry button now resends the last message

### DIFF
--- a/src/components/chat/hooks/use-chat-messaging.ts
+++ b/src/components/chat/hooks/use-chat-messaging.ts
@@ -1135,8 +1135,7 @@ export function useChatMessaging({
         const originalMessage = currentChat.messages[i]
         patchStatus(currentChat.id, { streamError: null })
         const truncatedMessages = currentChat.messages.slice(0, i)
-        const attachments =
-          originalMessage.attachments ?? getMessageAttachments(originalMessage)
+        const attachments = getMessageAttachments(originalMessage)
         handleQuery(
           originalMessage.content || '',
           attachments.length > 0 ? attachments : undefined,

--- a/src/components/chat/hooks/use-chat-messaging.ts
+++ b/src/components/chat/hooks/use-chat-messaging.ts
@@ -1124,17 +1124,30 @@ export function useChatMessaging({
     editMessage,
   ])
 
-  // Re-send the most recent user message, e.g. after a failed stream
+  // Re-send the most recent user message, e.g. after a failed stream.
+  // Calls handleQuery directly instead of going through regenerateMessage
+  // → editMessage, whose closure-based guards (pendingRegenerateRef,
+  // loadingState) can be stale after a stream error and silently no-op.
   const retryLastMessage = useCallback(() => {
     if (!currentChat) return
     for (let i = currentChat.messages.length - 1; i >= 0; i--) {
       if (currentChat.messages[i].role === 'user') {
+        const originalMessage = currentChat.messages[i]
         patchStatus(currentChat.id, { streamError: null })
-        regenerateMessage(i)
+        const truncatedMessages = currentChat.messages.slice(0, i)
+        const attachments =
+          originalMessage.attachments ?? getMessageAttachments(originalMessage)
+        handleQuery(
+          originalMessage.content || '',
+          attachments.length > 0 ? attachments : undefined,
+          undefined,
+          truncatedMessages,
+          originalMessage.quote,
+        )
         return
       }
     }
-  }, [currentChat, regenerateMessage, patchStatus])
+  }, [currentChat, patchStatus, handleQuery])
 
   return {
     input,

--- a/tests/components/chat/use-chat-messaging.retry.test.tsx
+++ b/tests/components/chat/use-chat-messaging.retry.test.tsx
@@ -1,0 +1,166 @@
+import { useChatMessaging } from '@/components/chat/hooks/use-chat-messaging'
+import type { Chat, Message } from '@/components/chat/types'
+import { act, renderHook } from '@testing-library/react'
+import { type Dispatch, type RefObject, type SetStateAction } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const abortMock = vi.fn()
+const patchStatusMock = vi.fn()
+const resetStatusMock = vi.fn()
+const moveStatusMock = vi.fn()
+const registerControllerMock = vi.fn()
+const clearControllerMock = vi.fn()
+
+vi.mock('@clerk/nextjs', () => ({
+  useAuth: () => ({
+    isSignedIn: false,
+  }),
+}))
+
+vi.mock('@/components/project', () => ({
+  useProject: () => ({
+    isProjectMode: false,
+    activeProject: null,
+  }),
+}))
+
+vi.mock('@/services/cloud/streaming-tracker', () => ({
+  streamingTracker: {
+    isStreaming: vi.fn(() => false),
+    endStreaming: vi.fn(),
+    startStreaming: vi.fn(),
+    onStreamEnd: vi.fn(),
+  },
+}))
+
+vi.mock('@/components/chat/hooks/use-chat-streams', async () => {
+  const actual = await vi.importActual<
+    typeof import('@/components/chat/hooks/use-chat-streams')
+  >('@/components/chat/hooks/use-chat-streams')
+
+  return {
+    ...actual,
+    useChatStreams: () => ({
+      statusByChat: {},
+      patchStatus: patchStatusMock,
+      resetStatus: resetStatusMock,
+      moveStatus: moveStatusMock,
+      registerController: registerControllerMock,
+      clearController: clearControllerMock,
+      abort: abortMock,
+    }),
+  }
+})
+
+vi.mock('@/services/inference/inference-client', () => ({
+  sendChatStream: vi.fn(async function* () {
+    yield { type: 'content', text: 'ok' }
+  }),
+}))
+
+vi.mock('@/services/inference/title', () => ({
+  generateTitle: vi.fn(() => Promise.resolve('Title')),
+}))
+
+vi.mock('@/services/inference/tinfoil-client', () => ({
+  getRateLimitInfo: vi.fn(() => null),
+  refreshRateLimit: vi.fn(),
+}))
+
+vi.mock('@/services/storage/chat-storage', () => ({
+  chatStorage: {
+    saveChatAndSync: vi.fn(() => Promise.resolve()),
+    saveChat: vi.fn(() => Promise.resolve()),
+  },
+}))
+
+vi.mock('@/services/storage/session-storage', () => ({
+  sessionChatStorage: {
+    saveChat: vi.fn(),
+  },
+}))
+
+vi.mock('@/utils/cloud-sync-settings', () => ({
+  isCloudSyncEnabled: vi.fn(() => false),
+}))
+
+vi.mock('@/utils/error-handling', () => ({
+  logError: vi.fn(),
+  logInfo: vi.fn(),
+  logWarning: vi.fn(),
+}))
+
+vi.mock('@/utils/reverse-id', () => ({
+  generateReverseId: vi.fn(() => ({
+    id: 'test-id',
+    timestamp: Date.now(),
+  })),
+}))
+
+vi.mock('@/services/exec-snapshot/access-token', () => ({
+  generateCodeExecutionAccessToken: vi.fn(() => 'token'),
+}))
+
+vi.mock('@/services/exec-snapshot/use-exec-snapshot', () => ({
+  getCodeExecutionContainerAuthTokenForChat: vi.fn(() => Promise.resolve(null)),
+}))
+
+function createChatWithUserMessage(id: string): Chat {
+  const userMessage: Message = {
+    role: 'user',
+    content: 'Hello',
+    timestamp: new Date(),
+  }
+  return {
+    id,
+    title: `Chat ${id}`,
+    messages: [userMessage],
+    createdAt: new Date(),
+    isBlankChat: false,
+  }
+}
+
+const noopSetChats: Dispatch<SetStateAction<Chat[]>> = (_value) => undefined
+const noopSetCurrentChat: Dispatch<SetStateAction<Chat>> = (_value) => undefined
+const messagesEndRef = { current: null } as RefObject<HTMLDivElement | null>
+
+describe('useChatMessaging retryLastMessage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('calls handleQuery directly instead of going through regenerateMessage guards', () => {
+    const chat = createChatWithUserMessage('chat-a')
+
+    const { result } = renderHook(() =>
+      useChatMessaging({
+        systemPrompt: '',
+        rules: '',
+        storeHistory: false,
+        models: [],
+        selectedModel: 'test-model',
+        chats: [chat],
+        currentChat: chat,
+        setChats: noopSetChats,
+        setCurrentChat: noopSetCurrentChat,
+        messagesEndRef,
+      }),
+    )
+
+    act(() => {
+      result.current.retryLastMessage()
+    })
+
+    // streamError should be cleared
+    expect(patchStatusMock).toHaveBeenCalledWith('chat-a', {
+      streamError: null,
+    })
+
+    // handleQuery should have been called, which triggers resetStatus
+    expect(resetStatusMock).toHaveBeenCalledWith('chat-a', {
+      loadingState: 'loading',
+      isWaitingForResponse: true,
+      isStreaming: true,
+    })
+  })
+})

--- a/tests/components/chat/use-chat-messaging.retry.test.tsx
+++ b/tests/components/chat/use-chat-messaging.retry.test.tsx
@@ -151,12 +151,10 @@ describe('useChatMessaging retryLastMessage', () => {
       result.current.retryLastMessage()
     })
 
-    // streamError should be cleared
     expect(patchStatusMock).toHaveBeenCalledWith('chat-a', {
       streamError: null,
     })
 
-    // handleQuery should have been called, which triggers resetStatus
     expect(resetStatusMock).toHaveBeenCalledWith('chat-a', {
       loadingState: 'loading',
       isWaitingForResponse: true,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the Retry action so it resends the last user message after a failed stream by calling `handleQuery` directly, with proper attachment handling for legacy messages.

- **Bug Fixes**
  - `retryLastMessage` now calls `handleQuery` with the original message (content, quote) and truncated history, using `getMessageAttachments` to include attachments and bypass stale `regenerateMessage`/`editMessage` guards.
  - Clears `streamError` and resets loading/streaming status; added `use-chat-messaging.retry.test.tsx` to cover the flow.

<sup>Written for commit 5fbc8dbc9eb73ea06adb26e8525fed31724c3efa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/442?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

