### PR TITLE
fix: apply saved chat font before the page first renders

### DIFF
--- a/src/components/chat/chat-input.tsx
+++ b/src/components/chat/chat-input.tsx
@@ -34,7 +34,6 @@ import {
 } from './components/context-usage-indicator'
 import { MacFileIcon } from './components/mac-file-icon'
 import { CONSTANTS } from './constants'
-import { CHAT_FONT_CLASSES, useChatFont } from './hooks/use-chat-font'
 import type { PromptPreset } from './prompts/types'
 import type { ProcessedDocument } from './renderers/types'
 import type { LoadingState } from './types'
@@ -124,7 +123,6 @@ export function ChatInput({
   const fileInputRef = useRef<HTMLInputElement>(null)
   const documentsScrollRef = useRef<HTMLDivElement>(null)
   const { toast } = useToast()
-  const chatFont = useChatFont()
   const { isProjectMode, activeProject, loadingProject } = useProject()
   const [textareaResetNonce, setTextareaResetNonce] = useState(0)
   const prevInputValueRef = useRef(input)
@@ -1086,8 +1084,7 @@ export function ChatInput({
             placeholder={hasMessages ? 'Reply to Tin...' : placeholder}
             rows={1}
             className={cn(
-              'w-full resize-none bg-transparent text-lg leading-relaxed text-content-primary placeholder:text-content-muted focus:outline-none',
-              CHAT_FONT_CLASSES[chatFont],
+              'w-full resize-none bg-transparent font-chat text-lg leading-relaxed text-content-primary placeholder:text-content-muted focus:outline-none',
             )}
             style={{
               minHeight: inputMinHeight,

--- a/src/components/chat/chat-messages.tsx
+++ b/src/components/chat/chat-messages.tsx
@@ -9,7 +9,6 @@ import 'katex/dist/katex.min.css'
 import React, { memo, useEffect, useMemo, useRef, useState } from 'react'
 import { CONSTANTS } from './constants'
 import { ensureTimeline } from './ensure-timeline'
-import { CHAT_FONT_CLASSES, useChatFont } from './hooks/use-chat-font'
 import type { ReasoningEffort } from './hooks/use-reasoning-effort'
 import { ImageGalleryProvider } from './image-gallery-context'
 import { PrintableChat } from './PrintableChat'
@@ -236,7 +235,6 @@ export function ChatMessages({
   onSelectPromptPreset,
 }: ChatMessagesProps) {
   const [mounted, setMounted] = useState(false)
-  const chatFont = useChatFont()
   const [showSpacer, setShowSpacer] = useState(false)
   const prevMessageCountRef = React.useRef(messages.length)
   const prevShowScrollButtonRef = React.useRef(showScrollButton)
@@ -372,7 +370,7 @@ export function ChatMessages({
         aria-label="Conversation"
         aria-live="polite"
         aria-busy={isStreamingResponse}
-        className={`mx-auto w-full min-w-0 px-0 pb-6 pt-24 md:px-4 ${CHAT_FONT_CLASSES[chatFont]}`}
+        className="mx-auto w-full min-w-0 px-0 pb-6 pt-24 font-chat md:px-4"
       >
         {/* Archived Messages - only shown if there are more than the max prompt messages */}
         {archivedMessages.length > 0 && (

--- a/src/components/chat/hooks/use-chat-font.ts
+++ b/src/components/chat/hooks/use-chat-font.ts
@@ -1,14 +1,7 @@
 import { SETTINGS_CHAT_FONT } from '@/constants/storage-keys'
-import { useEffect, useState } from 'react'
+import { useEffect } from 'react'
 
 export type ChatFont = 'system' | 'serif' | 'mono' | 'dyslexic'
-
-export const CHAT_FONT_CLASSES: Record<ChatFont, string> = {
-  system: 'font-system',
-  serif: 'font-lora',
-  mono: 'font-aeonik-fono',
-  dyslexic: 'font-opendyslexic',
-}
 
 export const normalizeChatFont = (
   value: string | null | undefined,
@@ -20,18 +13,19 @@ export const normalizeChatFont = (
   return 'system'
 }
 
-export const useChatFont = () => {
-  const [chatFont, setChatFont] = useState<ChatFont>('system')
+const applyChatFont = (font: ChatFont) => {
+  document.documentElement.setAttribute('data-chat-font', font)
+}
 
+/**
+ * Keeps the data-chat-font attribute on <html> in sync with the saved
+ * setting. The attribute is first set before paint by an inline script in
+ * _document.tsx; elements using the `font-chat` class pick the font up from
+ * CSS (see globals.css), so no per-component state is needed.
+ */
+export const useChatFontSync = () => {
   useEffect(() => {
-    const loadChatFont = () => {
-      if (typeof window !== 'undefined') {
-        const saved = localStorage.getItem(SETTINGS_CHAT_FONT)
-        setChatFont(normalizeChatFont(saved))
-      }
-    }
-
-    loadChatFont()
+    applyChatFont(normalizeChatFont(localStorage.getItem(SETTINGS_CHAT_FONT)))
 
     const handleStorageChange = (e: StorageEvent | CustomEvent) => {
       let key: string | null = null
@@ -46,7 +40,7 @@ export const useChatFont = () => {
       }
 
       if (key === SETTINGS_CHAT_FONT) {
-        setChatFont(normalizeChatFont(newValue))
+        applyChatFont(normalizeChatFont(newValue))
       }
     }
 
@@ -63,6 +57,4 @@ export const useChatFont = () => {
       )
     }
   }, [])
-
-  return chatFont
 }

--- a/src/components/chat/hooks/use-chat-font.ts
+++ b/src/components/chat/hooks/use-chat-font.ts
@@ -25,7 +25,13 @@ const applyChatFont = (font: ChatFont) => {
  */
 export const useChatFontSync = () => {
   useEffect(() => {
-    applyChatFont(normalizeChatFont(localStorage.getItem(SETTINGS_CHAT_FONT)))
+    let saved: string | null = null
+    try {
+      saved = localStorage.getItem(SETTINGS_CHAT_FONT)
+    } catch {
+      // Storage can be blocked (e.g. disabled cookies); keep the default font.
+    }
+    applyChatFont(normalizeChatFont(saved))
 
     const handleStorageChange = (e: StorageEvent | CustomEvent) => {
       let key: string | null = null

--- a/src/components/chat/renderers/default/DefaultMessageRenderer.tsx
+++ b/src/components/chat/renderers/default/DefaultMessageRenderer.tsx
@@ -13,7 +13,6 @@ import { BsCheckLg } from 'react-icons/bs'
 import { GoClockFill } from 'react-icons/go'
 import { RxCopy } from 'react-icons/rx'
 import { hasMessageAttachments } from '../../attachment-helpers'
-import { CHAT_FONT_CLASSES, useChatFont } from '../../hooks/use-chat-font'
 import { CodeExecProcess } from '../components/CodeExecProcess'
 import { DocumentList } from '../components/DocumentList'
 import { MessageActions } from '../components/MessageActions'
@@ -36,7 +35,6 @@ const DefaultMessageComponent = ({
   onRegenerateMessage,
 }: MessageRenderProps) => {
   const isUser = message.role === 'user'
-  const chatFont = useChatFont()
   const [isEditing, setIsEditing] = React.useState(false)
   const [editContent, setEditContent] = React.useState(message.content || '')
   const [copiedUser, setCopiedUser] = React.useState(false)
@@ -567,8 +565,7 @@ const DefaultMessageComponent = ({
                       }
                     }}
                     className={cn(
-                      'w-full resize-none bg-transparent text-base leading-relaxed text-content-primary placeholder:text-content-muted focus:outline-none',
-                      CHAT_FONT_CLASSES[chatFont],
+                      'w-full resize-none bg-transparent font-chat text-base leading-relaxed text-content-primary placeholder:text-content-muted focus:outline-none',
                     )}
                     rows={Math.min(
                       10,

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,4 +1,5 @@
 import { AuthCleanupHandler } from '@/components/auth-cleanup-handler'
+import { useChatFontSync } from '@/components/chat/hooks/use-chat-font'
 import { SignoutProgressOverlay } from '@/components/signout-progress-overlay'
 import { Toaster } from '@/components/ui/toaster'
 import '@/styles/globals.css'
@@ -114,6 +115,8 @@ const openDyslexic = localFont({
 migrateStorageKeys()
 
 export default function App({ Component, pageProps }: AppProps) {
+  useChatFontSync()
+
   return (
     <>
       <Head>

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -33,6 +33,21 @@ export default function Document() {
     })();
   `
 
+  // Inline script to apply the saved chat font before first paint. The app is
+  // statically exported, so the prerendered HTML would otherwise show the
+  // default font until React hydrates. CSS keys the chat font off this
+  // attribute (see globals.css).
+  const chatFontScript = `
+    (function() {
+      try {
+        var font = localStorage.getItem('tinfoil-settings-chat-font');
+        if (font === 'serif' || font === 'mono' || font === 'dyslexic') {
+          document.documentElement.setAttribute('data-chat-font', font);
+        }
+      } catch (_) {}
+    })();
+  `
+
   // Inline script to set --app-height before first paint, so the bottom-anchored
   // chat input is positioned correctly on every browser, including ones that
   // don't support 100dvh (older Chrome/Firefox/Edge on Android, in-app webviews).
@@ -58,6 +73,7 @@ export default function Document() {
     <Html lang="en" data-theme="light" className="overflow-x-hidden">
       <Head>
         <script dangerouslySetInnerHTML={{ __html: themeScript }} />
+        <script dangerouslySetInnerHTML={{ __html: chatFontScript }} />
         <script dangerouslySetInnerHTML={{ __html: appHeightScript }} />
         <link rel="preconnect" href="https://clerk.accounts.dev" />
 

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -36,11 +36,15 @@ export default function Document() {
   // Inline script to apply the saved chat font before first paint. The app is
   // statically exported, so the prerendered HTML would otherwise show the
   // default font until React hydrates. CSS keys the chat font off this
-  // attribute (see globals.css).
+  // attribute (see globals.css). The storage key and font names must stay in
+  // sync with SETTINGS_CHAT_FONT (constants/storage-keys.ts) and
+  // normalizeChatFont (components/chat/hooks/use-chat-font.ts). The legacy
+  // 'chatFont' key is read as a fallback until migrateStorageKeys() runs.
   const chatFontScript = `
     (function() {
       try {
-        var font = localStorage.getItem('tinfoil-settings-chat-font');
+        var font = localStorage.getItem('tinfoil-settings-chat-font')
+          || localStorage.getItem('chatFont');
         if (font === 'serif' || font === 'mono' || font === 'dyslexic') {
           document.documentElement.setAttribute('data-chat-font', font);
         }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,3 +1,22 @@
+/* Chat font selection. The data-chat-font attribute is set on <html> before
+   first paint (see _document.tsx) and kept in sync by useChatFontSync, so the
+   statically exported HTML renders with the saved font immediately. The
+   font-chat Tailwind utility reads this variable. */
+:root {
+  --font-chat:
+    system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
+    Helvetica, Arial, sans-serif;
+}
+html[data-chat-font='serif'] {
+  --font-chat: var(--font-lora), serif;
+}
+html[data-chat-font='mono'] {
+  --font-chat: var(--font-aeonik-fono), sans-serif;
+}
+html[data-chat-font='dyslexic'] {
+  --font-chat: var(--font-opendyslexic), sans-serif;
+}
+
 /* Use dynamic viewport units for better mobile handling */
 .h-dvh {
   height: 100dvh;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -36,6 +36,9 @@ module.exports = {
         ],
         opendyslexic: ['var(--font-opendyslexic)', 'sans-serif'],
         lora: ['var(--font-lora)', 'serif'],
+        // User-selected chat font, resolved via the data-chat-font attribute
+        // on <html> (see globals.css)
+        chat: ['var(--font-chat)'],
         mono: ['ui-monospace', 'SFMono-Regular', 'Consolas', 'monospace'],
       },
       borderRadius: {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Apply the saved chat font before first paint to remove the font flash in chat views. Uses a `data-chat-font` attribute and a CSS variable so the correct font renders immediately.

- **Bug Fixes**
  - Add inline script in `_document.tsx` to set `data-chat-font` from `localStorage` before paint, with a fallback to the legacy `chatFont` key.
  - Introduce `--font-chat` in `globals.css` and Tailwind `font-chat`; update chat components to use `font-chat`.
  - Replace `useChatFont` and `CHAT_FONT_CLASSES` with `useChatFontSync` in `_app` to keep the attribute in sync via storage events and tolerate blocked storage.

<sup>Written for commit f2cdd1c15c03be6c809973a234697a125af9eb79. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/445?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

