### PR TITLE
fix: keep subscription access state in sync

### DIFF
--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -23,7 +23,7 @@ import { useToast } from '@/hooks/use-toast'
 import {
   getRateLimitInfo,
   getSessionToken,
-  invalidateAnonymousSessionCache,
+  invalidateSessionCache,
   snapshotAndDecrementRemaining,
   type RateLimitInfo,
 } from '@/services/inference/tinfoil-client'
@@ -1041,17 +1041,16 @@ export function ChatInterface({
     }
   }, [])
 
-  // Once the user signs in (and the auth token manager has been
-  // initialized via useCloudSync), discard any anonymous session token /
-  // free-tier rate-limit info cached before sign-in and force a fresh
-  // fetch so the banner reflects the authenticated user's quota.
+  // Refresh credentials after sign-in or an entitlement transition so a
+  // free-tier token cannot remain cached after upgrade and a premium token
+  // cannot remain cached after access ends.
   useEffect(() => {
     if (!isSignedIn || !cloudSyncInitialized) return
-    invalidateAnonymousSessionCache()
+    invalidateSessionCache()
     void getSessionToken().catch(() => {
       // best-effort; the next real request will retry
     })
-  }, [isSignedIn, cloudSyncInitialized])
+  }, [isSignedIn, cloudSyncInitialized, chat_subscription_active])
 
   // Handle upgrade requests from error CTA buttons
   useEffect(() => {

--- a/src/hooks/use-subscription-status.ts
+++ b/src/hooks/use-subscription-status.ts
@@ -1,6 +1,6 @@
 import { SETTINGS_CACHED_SUBSCRIPTION_STATUS } from '@/constants/storage-keys'
 import { useUser } from '@clerk/nextjs'
-import { useEffect, useMemo } from 'react'
+import { useEffect, useState } from 'react'
 
 type StripeSubscriptionStatus =
   | 'active'
@@ -22,6 +22,7 @@ const SUPPORTED_STATUSES = new Set<StripeSubscriptionStatus>([
   'trialing',
   'unpaid',
 ])
+const MAX_TIMEOUT_MS = 2_147_483_647
 
 const isValidStatus = (status: unknown): status is StripeSubscriptionStatus =>
   typeof status === 'string' &&
@@ -40,7 +41,7 @@ const parseExpiration = (expiration: unknown): Date | null => {
   return parsed
 }
 
-const hasActiveSubscription = (
+export const hasActiveSubscription = (
   status: StripeSubscriptionStatus | null,
   expiration: Date | null,
   now: Date,
@@ -50,7 +51,7 @@ const hasActiveSubscription = (
   }
 
   if (status === 'active' || status === 'trialing') {
-    return true
+    return !expiration || expiration.getTime() > now.getTime()
   }
 
   if (status === 'canceled' && expiration) {
@@ -66,29 +67,31 @@ const hasActiveSubscription = (
  */
 export function useSubscriptionStatus() {
   const { user, isLoaded } = useUser()
+  const [expirationTick, setExpirationTick] = useState(0)
 
-  const subscriptionStatus = useMemo(() => {
-    if (!isLoaded || !user) {
-      return { chat_subscription_active: false }
-    }
+  const publicMetadata = (user?.publicMetadata ?? {}) as Record<string, unknown>
+  const rawChatStatus = publicMetadata['chat_subscription_status']
+  const chatStatus = isValidStatus(rawChatStatus) ? rawChatStatus : null
+  const chatExpiration = parseExpiration(
+    publicMetadata['chat_subscription_expires_at'],
+  )
+  const expirationTime = chatExpiration?.getTime() ?? null
 
-    const publicMetadata = (user.publicMetadata ?? {}) as Record<
-      string,
-      unknown
-    >
-
-    const rawChatStatus = publicMetadata['chat_subscription_status']
-    const chatStatus = isValidStatus(rawChatStatus) ? rawChatStatus : null
-
-    const chatExpiration = parseExpiration(
-      publicMetadata['chat_subscription_expires_at'],
+  useEffect(() => {
+    if (expirationTime === null) return
+    const delay = expirationTime - Date.now()
+    if (delay <= 0) return
+    const timeout = window.setTimeout(
+      () => setExpirationTick((tick) => tick + 1),
+      Math.min(delay + 1, MAX_TIMEOUT_MS),
     )
+    return () => window.clearTimeout(timeout)
+  }, [expirationTime, expirationTick])
 
-    const now = new Date()
-    const chatActive = hasActiveSubscription(chatStatus, chatExpiration, now)
-
-    return { chat_subscription_active: chatActive }
-  }, [user, isLoaded])
+  const chatSubscriptionActive =
+    isLoaded &&
+    !!user &&
+    hasActiveSubscription(chatStatus, chatExpiration, new Date())
 
   // Persist subscription status so next page load can use it immediately
   useEffect(() => {
@@ -100,16 +103,18 @@ export function useSubscriptionStatus() {
       }
       localStorage.setItem(
         SETTINGS_CACHED_SUBSCRIPTION_STATUS,
-        JSON.stringify(subscriptionStatus),
+        JSON.stringify({
+          chat_subscription_active: chatSubscriptionActive,
+        }),
       )
     } catch {
       // best-effort
     }
-  }, [isLoaded, user, subscriptionStatus])
+  }, [isLoaded, user, chatSubscriptionActive])
 
   return {
     isLoading: !isLoaded,
     error: null,
-    ...subscriptionStatus,
+    chat_subscription_active: chatSubscriptionActive,
   }
 }

--- a/src/hooks/use-subscription-status.ts
+++ b/src/hooks/use-subscription-status.ts
@@ -67,7 +67,7 @@ export const hasActiveSubscription = (
  */
 export function useSubscriptionStatus() {
   const { user, isLoaded } = useUser()
-  const [expirationTick, setExpirationTick] = useState(0)
+  const [, setExpirationTick] = useState(0)
 
   const publicMetadata = (user?.publicMetadata ?? {}) as Record<string, unknown>
   const rawChatStatus = publicMetadata['chat_subscription_status']
@@ -79,14 +79,23 @@ export function useSubscriptionStatus() {
 
   useEffect(() => {
     if (expirationTime === null) return
-    const delay = expirationTime - Date.now()
-    if (delay <= 0) return
-    const timeout = window.setTimeout(
-      () => setExpirationTick((tick) => tick + 1),
-      Math.min(delay + 1, MAX_TIMEOUT_MS),
-    )
-    return () => window.clearTimeout(timeout)
-  }, [expirationTime, expirationTick])
+    let timeout: number | undefined
+    const scheduleExpiration = () => {
+      const delay = expirationTime - Date.now()
+      if (delay <= 0) {
+        setExpirationTick((tick) => tick + 1)
+        return
+      }
+      timeout = window.setTimeout(
+        scheduleExpiration,
+        Math.min(delay + 1, MAX_TIMEOUT_MS),
+      )
+    }
+    scheduleExpiration()
+    return () => {
+      if (timeout !== undefined) window.clearTimeout(timeout)
+    }
+  }, [expirationTime])
 
   const chatSubscriptionActive =
     isLoaded &&

--- a/src/services/inference/tinfoil-client.ts
+++ b/src/services/inference/tinfoil-client.ts
@@ -38,6 +38,7 @@ let cachedSessionTokenWasAuthenticated = false
 let cachedRateLimit: RateLimitInfo | null = null
 let remainingBeforeRequest: number | null = null
 let refreshInFlight: Promise<void> | null = null
+let sessionCacheGeneration = 0
 
 function dispatchRateLimitUpdate(): void {
   if (typeof window !== 'undefined') {
@@ -90,6 +91,7 @@ function surfaceHourlyLimit(parsedError: ServerErrorBody | null): never {
 // through the opaque path.
 async function fetchChatJWT(
   authBearer: string,
+  cacheGeneration: number,
 ): Promise<{ key: string; expiresAt: number | null } | null> {
   let response: Response
   try {
@@ -124,6 +126,7 @@ async function fetchChatJWT(
 
   const parsedError = parseErrorBody(await response.text())
   if (isHourlyLimit(response.status, parsedError)) {
+    if (cacheGeneration !== sessionCacheGeneration) return null
     surfaceHourlyLimit(parsedError)
   }
   return null
@@ -133,6 +136,8 @@ async function fetchSessionToken(): Promise<string> {
   if (IS_DEV) {
     return DEV_API_KEY
   }
+
+  const cacheGeneration = sessionCacheGeneration
 
   // If the user was previously signed in, wait for Clerk to initialize
   // the auth token manager before fetching — otherwise we'd get an
@@ -163,6 +168,9 @@ async function fetchSessionToken(): Promise<string> {
         },
       )
     }
+  }
+  if (cacheGeneration !== sessionCacheGeneration) {
+    return fetchSessionToken()
   }
   const usedAuthHeader = authBearer !== null
 
@@ -196,7 +204,10 @@ async function fetchSessionToken(): Promise<string> {
   // Anonymous users (and signed-in users without an active subscription) fall
   // back to the opaque /api/keys/chat path below.
   if (authBearer) {
-    const jwt = await fetchChatJWT(authBearer)
+    const jwt = await fetchChatJWT(authBearer, cacheGeneration)
+    if (cacheGeneration !== sessionCacheGeneration) {
+      return fetchSessionToken()
+    }
     if (jwt !== null) {
       cachedSessionToken = jwt.key
       cachedSessionTokenWasAuthenticated = true
@@ -216,9 +227,15 @@ async function fetchSessionToken(): Promise<string> {
   const response = await fetch(`${API_BASE_URL}/api/keys/chat`, {
     headers,
   })
+  if (cacheGeneration !== sessionCacheGeneration) {
+    return fetchSessionToken()
+  }
 
   if (!response.ok) {
     const errorText = await response.text()
+    if (cacheGeneration !== sessionCacheGeneration) {
+      return fetchSessionToken()
+    }
     logError('Failed to fetch session token from server', undefined, {
       component: 'tinfoil-client',
       action: 'fetchSessionToken',
@@ -242,6 +259,9 @@ async function fetchSessionToken(): Promise<string> {
   }
 
   const data = await response.json()
+  if (cacheGeneration !== sessionCacheGeneration) {
+    return fetchSessionToken()
+  }
   cachedSessionToken = data.key
   cachedSessionTokenWasAuthenticated = usedAuthHeader
   if (data.expires_at) {
@@ -295,7 +315,8 @@ export function snapshotAndDecrementRemaining(): void {
 export async function refreshRateLimit(): Promise<void> {
   if (refreshInFlight) return refreshInFlight
 
-  refreshInFlight = (async () => {
+  const refresh = (async () => {
+    const refreshGeneration = sessionCacheGeneration
     const snapshot = remainingBeforeRequest
     remainingBeforeRequest = null
     cachedSessionToken = null
@@ -303,6 +324,7 @@ export async function refreshRateLimit(): Promise<void> {
     try {
       await fetchSessionToken()
       if (
+        refreshGeneration === sessionCacheGeneration &&
         snapshot !== null &&
         cachedRateLimit &&
         cachedRateLimit.remaining >= snapshot
@@ -318,31 +340,38 @@ export async function refreshRateLimit(): Promise<void> {
         component: 'tinfoil-client',
         action: 'refreshRateLimit',
       })
-    } finally {
-      refreshInFlight = null
     }
   })()
+  refreshInFlight = refresh
 
-  return refreshInFlight
+  try {
+    await refresh
+  } finally {
+    if (refreshInFlight === refresh) {
+      refreshInFlight = null
+    }
+  }
 }
 
 export function resetTinfoilClient(): void {
+  sessionCacheGeneration++
   clientInstance = null
   secureClient = null
   lastSessionToken = null
   cachedSessionToken = null
   cachedSessionTokenExpiresAt = null
   cachedSessionTokenWasAuthenticated = false
-  remainingBeforeRequest = null
   cachedRateLimit = null
   remainingBeforeRequest = null
   refreshInFlight = null
 }
 
 export function invalidateSessionCache(): void {
+  sessionCacheGeneration++
   cachedSessionToken = null
   cachedSessionTokenExpiresAt = null
   cachedSessionTokenWasAuthenticated = false
+  remainingBeforeRequest = null
   if (cachedRateLimit !== null) {
     cachedRateLimit = null
     dispatchRateLimitUpdate()

--- a/src/services/inference/tinfoil-client.ts
+++ b/src/services/inference/tinfoil-client.ts
@@ -333,21 +333,16 @@ export function resetTinfoilClient(): void {
   cachedSessionToken = null
   cachedSessionTokenExpiresAt = null
   cachedSessionTokenWasAuthenticated = false
+  remainingBeforeRequest = null
   cachedRateLimit = null
   remainingBeforeRequest = null
   refreshInFlight = null
 }
 
-/**
- * Discards any cached anonymous session token + rate limit so the next
- * request fetches a fresh authenticated token from the server.  Called
- * after sign-in transitions so a leftover anonymous free-tier banner
- * does not persist for a now-authenticated user.
- */
-export function invalidateAnonymousSessionCache(): void {
-  if (cachedSessionTokenWasAuthenticated) return
+export function invalidateSessionCache(): void {
   cachedSessionToken = null
   cachedSessionTokenExpiresAt = null
+  cachedSessionTokenWasAuthenticated = false
   if (cachedRateLimit !== null) {
     cachedRateLimit = null
     dispatchRateLimitUpdate()

--- a/src/services/inference/tinfoil-client.ts
+++ b/src/services/inference/tinfoil-client.ts
@@ -40,6 +40,14 @@ let remainingBeforeRequest: number | null = null
 let refreshInFlight: Promise<void> | null = null
 let sessionCacheGeneration = 0
 
+class SessionCacheInvalidatedError extends Error {}
+
+function assertSessionCacheGeneration(cacheGeneration: number): void {
+  if (cacheGeneration !== sessionCacheGeneration) {
+    throw new SessionCacheInvalidatedError()
+  }
+}
+
 function dispatchRateLimitUpdate(): void {
   if (typeof window !== 'undefined') {
     window.dispatchEvent(new CustomEvent('rateLimitUpdated'))
@@ -126,18 +134,20 @@ async function fetchChatJWT(
 
   const parsedError = parseErrorBody(await response.text())
   if (isHourlyLimit(response.status, parsedError)) {
-    if (cacheGeneration !== sessionCacheGeneration) return null
+    assertSessionCacheGeneration(cacheGeneration)
     surfaceHourlyLimit(parsedError)
   }
   return null
 }
 
-async function fetchSessionToken(): Promise<string> {
+async function fetchSessionTokenForGeneration(
+  cacheGeneration: number,
+): Promise<string> {
   if (IS_DEV) {
     return DEV_API_KEY
   }
 
-  const cacheGeneration = sessionCacheGeneration
+  assertSessionCacheGeneration(cacheGeneration)
 
   // If the user was previously signed in, wait for Clerk to initialize
   // the auth token manager before fetching — otherwise we'd get an
@@ -169,9 +179,7 @@ async function fetchSessionToken(): Promise<string> {
       )
     }
   }
-  if (cacheGeneration !== sessionCacheGeneration) {
-    return fetchSessionToken()
-  }
+  assertSessionCacheGeneration(cacheGeneration)
   const usedAuthHeader = authBearer !== null
 
   // If the cached token was fetched anonymously but we now have an
@@ -205,9 +213,7 @@ async function fetchSessionToken(): Promise<string> {
   // back to the opaque /api/keys/chat path below.
   if (authBearer) {
     const jwt = await fetchChatJWT(authBearer, cacheGeneration)
-    if (cacheGeneration !== sessionCacheGeneration) {
-      return fetchSessionToken()
-    }
+    assertSessionCacheGeneration(cacheGeneration)
     if (jwt !== null) {
       cachedSessionToken = jwt.key
       cachedSessionTokenWasAuthenticated = true
@@ -227,15 +233,11 @@ async function fetchSessionToken(): Promise<string> {
   const response = await fetch(`${API_BASE_URL}/api/keys/chat`, {
     headers,
   })
-  if (cacheGeneration !== sessionCacheGeneration) {
-    return fetchSessionToken()
-  }
+  assertSessionCacheGeneration(cacheGeneration)
 
   if (!response.ok) {
     const errorText = await response.text()
-    if (cacheGeneration !== sessionCacheGeneration) {
-      return fetchSessionToken()
-    }
+    assertSessionCacheGeneration(cacheGeneration)
     logError('Failed to fetch session token from server', undefined, {
       component: 'tinfoil-client',
       action: 'fetchSessionToken',
@@ -259,9 +261,7 @@ async function fetchSessionToken(): Promise<string> {
   }
 
   const data = await response.json()
-  if (cacheGeneration !== sessionCacheGeneration) {
-    return fetchSessionToken()
-  }
+  assertSessionCacheGeneration(cacheGeneration)
   cachedSessionToken = data.key
   cachedSessionTokenWasAuthenticated = usedAuthHeader
   if (data.expires_at) {
@@ -282,6 +282,16 @@ async function fetchSessionToken(): Promise<string> {
   dispatchRateLimitUpdate()
 
   return data.key
+}
+
+async function fetchSessionToken(): Promise<string> {
+  while (true) {
+    try {
+      return await fetchSessionTokenForGeneration(sessionCacheGeneration)
+    } catch (error) {
+      if (!(error instanceof SessionCacheInvalidatedError)) throw error
+    }
+  }
 }
 
 export function getRateLimitInfo(): RateLimitInfo | null {
@@ -322,7 +332,7 @@ export async function refreshRateLimit(): Promise<void> {
     cachedSessionToken = null
     cachedSessionTokenExpiresAt = null
     try {
-      await fetchSessionToken()
+      await fetchSessionTokenForGeneration(refreshGeneration)
       if (
         refreshGeneration === sessionCacheGeneration &&
         snapshot !== null &&
@@ -336,6 +346,7 @@ export async function refreshRateLimit(): Promise<void> {
         dispatchRateLimitUpdate()
       }
     } catch (error) {
+      if (error instanceof SessionCacheInvalidatedError) return
       logError('Failed to refresh rate limit from server', error, {
         component: 'tinfoil-client',
         action: 'refreshRateLimit',
@@ -368,6 +379,7 @@ export function resetTinfoilClient(): void {
 
 export function invalidateSessionCache(): void {
   sessionCacheGeneration++
+  refreshInFlight = null
   cachedSessionToken = null
   cachedSessionTokenExpiresAt = null
   cachedSessionTokenWasAuthenticated = false

--- a/tests/hooks/use-subscription-status.test.ts
+++ b/tests/hooks/use-subscription-status.test.ts
@@ -18,6 +18,11 @@ describe('hasActiveSubscription', () => {
     expect(hasActiveSubscription('active', past, now)).toBe(false)
   })
 
+  it('allows trialing subscriptions with or without a future cutoff', () => {
+    expect(hasActiveSubscription('trialing', null, now)).toBe(true)
+    expect(hasActiveSubscription('trialing', future, now)).toBe(true)
+  })
+
   it('allows canceled subscriptions before their cutoff', () => {
     expect(hasActiveSubscription('canceled', future, now)).toBe(true)
   })

--- a/tests/hooks/use-subscription-status.test.ts
+++ b/tests/hooks/use-subscription-status.test.ts
@@ -1,0 +1,29 @@
+import { hasActiveSubscription } from '@/hooks/use-subscription-status'
+import { describe, expect, it } from 'vitest'
+
+describe('hasActiveSubscription', () => {
+  const now = new Date('2026-07-23T12:00:00Z')
+  const future = new Date('2026-08-23T12:00:00Z')
+  const past = new Date('2026-07-22T12:00:00Z')
+
+  it('allows active subscriptions without a cutoff', () => {
+    expect(hasActiveSubscription('active', null, now)).toBe(true)
+  })
+
+  it('allows active subscriptions before their cutoff', () => {
+    expect(hasActiveSubscription('active', future, now)).toBe(true)
+  })
+
+  it('rejects active subscriptions after their cutoff', () => {
+    expect(hasActiveSubscription('active', past, now)).toBe(false)
+  })
+
+  it('allows canceled subscriptions before their cutoff', () => {
+    expect(hasActiveSubscription('canceled', future, now)).toBe(true)
+  })
+
+  it('rejects canceled subscriptions without a future cutoff', () => {
+    expect(hasActiveSubscription('canceled', null, now)).toBe(false)
+    expect(hasActiveSubscription('canceled', past, now)).toBe(false)
+  })
+})

--- a/tests/services/inference/tinfoil-client-cache.test.ts
+++ b/tests/services/inference/tinfoil-client-cache.test.ts
@@ -1,0 +1,108 @@
+import {
+  getRateLimitInfo,
+  invalidateSessionCache,
+  refreshRateLimit,
+  resetTinfoilClient,
+} from '@/services/inference/tinfoil-client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/config', () => ({
+  API_BASE_URL: 'https://api.example.com',
+  DEV_API_KEY: '',
+  IS_DEV: false,
+}))
+
+vi.mock('@/services/auth', () => ({
+  authTokenManager: {
+    isInitialized: () => false,
+    waitForInit: vi.fn(),
+    getValidToken: vi.fn(),
+  },
+}))
+
+vi.mock('@/utils/error-handling', () => ({
+  logError: vi.fn(),
+}))
+
+const chatKeyResponse = (key: string, remaining: number) =>
+  new Response(
+    JSON.stringify({
+      key,
+      is_free_tier: true,
+      rate_limit: {
+        max_requests: 7,
+        remaining,
+        resets_at: '2026-07-24T00:00:00Z',
+      },
+    }),
+    { status: 200 },
+  )
+
+describe('tinfoil-client session cache', () => {
+  beforeEach(() => {
+    resetTinfoilClient()
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('does not restore stale rate limits after invalidation', async () => {
+    let resolveStaleResponse: (response: Response) => void = () => {}
+    const staleResponse = new Promise<Response>((resolve) => {
+      resolveStaleResponse = resolve
+    })
+    const fetchMock = vi
+      .fn()
+      .mockReturnValueOnce(staleResponse)
+      .mockResolvedValueOnce(chatKeyResponse('current-key', 6))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const refresh = refreshRateLimit()
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
+
+    invalidateSessionCache()
+    resolveStaleResponse(chatKeyResponse('stale-key', 1))
+    await refresh
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(getRateLimitInfo()?.remaining).toBe(6)
+  })
+
+  it('keeps tracking a newer refresh when an older refresh finishes', async () => {
+    let resolveOldResponse: (response: Response) => void = () => {}
+    let resolveNewResponse: (response: Response) => void = () => {}
+    const oldResponse = new Promise<Response>((resolve) => {
+      resolveOldResponse = resolve
+    })
+    const newResponse = new Promise<Response>((resolve) => {
+      resolveNewResponse = resolve
+    })
+    const fetchMock = vi
+      .fn()
+      .mockReturnValueOnce(oldResponse)
+      .mockReturnValueOnce(newResponse)
+      .mockResolvedValueOnce(chatKeyResponse('retried-key', 5))
+      .mockResolvedValue(chatKeyResponse('unexpected-key', 4))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const oldRefresh = refreshRateLimit()
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
+
+    resetTinfoilClient()
+    const newRefresh = refreshRateLimit()
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
+
+    resolveOldResponse(chatKeyResponse('stale-key', 1))
+    await oldRefresh
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+
+    const coalescedRefresh = refreshRateLimit()
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+
+    resolveNewResponse(chatKeyResponse('current-key', 6))
+    await Promise.all([newRefresh, coalescedRefresh])
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+  })
+})

--- a/tests/services/inference/tinfoil-client-cache.test.ts
+++ b/tests/services/inference/tinfoil-client-cache.test.ts
@@ -50,21 +50,30 @@ describe('tinfoil-client session cache', () => {
 
   it('does not restore stale rate limits after invalidation', async () => {
     let resolveStaleResponse: (response: Response) => void = () => {}
+    let resolveCurrentResponse: (response: Response) => void = () => {}
     const staleResponse = new Promise<Response>((resolve) => {
       resolveStaleResponse = resolve
+    })
+    const currentResponse = new Promise<Response>((resolve) => {
+      resolveCurrentResponse = resolve
     })
     const fetchMock = vi
       .fn()
       .mockReturnValueOnce(staleResponse)
-      .mockResolvedValueOnce(chatKeyResponse('current-key', 6))
+      .mockReturnValueOnce(currentResponse)
     vi.stubGlobal('fetch', fetchMock)
 
-    const refresh = refreshRateLimit()
+    const staleRefresh = refreshRateLimit()
     await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
 
     invalidateSessionCache()
+    const currentRefresh = refreshRateLimit()
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
+
     resolveStaleResponse(chatKeyResponse('stale-key', 1))
-    await refresh
+    await staleRefresh
+    resolveCurrentResponse(chatKeyResponse('current-key', 6))
+    await currentRefresh
 
     expect(fetchMock).toHaveBeenCalledTimes(2)
     expect(getRateLimitInfo()?.remaining).toBe(6)
@@ -83,7 +92,6 @@ describe('tinfoil-client session cache', () => {
       .fn()
       .mockReturnValueOnce(oldResponse)
       .mockReturnValueOnce(newResponse)
-      .mockResolvedValueOnce(chatKeyResponse('retried-key', 5))
       .mockResolvedValue(chatKeyResponse('unexpected-key', 4))
     vi.stubGlobal('fetch', fetchMock)
 
@@ -96,13 +104,13 @@ describe('tinfoil-client session cache', () => {
 
     resolveOldResponse(chatKeyResponse('stale-key', 1))
     await oldRefresh
-    expect(fetchMock).toHaveBeenCalledTimes(3)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
 
     const coalescedRefresh = refreshRateLimit()
-    expect(fetchMock).toHaveBeenCalledTimes(3)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
 
     resolveNewResponse(chatKeyResponse('current-key', 6))
     await Promise.all([newRefresh, coalescedRefresh])
-    expect(fetchMock).toHaveBeenCalledTimes(3)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
   })
 })


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Keep subscription access and rate-limit state in sync with sign-in/entitlement changes, and prevent stale cache updates. Tokens and banners update immediately on upgrade, downgrade, or expiry.

- **Bug Fixes**
  - Refresh creds on sign-in and `chat_subscription_active` changes; use generation guards and ignore stale refreshes so older responses can’t overwrite tokens or rate limits; rename `invalidateAnonymousSessionCache` -> `invalidateSessionCache`.
  - Only treat `active`/`trialing` as active until their expiry; auto-recheck at the cutoff and persist the computed status for faster reloads.

<sup>Written for commit 787a2f1f80c1ac1f8d2a8190d4eaf58a8ca8081e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/443?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

