### PR TITLE
fix: enable web search in new chats

### DIFF
--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -12,7 +12,6 @@ import {
   SETTINGS_HAS_SEEN_WEB_SEARCH_INTRO,
   SETTINGS_PII_CHECK_ENABLED,
   SETTINGS_WEB_SEARCH_AVAILABLE,
-  SETTINGS_WEB_SEARCH_ENABLED,
   UI_EXPAND_PROJECT_DOCUMENTS,
 } from '@/constants/storage-keys'
 import { useChatRouter } from '@/hooks/use-chat-router'
@@ -109,7 +108,11 @@ import {
   OPEN_ARTIFACT_PREVIEW_EVENT,
   type ArtifactPreviewSidebarDetail,
 } from './genui/widgets/ArtifactPreview'
-import { canToggleTemporaryChat, sortChats } from './hooks/chat-operations'
+import {
+  canToggleTemporaryChat,
+  resolveWebSearchEnabled,
+  sortChats,
+} from './hooks/chat-operations'
 import { useChatState } from './hooks/use-chat-state'
 import { useCustomSystemPrompt } from './hooks/use-custom-system-prompt'
 import { useMessageQueue } from './hooks/use-message-queue'
@@ -469,15 +472,6 @@ export function ChatInterface({
   const [artifactPreview, setArtifactPreview] =
     useState<ArtifactPreviewSidebarDetail | null>(null)
 
-  // Global web search default (persisted in localStorage). Serves as the
-  // fallback for chats without a per-chat preference; the toolbar toggle
-  // writes a per-chat override instead of mutating this value.
-  const [webSearchEnabled, setWebSearchEnabled] = useState(() => {
-    if (typeof window === 'undefined') return true
-    const saved = localStorage.getItem(SETTINGS_WEB_SEARCH_ENABLED)
-    return saved === null ? true : saved === 'true'
-  })
-
   const [webSearchAvailable, setWebSearchAvailable] = useState(() => {
     if (typeof window === 'undefined') return true
     const saved = localStorage.getItem(SETTINGS_WEB_SEARCH_AVAILABLE)
@@ -773,7 +767,6 @@ export function ChatInterface({
     thinkingEnabled,
     initialChatId,
     isLocalChatUrl,
-    webSearchEnabled,
     webSearchAvailable,
     // Feature flag gates key derivation in useExecSnapshot; the toggle
     // gates request plumbing. Both layers must be on to use code-exec.
@@ -785,10 +778,10 @@ export function ChatInterface({
 
   const isTemporaryMode = currentChat?.isTemporary === true
 
-  // Per-chat web search preference wins; chats that never touched the
-  // toggle fall back to the global default.
-  const effectiveWebSearchEnabled =
-    webSearchAvailable && (currentChat?.webSearchEnabled ?? webSearchEnabled)
+  const effectiveWebSearchEnabled = resolveWebSearchEnabled(
+    webSearchAvailable,
+    currentChat?.webSearchEnabled,
+  )
 
   const currentChatRef = useRef<Chat | null>(null)
   useEffect(() => {
@@ -1063,17 +1056,9 @@ export function ChatInterface({
     }
   }, [])
 
-  // Persist web search toggle to localStorage
-  useEffect(() => {
-    localStorage.setItem(SETTINGS_WEB_SEARCH_ENABLED, String(webSearchEnabled))
-  }, [webSearchEnabled])
-
   const handleWebSearchToggle = useCallback(() => {
-    if (!currentChat) {
-      setWebSearchEnabled((prev) => !prev)
-      return
-    }
-    const next = !(currentChat.webSearchEnabled ?? webSearchEnabled)
+    if (!currentChat) return
+    const next = !resolveWebSearchEnabled(true, currentChat.webSearchEnabled)
     const updatedChat: Chat = {
       ...currentChat,
       webSearchEnabled: next,
@@ -1098,7 +1083,7 @@ export function ChatInterface({
         })
       })
     }
-  }, [currentChat, webSearchEnabled, setCurrentChat, setChats, isSignedIn])
+  }, [currentChat, setCurrentChat, setChats, isSignedIn])
 
   // Persist code execution toggle to localStorage
   useEffect(() => {
@@ -1121,11 +1106,6 @@ export function ChatInterface({
   }, [])
 
   useEffect(() => {
-    const handleWebSearchChange = (
-      event: CustomEvent<{ enabled: boolean }>,
-    ) => {
-      setWebSearchEnabled(event.detail.enabled)
-    }
     const handleWebSearchAvailableChange = (
       event: CustomEvent<{ enabled: boolean }>,
     ) => {
@@ -1138,10 +1118,6 @@ export function ChatInterface({
     }
 
     window.addEventListener(
-      'webSearchEnabledChanged',
-      handleWebSearchChange as EventListener,
-    )
-    window.addEventListener(
       'webSearchAvailableChanged',
       handleWebSearchAvailableChange as EventListener,
     )
@@ -1151,10 +1127,6 @@ export function ChatInterface({
     )
 
     return () => {
-      window.removeEventListener(
-        'webSearchEnabledChanged',
-        handleWebSearchChange as EventListener,
-      )
       window.removeEventListener(
         'webSearchAvailableChanged',
         handleWebSearchAvailableChange as EventListener,

--- a/src/components/chat/hooks/chat-operations.ts
+++ b/src/components/chat/hooks/chat-operations.ts
@@ -28,6 +28,13 @@ export function canToggleTemporaryChat(chat: Chat | null | undefined): boolean {
   return !chat || chat.isBlankChat === true || chat.isTemporary === true
 }
 
+export function resolveWebSearchEnabled(
+  webSearchAvailable: boolean,
+  chatWebSearchEnabled?: boolean,
+): boolean {
+  return webSearchAvailable && (chatWebSearchEnabled ?? true)
+}
+
 /**
  * Loads all chats from storage
  */

--- a/src/components/chat/hooks/use-chat-messaging.ts
+++ b/src/components/chat/hooks/use-chat-messaging.ts
@@ -39,7 +39,11 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { getMessageAttachments, getMessageImages } from '../attachment-helpers'
 import { CONSTANTS } from '../constants'
 import type { Chat, LoadingState, Message } from '../types'
-import { createBlankChat, sortChats } from './chat-operations'
+import {
+  createBlankChat,
+  resolveWebSearchEnabled,
+  sortChats,
+} from './chat-operations'
 import { createUpdateChatWithHistoryCheck } from './chat-persistence'
 import { processStreamingResponse } from './streaming'
 import {
@@ -63,8 +67,6 @@ interface UseChatMessagingProps {
   scrollToBottom?: () => void
   reasoningEffort?: ReasoningEffort
   thinkingEnabled?: boolean
-  // Global default; the chat's own webSearchEnabled field overrides it.
-  webSearchEnabled?: boolean
   webSearchAvailable?: boolean
   codeExecutionEnabled?: boolean
   piiCheckEnabled?: boolean
@@ -116,7 +118,6 @@ export function useChatMessaging({
   scrollToBottom,
   reasoningEffort,
   thinkingEnabled,
-  webSearchEnabled,
   webSearchAvailable,
   codeExecutionEnabled,
   piiCheckEnabled,
@@ -624,9 +625,10 @@ export function useChatMessaging({
         const preferMultimodal = updatedMessages.some(
           (m) => getMessageImages(m).length > 0,
         )
-        const chatWebSearchEnabled =
-          (webSearchAvailable ?? true) &&
-          (updatedChat.webSearchEnabled ?? webSearchEnabled ?? true)
+        const chatWebSearchEnabled = resolveWebSearchEnabled(
+          webSearchAvailable ?? true,
+          updatedChat.webSearchEnabled,
+        )
         const preferToolCalling = Boolean(
           chatWebSearchEnabled ||
           codeExecutionEnabled ||
@@ -922,7 +924,6 @@ export function useChatMessaging({
       thinkingEnabled,
       isProjectMode,
       activeProject,
-      webSearchEnabled,
       webSearchAvailable,
       codeExecutionEnabled,
       piiCheckEnabled,

--- a/src/components/chat/hooks/use-chat-state.ts
+++ b/src/components/chat/hooks/use-chat-state.ts
@@ -97,7 +97,6 @@ export function useChatState({
   thinkingEnabled,
   initialChatId,
   isLocalChatUrl = false,
-  webSearchEnabled,
   webSearchAvailable,
   canUseCodeExecution = false,
   codeExecutionEnabled,
@@ -113,8 +112,6 @@ export function useChatState({
   thinkingEnabled?: boolean
   initialChatId?: string | null
   isLocalChatUrl?: boolean
-  // Global default; each chat's own webSearchEnabled field overrides it.
-  webSearchEnabled?: boolean
   webSearchAvailable?: boolean
   // Feature flag: when false, useExecSnapshot stays a no-op and no
   // key material is derived. Distinct from `codeExecutionEnabled`,
@@ -249,7 +246,6 @@ export function useChatState({
     scrollToBottom,
     reasoningEffort,
     thinkingEnabled,
-    webSearchEnabled,
     webSearchAvailable,
     // code-exec requires encryptionKey for snapshots
     codeExecutionEnabled:

--- a/tests/components/chat/chat-operations.test.ts
+++ b/tests/components/chat/chat-operations.test.ts
@@ -1,4 +1,7 @@
-import { canToggleTemporaryChat } from '@/components/chat/hooks/chat-operations'
+import {
+  canToggleTemporaryChat,
+  resolveWebSearchEnabled,
+} from '@/components/chat/hooks/chat-operations'
 import type { Chat } from '@/components/chat/types'
 import { describe, expect, it } from 'vitest'
 
@@ -31,5 +34,19 @@ describe('canToggleTemporaryChat', () => {
         createChat({ isBlankChat: false, isTemporary: true }),
       ),
     ).toBe(true)
+  })
+})
+
+describe('resolveWebSearchEnabled', () => {
+  it('enables web search by default when it is available', () => {
+    expect(resolveWebSearchEnabled(true)).toBe(true)
+  })
+
+  it('preserves an existing chat override', () => {
+    expect(resolveWebSearchEnabled(true, false)).toBe(false)
+  })
+
+  it('disables web search when it is unavailable', () => {
+    expect(resolveWebSearchEnabled(false, true)).toBe(false)
   })
 })


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enable web search by default in new chats and honor per‑chat overrides. Removed the old global/localStorage toggle so behavior is consistent and predictable.

- **Bug Fixes**
  - New chats start with web search ON when available; existing chat overrides still apply.
  - Web search toggle updates the current chat only; removed global persistence and related events.
  - Centralized logic via `resolveWebSearchEnabled` used in UI and messaging; added unit tests.

<sup>Written for commit fab9c9a312462bfe11700edf1ea763f21e1b6604. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/444?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

