### PR TITLE
Fix: remove chat pages from plausible

### DIFF
--- a/public/js/plausible.js
+++ b/public/js/plausible.js
@@ -53,7 +53,10 @@
   function x() {
     return (
       '/share' === location.pathname ||
-      0 === location.pathname.indexOf('/share/')
+      0 === location.pathname.indexOf('/share/') ||
+      '/chat' === location.pathname ||
+      0 === location.pathname.indexOf('/chat/') ||
+      /^\/project\/[^/]+\/chat(?:\/|$)/.test(location.pathname)
     )
   }
   function f() {

--- a/public/js/plausible.js
+++ b/public/js/plausible.js
@@ -50,6 +50,12 @@
   function v() {
     return u ? s + (Date.now() - u) : s
   }
+  function x() {
+    return (
+      '/share' === location.pathname ||
+      0 === location.pathname.indexOf('/share/')
+    )
+  }
   function f() {
     var t = document.body || {},
       n = document.documentElement || {}
@@ -71,6 +77,7 @@
   }
   function g(i, v) {
     var g = 'pageview' === i
+    if (x()) return m(i, v)
     if (
       (g && c && (w(), (n = f()), (e = h())),
       /^localhost$|^127(\.[0-9]+){0,2}\.[0-9]+$|^\[::1?\]$/.test(

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -9,6 +9,9 @@ import { ClerkProvider } from '@clerk/nextjs'
 import type { AppProps } from 'next/app'
 import localFont from 'next/font/local'
 import Head from 'next/head'
+import Script from 'next/script'
+
+const SHARED_CHAT_ROUTE = '/share/[[...slug]]'
 
 const aeonikFono = localFont({
   src: [
@@ -114,7 +117,7 @@ const openDyslexic = localFont({
 
 migrateStorageKeys()
 
-export default function App({ Component, pageProps }: AppProps) {
+export default function App({ Component, pageProps, router }: AppProps) {
   useChatFontSync()
 
   return (
@@ -153,6 +156,17 @@ export default function App({ Component, pageProps }: AppProps) {
           content="Private AI chat application supporting open source models through Tinfoil"
         />
       </Head>
+      {router.pathname !== SHARED_CHAT_ROUTE && (
+        <Script
+          defer
+          data-domain="chat.tinfoil.sh"
+          data-api="https://plausible.io/api/event"
+          src="/js/plausible.js"
+          integrity="sha384-rgNzWRUP78OzHT0L9HCoK0WC+gccgf9jPZT65GCqSE3ZKQWZtT/ptpetz0T2WB4b"
+          crossOrigin="anonymous"
+          strategy="afterInteractive"
+        />
+      )}
       <style jsx global>{`
         :root {
           --font-aeonik-fono: ${aeonikFono.style.fontFamily};

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -11,7 +11,13 @@ import localFont from 'next/font/local'
 import Head from 'next/head'
 import Script from 'next/script'
 
-const SHARED_CHAT_ROUTE = '/share/[[...slug]]'
+const ANALYTICS_EXCLUDED_ROUTES = new Set([
+  '/share/[[...slug]]',
+  '/chat/[[...slug]]',
+  '/chat/[chatId]',
+  '/chat/local/[chatId]',
+  '/project/[projectId]/chat/[chatId]',
+])
 
 const aeonikFono = localFont({
   src: [
@@ -156,13 +162,13 @@ export default function App({ Component, pageProps, router }: AppProps) {
           content="Private AI chat application supporting open source models through Tinfoil"
         />
       </Head>
-      {router.pathname !== SHARED_CHAT_ROUTE && (
+      {!ANALYTICS_EXCLUDED_ROUTES.has(router.pathname) && (
         <Script
           defer
           data-domain="chat.tinfoil.sh"
           data-api="https://plausible.io/api/event"
           src="/js/plausible.js"
-          integrity="sha384-rgNzWRUP78OzHT0L9HCoK0WC+gccgf9jPZT65GCqSE3ZKQWZtT/ptpetz0T2WB4b"
+          integrity="sha384-b9XvNgc2+VPXI896lpD5wayk8mrDF40D+0aMR10g+8OO5zij+GXEhu2NhUSz1Oxz"
           crossOrigin="anonymous"
           strategy="afterInteractive"
         />

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,5 +1,4 @@
 import { Head, Html, Main, NextScript } from 'next/document'
-import Script from 'next/script'
 
 export default function Document() {
   // Inline script to set theme before first paint to prevent flash
@@ -135,16 +134,6 @@ export default function Document() {
 
         <link rel="icon" href="/android-chrome-192x192.png" sizes="192x192" />
         <link rel="icon" href="/android-chrome-512x512.png" sizes="512x512" />
-
-        <Script
-          defer
-          data-domain="chat.tinfoil.sh"
-          data-api="https://plausible.io/api/event"
-          src="/js/plausible.js"
-          integrity="sha384-2koU+A5hG/EjBLH1x5k5ThN+dPO7wtgAfkwcsSgQq3kNc0ouUd56j17YOJ0aE0yv"
-          crossOrigin="anonymous"
-          strategy="afterInteractive"
-        />
       </Head>
       <body className="font-aeonik-fono antialiased">
         <Main />

--- a/tests/pages/plausible-analytics.test.ts
+++ b/tests/pages/plausible-analytics.test.ts
@@ -1,0 +1,118 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { runInNewContext } from 'node:vm'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const plausibleScript = readFileSync(
+  resolve(process.cwd(), 'public/js/plausible.js'),
+  'utf8',
+)
+
+type Plausible = (eventName: string, options?: object) => void
+
+function loadPlausible(url: string) {
+  const parsedUrl = new URL(url)
+  const location = {
+    href: parsedUrl.href,
+    hostname: parsedUrl.hostname,
+    pathname: parsedUrl.pathname,
+    protocol: parsedUrl.protocol,
+  }
+  const fetchMock = vi.fn().mockResolvedValue({ status: 202 })
+  const windowMock: {
+    addEventListener: ReturnType<typeof vi.fn>
+    fetch: typeof fetchMock
+    history: {
+      pushState: (
+        data: unknown,
+        unused: string,
+        url?: string | URL | null,
+      ) => void
+    }
+    localStorage: object
+    navigator: { webdriver: boolean }
+    plausible?: Plausible
+  } = {
+    addEventListener: vi.fn(),
+    fetch: fetchMock,
+    history: {
+      pushState: vi.fn(),
+    },
+    localStorage: {},
+    navigator: {
+      webdriver: false,
+    },
+  }
+  const documentMock = {
+    addEventListener: vi.fn(),
+    body: {},
+    currentScript: {
+      getAttribute: (name: string) => {
+        if (name === 'data-api') return 'https://plausible.io/api/event'
+        if (name === 'data-domain') return 'chat.tinfoil.sh'
+        return null
+      },
+      src: 'https://chat.tinfoil.sh/js/plausible.js',
+    },
+    documentElement: {
+      clientHeight: 800,
+    },
+    hasFocus: () => true,
+    referrer: '',
+    visibilityState: 'visible',
+  }
+
+  runInNewContext(plausibleScript, {
+    URL,
+    console,
+    document: documentMock,
+    fetch: fetchMock,
+    location,
+    setInterval,
+    window: windowMock,
+  })
+
+  return {
+    fetchMock,
+    history: windowMock.history,
+    location,
+    plausible: windowMock.plausible,
+  }
+}
+
+describe('Plausible analytics', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('does not send events from shared chat URLs', () => {
+    const analytics = loadPlausible(
+      'https://chat.tinfoil.sh/share/chat-id#v2:throwaway-key',
+    )
+
+    analytics.plausible?.('Share Viewed')
+
+    expect(analytics.fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('stops sending events after navigating to a shared chat URL', () => {
+    const analytics = loadPlausible('https://chat.tinfoil.sh/chat/local/id')
+    expect(analytics.fetchMock).toHaveBeenCalledTimes(1)
+
+    analytics.location.href =
+      'https://chat.tinfoil.sh/share/chat-id#v2:throwaway-key'
+    analytics.location.pathname = '/share/chat-id'
+    analytics.history.pushState({}, '', '/share/chat-id')
+
+    expect(analytics.fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('continues sending pageviews from non-share routes', () => {
+    const analytics = loadPlausible('https://chat.tinfoil.sh/shared')
+
+    expect(analytics.fetchMock).toHaveBeenCalledTimes(1)
+    const request = analytics.fetchMock.mock.calls[0][1]
+    const body = JSON.parse(String(request.body)) as { u: string }
+    expect(body.u).toBe('https://chat.tinfoil.sh/shared')
+  })
+})

--- a/tests/pages/plausible-analytics.test.ts
+++ b/tests/pages/plausible-analytics.test.ts
@@ -85,24 +85,27 @@ describe('Plausible analytics', () => {
     vi.restoreAllMocks()
   })
 
-  it('does not send events from shared chat URLs', () => {
-    const analytics = loadPlausible(
-      'https://chat.tinfoil.sh/share/chat-id#v2:throwaway-key',
-    )
+  it.each([
+    ['shared chat', 'https://chat.tinfoil.sh/share/chat-id#v2:throwaway-key'],
+    ['chat root', 'https://chat.tinfoil.sh/chat'],
+    ['chat', 'https://chat.tinfoil.sh/chat/chat-id'],
+    ['local chat', 'https://chat.tinfoil.sh/chat/local/chat-id'],
+    ['project chat', 'https://chat.tinfoil.sh/project/project-id/chat/chat-id'],
+  ])('does not send events from %s URLs', (_, url) => {
+    const analytics = loadPlausible(url)
 
-    analytics.plausible?.('Share Viewed')
+    analytics.plausible?.('Chat Viewed')
 
     expect(analytics.fetchMock).not.toHaveBeenCalled()
   })
 
-  it('stops sending events after navigating to a shared chat URL', () => {
-    const analytics = loadPlausible('https://chat.tinfoil.sh/chat/local/id')
+  it('stops sending events after navigating to a chat URL', () => {
+    const analytics = loadPlausible('https://chat.tinfoil.sh/signin')
     expect(analytics.fetchMock).toHaveBeenCalledTimes(1)
 
-    analytics.location.href =
-      'https://chat.tinfoil.sh/share/chat-id#v2:throwaway-key'
-    analytics.location.pathname = '/share/chat-id'
-    analytics.history.pushState({}, '', '/share/chat-id')
+    analytics.location.href = 'https://chat.tinfoil.sh/chat/local/chat-id'
+    analytics.location.pathname = '/chat/local/chat-id'
+    analytics.history.pushState({}, '', '/chat/local/chat-id')
 
     expect(analytics.fetchMock).toHaveBeenCalledTimes(1)
   })


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Exclude all chat and shared chat pages from Plausible analytics to protect user privacy. Adds conditional script loading and in-script guards so no events are sent from chat routes.

- **Bug Fixes**
  - In plausible client (`public/js/plausible.js`): added path checks for `/share`, `/chat`, and `/project/{id}/chat` to skip sending events.
  - In app (`src/pages/_app.tsx`): load Plausible via `next/script` only on non-chat routes; removed the script from `_document.tsx`.
  - Tests: added coverage to ensure no events fire on chat URLs and that navigation into chat stops further events; non-chat routes still send pageviews.

<sup>Written for commit 3a4a0bb0d44a2f94427248a3ba9c933a923dd9eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/449?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

