### PR TITLE
Fix: message queue send

### DIFF
--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -852,6 +852,7 @@ export function ChatInterface({
     queuedMessages,
     submit: submitMessage,
     removeQueuedMessage,
+    sendQueuedMessage,
   } = useMessageQueue({
     chatId: currentChat?.id ?? null,
     loadingState,
@@ -3463,6 +3464,7 @@ export function ChatInterface({
                       <MessageQueue
                         queue={queuedMessages}
                         onRemove={removeQueuedMessage}
+                        onSend={sendQueuedMessage}
                       />
                       <ChatInput
                         input={input}

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -853,6 +853,7 @@ export function ChatInterface({
     submit: submitMessage,
     removeQueuedMessage,
     sendQueuedMessage,
+    notifyGenerationCancelled,
   } = useMessageQueue({
     chatId: currentChat?.id ?? null,
     loadingState,
@@ -860,7 +861,17 @@ export function ChatInterface({
     isRateLimited,
     onBeforeDispatch: handleQueueDispatch,
     onRateLimited: handleQueueRateLimited,
+    cancelGeneration,
   })
+
+  // Stop button path: tell the queue about the cancellation first so its
+  // pump abandons the cancelled dispatch (whose promise may never settle)
+  // and resumes draining queued messages once the chat goes idle.
+  const cancelGenerationAndResumeQueue = useCallback(() => {
+    const id = currentChat?.id
+    if (id != null) notifyGenerationCancelled(id)
+    void cancelGeneration()
+  }, [currentChat?.id, notifyGenerationCancelled, cancelGeneration])
 
   const canEnableCodeExecution =
     canUseCodeExecution && codeExecutionEncryptionKey != null
@@ -3370,7 +3381,7 @@ export function ChatInterface({
                     setInput={setInput}
                     loadingState={loadingState}
                     retryInfo={retryInfo}
-                    cancelGeneration={cancelGeneration}
+                    cancelGeneration={cancelGenerationAndResumeQueue}
                     inputRef={inputRef}
                     handleInputFocus={handleInputFocusWithRateLimitCheck}
                     handleDocumentUpload={handleFileUpload}
@@ -3471,7 +3482,7 @@ export function ChatInterface({
                         setInput={setInput}
                         handleSubmit={handleSubmit}
                         loadingState={loadingState}
-                        cancelGeneration={cancelGeneration}
+                        cancelGeneration={cancelGenerationAndResumeQueue}
                         inputRef={inputRef}
                         handleInputFocus={handleInputFocusWithRateLimitCheck}
                         inputMinHeight={inputMinHeight}

--- a/src/components/chat/hooks/use-message-queue.ts
+++ b/src/components/chat/hooks/use-message-queue.ts
@@ -29,6 +29,7 @@ type UseMessageQueueReturn = {
   queuedMessages: QueuedMessage[]
   submit: (input: QueueSubmitInput) => void
   removeQueuedMessage: (id: string) => void
+  sendQueuedMessage: (id: string) => void
 }
 
 const isBrowser = typeof window !== 'undefined'
@@ -345,5 +346,66 @@ export function useMessageQueue({
     [getQueue, setQueueFor],
   )
 
-  return { queuedMessages: queue, submit, removeQueuedMessage }
+  // Explicit "send now" for a single queued message. Dispatches directly
+  // (bypassing the pump) so it works even when a pump is wedged awaiting a
+  // cancelled stream's promise. While the chat is still busy it instead
+  // promotes the message to the front of the queue, since dispatching into
+  // a non-idle chat would be silently dropped by handleQuery's busy guard.
+  const sendQueuedMessage = useCallback(
+    (queuedId: string): void => {
+      const id = currentChatIdRef.current
+      if (id == null) return
+      const currentQueue = getQueue(id)
+      const item = currentQueue.find((m) => m.id === queuedId)
+      if (!item) return
+
+      if (loadingStateRef.current !== 'idle') {
+        setQueueFor(id, [
+          item,
+          ...currentQueue.filter((m) => m.id !== queuedId),
+        ])
+        void runPump(id)
+        return
+      }
+
+      if (isRateLimitedRef.current()) {
+        if (!rateLimitPromptShownRef.current) {
+          rateLimitPromptShownRef.current = true
+          onRateLimitedRef.current?.()
+        }
+        return
+      }
+      rateLimitPromptShownRef.current = false
+
+      setQueueFor(
+        id,
+        currentQueue.filter((m) => m.id !== queuedId),
+      )
+      onBeforeDispatchRef.current?.()
+      try {
+        const result = handleQueryRef.current(
+          item.text,
+          item.attachments,
+          undefined,
+          undefined,
+          item.quote,
+        )
+        if (result && typeof (result as Promise<unknown>).then === 'function') {
+          void (result as Promise<unknown>).catch(() => {
+            /* errors are surfaced by the chat itself */
+          })
+        }
+      } catch {
+        /* errors are surfaced by the chat itself */
+      }
+    },
+    [getQueue, setQueueFor, runPump],
+  )
+
+  return {
+    queuedMessages: queue,
+    submit,
+    removeQueuedMessage,
+    sendQueuedMessage,
+  }
 }

--- a/src/components/chat/hooks/use-message-queue.ts
+++ b/src/components/chat/hooks/use-message-queue.ts
@@ -23,6 +23,7 @@ type UseMessageQueueArgs = {
   isRateLimited: () => boolean
   onBeforeDispatch?: () => void
   onRateLimited?: () => void
+  cancelGeneration?: (chatId?: string) => void | Promise<void>
 }
 
 type UseMessageQueueReturn = {
@@ -30,6 +31,7 @@ type UseMessageQueueReturn = {
   submit: (input: QueueSubmitInput) => void
   removeQueuedMessage: (id: string) => void
   sendQueuedMessage: (id: string) => void
+  notifyGenerationCancelled: (chatId: string) => void
 }
 
 const isBrowser = typeof window !== 'undefined'
@@ -98,6 +100,16 @@ function writeToStorage(key: string | null, queue: QueuedMessage[]): void {
  *   then loops to the next message. Stale `loadingState` writes from a
  *   previously-cancelled stream can't trigger anything because nothing
  *   observes them.
+ *
+ * Cancellation (Stop button):
+ *
+ *   A cancelled stream's promise is not guaranteed to settle (cleanup can
+ *   hang), which would wedge the pump forever. Callers report explicit
+ *   cancellations via `notifyGenerationCancelled(chatId)`; the pump races
+ *   its dispatch await against that signal, abandons the dead promise,
+ *   and resumes draining once the chat settles back to idle. This is an
+ *   explicit structured signal, not a `loadingState` heuristic, so stale
+ *   idle writes still can't cause a parallel dispatch.
  */
 export function useMessageQueue({
   chatId,
@@ -106,6 +118,7 @@ export function useMessageQueue({
   isRateLimited,
   onBeforeDispatch,
   onRateLimited,
+  cancelGeneration,
 }: UseMessageQueueArgs): UseMessageQueueReturn {
   // Per-chat queues so several conversations can hold pending messages at
   // once. Hydrated lazily from sessionStorage on first access.
@@ -149,10 +162,12 @@ export function useMessageQueue({
   const isRateLimitedRef = useRef(isRateLimited)
   const onBeforeDispatchRef = useRef(onBeforeDispatch)
   const onRateLimitedRef = useRef(onRateLimited)
+  const cancelGenerationRef = useRef(cancelGeneration)
   handleQueryRef.current = handleQuery
   isRateLimitedRef.current = isRateLimited
   onBeforeDispatchRef.current = onBeforeDispatch
   onRateLimitedRef.current = onRateLimited
+  cancelGenerationRef.current = cancelGeneration
 
   // Live mirror of the active chat's `loadingState`, used by the pump to
   // gate the next dispatch on that chat actually being idle.
@@ -178,6 +193,47 @@ export function useMessageQueue({
 
   // Rate-limit prompt latch: show at most once per exhaustion window.
   const rateLimitPromptShownRef = useRef(false)
+
+  // Resolvers armed while a pump awaits a dispatch, keyed by chat id.
+  // Fired by `notifyGenerationCancelled` so a cancelled stream whose
+  // promise never settles can't wedge the pump.
+  const cancelWaitersRef = useRef<Map<string, Set<() => void>>>(new Map())
+
+  const notifyGenerationCancelled = useCallback((id: string): void => {
+    const waiters = cancelWaitersRef.current.get(id)
+    if (!waiters) return
+    cancelWaitersRef.current.delete(id)
+    for (const resolve of waiters) resolve()
+  }, [])
+
+  // Resolves when the given chat's generation is explicitly cancelled.
+  // `arm` registers the resolver; callers must `disarm` after the race so
+  // abandoned resolvers don't accumulate.
+  const armCancelWaiter = useCallback(
+    (id: string): { promise: Promise<void>; disarm: () => void } => {
+      let resolver!: () => void
+      const promise = new Promise<void>((resolve) => {
+        resolver = resolve
+      })
+      let set = cancelWaitersRef.current.get(id)
+      if (!set) {
+        set = new Set()
+        cancelWaitersRef.current.set(id, set)
+      }
+      set.add(resolver)
+      // Scan every entry rather than only `id`: a blank chat's waiters get
+      // re-keyed to the real id mid-dispatch (see the chat-sync effect).
+      const disarm = () => {
+        for (const [key, current] of cancelWaitersRef.current) {
+          if (current.delete(resolver) && current.size === 0) {
+            cancelWaitersRef.current.delete(key)
+          }
+        }
+      }
+      return { promise, disarm }
+    },
+    [],
+  )
 
   // One single-flight pump per chat. Dispatch always targets the chat on
   // screen (handleQuery is bound to it), so the pump only proceeds while
@@ -228,7 +284,20 @@ export function useMessageQueue({
               result &&
               typeof (result as Promise<unknown>).then === 'function'
             ) {
-              await (result as Promise<unknown>)
+              // Race the dispatch against an explicit cancellation signal:
+              // a cancelled stream's promise may never settle, and without
+              // the race the pump would wedge on it and stop draining.
+              const cancelWaiter = armCancelWaiter(pump.id)
+              try {
+                await Promise.race([
+                  (result as Promise<unknown>).catch(() => {
+                    /* errors are surfaced by the chat itself; keep draining */
+                  }),
+                  cancelWaiter.promise,
+                ])
+              } finally {
+                cancelWaiter.disarm()
+              }
             }
           } catch {
             /* errors are surfaced by the chat itself; keep draining */
@@ -253,7 +322,7 @@ export function useMessageQueue({
         }
       }
     },
-    [getQueue, setQueueFor, waitForIdle],
+    [getQueue, setQueueFor, waitForIdle, armCancelWaiter],
   )
 
   // When the rate limit clears, reset the one-shot prompt latch and resume
@@ -326,6 +395,18 @@ export function useMessageQueue({
         pumpsRef.current.delete('')
         pumpsRef.current.set(chatId, pump)
       }
+      // Follow the conversion for armed cancel waiters too, so a Stop on
+      // the (now real) chat still unwedges a dispatch started while blank.
+      const cancelWaiters = cancelWaitersRef.current.get('')
+      if (cancelWaiters) {
+        cancelWaitersRef.current.delete('')
+        const existing = cancelWaitersRef.current.get(chatId)
+        if (existing) {
+          for (const waiter of cancelWaiters) existing.add(waiter)
+        } else {
+          cancelWaitersRef.current.set(chatId, cancelWaiters)
+        }
+      }
     }
 
     setQueue(getQueue(chatId))
@@ -346,11 +427,14 @@ export function useMessageQueue({
     [getQueue, setQueueFor],
   )
 
-  // Explicit "send now" for a single queued message. Dispatches directly
-  // (bypassing the pump) so it works even when a pump is wedged awaiting a
-  // cancelled stream's promise. While the chat is still busy it instead
-  // promotes the message to the front of the queue, since dispatching into
-  // a non-idle chat would be silently dropped by handleQuery's busy guard.
+  // Explicit "send now" for a single queued message. When the chat is
+  // idle it dispatches directly (bypassing the pump) so it works even if a
+  // pump is wedged awaiting a dead promise. When the chat is still busy it
+  // interrupts: the message is promoted to the front of the queue, the
+  // active stream is cancelled, and the pump dispatches it as soon as the
+  // cancellation settles the chat back to idle. Dispatching straight into
+  // a busy chat is never attempted since handleQuery's busy guard would
+  // silently drop the message.
   const sendQueuedMessage = useCallback(
     (queuedId: string): void => {
       const id = currentChatIdRef.current
@@ -364,6 +448,8 @@ export function useMessageQueue({
           item,
           ...currentQueue.filter((m) => m.id !== queuedId),
         ])
+        notifyGenerationCancelled(id)
+        void cancelGenerationRef.current?.(id)
         void runPump(id)
         return
       }
@@ -399,7 +485,7 @@ export function useMessageQueue({
         /* errors are surfaced by the chat itself */
       }
     },
-    [getQueue, setQueueFor, runPump],
+    [getQueue, setQueueFor, runPump, notifyGenerationCancelled],
   )
 
   return {
@@ -407,5 +493,6 @@ export function useMessageQueue({
     submit,
     removeQueuedMessage,
     sendQueuedMessage,
+    notifyGenerationCancelled,
   }
 }

--- a/src/components/chat/hooks/use-message-queue.ts
+++ b/src/components/chat/hooks/use-message-queue.ts
@@ -427,14 +427,15 @@ export function useMessageQueue({
     [getQueue, setQueueFor],
   )
 
-  // Explicit "send now" for a single queued message. When the chat is
-  // idle it dispatches directly (bypassing the pump) so it works even if a
-  // pump is wedged awaiting a dead promise. When the chat is still busy it
-  // interrupts: the message is promoted to the front of the queue, the
-  // active stream is cancelled, and the pump dispatches it as soon as the
-  // cancellation settles the chat back to idle. Dispatching straight into
-  // a busy chat is never attempted since handleQuery's busy guard would
-  // silently drop the message.
+  // Explicit "send now" for a single queued message: promote it to the
+  // front of the queue and let the pump dispatch it, so every send stays
+  // serialized and the rest of the queue keeps draining afterwards. The
+  // cancel signal unwedges a pump parked on a dead dispatch (making the
+  // button work even then), and when the chat is still busy the active
+  // stream is cancelled so the promoted message goes out as soon as the
+  // chat settles back to idle. Dispatching straight into a busy chat is
+  // never attempted since handleQuery's busy guard would silently drop
+  // the message.
   const sendQueuedMessage = useCallback(
     (queuedId: string): void => {
       const id = currentChatIdRef.current
@@ -443,47 +444,12 @@ export function useMessageQueue({
       const item = currentQueue.find((m) => m.id === queuedId)
       if (!item) return
 
+      setQueueFor(id, [item, ...currentQueue.filter((m) => m.id !== queuedId)])
+      notifyGenerationCancelled(id)
       if (loadingStateRef.current !== 'idle') {
-        setQueueFor(id, [
-          item,
-          ...currentQueue.filter((m) => m.id !== queuedId),
-        ])
-        notifyGenerationCancelled(id)
         void cancelGenerationRef.current?.(id)
-        void runPump(id)
-        return
       }
-
-      if (isRateLimitedRef.current()) {
-        if (!rateLimitPromptShownRef.current) {
-          rateLimitPromptShownRef.current = true
-          onRateLimitedRef.current?.()
-        }
-        return
-      }
-      rateLimitPromptShownRef.current = false
-
-      setQueueFor(
-        id,
-        currentQueue.filter((m) => m.id !== queuedId),
-      )
-      onBeforeDispatchRef.current?.()
-      try {
-        const result = handleQueryRef.current(
-          item.text,
-          item.attachments,
-          undefined,
-          undefined,
-          item.quote,
-        )
-        if (result && typeof (result as Promise<unknown>).then === 'function') {
-          void (result as Promise<unknown>).catch(() => {
-            /* errors are surfaced by the chat itself */
-          })
-        }
-      } catch {
-        /* errors are surfaced by the chat itself */
-      }
+      void runPump(id)
     },
     [getQueue, setQueueFor, runPump, notifyGenerationCancelled],
   )

--- a/src/components/chat/message-queue.tsx
+++ b/src/components/chat/message-queue.tsx
@@ -1,3 +1,4 @@
+import { FiArrowUp } from '@/components/icons/lazy-icons'
 import { cn } from '@/components/ui/utils'
 import { TrashIcon } from '@heroicons/react/24/outline'
 import { HiOutlineQueueList } from 'react-icons/hi2'
@@ -41,9 +42,10 @@ function QueuedImagePreview({ attachments }: { attachments?: Attachment[] }) {
 type MessageQueueProps = {
   queue: QueuedMessage[]
   onRemove: (id: string) => void
+  onSend: (id: string) => void
 }
 
-export function MessageQueue({ queue, onRemove }: MessageQueueProps) {
+export function MessageQueue({ queue, onRemove, onSend }: MessageQueueProps) {
   if (queue.length === 0) return null
 
   return (
@@ -77,6 +79,14 @@ export function MessageQueue({ queue, onRemove }: MessageQueueProps) {
                 {truncated || fallbackLabel}
               </p>
             </div>
+            <button
+              type="button"
+              onClick={() => onSend(item.id)}
+              aria-label="Send queued message now"
+              className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full text-content-secondary transition-colors hover:bg-surface-chat-background hover:text-content-primary"
+            >
+              <FiArrowUp className="h-4 w-4" />
+            </button>
             <button
               type="button"
               onClick={() => onRemove(item.id)}

--- a/tests/components/chat/message-queue.test.tsx
+++ b/tests/components/chat/message-queue.test.tsx
@@ -1,5 +1,5 @@
 import { MessageQueue } from '@/components/chat/message-queue'
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 
 describe('MessageQueue', () => {
@@ -23,10 +23,36 @@ describe('MessageQueue', () => {
           },
         ]}
         onRemove={vi.fn()}
+        onSend={vi.fn()}
       />,
     )
 
     const image = screen.getByRole('img', { name: 'cat.png' })
     expect(image).toHaveAttribute('src', 'data:image/png;base64,thumbnail-data')
+  })
+
+  it('sends the clicked queued message via the send button', () => {
+    const onSend = vi.fn()
+    const onRemove = vi.fn()
+    render(
+      <MessageQueue
+        queue={[
+          { id: 'queued-1', text: 'first' },
+          { id: 'queued-2', text: 'second' },
+        ]}
+        onRemove={onRemove}
+        onSend={onSend}
+      />,
+    )
+
+    const sendButtons = screen.getAllByRole('button', {
+      name: 'Send queued message now',
+    })
+    expect(sendButtons).toHaveLength(2)
+
+    fireEvent.click(sendButtons[1])
+    expect(onSend).toHaveBeenCalledTimes(1)
+    expect(onSend).toHaveBeenCalledWith('queued-2')
+    expect(onRemove).not.toHaveBeenCalled()
   })
 })

--- a/tests/components/chat/use-message-queue.concurrency.test.tsx
+++ b/tests/components/chat/use-message-queue.concurrency.test.tsx
@@ -358,6 +358,126 @@ describe('useMessageQueue concurrency', () => {
     expect(result.current.queuedMessages.map((m) => m.text)).toEqual(['a-msg'])
   })
 
+  it('sends a queued message on demand while the pump is wedged on a cancelled stream', async () => {
+    // First dispatch's promise never settles, mimicking a stream whose
+    // cleanup hangs after the user presses Stop. The chat itself goes idle.
+    const handleQuery = vi.fn((text: string) => {
+      if (text === 'A') return new Promise<void>(() => {})
+      return Promise.resolve()
+    })
+
+    const { result, rerender } = renderHook(
+      ({ loadingState }) =>
+        useMessageQueue({
+          chatId: 'chat-a',
+          loadingState,
+          handleQuery,
+          isRateLimited: () => false,
+        }),
+      { initialProps: { loadingState: 'idle' as LoadingState } },
+    )
+
+    act(() => {
+      result.current.submit({ text: 'A' })
+    })
+    await flushMicrotasks()
+    expect(handleQuery).toHaveBeenCalledTimes(1)
+
+    rerender({ loadingState: 'loading' as LoadingState })
+    act(() => {
+      result.current.submit({ text: 'B', quote: 'quoted' })
+    })
+    await flushMicrotasks()
+    expect(handleQuery).toHaveBeenCalledTimes(1)
+
+    // User presses Stop; the chat goes idle but the pump stays parked on
+    // A's unsettled promise, so B is not auto-dispatched.
+    rerender({ loadingState: 'idle' as LoadingState })
+    await flushMicrotasks()
+    expect(handleQuery).toHaveBeenCalledTimes(1)
+
+    const queuedId = result.current.queuedMessages[0].id
+    act(() => {
+      result.current.sendQueuedMessage(queuedId)
+    })
+    await flushMicrotasks()
+
+    expect(handleQuery).toHaveBeenCalledTimes(2)
+    expect(handleQuery).toHaveBeenLastCalledWith(
+      'B',
+      undefined,
+      undefined,
+      undefined,
+      'quoted',
+    )
+    expect(result.current.queuedMessages).toEqual([])
+  })
+
+  it('promotes a queued message to the front when sent while the chat is busy', async () => {
+    const handleQuery = vi.fn(() => new Promise<void>(() => {}))
+
+    const { result } = renderHook(() =>
+      useMessageQueue({
+        chatId: 'chat-a',
+        loadingState: 'loading' as LoadingState,
+        handleQuery,
+        isRateLimited: () => false,
+      }),
+    )
+
+    act(() => {
+      result.current.submit({ text: 'q1' })
+      result.current.submit({ text: 'q2' })
+    })
+    await flushMicrotasks()
+    expect(handleQuery).not.toHaveBeenCalled()
+
+    const secondId = result.current.queuedMessages[1].id
+    act(() => {
+      result.current.sendQueuedMessage(secondId)
+    })
+    await flushMicrotasks()
+
+    // Not dispatched into a busy chat (handleQuery would drop it), just
+    // reordered so it goes out first once the chat is idle.
+    expect(handleQuery).not.toHaveBeenCalled()
+    expect(result.current.queuedMessages.map((m) => m.text)).toEqual([
+      'q2',
+      'q1',
+    ])
+  })
+
+  it('holds an on-demand send while rate-limited', async () => {
+    const handleQuery = vi.fn(() => Promise.resolve())
+    const onRateLimited = vi.fn()
+
+    const { result } = renderHook(() =>
+      useMessageQueue({
+        chatId: 'chat-a',
+        loadingState: 'idle' as LoadingState,
+        handleQuery,
+        isRateLimited: () => true,
+        onRateLimited,
+      }),
+    )
+
+    act(() => {
+      result.current.submit({ text: 'q1' })
+    })
+    await flushMicrotasks()
+    expect(handleQuery).not.toHaveBeenCalled()
+
+    const queuedId = result.current.queuedMessages[0].id
+    act(() => {
+      result.current.sendQueuedMessage(queuedId)
+    })
+    await flushMicrotasks()
+
+    expect(handleQuery).not.toHaveBeenCalled()
+    expect(result.current.queuedMessages.map((m) => m.text)).toEqual(['q1'])
+    expect(onRateLimited).toHaveBeenCalled()
+  })
+
   it('drains multiple messages when handleQuery is synchronous (void)', async () => {
     const calls: string[] = []
     const handleQuery = vi.fn((text: string) => {

--- a/tests/components/chat/use-message-queue.concurrency.test.tsx
+++ b/tests/components/chat/use-message-queue.concurrency.test.tsx
@@ -9,6 +9,15 @@ async function flushMicrotasks(): Promise<void> {
   })
 }
 
+// handleQuery mock whose 'A' dispatch never settles, mimicking a cancelled
+// stream whose cleanup hangs; every other dispatch resolves immediately.
+function createWedgedHandleQuery() {
+  return vi.fn((text: string) => {
+    if (text === 'A') return new Promise<void>(() => {})
+    return Promise.resolve()
+  })
+}
+
 describe('useMessageQueue concurrency', () => {
   beforeEach(() => {
     window.sessionStorage.clear()
@@ -359,12 +368,9 @@ describe('useMessageQueue concurrency', () => {
   })
 
   it('sends a queued message on demand while the pump is wedged on a cancelled stream', async () => {
-    // First dispatch's promise never settles, mimicking a stream whose
-    // cleanup hangs after the user presses Stop. The chat itself goes idle.
-    const handleQuery = vi.fn((text: string) => {
-      if (text === 'A') return new Promise<void>(() => {})
-      return Promise.resolve()
-    })
+    // The chat goes idle after Stop but the pump stays parked on A's
+    // unsettled promise.
+    const handleQuery = createWedgedHandleQuery()
 
     const { result, rerender } = renderHook(
       ({ loadingState }) =>
@@ -386,12 +392,13 @@ describe('useMessageQueue concurrency', () => {
     rerender({ loadingState: 'loading' as LoadingState })
     act(() => {
       result.current.submit({ text: 'B', quote: 'quoted' })
+      result.current.submit({ text: 'C' })
     })
     await flushMicrotasks()
     expect(handleQuery).toHaveBeenCalledTimes(1)
 
     // User presses Stop; the chat goes idle but the pump stays parked on
-    // A's unsettled promise, so B is not auto-dispatched.
+    // A's unsettled promise, so nothing is auto-dispatched.
     rerender({ loadingState: 'idle' as LoadingState })
     await flushMicrotasks()
     expect(handleQuery).toHaveBeenCalledTimes(1)
@@ -402,24 +409,24 @@ describe('useMessageQueue concurrency', () => {
     })
     await flushMicrotasks()
 
-    expect(handleQuery).toHaveBeenCalledTimes(2)
-    expect(handleQuery).toHaveBeenLastCalledWith(
+    // The send unwedges the pump, which dispatches B and then keeps
+    // draining the rest of the queue (C) without further manual sends.
+    expect(handleQuery).toHaveBeenCalledTimes(3)
+    expect(handleQuery.mock.calls[1]).toEqual([
       'B',
       undefined,
       undefined,
       undefined,
       'quoted',
-    )
+    ])
+    expect(handleQuery.mock.calls[2][0]).toBe('C')
     expect(result.current.queuedMessages).toEqual([])
   })
 
   it('interrupts the active stream when sending a queued message midstream', async () => {
     // The active stream's promise never settles even after cancellation,
     // mimicking the worst-case cancelled-stream cleanup.
-    const handleQuery = vi.fn((text: string) => {
-      if (text === 'A') return new Promise<void>(() => {})
-      return Promise.resolve()
-    })
+    const handleQuery = createWedgedHandleQuery()
     const cancelGeneration = vi.fn()
 
     const { result, rerender } = renderHook(
@@ -471,10 +478,7 @@ describe('useMessageQueue concurrency', () => {
   })
 
   it('auto-drains after Stop even when the cancelled dispatch never settles', async () => {
-    const handleQuery = vi.fn((text: string) => {
-      if (text === 'A') return new Promise<void>(() => {})
-      return Promise.resolve()
-    })
+    const handleQuery = createWedgedHandleQuery()
 
     const { result, rerender } = renderHook(
       ({ loadingState }) =>

--- a/tests/components/chat/use-message-queue.concurrency.test.tsx
+++ b/tests/components/chat/use-message-queue.concurrency.test.tsx
@@ -413,38 +413,111 @@ describe('useMessageQueue concurrency', () => {
     expect(result.current.queuedMessages).toEqual([])
   })
 
-  it('promotes a queued message to the front when sent while the chat is busy', async () => {
-    const handleQuery = vi.fn(() => new Promise<void>(() => {}))
+  it('interrupts the active stream when sending a queued message midstream', async () => {
+    // The active stream's promise never settles even after cancellation,
+    // mimicking the worst-case cancelled-stream cleanup.
+    const handleQuery = vi.fn((text: string) => {
+      if (text === 'A') return new Promise<void>(() => {})
+      return Promise.resolve()
+    })
+    const cancelGeneration = vi.fn()
 
-    const { result } = renderHook(() =>
-      useMessageQueue({
-        chatId: 'chat-a',
-        loadingState: 'loading' as LoadingState,
-        handleQuery,
-        isRateLimited: () => false,
-      }),
+    const { result, rerender } = renderHook(
+      ({ loadingState }) =>
+        useMessageQueue({
+          chatId: 'chat-a',
+          loadingState,
+          handleQuery,
+          isRateLimited: () => false,
+          cancelGeneration,
+        }),
+      { initialProps: { loadingState: 'idle' as LoadingState } },
     )
 
+    act(() => {
+      result.current.submit({ text: 'A' })
+    })
+    await flushMicrotasks()
+    expect(handleQuery).toHaveBeenCalledTimes(1)
+
+    rerender({ loadingState: 'loading' as LoadingState })
     act(() => {
       result.current.submit({ text: 'q1' })
       result.current.submit({ text: 'q2' })
     })
     await flushMicrotasks()
-    expect(handleQuery).not.toHaveBeenCalled()
+    expect(handleQuery).toHaveBeenCalledTimes(1)
 
+    // Send q2 midstream: the active stream is cancelled and q2 jumps the
+    // queue, dispatching as soon as the chat settles back to idle.
     const secondId = result.current.queuedMessages[1].id
     act(() => {
       result.current.sendQueuedMessage(secondId)
     })
     await flushMicrotasks()
-
-    // Not dispatched into a busy chat (handleQuery would drop it), just
-    // reordered so it goes out first once the chat is idle.
-    expect(handleQuery).not.toHaveBeenCalled()
+    expect(cancelGeneration).toHaveBeenCalledWith('chat-a')
     expect(result.current.queuedMessages.map((m) => m.text)).toEqual([
       'q2',
       'q1',
     ])
+
+    // Cancellation settles the chat to idle; q2 goes out first, then q1.
+    rerender({ loadingState: 'idle' as LoadingState })
+    await flushMicrotasks()
+    expect(handleQuery).toHaveBeenCalledTimes(3)
+    expect(handleQuery.mock.calls[1][0]).toBe('q2')
+    expect(handleQuery.mock.calls[2][0]).toBe('q1')
+    expect(result.current.queuedMessages).toEqual([])
+  })
+
+  it('auto-drains after Stop even when the cancelled dispatch never settles', async () => {
+    const handleQuery = vi.fn((text: string) => {
+      if (text === 'A') return new Promise<void>(() => {})
+      return Promise.resolve()
+    })
+
+    const { result, rerender } = renderHook(
+      ({ loadingState }) =>
+        useMessageQueue({
+          chatId: 'chat-a',
+          loadingState,
+          handleQuery,
+          isRateLimited: () => false,
+        }),
+      { initialProps: { loadingState: 'idle' as LoadingState } },
+    )
+
+    act(() => {
+      result.current.submit({ text: 'A' })
+    })
+    await flushMicrotasks()
+    expect(handleQuery).toHaveBeenCalledTimes(1)
+
+    rerender({ loadingState: 'loading' as LoadingState })
+    act(() => {
+      result.current.submit({ text: 'B' })
+    })
+    await flushMicrotasks()
+    expect(handleQuery).toHaveBeenCalledTimes(1)
+
+    // Stop button: the cancellation is reported explicitly, then the chat
+    // settles to idle. The pump abandons A's dead promise and sends B
+    // without any manual action.
+    act(() => {
+      result.current.notifyGenerationCancelled('chat-a')
+    })
+    rerender({ loadingState: 'idle' as LoadingState })
+    await flushMicrotasks()
+
+    expect(handleQuery).toHaveBeenCalledTimes(2)
+    expect(handleQuery).toHaveBeenLastCalledWith(
+      'B',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+    )
+    expect(result.current.queuedMessages).toEqual([])
   })
 
   it('holds an on-demand send while rate-limited', async () => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a “Send now” action for queued messages and makes the queue reliably resume or interrupt after Stop. Prevents the pump from stalling on cancelled streams and keeps draining after manual sends.

- **New Features**
  - Added a send button in the Message Queue UI to send a queued message immediately.
  - `useMessageQueue` exposes `sendQueuedMessage` and `notifyGenerationCancelled`; `MessageQueue` accepts `onSend`.
  - When busy, sending moves the item to the front, cancels the active stream, and dispatches once idle; when idle, it sends immediately; the queue continues draining afterward; respects rate limits.

- **Bug Fixes**
  - Queue no longer wedges after Stop: the pump races dispatch against an explicit cancellation signal and keeps draining.
  - Stop now notifies the queue before cancelling generation, abandoning dead promises and resuming processing.
  - Added tests for on-demand send while wedged, midstream interruption, auto-drain after Stop, and rate-limited sends.

<sup>Written for commit 30c99a6c8d38533181c64bfa2f3e1bc6f3825482. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/446?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

