### PR TITLE
fix: reliably remove chats deleted on other devices

### DIFF
--- a/src/constants/storage-keys.ts
+++ b/src/constants/storage-keys.ts
@@ -116,6 +116,11 @@ export const USER_PREFS_NATIVE_APP_DISMISSED =
 // --- localStorage: Sync/data state -----------------------------------------
 export const SYNC_CHATS = 'tinfoil-sync-chats'
 export const SYNC_CHAT_STATUS = 'tinfoil-sync-chat-status'
+// Server timestamp up to which chat delete tombstones have been fetched AND
+// applied locally. Kept separate from SYNC_CHAT_STATUS: the status cache is
+// a disposable freshness snapshot, while this watermark encodes durable
+// reconciliation progress and must never advance past an unapplied tombstone.
+export const SYNC_CHAT_DELETES_WATERMARK = 'tinfoil-sync-chat-deletes-watermark'
 export const SYNC_ALL_CHATS_STATUS = 'tinfoil-sync-all-chats-status'
 export const SYNC_PROJECT_CHAT_STATUS_PREFIX =
   'tinfoil-sync-project-chat-status-'

--- a/src/services/cloud/chat-deletes-watermark.ts
+++ b/src/services/cloud/chat-deletes-watermark.ts
@@ -1,0 +1,76 @@
+/**
+ * Chat Deletes Watermark
+ *
+ * Durable cursor for the remote-deletion reconciliation pass, persisted in
+ * localStorage. It records the server timestamp up to which chat tombstones
+ * have been fetched AND applied locally.
+ *
+ * Deliberately independent from the sync-status cache: that cache is a
+ * disposable freshness snapshot (cleared on account change, eviction sweeps,
+ * cache misses) that advances whenever any sync pass completes. Reusing its
+ * `lastUpdated` as the deletion cursor meant a single skipped or failed
+ * deletion pass permanently hid the missed tombstones, leaving deleted chats
+ * resurrectable on this device.
+ */
+
+import { SYNC_CHAT_DELETES_WATERMARK } from '@/constants/storage-keys'
+
+/**
+ * Seed for devices with no persisted watermark. The first pass replays every
+ * retained tombstone, which is idempotent: already-deleted chats are absent
+ * locally and only refresh the in-memory tracker.
+ */
+export const CHAT_DELETES_WATERMARK_EPOCH = '1970-01-01T00:00:00.000Z'
+
+/**
+ * Safety overlap subtracted from the newest observed server timestamp before
+ * persisting. Tombstones written concurrently with a pass (same-millisecond
+ * ties, replication lag) are re-listed by the next pass instead of being
+ * skipped; re-applying a tombstone is a no-op.
+ */
+export const CHAT_DELETES_WATERMARK_OVERLAP_MS = 5_000
+
+export function loadChatDeletesWatermark(): string {
+  if (typeof window === 'undefined') return CHAT_DELETES_WATERMARK_EPOCH
+  try {
+    const raw = localStorage.getItem(SYNC_CHAT_DELETES_WATERMARK)
+    if (raw && !Number.isNaN(Date.parse(raw))) {
+      return raw
+    }
+  } catch {
+    // Unreadable storage degrades to a full tombstone replay, never to
+    // skipped deletions.
+  }
+  return CHAT_DELETES_WATERMARK_EPOCH
+}
+
+/**
+ * Persist a new watermark derived from the newest event timestamp observed
+ * in a fully reconciled pass. Monotonic: a stale candidate (overlap window,
+ * concurrent passes) never regresses the stored value.
+ */
+export function advanceChatDeletesWatermark(latestEventAtMs: number): void {
+  if (typeof window === 'undefined') return
+  if (!Number.isFinite(latestEventAtMs)) return
+  const candidateMs = latestEventAtMs - CHAT_DELETES_WATERMARK_OVERLAP_MS
+  if (candidateMs <= 0) return
+  if (candidateMs <= Date.parse(loadChatDeletesWatermark())) return
+  try {
+    localStorage.setItem(
+      SYNC_CHAT_DELETES_WATERMARK,
+      new Date(candidateMs).toISOString(),
+    )
+  } catch {
+    // Persisting is best-effort; the next pass re-reads the old value and
+    // replays a wider window.
+  }
+}
+
+export function clearChatDeletesWatermark(): void {
+  if (typeof window === 'undefined') return
+  try {
+    localStorage.removeItem(SYNC_CHAT_DELETES_WATERMARK)
+  } catch {
+    // best-effort
+  }
+}

--- a/src/services/cloud/chat-deletes-watermark.ts
+++ b/src/services/cloud/chat-deletes-watermark.ts
@@ -53,7 +53,6 @@ export function advanceChatDeletesWatermark(latestEventAtMs: number): void {
   if (typeof window === 'undefined') return
   if (!Number.isFinite(latestEventAtMs)) return
   const candidateMs = latestEventAtMs - CHAT_DELETES_WATERMARK_OVERLAP_MS
-  if (candidateMs <= 0) return
   if (candidateMs <= Date.parse(loadChatDeletesWatermark())) return
   try {
     localStorage.setItem(

--- a/src/services/cloud/chat-ingestion.ts
+++ b/src/services/cloud/chat-ingestion.ts
@@ -230,10 +230,18 @@ export async function syncRemoteDeletions(
         Math.max(ms, latestUpdateAtMs.get(update.id) ?? 0),
       )
     }
+    let allResolved = true
     const latestDeleteAtMs = new Map<string, number>()
     for (const del of deletes) {
       const ms = Date.parse(del.deletedAt)
-      if (Number.isNaN(ms)) continue
+      if (Number.isNaN(ms)) {
+        // A tombstone whose timestamp cannot be parsed cannot be
+        // arbitrated or applied. Hold the watermark behind it so the next
+        // pass replays it, instead of advancing past the deletion and
+        // skipping it forever.
+        allResolved = false
+        continue
+      }
       latestEventAtMs = Math.max(latestEventAtMs, ms)
       latestDeleteAtMs.set(
         del.id,
@@ -242,7 +250,6 @@ export async function syncRemoteDeletions(
     }
 
     let failed = false
-    let allResolved = true
     const successfulIds: string[] = []
     for (const [id, deletedAtMs] of latestDeleteAtMs) {
       if (!isCurrent()) return { reconciled: false, failed: true }

--- a/src/services/cloud/chat-ingestion.ts
+++ b/src/services/cloud/chat-ingestion.ts
@@ -15,6 +15,10 @@ import {
   type ProcessRemoteChatOptions,
   type RemoteChatData,
 } from './chat-codec'
+import {
+  advanceChatDeletesWatermark,
+  loadChatDeletesWatermark,
+} from './chat-deletes-watermark'
 import { cloudStorage } from './cloud-storage'
 import { shouldIngestRemoteChat } from './sync-predicates'
 
@@ -182,24 +186,79 @@ export async function ingestRemoteChats(
   return result
 }
 
+export interface RemoteDeletionsResult {
+  /**
+   * Every tombstone in the fetched window was resolved: applied locally,
+   * already absent, kept as local-only, or superseded by a newer remote
+   * write. Only a reconciled pass advances the durable watermark.
+   */
+  reconciled: boolean
+  /**
+   * The tombstone fetch or an application step errored. Local state cannot
+   * yet be trusted against remote deletions, so callers must not upload
+   * dirty chats (a re-upload would resurrect a chat deleted elsewhere).
+   */
+  failed: boolean
+}
+
 /**
- * Delete local chats that were deleted remotely since the given timestamp.
- * Emits a chat event if any chats were deleted.
+ * Delete local chats whose remote rows carry deletion tombstones, resuming
+ * from the durable deletes watermark. Emits a chat event if any chats were
+ * deleted, and advances the watermark only after a fully reconciled pass so
+ * a failed or interrupted pass replays the same window next time.
  */
 export async function syncRemoteDeletions(
-  since: string,
   logAction: string,
   isCurrent: () => boolean = () => true,
-): Promise<void> {
+): Promise<RemoteDeletionsResult> {
   try {
-    const { deletedIds } = await cloudStorage.getDeletedChatsSince(since)
-    if (!isCurrent()) return
+    const since = loadChatDeletesWatermark()
+    const { updates, deletes } = await cloudStorage.listChatEventsSince(since)
+    if (!isCurrent()) return { reconciled: false, failed: true }
+
+    // Newest server-side write per chat in this window. A tombstone is only
+    // authoritative when no later write exists: a row re-created after its
+    // tombstone (restore, or an upload that raced the delete) must survive.
+    const latestUpdateAtMs = new Map<string, number>()
+    let latestEventAtMs = Number.NEGATIVE_INFINITY
+    for (const update of updates) {
+      const ms = Date.parse(update.updatedAt)
+      if (Number.isNaN(ms)) continue
+      latestEventAtMs = Math.max(latestEventAtMs, ms)
+      latestUpdateAtMs.set(
+        update.id,
+        Math.max(ms, latestUpdateAtMs.get(update.id) ?? 0),
+      )
+    }
+    const latestDeleteAtMs = new Map<string, number>()
+    for (const del of deletes) {
+      const ms = Date.parse(del.deletedAt)
+      if (Number.isNaN(ms)) continue
+      latestEventAtMs = Math.max(latestEventAtMs, ms)
+      latestDeleteAtMs.set(
+        del.id,
+        Math.max(ms, latestDeleteAtMs.get(del.id) ?? 0),
+      )
+    }
+
+    let failed = false
+    let allResolved = true
     const successfulIds: string[] = []
-    for (const id of deletedIds) {
-      if (!isCurrent()) break
+    for (const [id, deletedAtMs] of latestDeleteAtMs) {
+      if (!isCurrent()) return { reconciled: false, failed: true }
+      if ((latestUpdateAtMs.get(id) ?? 0) > deletedAtMs) {
+        // The row was re-created after the tombstone; the live row wins.
+        // Unblock ingestion in case an earlier pass recorded the tombstone.
+        // On a same-millisecond tie deletion wins instead: a live row
+        // wrongly deleted locally is re-downloaded once the tracker entry
+        // expires with the session, while a dead row wrongly kept local
+        // would never be cleaned up.
+        deletedChatsTracker.removeFromDeleted(id)
+        continue
+      }
       try {
         const localChat = await indexedDBStorage.getChat(id)
-        if (!isCurrent()) break
+        if (!isCurrent()) return { reconciled: false, failed: true }
         // Already gone locally (e.g. a prior reconciliation pass handled
         // it) or a local-only chat the cloud never owned. Skipping keeps
         // repeated reconciliation passes idempotent and event-free.
@@ -218,14 +277,22 @@ export async function syncRemoteDeletions(
           localChat.updatedAt,
           isCurrent,
         )
-        if (!isCurrent()) break
-        if (!deleted) continue
+        if (!isCurrent()) return { reconciled: false, failed: true }
+        if (!deleted) {
+          // The row changed under us (an in-flight local edit). Leave it
+          // for the conflict path to arbitrate and hold the watermark
+          // behind this tombstone so the next pass re-checks it.
+          allResolved = false
+          continue
+        }
         // Mirror the deletion into the in-memory tracker so any concurrent
         // listing/ingest pass that already observed the chat won't bring
         // it back into IndexedDB before the next deletion sync runs.
         deletedChatsTracker.markAsDeleted(id)
         successfulIds.push(id)
       } catch (error) {
+        failed = true
+        allResolved = false
         logError(
           `Failed to delete chat ${id} during remote deletion sync`,
           error,
@@ -239,10 +306,15 @@ export async function syncRemoteDeletions(
     if (successfulIds.length > 0 && isCurrent()) {
       chatEvents.emit({ reason: 'sync', ids: successfulIds })
     }
+    if (allResolved && Number.isFinite(latestEventAtMs) && isCurrent()) {
+      advanceChatDeletesWatermark(latestEventAtMs)
+    }
+    return { reconciled: allResolved, failed }
   } catch (error) {
     logError('Failed to check for remotely deleted chats', error, {
       component: 'CloudSync',
       action: logAction,
     })
+    return { reconciled: false, failed: true }
   }
 }

--- a/src/services/cloud/chat-ingestion.ts
+++ b/src/services/cloud/chat-ingestion.ts
@@ -238,7 +238,10 @@ export async function syncRemoteDeletions(
         // A tombstone whose timestamp cannot be parsed cannot be
         // arbitrated or applied. Hold the watermark behind it so the next
         // pass replays it, instead of advancing past the deletion and
-        // skipping it forever.
+        // skipping it forever. Record it in the tracker too, so ingestion
+        // and the gone-row restore path won't resurrect a dirty local
+        // copy while arbitration is impossible.
+        deletedChatsTracker.markAsDeleted(del.id)
         allResolved = false
         continue
       }

--- a/src/services/cloud/cloud-storage.ts
+++ b/src/services/cloud/cloud-storage.ts
@@ -708,8 +708,18 @@ export class CloudStorageService {
     return
   }
 
-  async getDeletedChatsSince(since: string): Promise<{ deletedIds: string[] }> {
-    const deletedIds: string[] = []
+  /**
+   * Walk the list-status pages once and return both event streams since
+   * `since`: row updates and delete tombstones. The deletion reconciliation
+   * pass needs both from the same walk so it can arbitrate a tombstone
+   * against a later re-create of the same row.
+   */
+  async listChatEventsSince(since: string): Promise<{
+    updates: Array<{ id: string; updatedAt: string }>
+    deletes: Array<{ id: string; deletedAt: string }>
+  }> {
+    const updates: Array<{ id: string; updatedAt: string }> = []
+    const deletes: Array<{ id: string; deletedAt: string }> = []
     let cursor: string | undefined = since
     do {
       const status = await enclaveListStatus({
@@ -717,10 +727,15 @@ export class CloudStorageService {
         cursor,
         limit: 500,
       })
-      for (const d of status.deletes) deletedIds.push(d.id)
+      for (const u of status.updates) {
+        updates.push({ id: u.id, updatedAt: u.updated_at })
+      }
+      for (const d of status.deletes) {
+        deletes.push({ id: d.id, deletedAt: d.deleted_at })
+      }
       cursor = status.next_cursor
     } while (cursor)
-    return { deletedIds }
+    return { updates, deletes }
   }
 
   async getChatsUpdatedSince(options: {

--- a/src/services/cloud/cloud-sync.ts
+++ b/src/services/cloud/cloud-sync.ts
@@ -143,6 +143,14 @@ export class CloudSyncService {
     this.uploadCoalescer.clear()
     this.streamingCallbacks.clear()
     this.clearSyncStatus()
+    // The deletes watermark is scoped to the account's tombstone history,
+    // so the next account (or re-login) must replay from epoch rather than
+    // resume at the previous account's position. Deliberately not part of
+    // clearSyncStatus(): the start-fresh flow (§H4) clears the status
+    // caches while local chats await re-upload as fresh creates, and an
+    // epoch replay there could apply surviving tombstones to the very
+    // chats the user chose to keep.
+    clearChatDeletesWatermark()
   }
 
   /**
@@ -578,10 +586,6 @@ export class CloudSyncService {
       cache.clear()
     }
     this.projectSyncCaches.clear()
-    // The deletes watermark is scoped to the account's tombstone history,
-    // so the next account (or re-login) must replay from epoch rather than
-    // resume at the previous account's position.
-    clearChatDeletesWatermark()
     // `cloudSync` is a module-level singleton so this flag survives
     // logout → login on the same page load. Without the reset, the
     // second user's first syncAllChats would skip the legacy-blob

--- a/src/services/cloud/cloud-sync.ts
+++ b/src/services/cloud/cloud-sync.ts
@@ -71,6 +71,8 @@ const UPLOAD_BASE_DELAY_MS = 1000
 const UPLOAD_MAX_DELAY_MS = 8000
 const UPLOAD_MAX_RETRIES = 3
 const REMOTE_LIST_MAX_ATTEMPTS = 2
+const UPLOADS_SKIPPED_UNRECONCILED_DELETIONS_ERROR =
+  'Skipped uploading local changes: remote deletions could not be reconciled'
 const isStreaming = (id: string) => streamingTracker.isStreaming(id)
 
 export class CloudSyncService {
@@ -468,9 +470,7 @@ export class CloudSyncService {
         // Uploading dirty chats before deletions reconcile can resurrect
         // chats deleted on another device, so keep local changes queued
         // until a pass succeeds.
-        result.errors.push(
-          'Skipped uploading local changes: remote deletions could not be reconciled',
-        )
+        result.errors.push(UPLOADS_SKIPPED_UNRECONCILED_DELETIONS_ERROR)
       } else {
         // Backup any unsynced local changes
         const backupResult = await this.backupUnsyncedChats()
@@ -940,6 +940,20 @@ export class CloudSyncService {
           !localChat.isLocalOnly &&
           !deletedChatsTracker.isDeleted(chatId)
         ) {
+          // The row may have been tombstoned after this pass fetched its
+          // deletion window, in which case the tracker doesn't know about
+          // it yet. Reconcile deletions now so a fresh tombstone is
+          // applied and recorded rather than overwritten by the restore
+          // below; a failed pass skips the restore and the next sync
+          // retries the upload (and this arbitration) from scratch.
+          const deletions = await syncRemoteDeletions(
+            'resolveConflictByPullingRemote',
+            () => this.isCurrentGeneration(generation),
+          )
+          if (!this.isCurrentGeneration(generation)) return
+          if (deletions.failed || deletedChatsTracker.isDeleted(chatId)) {
+            return
+          }
           await this.backupChatNow(chatId, { restoreDeleted: true })
           if (!this.isCurrentGeneration(generation)) return
           reportChatSynced(chatId)
@@ -1188,9 +1202,7 @@ export class CloudSyncService {
         // Uploading dirty chats before deletions reconcile can resurrect
         // chats deleted on another device, so keep local changes queued
         // until a pass succeeds.
-        result.errors.push(
-          'Skipped uploading local changes: remote deletions could not be reconciled',
-        )
+        result.errors.push(UPLOADS_SKIPPED_UNRECONCILED_DELETIONS_ERROR)
       } else {
         // Backup any unsynced local changes
         const backupResult = await this.backupUnsyncedChats()

--- a/src/services/cloud/cloud-sync.ts
+++ b/src/services/cloud/cloud-sync.ts
@@ -19,6 +19,7 @@ import {
   primaryKeyIdHexOrNull,
 } from './cek-encoding'
 import { processRemoteChat } from './chat-codec'
+import { clearChatDeletesWatermark } from './chat-deletes-watermark'
 import { ingestRemoteChats, syncRemoteDeletions } from './chat-ingestion'
 import { canWriteToCloud } from './cloud-key-authorization'
 import {
@@ -450,19 +451,24 @@ export class CloudSyncService {
       // device deleted a chat, we must drop it locally first; otherwise
       // backupUnsyncedChats can re-upload a chat with pending edits and
       // resurrect it server-side.
-      if (cachedStatus?.lastUpdated) {
-        await syncRemoteDeletions(
-          cachedStatus.lastUpdated,
-          'syncChangedChats',
-          () => this.isCurrentGeneration(generation),
-        )
-      }
+      const deletions = await syncRemoteDeletions('syncChangedChats', () =>
+        this.isCurrentGeneration(generation),
+      )
       if (!this.isCurrentGeneration(generation)) return result
 
-      // Backup any unsynced local changes
-      const backupResult = await this.backupUnsyncedChats()
-      result.uploaded = backupResult.uploaded
-      result.errors.push(...backupResult.errors)
+      if (deletions.failed) {
+        // Uploading dirty chats before deletions reconcile can resurrect
+        // chats deleted on another device, so keep local changes queued
+        // until a pass succeeds.
+        result.errors.push(
+          'Skipped uploading local changes: remote deletions could not be reconciled',
+        )
+      } else {
+        // Backup any unsynced local changes
+        const backupResult = await this.backupUnsyncedChats()
+        result.uploaded = backupResult.uploaded
+        result.errors.push(...backupResult.errors)
+      }
 
       if (!cachedStatus?.lastUpdated) {
         // No cached status, fall back to full sync (first page only)
@@ -572,6 +578,10 @@ export class CloudSyncService {
       cache.clear()
     }
     this.projectSyncCaches.clear()
+    // The deletes watermark is scoped to the account's tombstone history,
+    // so the next account (or re-login) must replay from epoch rather than
+    // resume at the previous account's position.
+    clearChatDeletesWatermark()
     // `cloudSync` is a module-level singleton so this flag survives
     // logout → login on the same page load. Without the reset, the
     // second user's first syncAllChats would skip the legacy-blob
@@ -911,10 +921,30 @@ export class CloudSyncService {
         cloudStorage.downloadChat(chatId),
       ])
 
-      // The remote row vanished (concurrent delete). Leave the local
-      // copy untouched; it stays `locallyModified` and the deletion
-      // reconciles on the next sync cycle.
+      // The remote row vanished (concurrent delete). A clean local copy
+      // is removed by the deletion reconciliation pass. A locally
+      // modified copy carries writes the server never saw; there is no
+      // etag left to CAS against, so a plain re-upload would loop on
+      // STALE_BLOB forever. Per §C5 the newer local content wins by
+      // re-creating the row through the explicit restore path — unless
+      // the reconciliation pass has already recorded the tombstone, in
+      // which case the deletion is being applied right now and wins.
       if (!remoteChat) {
+        if (!this.isCurrentGeneration(generation)) return
+        if (
+          localChat?.locallyModified &&
+          !localChat.isLocalOnly &&
+          !deletedChatsTracker.isDeleted(chatId)
+        ) {
+          await this.backupChatNow(chatId, { restoreDeleted: true })
+          if (!this.isCurrentGeneration(generation)) return
+          reportChatSynced(chatId)
+          logInfo('Conflict resolved by restoring locally modified chat', {
+            component: 'CloudSync',
+            action: 'resolveConflictByPullingRemote',
+            metadata: { chatId },
+          })
+        }
         return
       }
       if (!this.isCurrentGeneration(generation)) return
@@ -1142,24 +1172,27 @@ export class CloudSyncService {
     }
 
     try {
-      const cachedStatus = this.chatSyncCache.load()
-
       // Apply remote deletions BEFORE uploading local changes so a chat
       // deleted on another device is dropped locally first, instead of
       // getting re-uploaded by backupUnsyncedChats.
-      if (cachedStatus?.lastUpdated) {
-        await syncRemoteDeletions(
-          cachedStatus.lastUpdated,
-          'syncAllChats',
-          () => this.isCurrentGeneration(generation),
-        )
-      }
+      const deletions = await syncRemoteDeletions('syncAllChats', () =>
+        this.isCurrentGeneration(generation),
+      )
       if (!this.isCurrentGeneration(generation)) return result
 
-      // Backup any unsynced local changes
-      const backupResult = await this.backupUnsyncedChats()
-      result.uploaded = backupResult.uploaded
-      result.errors.push(...backupResult.errors)
+      if (deletions.failed) {
+        // Uploading dirty chats before deletions reconcile can resurrect
+        // chats deleted on another device, so keep local changes queued
+        // until a pass succeeds.
+        result.errors.push(
+          'Skipped uploading local changes: remote deletions could not be reconciled',
+        )
+      } else {
+        // Backup any unsynced local changes
+        const backupResult = await this.backupUnsyncedChats()
+        result.uploaded = backupResult.uploaded
+        result.errors.push(...backupResult.errors)
+      }
 
       // Then, get list of remote chats with content
       const remoteList = await this.listChatsWithRetry({
@@ -1490,12 +1523,9 @@ export class CloudSyncService {
       // the next tick. The pass is idempotent and only emits when a chat
       // is actually removed locally.
       if (!projectId) {
-        const cachedStatus = this.chatSyncCache.load()
-        if (cachedStatus?.lastUpdated) {
-          await syncRemoteDeletions(cachedStatus.lastUpdated, 'smartSync', () =>
-            this.isCurrentGeneration(generation),
-          )
-        }
+        await syncRemoteDeletions('smartSync', () =>
+          this.isCurrentGeneration(generation),
+        )
       }
       if (!this.isCurrentGeneration(generation)) {
         return { uploaded: 0, downloaded: 0, errors: [] }

--- a/tests/services/cloud/chat-ingestion.test.ts
+++ b/tests/services/cloud/chat-ingestion.test.ts
@@ -268,6 +268,9 @@ describe('syncRemoteDeletions', () => {
     // advance the watermark past the deletion it could not arbitrate.
     expect(result).toEqual({ reconciled: false, failed: false })
     expect(mockMarkAsDeleted).toHaveBeenCalledWith('gone')
+    // The unarbitratable tombstone is still tracked so ingestion and the
+    // gone-row restore path cannot resurrect the chat in the meantime.
+    expect(mockMarkAsDeleted).toHaveBeenCalledWith('malformed')
     expect(localStorage.getItem(SYNC_CHAT_DELETES_WATERMARK)).toBeNull()
   })
 

--- a/tests/services/cloud/chat-ingestion.test.ts
+++ b/tests/services/cloud/chat-ingestion.test.ts
@@ -1,16 +1,22 @@
+import { SYNC_CHAT_DELETES_WATERMARK } from '@/constants/storage-keys'
+import {
+  CHAT_DELETES_WATERMARK_EPOCH,
+  CHAT_DELETES_WATERMARK_OVERLAP_MS,
+} from '@/services/cloud/chat-deletes-watermark'
 import {
   ingestRemoteChats,
   syncRemoteDeletions,
 } from '@/services/cloud/chat-ingestion'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const mockGetDeletedChatsSince = vi.fn()
+const mockListChatEventsSince = vi.fn()
 const mockGetChat = vi.fn()
 const mockDeleteChatIfUnchanged = vi.fn()
 const mockApplyRemoteChatIfFresh = vi.fn()
 const mockProcessRemoteChat = vi.fn()
 const mockIsDeleted = vi.fn()
 const mockMarkAsDeleted = vi.fn()
+const mockRemoveFromDeleted = vi.fn()
 const mockEmit = vi.fn()
 
 vi.mock('@/utils/error-handling', () => ({
@@ -19,7 +25,7 @@ vi.mock('@/utils/error-handling', () => ({
 
 vi.mock('@/services/cloud/cloud-storage', () => ({
   cloudStorage: {
-    getDeletedChatsSince: (...args: any[]) => mockGetDeletedChatsSince(...args),
+    listChatEventsSince: (...args: any[]) => mockListChatEventsSince(...args),
   },
 }))
 
@@ -37,6 +43,7 @@ vi.mock('@/services/storage/deleted-chats-tracker', () => ({
   deletedChatsTracker: {
     markAsDeleted: (...args: any[]) => mockMarkAsDeleted(...args),
     isDeleted: (...args: any[]) => mockIsDeleted(...args),
+    removeFromDeleted: (...args: any[]) => mockRemoveFromDeleted(...args),
   },
 }))
 
@@ -51,17 +58,28 @@ vi.mock('@/services/cloud/chat-codec', () => ({
 }))
 
 describe('syncRemoteDeletions', () => {
+  const deletedAt = '2026-01-01T00:00:10.000Z'
+  const events = (
+    deletes: Array<{ id: string; deletedAt: string }>,
+    updates: Array<{ id: string; updatedAt: string }> = [],
+  ) => ({ updates, deletes })
+
   beforeEach(() => {
     vi.clearAllMocks()
+    localStorage.removeItem(SYNC_CHAT_DELETES_WATERMARK)
     mockDeleteChatIfUnchanged.mockResolvedValue(true)
     mockApplyRemoteChatIfFresh.mockResolvedValue({ applied: true })
     mockIsDeleted.mockReturnValue(false)
+    mockListChatEventsSince.mockResolvedValue(events([]))
   })
 
   it('preserves local-only chats when their cloud copy was deleted', async () => {
-    mockGetDeletedChatsSince.mockResolvedValue({
-      deletedIds: ['local-chat', 'cloud-chat'],
-    })
+    mockListChatEventsSince.mockResolvedValue(
+      events([
+        { id: 'local-chat', deletedAt },
+        { id: 'cloud-chat', deletedAt },
+      ]),
+    )
     mockGetChat.mockImplementation(async (id: string) => {
       if (id === 'local-chat') return { id, isLocalOnly: true }
       if (id === 'cloud-chat') {
@@ -74,7 +92,7 @@ describe('syncRemoteDeletions', () => {
       return null
     })
 
-    await syncRemoteDeletions('2026-01-01T00:00:00.000Z', 'test')
+    const result = await syncRemoteDeletions('test')
 
     expect(mockDeleteChatIfUnchanged).toHaveBeenCalledTimes(1)
     expect(mockDeleteChatIfUnchanged).toHaveBeenCalledWith(
@@ -88,15 +106,16 @@ describe('syncRemoteDeletions', () => {
       reason: 'sync',
       ids: ['cloud-chat'],
     })
+    expect(result).toEqual({ reconciled: true, failed: false })
   })
 
   it('records the tombstone for chats already absent locally without emitting', async () => {
-    mockGetDeletedChatsSince.mockResolvedValue({
-      deletedIds: ['already-gone'],
-    })
+    mockListChatEventsSince.mockResolvedValue(
+      events([{ id: 'already-gone', deletedAt }]),
+    )
     mockGetChat.mockResolvedValue(null)
 
-    await syncRemoteDeletions('2026-01-01T00:00:00.000Z', 'test')
+    await syncRemoteDeletions('test')
 
     expect(mockDeleteChatIfUnchanged).not.toHaveBeenCalled()
     expect(mockMarkAsDeleted).toHaveBeenCalledWith('already-gone')
@@ -105,23 +124,24 @@ describe('syncRemoteDeletions', () => {
 
   it('does not apply deletions after the account generation changes', async () => {
     let current = true
-    mockGetDeletedChatsSince.mockImplementation(async () => {
+    mockListChatEventsSince.mockImplementation(async () => {
       current = false
-      return { deletedIds: ['old-account-chat'] }
+      return events([{ id: 'old-account-chat', deletedAt }])
     })
 
-    await syncRemoteDeletions('2026-01-01T00:00:00.000Z', 'test', () => current)
+    const result = await syncRemoteDeletions('test', () => current)
 
     expect(mockGetChat).not.toHaveBeenCalled()
     expect(mockDeleteChatIfUnchanged).not.toHaveBeenCalled()
     expect(mockEmit).not.toHaveBeenCalled()
+    expect(result).toEqual({ reconciled: false, failed: true })
   })
 
   it('does not publish a deletion after the account generation changes', async () => {
     let current = true
-    mockGetDeletedChatsSince.mockResolvedValue({
-      deletedIds: ['old-account-chat'],
-    })
+    mockListChatEventsSince.mockResolvedValue(
+      events([{ id: 'old-account-chat', deletedAt }]),
+    )
     mockGetChat.mockResolvedValue({
       id: 'old-account-chat',
       isLocalOnly: false,
@@ -132,7 +152,7 @@ describe('syncRemoteDeletions', () => {
       return true
     })
 
-    await syncRemoteDeletions('2026-01-01T00:00:00.000Z', 'test', () => current)
+    await syncRemoteDeletions('test', () => current)
 
     expect(mockMarkAsDeleted).not.toHaveBeenCalled()
     expect(mockEmit).not.toHaveBeenCalled()
@@ -140,9 +160,12 @@ describe('syncRemoteDeletions', () => {
 
   it('does not emit earlier deletions after a later iteration is invalidated', async () => {
     let current = true
-    mockGetDeletedChatsSince.mockResolvedValue({
-      deletedIds: ['deleted-chat', 'stale-chat'],
-    })
+    mockListChatEventsSince.mockResolvedValue(
+      events([
+        { id: 'deleted-chat', deletedAt },
+        { id: 'stale-chat', deletedAt },
+      ]),
+    )
     mockGetChat.mockResolvedValue({
       isLocalOnly: false,
       updatedAt: '2026-01-02T00:00:00.000Z',
@@ -154,10 +177,106 @@ describe('syncRemoteDeletions', () => {
         return false
       })
 
-    await syncRemoteDeletions('2026-01-01T00:00:00.000Z', 'test', () => current)
+    await syncRemoteDeletions('test', () => current)
 
     expect(mockMarkAsDeleted).toHaveBeenCalledWith('deleted-chat')
     expect(mockEmit).not.toHaveBeenCalled()
+  })
+
+  it('starts from epoch when no watermark is persisted and resumes from it afterwards', async () => {
+    mockGetChat.mockResolvedValue(null)
+
+    await syncRemoteDeletions('test')
+    expect(mockListChatEventsSince).toHaveBeenCalledWith(
+      CHAT_DELETES_WATERMARK_EPOCH,
+    )
+    // An empty window leaves the watermark untouched.
+    expect(localStorage.getItem(SYNC_CHAT_DELETES_WATERMARK)).toBeNull()
+
+    localStorage.setItem(
+      SYNC_CHAT_DELETES_WATERMARK,
+      '2026-01-01T00:00:00.000Z',
+    )
+    await syncRemoteDeletions('test')
+    expect(mockListChatEventsSince).toHaveBeenLastCalledWith(
+      '2026-01-01T00:00:00.000Z',
+    )
+  })
+
+  it('advances the watermark past applied tombstones with a safety overlap', async () => {
+    mockListChatEventsSince.mockResolvedValue(
+      events(
+        [{ id: 'gone', deletedAt }],
+        [{ id: 'other', updatedAt: '2026-01-01T00:00:20.000Z' }],
+      ),
+    )
+    mockGetChat.mockResolvedValue(null)
+
+    const result = await syncRemoteDeletions('test')
+
+    expect(result).toEqual({ reconciled: true, failed: false })
+    expect(localStorage.getItem(SYNC_CHAT_DELETES_WATERMARK)).toBe(
+      new Date(
+        Date.parse('2026-01-01T00:00:20.000Z') -
+          CHAT_DELETES_WATERMARK_OVERLAP_MS,
+      ).toISOString(),
+    )
+  })
+
+  it('holds the watermark when applying a tombstone fails', async () => {
+    mockListChatEventsSince.mockResolvedValue(
+      events([{ id: 'failing', deletedAt }]),
+    )
+    mockGetChat.mockRejectedValue(new Error('idb unavailable'))
+
+    const result = await syncRemoteDeletions('test')
+
+    expect(result).toEqual({ reconciled: false, failed: true })
+    expect(localStorage.getItem(SYNC_CHAT_DELETES_WATERMARK)).toBeNull()
+  })
+
+  it('holds the watermark when a local row changed under the tombstone, without reporting failure', async () => {
+    mockListChatEventsSince.mockResolvedValue(
+      events([{ id: 'edited-during-pass', deletedAt }]),
+    )
+    mockGetChat.mockResolvedValue({
+      id: 'edited-during-pass',
+      isLocalOnly: false,
+      updatedAt: '2026-01-02T00:00:00.000Z',
+    })
+    mockDeleteChatIfUnchanged.mockResolvedValue(false)
+
+    const result = await syncRemoteDeletions('test')
+
+    expect(result).toEqual({ reconciled: false, failed: false })
+    expect(mockMarkAsDeleted).not.toHaveBeenCalled()
+    expect(localStorage.getItem(SYNC_CHAT_DELETES_WATERMARK)).toBeNull()
+  })
+
+  it('keeps a chat whose row was re-created after its tombstone and unblocks ingestion', async () => {
+    mockListChatEventsSince.mockResolvedValue(
+      events(
+        [{ id: 'restored', deletedAt }],
+        [{ id: 'restored', updatedAt: '2026-01-01T00:00:11.000Z' }],
+      ),
+    )
+
+    const result = await syncRemoteDeletions('test')
+
+    expect(mockGetChat).not.toHaveBeenCalled()
+    expect(mockDeleteChatIfUnchanged).not.toHaveBeenCalled()
+    expect(mockRemoveFromDeleted).toHaveBeenCalledWith('restored')
+    expect(result).toEqual({ reconciled: true, failed: false })
+  })
+
+  it('reports failure without touching local rows when the tombstone fetch fails', async () => {
+    mockListChatEventsSince.mockRejectedValue(new Error('network down'))
+
+    const result = await syncRemoteDeletions('test')
+
+    expect(result).toEqual({ reconciled: false, failed: true })
+    expect(mockGetChat).not.toHaveBeenCalled()
+    expect(localStorage.getItem(SYNC_CHAT_DELETES_WATERMARK)).toBeNull()
   })
 })
 

--- a/tests/services/cloud/chat-ingestion.test.ts
+++ b/tests/services/cloud/chat-ingestion.test.ts
@@ -253,6 +253,24 @@ describe('syncRemoteDeletions', () => {
     expect(localStorage.getItem(SYNC_CHAT_DELETES_WATERMARK)).toBeNull()
   })
 
+  it('holds the watermark when a tombstone timestamp cannot be parsed', async () => {
+    mockListChatEventsSince.mockResolvedValue(
+      events([
+        { id: 'malformed', deletedAt: 'not-a-timestamp' },
+        { id: 'gone', deletedAt },
+      ]),
+    )
+    mockGetChat.mockResolvedValue(null)
+
+    const result = await syncRemoteDeletions('test')
+
+    // The parseable tombstone is still applied, but the pass must not
+    // advance the watermark past the deletion it could not arbitrate.
+    expect(result).toEqual({ reconciled: false, failed: false })
+    expect(mockMarkAsDeleted).toHaveBeenCalledWith('gone')
+    expect(localStorage.getItem(SYNC_CHAT_DELETES_WATERMARK)).toBeNull()
+  })
+
   it('keeps a chat whose row was re-created after its tombstone and unblocks ingestion', async () => {
     mockListChatEventsSince.mockResolvedValue(
       events(

--- a/tests/services/cloud/cloud-sync.test.ts
+++ b/tests/services/cloud/cloud-sync.test.ts
@@ -1,5 +1,9 @@
-import { SYNC_CHAT_STATUS } from '@/constants/storage-keys'
+import {
+  SYNC_CHAT_DELETES_WATERMARK,
+  SYNC_CHAT_STATUS,
+} from '@/constants/storage-keys'
 import { CloudSyncService } from '@/services/cloud/cloud-sync'
+import { deletedChatsTracker } from '@/services/storage/deleted-chats-tracker'
 import { SyncEnclaveError } from '@/services/sync-enclave/sync-enclave-client'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -255,7 +259,10 @@ describe('CloudSyncService', () => {
       savedIds: [],
     })
     mockCanWriteToCloud.mockResolvedValue(true)
-    mockSyncRemoteDeletions.mockResolvedValue(undefined)
+    mockSyncRemoteDeletions.mockResolvedValue({
+      reconciled: true,
+      failed: false,
+    })
   })
 
   describe('backupChat', () => {
@@ -651,6 +658,56 @@ describe('CloudSyncService', () => {
   })
 
   describe('syncAllChats', () => {
+    it('runs the deletion reconciliation pass even without cached sync status', async () => {
+      mockGetUnsyncedChats.mockResolvedValue([])
+      mockGetAllChats.mockResolvedValue([])
+      mockListChats.mockResolvedValue({ conversations: [], hasMore: false })
+
+      const service = new CloudSyncService()
+      await service.syncAllChats()
+
+      expect(mockSyncRemoteDeletions).toHaveBeenCalledWith(
+        'syncAllChats',
+        expect.any(Function),
+      )
+    })
+
+    it('skips uploading local changes when remote deletions could not be reconciled', async () => {
+      mockSyncRemoteDeletions.mockResolvedValue({
+        reconciled: false,
+        failed: true,
+      })
+      mockGetAllChats.mockResolvedValue([])
+      mockListChats.mockResolvedValue({ conversations: [], hasMore: false })
+
+      const service = new CloudSyncService()
+      const result = await service.syncAllChats()
+
+      // Uploading before deletions reconcile could resurrect chats that
+      // were deleted on another device, so the upload leg is skipped
+      // while downloads still proceed.
+      expect(mockGetUnsyncedChats).not.toHaveBeenCalled()
+      expect(mockUploadChat).not.toHaveBeenCalled()
+      expect(mockListChats).toHaveBeenCalled()
+      expect(result.uploaded).toBe(0)
+      expect(result.errors.some((e) => e.includes('remote deletions'))).toBe(
+        true,
+      )
+      expect(mockReportSyncSuccess).not.toHaveBeenCalled()
+    })
+
+    it('clears the deletes watermark on account change', () => {
+      localStorage.setItem(
+        SYNC_CHAT_DELETES_WATERMARK,
+        '2026-01-01T00:00:00.000Z',
+      )
+
+      const service = new CloudSyncService()
+      service.resetForAccountChange()
+
+      expect(localStorage.getItem(SYNC_CHAT_DELETES_WATERMARK)).toBeNull()
+    })
+
     it('retries listing remote chats before succeeding', async () => {
       mockGetUnsyncedChats.mockResolvedValue([])
       mockGetAllChats.mockResolvedValue([])
@@ -783,8 +840,7 @@ describe('CloudSyncService', () => {
       mockListChats.mockResolvedValue({ conversations: [], hasMore: false })
       mockGetCloudChatCount.mockResolvedValue(0)
       let finishCrossScope:
-        | ((status: { count: number; lastUpdated: null }) => void)
-        | undefined
+        ((status: { count: number; lastUpdated: null }) => void) | undefined
       mockGetAllChatsSyncStatus.mockReturnValue(
         new Promise((resolve) => {
           finishCrossScope = resolve
@@ -1225,18 +1281,52 @@ describe('CloudSyncService', () => {
       expect(mockReportChatSynced).not.toHaveBeenCalled()
     })
 
-    it('leaves the local copy untouched when the remote row is gone', async () => {
+    it('re-creates the remote row when it vanished under a locally modified chat', async () => {
+      // The chat carries local writes the server never saw and no etag
+      // remains to CAS against, so LWW resolves by restoring the row.
       mockGetChat.mockResolvedValue(localChat('2024-06-01T00:00:00.000Z', 1))
       mockDownloadChat.mockResolvedValue(null)
-      mockUploadChat.mockRejectedValueOnce(staleBlob())
+      mockUploadChat
+        .mockRejectedValueOnce(staleBlob())
+        .mockResolvedValue({ syncVersion: 2, rewrites: [] })
 
       const service = new CloudSyncService()
       await service.backupChat('conflict-1')
       await service.waitForUpload('conflict-1')
       await flush()
 
+      expect(mockUploadChat).toHaveBeenCalledTimes(2)
+      expect(mockUploadChat.mock.calls[1]?.[1]).toMatchObject({
+        restoreDeleted: true,
+      })
+      expect(mockFinalizeUpload).toHaveBeenCalledWith(
+        expect.objectContaining({ chatId: 'conflict-1' }),
+      )
+      expect(mockReportChatSynced).toHaveBeenCalledWith('conflict-1')
       expect(mockApplyRemoteChatIfFresh).not.toHaveBeenCalled()
       expect(mockRebaseSyncVersion).not.toHaveBeenCalled()
+    })
+
+    it('leaves the local copy untouched when the remote row is gone and its tombstone is already recorded', async () => {
+      // The deletion reconciliation pass has claimed this chat; restoring
+      // it would resurrect a chat the user deleted on another device.
+      deletedChatsTracker.markAsDeleted('conflict-1')
+      try {
+        mockGetChat.mockResolvedValue(localChat('2024-06-01T00:00:00.000Z', 1))
+        mockDownloadChat.mockResolvedValue(null)
+        mockUploadChat.mockRejectedValueOnce(staleBlob())
+
+        const service = new CloudSyncService()
+        await service.backupChat('conflict-1')
+        await service.waitForUpload('conflict-1')
+        await flush()
+
+        expect(mockUploadChat).toHaveBeenCalledTimes(1)
+        expect(mockApplyRemoteChatIfFresh).not.toHaveBeenCalled()
+        expect(mockRebaseSyncVersion).not.toHaveBeenCalled()
+      } finally {
+        deletedChatsTracker.removeFromDeleted('conflict-1')
+      }
     })
   })
 
@@ -1334,8 +1424,7 @@ describe('CloudSyncService', () => {
       }
       mockGetChat.mockResolvedValue(chat)
       let finishUpload:
-        | ((value: { syncVersion: number; rewrites: [] }) => void)
-        | undefined
+        ((value: { syncVersion: number; rewrites: [] }) => void) | undefined
       mockUploadChat.mockReturnValue(
         new Promise((resolve) => {
           finishUpload = resolve

--- a/tests/services/cloud/cloud-sync.test.ts
+++ b/tests/services/cloud/cloud-sync.test.ts
@@ -194,6 +194,7 @@ describe('CloudSyncService', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     localStorage.removeItem(SYNC_CHAT_STATUS)
+    localStorage.removeItem(SYNC_CHAT_DELETES_WATERMARK)
     mockSaveChat.mockResolvedValue(undefined)
     mockSaveExistingChat.mockResolvedValue(undefined)
     mockMarkAsSynced.mockResolvedValue(undefined)
@@ -1322,6 +1323,56 @@ describe('CloudSyncService', () => {
       expect(mockReportChatSynced).toHaveBeenCalledWith('conflict-1')
       expect(mockApplyRemoteChatIfFresh).not.toHaveBeenCalled()
       expect(mockRebaseSyncVersion).not.toHaveBeenCalled()
+      // The restore arbitration re-checks the deletion window first so a
+      // tombstone written after the last pass cannot be overwritten.
+      expect(mockSyncRemoteDeletions).toHaveBeenCalledWith(
+        'resolveConflictByPullingRemote',
+        expect.any(Function),
+      )
+    })
+
+    it('does not restore a vanished row when the fresh deletion pass records its tombstone', async () => {
+      mockGetChat.mockResolvedValue(localChat('2024-06-01T00:00:00.000Z', 1))
+      mockDownloadChat.mockResolvedValue(null)
+      mockUploadChat.mockRejectedValueOnce(staleBlob())
+      // The pre-restore reconciliation discovers the deletion that made
+      // the row vanish and applies it.
+      mockSyncRemoteDeletions.mockImplementation(async () => {
+        deletedChatsTracker.markAsDeleted('conflict-1')
+        return { reconciled: true, failed: false }
+      })
+
+      try {
+        const service = new CloudSyncService()
+        await service.backupChat('conflict-1')
+        await service.waitForUpload('conflict-1')
+        await flush()
+
+        expect(mockUploadChat).toHaveBeenCalledTimes(1)
+        expect(mockReportChatSynced).not.toHaveBeenCalled()
+      } finally {
+        deletedChatsTracker.removeFromDeleted('conflict-1')
+      }
+    })
+
+    it('does not restore a vanished row when the fresh deletion pass fails', async () => {
+      mockGetChat.mockResolvedValue(localChat('2024-06-01T00:00:00.000Z', 1))
+      mockDownloadChat.mockResolvedValue(null)
+      mockUploadChat.mockRejectedValueOnce(staleBlob())
+      mockSyncRemoteDeletions.mockResolvedValue({
+        reconciled: false,
+        failed: true,
+      })
+
+      const service = new CloudSyncService()
+      await service.backupChat('conflict-1')
+      await service.waitForUpload('conflict-1')
+      await flush()
+
+      // Without a trustworthy deletion window the restore is deferred;
+      // the chat stays locally modified so the next sync retries.
+      expect(mockUploadChat).toHaveBeenCalledTimes(1)
+      expect(mockReportChatSynced).not.toHaveBeenCalled()
     })
 
     it('leaves the local copy untouched when the remote row is gone and its tombstone is already recorded', async () => {

--- a/tests/services/cloud/cloud-sync.test.ts
+++ b/tests/services/cloud/cloud-sync.test.ts
@@ -708,6 +708,23 @@ describe('CloudSyncService', () => {
       expect(localStorage.getItem(SYNC_CHAT_DELETES_WATERMARK)).toBeNull()
     })
 
+    it('keeps the deletes watermark when only the status caches are cleared', () => {
+      localStorage.setItem(
+        SYNC_CHAT_DELETES_WATERMARK,
+        '2026-01-01T00:00:00.000Z',
+      )
+
+      // The start-fresh flow clears the status caches while local chats
+      // await re-upload; an epoch replay there could apply surviving
+      // tombstones to the chats being re-uploaded.
+      const service = new CloudSyncService()
+      service.clearSyncStatus()
+
+      expect(localStorage.getItem(SYNC_CHAT_DELETES_WATERMARK)).toBe(
+        '2026-01-01T00:00:00.000Z',
+      )
+    })
+
     it('retries listing remote chats before succeeding', async () => {
       mockGetUnsyncedChats.mockResolvedValue([])
       mockGetAllChats.mockResolvedValue([])


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes remote deletion reconciliation so chats deleted on other devices are removed reliably and never resurrected by local uploads. Adds a durable deletes watermark and safer ordering to keep deletion history intact across start‑fresh flows.

- **Bug Fixes**
  - Added a durable deletes watermark (`SYNC_CHAT_DELETES_WATERMARK`) seeded at epoch with a 5s overlap; advances only after a fully reconciled pass; cleared on account change, kept when only clearing status caches.
  - Switched to `listChatEventsSince` to fetch updates and deletes together; a later update wins over an earlier tombstone; never advance past tombstones with unreadable timestamps and record them to the deleted tracker to block restores/re-uploads for those chats until parseable.
  - Always run the deletion pass even without cached sync status; skip uploading local changes when the deletion pass fails to avoid resurrecting remotely deleted chats.
  - Conflict handling: if a locally modified chat lost its remote row, re-check remote deletions right before any restore; if a tombstone is recorded (including unreadable ones), skip restore and let deletion proceed; otherwise restore the row.
  - Expanded tests for watermark behavior, overlap safety, unreadable timestamps, failure paths, and the pre‑restore re‑check.

<sup>Written for commit 79f95d4829295e308ccb502c75674281030c152f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/448?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

