### PR TITLE
Use semantic controls throughout chat

### DIFF
--- a/src/components/chat/chat-input.tsx
+++ b/src/components/chat/chat-input.tsx
@@ -760,6 +760,7 @@ export function ChatInput({
                 >
                   {removeDocument && (
                     <button
+                      type="button"
                       onClick={(e) => {
                         e.stopPropagation()
                         removeDocument(doc.id)

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -71,6 +71,7 @@ import {
 } from '@/utils/cloud-sync-settings'
 import { logError } from '@/utils/error-handling'
 import { isProbablyTextFile, isSupportedFile } from '@/utils/file-types'
+import { getNewChatPath, isPlainPrimaryClick } from '@/utils/navigation'
 import {
   getProjectUploadPreference,
   setProjectUploadPreference,
@@ -2649,15 +2650,12 @@ export function ChatInterface({
           <p className="mb-6 text-content-secondary">
             This local chat may have been deleted from your browser.
           </p>
-          <button
-            onClick={() => {
-              clearUrl()
-              window.location.href = '/'
-            }}
+          <Link
+            href="/"
             className="rounded-lg bg-brand-accent-dark px-6 py-2.5 text-white transition-colors hover:bg-brand-accent-dark/90"
           >
             Start new chat
-          </button>
+          </Link>
         </div>
       </div>
     )
@@ -2679,15 +2677,12 @@ export function ChatInterface({
           <p className="mb-6 text-content-secondary">
             This chat may have been deleted or is no longer available.
           </p>
-          <button
-            onClick={() => {
-              clearUrl()
-              window.location.href = '/'
-            }}
+          <Link
+            href="/"
             className="rounded-lg bg-brand-accent-dark px-6 py-2.5 text-white transition-colors hover:bg-brand-accent-dark/90"
           >
             Start new chat
-          </button>
+          </Link>
         </div>
       </div>
     )
@@ -2735,15 +2730,12 @@ export function ChatInterface({
             >
               Try again
             </button>
-            <button
-              onClick={() => {
-                clearUrl()
-                window.location.href = '/'
-              }}
+            <Link
+              href="/"
               className="rounded-lg border border-border-subtle px-6 py-2.5 text-content-primary transition-colors hover:bg-surface-chat"
             >
               Start new chat
-            </button>
+            </Link>
           </div>
         </div>
       </div>
@@ -2908,14 +2900,18 @@ export function ChatInterface({
           {windowWidth < CONSTANTS.MOBILE_BREAKPOINT &&
             currentChat?.messages &&
             currentChat.messages.length > 0 && (
-              <button
-                type="button"
-                onClick={() => createNewChat()}
+              <Link
+                href={getNewChatPath(activeProject?.id)}
+                onClick={(e) => {
+                  if (!isPlainPrimaryClick(e)) return
+                  e.preventDefault()
+                  createNewChat()
+                }}
                 className="flex items-center justify-center rounded-lg border border-border-subtle bg-surface-chat-background p-2.5 text-content-secondary transition-all duration-200 hover:bg-surface-chat hover:text-content-primary"
                 aria-label="New chat"
               >
                 <PiNotePencilLight className="h-4 w-4" />
-              </button>
+              </Link>
             )}
 
           {canToggleTemporaryChat(currentChat) &&

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -181,6 +181,7 @@ type ChatInterfaceProps = {
   initialChatId?: string | null
   initialProjectId?: string | null
   isLocalChatUrl?: boolean
+  initialNewChatIsLocalOnly?: boolean
   /**
    * When true, suppresses auto-opening intro/setup modals on this mount
    * (onboarding, passkey setup/recovery prompts, cloud sync setup, and the
@@ -239,6 +240,7 @@ export function ChatInterface({
   initialChatId,
   initialProjectId,
   isLocalChatUrl: isLocalChatUrlProp,
+  initialNewChatIsLocalOnly = false,
   suppressIntroModals = false,
 }: ChatInterfaceProps) {
   const { toast } = useToast()
@@ -763,6 +765,7 @@ export function ChatInterface({
     thinkingEnabled,
     initialChatId,
     isLocalChatUrl,
+    initialNewChatIsLocalOnly,
     webSearchAvailable,
     // Feature flag gates key derivation in useExecSnapshot; the toggle
     // gates request plumbing. Both layers must be on to use code-exec.
@@ -2901,11 +2904,14 @@ export function ChatInterface({
             currentChat?.messages &&
             currentChat.messages.length > 0 && (
               <Link
-                href={getNewChatPath(activeProject?.id)}
+                href={getNewChatPath({
+                  isLocalOnly: currentChat.isLocalOnly,
+                  projectId: activeProject?.id,
+                })}
                 onClick={(e) => {
                   if (!isPlainPrimaryClick(e)) return
                   e.preventDefault()
-                  createNewChat()
+                  createNewChat(currentChat.isLocalOnly, true)
                 }}
                 className="flex items-center justify-center rounded-lg border border-border-subtle bg-surface-chat-background p-2.5 text-content-secondary transition-all duration-200 hover:bg-surface-chat hover:text-content-primary"
                 aria-label="New chat"
@@ -3064,6 +3070,7 @@ export function ChatInterface({
                   isOpen={isSidebarOpen}
                   setIsOpen={setIsSidebarOpen}
                   project={null}
+                  loadingProjectId={loadingProject?.id}
                   projectName={loadingProject?.name}
                   isLoading={true}
                   isDarkMode={isDarkMode}

--- a/src/components/chat/chat-list-item.tsx
+++ b/src/components/chat/chat-list-item.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { isPlainPrimaryClick } from '@/utils/navigation'
 import {
   CheckIcon,
   CloudArrowUpIcon,
@@ -11,6 +12,7 @@ import {
   TrashIcon,
   XMarkIcon,
 } from '@heroicons/react/24/outline'
+import Link from 'next/link'
 import { useEffect, useId, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { CiFloppyDisk } from 'react-icons/ci'
@@ -79,6 +81,7 @@ interface ChatListItemProps {
   isDraggable?: boolean
   showMoveToProject?: boolean
   projects?: ProjectOption[]
+  href?: string
   onSelect: () => void
   onStartEdit: () => void
   onTitleChange: (title: string) => void
@@ -91,6 +94,52 @@ interface ChatListItemProps {
   onConvertToCloud?: () => void
   onConvertToLocal?: () => void
   onRemoveFromProject?: () => void
+}
+
+function ChatSelectionControl({
+  href,
+  isSelected,
+  onSelect,
+  children,
+}: {
+  href?: string
+  isSelected: boolean
+  onSelect: () => void
+  children: React.ReactNode
+}) {
+  const className =
+    'min-w-0 flex-1 cursor-pointer rounded-md pr-2 text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-border-strong'
+  const ariaCurrent = isSelected ? 'page' : undefined
+
+  if (href) {
+    return (
+      <Link
+        href={href}
+        prefetch={false}
+        draggable={false}
+        aria-current={ariaCurrent}
+        className={className}
+        onClick={(event) => {
+          if (event.defaultPrevented || !isPlainPrimaryClick(event)) return
+          event.preventDefault()
+          onSelect()
+        }}
+      >
+        {children}
+      </Link>
+    )
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      aria-current={ariaCurrent}
+      className={className}
+    >
+      {children}
+    </button>
+  )
 }
 
 export function ChatListItem({
@@ -107,6 +156,7 @@ export function ChatListItem({
   isDraggable = false,
   showMoveToProject = false,
   projects = [],
+  href,
   onSelect,
   onStartEdit,
   onTitleChange,
@@ -311,14 +361,13 @@ export function ChatListItem({
           </form>
         </div>
       ) : (
-        <button
-          type="button"
-          onClick={onSelect}
-          aria-current={isSelected ? 'true' : undefined}
-          className="min-w-0 flex-1 cursor-pointer rounded-md pr-2 text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-border-strong"
+        <ChatSelectionControl
+          href={href}
+          isSelected={isSelected}
+          onSelect={onSelect}
         >
           <>
-            <div className="flex items-center gap-1.5">
+            <span className="flex items-center gap-1.5">
               {showEncryptionStatus && chat.decryptionFailed && (
                 <FaLock
                   className="h-3.5 w-3.5 flex-shrink-0 text-orange-500"
@@ -326,7 +375,7 @@ export function ChatListItem({
                   aria-hidden="true"
                 />
               )}
-              <div
+              <span
                 className={cn(
                   'truncate font-aeonik-fono text-sm font-medium',
                   chat.decryptionFailed
@@ -345,7 +394,7 @@ export function ChatListItem({
                 ) : (
                   displayTitle
                 )}
-              </div>
+              </span>
               {isStreaming ? (
                 <span
                   className="mx-2 flex w-[18px] flex-shrink-0 items-center justify-center"
@@ -356,14 +405,14 @@ export function ChatListItem({
                 </span>
               ) : (
                 isNewChat && (
-                  <div
+                  <span
                     className="h-1.5 w-1.5 rounded-full bg-blue-500"
                     title="New chat"
                     aria-hidden="true"
                   />
                 )
               )}
-            </div>
+            </span>
             {(chat.decryptionFailed ||
               (messageCount > 0 && timestamp) ||
               (showSyncStatus &&
@@ -372,22 +421,22 @@ export function ChatListItem({
                   (!chat.isBlankChat &&
                     chat.pendingSave &&
                     !isStreaming)))) && (
-              <div className="mt-1 flex min-h-[16px] w-full flex-wrap items-center gap-2 @container">
+              <span className="mt-1 flex min-h-[16px] w-full flex-wrap items-center gap-2 @container">
                 {chat.decryptionFailed ? (
-                  <div className="text-xs text-red-500">
+                  <span className="text-xs text-red-500">
                     {chat.dataCorrupted
                       ? 'Failed to decrypt: corrupted data'
                       : 'Failed to decrypt: wrong key'}
-                  </div>
+                  </span>
                 ) : messageCount > 0 && timestamp ? (
-                  <div className="text-xs leading-none text-content-muted">
+                  <span className="text-xs leading-none text-content-muted">
                     <span className="text-content-secondary">
                       {formatRelativeTime(createdAt ?? timestamp)}
                     </span>
                     {showUpdatedTime && (
                       <> · Updated {formatRelativeTime(timestamp)}</>
                     )}
-                  </div>
+                  </span>
                 ) : null}
                 {showSyncStatus && (
                   <>
@@ -430,10 +479,10 @@ export function ChatListItem({
                     ) : null}
                   </>
                 )}
-              </div>
+              </span>
             )}
           </>
-        </button>
+        </ChatSelectionControl>
       )}
 
       {!isEditing && (
@@ -441,6 +490,7 @@ export function ChatListItem({
           <div className="pointer-events-none hidden items-center opacity-0 transition-opacity md:flex md:group-focus-within:pointer-events-auto md:group-focus-within:opacity-100 md:group-hover:pointer-events-auto md:group-hover:opacity-100">
             {!chat.decryptionFailed && !chat.isBlankChat && (
               <button
+                type="button"
                 className={cn(
                   'mr-1 rounded p-1 transition-colors',
                   isDarkMode
@@ -456,6 +506,7 @@ export function ChatListItem({
             )}
             {!chat.isBlankChat && (
               <button
+                type="button"
                 className={cn(
                   'rounded p-1 transition-colors',
                   isDarkMode

--- a/src/components/chat/chat-list.tsx
+++ b/src/components/chat/chat-list.tsx
@@ -35,6 +35,7 @@ interface ChatListProps {
   isDraggable?: boolean
   showMoveToProject?: boolean
   projects?: ProjectOption[]
+  getChatHref?: (chat: ChatItemData) => string | undefined
   onSelectChat: (chatId: string) => void
   onAfterSelect?: () => void
   onUpdateTitle?: (chatId: string, title: string) => void
@@ -70,6 +71,7 @@ export function ChatList({
   isDraggable = false,
   showMoveToProject = false,
   projects = [],
+  getChatHref,
   onSelectChat,
   onAfterSelect,
   onUpdateTitle,
@@ -223,6 +225,7 @@ export function ChatList({
                   !chat.decryptionFailed
                 }
                 projects={projects}
+                href={getChatHref?.(chat)}
                 onSelect={() => handleSelect(chat)}
                 onStartEdit={() => handleStartEdit(chat)}
                 onTitleChange={setEditingTitle}

--- a/src/components/chat/chat-sidebar.tsx
+++ b/src/components/chat/chat-sidebar.tsx
@@ -63,6 +63,11 @@ import { useCloudPagination } from '@/hooks/use-cloud-pagination'
 
 import { useChatSearch } from '@/hooks/use-chat-search'
 import { logError } from '@/utils/error-handling'
+import {
+  getChatPath,
+  getNewChatPath,
+  isPlainPrimaryClick,
+} from '@/utils/navigation'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Link } from '../link'
 import { Logo } from '../logo'
@@ -839,19 +844,12 @@ export function ChatSidebar({
             <div className="flex flex-col items-center gap-1 px-2">
               {/* New chat button */}
               <div className="group relative">
-                <button
-                  type="button"
+                <Link
+                  href="/newchat"
                   onClick={(e) => {
-                    if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) {
-                      window.open('/newchat', '_blank', 'noopener,noreferrer')
-                      return
-                    }
-                    createNewChat(activeTab === 'local', true)
-                  }}
-                  onAuxClick={(e) => {
-                    if (e.button !== 1) return
+                    if (!isPlainPrimaryClick(e)) return
                     e.preventDefault()
-                    window.open('/newchat', '_blank', 'noopener,noreferrer')
+                    createNewChat(activeTab === 'local', true)
                   }}
                   className={cn(
                     'flex h-10 w-10 items-center justify-center rounded-lg transition-colors',
@@ -860,7 +858,7 @@ export function ChatSidebar({
                   aria-label="New chat"
                 >
                   <PiNotePencilLight className="h-5 w-5" />
-                </button>
+                </Link>
                 <span className="pointer-events-none absolute left-full top-1/2 z-50 ml-2 -translate-y-1/2 whitespace-nowrap rounded border border-border-subtle bg-surface-chat-background px-2 py-1 text-xs text-content-primary opacity-0 shadow-sm transition-opacity group-hover:opacity-100">
                   New chat{' '}
                   <span className="text-content-muted">
@@ -976,16 +974,7 @@ export function ChatSidebar({
         {/* Header */}
         <div className="flex h-16 flex-none items-center justify-between p-4">
           <div className="flex items-center gap-3">
-            <Link
-              href="/"
-              title="Home"
-              className="flex items-center"
-              onAuxClick={(e) => {
-                if (e.button !== 1) return
-                e.preventDefault()
-                window.open('/', '_blank', 'noopener,noreferrer')
-              }}
-            >
+            <Link href="/" title="Home" className="flex items-center">
               <Logo className="h-6 w-auto" dark={isDarkMode} />
             </Link>
             {/* Settings button */}
@@ -1174,64 +1163,59 @@ export function ChatSidebar({
 
           {/* New Chat button */}
           <div className="relative z-10 flex-none px-2 py-2">
-            <button
-              type="button"
-              aria-disabled={currentChat?.isBlankChat}
-              onClick={(e) => {
-                if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) {
-                  window.open('/newchat', '_blank', 'noopener,noreferrer')
-                  return
-                }
-                if (currentChat?.isBlankChat) return
-                createNewChat(activeTab === 'local', true)
-              }}
-              onAuxClick={(e) => {
-                if (e.button !== 1) return
-                e.preventDefault()
-                window.open('/newchat', '_blank', 'noopener,noreferrer')
-              }}
-              className={cn(
-                'flex w-full items-center justify-between rounded-lg border px-2 py-2 text-sm transition-colors',
-                currentChat?.isBlankChat
-                  ? 'cursor-default border-transparent bg-transparent text-content-muted'
-                  : isDarkMode
+            {currentChat?.isBlankChat ? (
+              <button
+                type="button"
+                disabled
+                className="flex w-full cursor-default items-center justify-between rounded-lg border border-transparent bg-transparent px-2 py-2 text-sm text-content-muted"
+              >
+                <span className="flex items-center gap-2">
+                  <PiNotePencilLight className="h-4 w-4" />
+                  <span className="font-aeonik font-medium">New chat</span>
+                </span>
+                <span className="text-xs text-content-muted">
+                  {modKey}
+                  {isMac ? '⇧' : 'Shift+'}O
+                </span>
+              </button>
+            ) : (
+              <Link
+                href="/newchat"
+                onClick={(e) => {
+                  if (!isPlainPrimaryClick(e)) return
+                  e.preventDefault()
+                  createNewChat(activeTab === 'local', true)
+                }}
+                className={cn(
+                  'flex w-full items-center justify-between rounded-lg border px-2 py-2 text-sm transition-colors',
+                  isDarkMode
                     ? 'border-border-strong bg-surface-chat text-content-primary hover:bg-surface-chat/80'
                     : 'border-border-subtle bg-white text-content-primary hover:bg-gray-50',
-              )}
-            >
-              <span className="flex items-center gap-2">
-                <PiNotePencilLight className="h-4 w-4" />
-                <span className="font-aeonik font-medium">New chat</span>
-              </span>
-              <span className="text-xs text-content-muted">
-                {modKey}
-                {isMac ? '⇧' : 'Shift+'}O
-              </span>
-            </button>
+                )}
+              >
+                <span className="flex items-center gap-2">
+                  <PiNotePencilLight className="h-4 w-4" />
+                  <span className="font-aeonik font-medium">New chat</span>
+                </span>
+                <span className="text-xs text-content-muted">
+                  {modKey}
+                  {isMac ? '⇧' : 'Shift+'}O
+                </span>
+              </Link>
+            )}
           </div>
 
           {/* Projects dropdown - show for premium users */}
           {isSignedIn && isPremium && (
             <div className="relative z-10 flex-none border-t border-border-subtle">
-              <div
-                role="button"
-                tabIndex={0}
+              <button
+                type="button"
                 aria-expanded={isProjectsExpanded}
                 onClick={() => {
                   const newExpanded = !isProjectsExpanded
                   setIsProjectsExpanded(newExpanded)
                   if (newExpanded && projects.length === 0) {
                     refreshProjects()
-                  }
-                }}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter' || e.key === ' ') {
-                    e.preventDefault()
-                    const newExpanded = !isProjectsExpanded
-                    setIsProjectsExpanded(newExpanded)
-                    if (newExpanded && projects.length === 0) {
-                      refreshProjects()
-                    }
                   }
                 }}
                 onDragOver={(e) => {
@@ -1286,14 +1270,14 @@ export function ChatSidebar({
                       : 'Projects'}
                   </span>
                 </span>
-                <div className="flex items-center gap-1">
+                <span className="flex items-center gap-1">
                   {isProjectsExpanded ? (
                     <ChevronDownIcon className="h-4 w-4" />
                   ) : (
                     <ChevronRightIcon className="h-4 w-4" />
                   )}
-                </div>
-              </div>
+                </span>
+              </button>
 
               {/* Expanded projects list */}
               <AnimatePresence initial={false}>
@@ -1377,32 +1361,115 @@ export function ChatSidebar({
                             </div>
                           ) : (
                             <>
-                              {projects.map((project) => (
-                                <div
-                                  key={project.id}
-                                  role="button"
-                                  tabIndex={project.decryptionFailed ? -1 : 0}
-                                  onClick={async () => {
-                                    if (project.decryptionFailed) return
-
-                                    if (onEnterProject) {
-                                      await onEnterProject(
-                                        project.id,
-                                        project.name,
-                                      )
-                                    }
-                                  }}
-                                  onKeyDown={(e) => {
-                                    if (
-                                      (e.key === 'Enter' || e.key === ' ') &&
-                                      onEnterProject &&
-                                      !project.decryptionFailed
-                                    ) {
-                                      e.preventDefault()
-                                      onEnterProject(project.id, project.name)
-                                    }
-                                  }}
-                                  onDragOver={(e) => {
+                              {projects.map((project) => {
+                                const projectContent = (
+                                  <>
+                                    {project.decryptionFailed ? (
+                                      <FaLock className="mt-0.5 h-4 w-4 shrink-0 self-start text-orange-500" />
+                                    ) : (
+                                      <FolderIcon
+                                        className={cn(
+                                          'mt-0.5 h-4 w-4 shrink-0 self-start',
+                                          !getProjectColor(project.color) &&
+                                            'text-content-muted',
+                                        )}
+                                        style={
+                                          getProjectColor(project.color)
+                                            ? {
+                                                color: getProjectColor(
+                                                  project.color,
+                                                )!.hex,
+                                              }
+                                            : undefined
+                                        }
+                                      />
+                                    )}
+                                    <div className="flex min-w-0 flex-1 flex-col text-left">
+                                      <span
+                                        className={cn(
+                                          'truncate leading-5',
+                                          project.decryptionFailed &&
+                                            'text-orange-500',
+                                        )}
+                                      >
+                                        {project.name}
+                                      </span>
+                                      <span
+                                        className={cn(
+                                          'text-xs',
+                                          project.decryptionFailed
+                                            ? 'text-red-500'
+                                            : 'text-content-muted',
+                                        )}
+                                      >
+                                        {project.decryptionFailed
+                                          ? 'Failed to decrypt: wrong key'
+                                          : `Updated ${formatRelativeTime(new Date(project.updatedAt))}`}
+                                      </span>
+                                    </div>
+                                    {project.decryptionFailed && (
+                                      <button
+                                        type="button"
+                                        onClick={async () => {
+                                          if (deletingProjectId === project.id)
+                                            return
+                                          setDeletingProjectId(project.id)
+                                          try {
+                                            await deleteProject(project.id)
+                                            await refreshProjects()
+                                          } catch (error) {
+                                            toast({
+                                              title: 'Failed to delete project',
+                                              description:
+                                                error instanceof Error
+                                                  ? error.message
+                                                  : 'Please try again.',
+                                              variant: 'destructive',
+                                            })
+                                          } finally {
+                                            setDeletingProjectId(null)
+                                          }
+                                        }}
+                                        disabled={
+                                          deletingProjectId === project.id
+                                        }
+                                        className={cn(
+                                          'shrink-0 rounded p-1 transition-colors',
+                                          isDarkMode
+                                            ? 'text-content-muted hover:bg-surface-chat hover:text-white'
+                                            : 'text-content-muted hover:bg-surface-sidebar hover:text-content-secondary',
+                                          deletingProjectId === project.id &&
+                                            'opacity-50',
+                                        )}
+                                        aria-label="Delete encrypted project"
+                                        title="Delete encrypted project"
+                                      >
+                                        {deletingProjectId === project.id ? (
+                                          <PiSpinner className="h-4 w-4 animate-spin" />
+                                        ) : (
+                                          <TrashIcon className="h-4 w-4" />
+                                        )}
+                                      </button>
+                                    )}
+                                  </>
+                                )
+                                const projectClassName = cn(
+                                  'group flex w-full items-center gap-2 rounded-lg border px-3 py-2 text-left text-sm transition-colors',
+                                  dropTargetProjectId === project.id
+                                    ? isDarkMode
+                                      ? 'border-white/30 bg-white/10'
+                                      : 'border-gray-400 bg-gray-200/30'
+                                    : 'border-transparent hover:border-border-subtle',
+                                  project.decryptionFailed
+                                    ? 'cursor-default'
+                                    : isDarkMode
+                                      ? 'cursor-pointer text-content-secondary hover:bg-surface-chat'
+                                      : 'cursor-pointer text-content-secondary hover:bg-surface-sidebar',
+                                )
+                                const projectDragHandlers = {
+                                  onDragOver: (
+                                    e: React.DragEvent<HTMLElement>,
+                                  ) => {
                                     if (
                                       e.dataTransfer.types.includes(
                                         'application/x-chat-id',
@@ -1413,8 +1480,10 @@ export function ChatSidebar({
                                       e.dataTransfer.dropEffect = 'move'
                                       setDropTargetProject(project.id)
                                     }
-                                  }}
-                                  onDragEnter={(e) => {
+                                  },
+                                  onDragEnter: (
+                                    e: React.DragEvent<HTMLElement>,
+                                  ) => {
                                     if (
                                       e.dataTransfer.types.includes(
                                         'application/x-chat-id',
@@ -1438,8 +1507,10 @@ export function ChatSidebar({
                                         400,
                                       )
                                     }
-                                  }}
-                                  onDragLeave={(e) => {
+                                  },
+                                  onDragLeave: (
+                                    e: React.DragEvent<HTMLElement>,
+                                  ) => {
                                     // Only clear if actually leaving the button (not just moving between children)
                                     if (
                                       !e.currentTarget.contains(
@@ -1456,8 +1527,10 @@ export function ChatSidebar({
                                         projectHoverTimerRef.current = null
                                       }
                                     }
-                                  }}
-                                  onDrop={async (e) => {
+                                  },
+                                  onDrop: async (
+                                    e: React.DragEvent<HTMLElement>,
+                                  ) => {
                                     e.preventDefault()
                                     if (projectHoverTimerRef.current) {
                                       clearTimeout(projectHoverTimerRef.current)
@@ -1487,109 +1560,45 @@ export function ChatSidebar({
                                       )
                                     }
                                     clearDragState()
-                                  }}
-                                  className={cn(
-                                    'group flex w-full items-center gap-2 rounded-lg border px-3 py-2 text-left text-sm transition-colors',
-                                    dropTargetProjectId === project.id
-                                      ? isDarkMode
-                                        ? 'border-white/30 bg-white/10'
-                                        : 'border-gray-400 bg-gray-200/30'
-                                      : 'border-transparent hover:border-border-subtle',
-                                    project.decryptionFailed
-                                      ? 'cursor-default'
-                                      : isDarkMode
-                                        ? 'cursor-pointer text-content-secondary hover:bg-surface-chat'
-                                        : 'cursor-pointer text-content-secondary hover:bg-surface-sidebar',
-                                  )}
-                                >
-                                  {project.decryptionFailed ? (
-                                    <FaLock className="mt-0.5 h-4 w-4 shrink-0 self-start text-orange-500" />
-                                  ) : (
-                                    <FolderIcon
-                                      className={cn(
-                                        'mt-0.5 h-4 w-4 shrink-0 self-start',
-                                        !getProjectColor(project.color) &&
-                                          'text-content-muted',
-                                      )}
-                                      style={
-                                        getProjectColor(project.color)
-                                          ? {
-                                              color: getProjectColor(
-                                                project.color,
-                                              )!.hex,
-                                            }
-                                          : undefined
-                                      }
-                                    />
-                                  )}
-                                  <div className="flex min-w-0 flex-1 flex-col text-left">
-                                    <span
-                                      className={cn(
-                                        'truncate leading-5',
-                                        project.decryptionFailed &&
-                                          'text-orange-500',
-                                      )}
+                                  },
+                                }
+
+                                if (project.decryptionFailed) {
+                                  return (
+                                    <div
+                                      key={project.id}
+                                      className={projectClassName}
                                     >
-                                      {project.name}
-                                    </span>
-                                    <span
-                                      className={cn(
-                                        'text-xs',
-                                        project.decryptionFailed
-                                          ? 'text-red-500'
-                                          : 'text-content-muted',
-                                      )}
-                                    >
-                                      {project.decryptionFailed
-                                        ? 'Failed to decrypt: wrong key'
-                                        : `Updated ${formatRelativeTime(new Date(project.updatedAt))}`}
-                                    </span>
-                                  </div>
-                                  {project.decryptionFailed && (
-                                    <button
-                                      onClick={async (e) => {
-                                        e.stopPropagation()
-                                        if (deletingProjectId === project.id)
-                                          return
-                                        setDeletingProjectId(project.id)
-                                        try {
-                                          await deleteProject(project.id)
-                                          await refreshProjects()
-                                        } catch (error) {
-                                          toast({
-                                            title: 'Failed to delete project',
-                                            description:
-                                              error instanceof Error
-                                                ? error.message
-                                                : 'Please try again.',
-                                            variant: 'destructive',
-                                          })
-                                        } finally {
-                                          setDeletingProjectId(null)
-                                        }
-                                      }}
-                                      disabled={
-                                        deletingProjectId === project.id
-                                      }
-                                      className={cn(
-                                        'shrink-0 rounded p-1 transition-colors',
-                                        isDarkMode
-                                          ? 'text-content-muted hover:bg-surface-chat hover:text-white'
-                                          : 'text-content-muted hover:bg-surface-sidebar hover:text-content-secondary',
-                                        deletingProjectId === project.id &&
-                                          'opacity-50',
-                                      )}
-                                      title="Delete encrypted project"
-                                    >
-                                      {deletingProjectId === project.id ? (
-                                        <PiSpinner className="h-4 w-4 animate-spin" />
-                                      ) : (
-                                        <TrashIcon className="h-4 w-4" />
-                                      )}
-                                    </button>
-                                  )}
-                                </div>
-                              ))}
+                                      {projectContent}
+                                    </div>
+                                  )
+                                }
+
+                                return (
+                                  <Link
+                                    key={project.id}
+                                    href={getNewChatPath(project.id)}
+                                    prefetch={false}
+                                    draggable={false}
+                                    onClick={(e) => {
+                                      if (
+                                        !isPlainPrimaryClick(e) ||
+                                        !onEnterProject
+                                      )
+                                        return
+                                      e.preventDefault()
+                                      void onEnterProject(
+                                        project.id,
+                                        project.name,
+                                      )
+                                    }}
+                                    className={projectClassName}
+                                    {...projectDragHandlers}
+                                  >
+                                    {projectContent}
+                                  </Link>
+                                )
+                              })}
 
                               {/* Load more button */}
                               {hasMoreProjects && (
@@ -1627,17 +1636,6 @@ export function ChatSidebar({
             )}
           >
             <div
-              role="button"
-              tabIndex={0}
-              aria-expanded={isChatHistoryExpanded}
-              aria-label="Chats"
-              onClick={() => setIsChatHistoryExpanded(!isChatHistoryExpanded)}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter' || e.key === ' ') {
-                  e.preventDefault()
-                  setIsChatHistoryExpanded(!isChatHistoryExpanded)
-                }
-              }}
               onDragOver={(e) => {
                 const chatId = e.dataTransfer.types.includes(
                   'application/x-chat-id',
@@ -1670,7 +1668,7 @@ export function ChatSidebar({
                 clearDragState()
               }}
               className={cn(
-                'flex w-full cursor-pointer items-center justify-between bg-surface-sidebar px-4 py-3 text-sm transition-colors',
+                'relative flex w-full items-center bg-surface-sidebar text-sm transition-colors',
                 isDropTargetChatHistory
                   ? isDarkMode
                     ? 'border border-white/30 bg-white/10'
@@ -1678,38 +1676,43 @@ export function ChatSidebar({
                   : 'text-content-secondary',
               )}
             >
-              <span className="flex items-center gap-2">
-                <IoChatbubblesOutline className="h-4 w-4" />
-                <span className="truncate font-aeonik font-medium">Chats</span>
-              </span>
-              <div className="flex items-center gap-1">
-                {isSignedIn && cloudSyncEnabled && onManualSync && (
-                  <button
-                    type="button"
-                    onClick={(e) => {
-                      e.stopPropagation()
-                      if (isSyncing) return
-                      void onManualSync()
-                    }}
-                    onKeyDown={(e) => e.stopPropagation()}
-                    disabled={isSyncing}
-                    aria-label="Sync chats"
-                    title="Sync chats"
-                    className="rounded p-1 text-content-muted transition-colors hover:text-content-secondary disabled:cursor-default disabled:opacity-60"
-                  >
-                    {isSyncing ? (
-                      <PiSpinner className="h-4 w-4 animate-spin" />
-                    ) : (
-                      <GoSync className="h-4 w-4" />
-                    )}
-                  </button>
-                )}
+              <button
+                type="button"
+                aria-expanded={isChatHistoryExpanded}
+                onClick={() => setIsChatHistoryExpanded(!isChatHistoryExpanded)}
+                className="flex w-full items-center justify-between px-4 py-3 text-left"
+              >
+                <span className="flex items-center gap-2">
+                  <IoChatbubblesOutline className="h-4 w-4" />
+                  <span className="truncate font-aeonik font-medium">
+                    Chats
+                  </span>
+                </span>
                 {isChatHistoryExpanded ? (
                   <ChevronDownIcon className="h-4 w-4" />
                 ) : (
                   <ChevronRightIcon className="h-4 w-4" />
                 )}
-              </div>
+              </button>
+              {isSignedIn && cloudSyncEnabled && onManualSync && (
+                <button
+                  type="button"
+                  onClick={() => {
+                    if (isSyncing) return
+                    void onManualSync()
+                  }}
+                  disabled={isSyncing}
+                  aria-label="Sync chats"
+                  title="Sync chats"
+                  className="absolute right-9 rounded p-1 text-content-muted transition-colors hover:text-content-secondary disabled:cursor-default disabled:opacity-60"
+                >
+                  {isSyncing ? (
+                    <PiSpinner className="h-4 w-4 animate-spin" />
+                  ) : (
+                    <GoSync className="h-4 w-4" />
+                  )}
+                </button>
+              )}
             </div>
 
             {/* Expanded Chats content */}
@@ -2062,6 +2065,13 @@ export function ChatSidebar({
                         isPremium &&
                         cloudSyncEnabled &&
                         !!onMoveChatToProject
+                      }
+                      getChatHref={(chat) =>
+                        chat.isBlankChat
+                          ? undefined
+                          : getChatPath(chat.id, {
+                              isLocalOnly: chat.isLocalOnly,
+                            })
                       }
                       onSelectChat={
                         isSearchActive

--- a/src/components/chat/chat-sidebar.tsx
+++ b/src/components/chat/chat-sidebar.tsx
@@ -251,6 +251,9 @@ export function ChatSidebar({
     upgradeError,
   } = useUpgradeToPro()
   const [activeTab, setActiveTab] = useState<'cloud' | 'local'>(() => {
+    if (currentChat?.isBlankChat && currentChat.isLocalOnly) {
+      return 'local'
+    }
     if (typeof window !== 'undefined') {
       const stored = sessionStorage.getItem(UI_SIDEBAR_ACTIVE_TAB)
       if (stored === 'local' && isLocalOnlyModeEnabled()) {
@@ -291,6 +294,7 @@ export function ChatSidebar({
     setIsMac(/Mac|iPod|iPhone|iPad/.test(navigator.platform))
   }, [])
   const modKey = isMac ? '⌘' : 'Ctrl+'
+  const newChatHref = getNewChatPath({ isLocalOnly: activeTab === 'local' })
 
   const {
     projects,
@@ -845,7 +849,7 @@ export function ChatSidebar({
               {/* New chat button */}
               <div className="group relative">
                 <Link
-                  href="/newchat"
+                  href={newChatHref}
                   onClick={(e) => {
                     if (!isPlainPrimaryClick(e)) return
                     e.preventDefault()
@@ -1163,46 +1167,33 @@ export function ChatSidebar({
 
           {/* New Chat button */}
           <div className="relative z-10 flex-none px-2 py-2">
-            {currentChat?.isBlankChat ? (
-              <button
-                type="button"
-                disabled
-                className="flex w-full cursor-default items-center justify-between rounded-lg border border-transparent bg-transparent px-2 py-2 text-sm text-content-muted"
-              >
-                <span className="flex items-center gap-2">
-                  <PiNotePencilLight className="h-4 w-4" />
-                  <span className="font-aeonik font-medium">New chat</span>
-                </span>
-                <span className="text-xs text-content-muted">
-                  {modKey}
-                  {isMac ? '⇧' : 'Shift+'}O
-                </span>
-              </button>
-            ) : (
-              <Link
-                href="/newchat"
-                onClick={(e) => {
-                  if (!isPlainPrimaryClick(e)) return
-                  e.preventDefault()
-                  createNewChat(activeTab === 'local', true)
-                }}
-                className={cn(
-                  'flex w-full items-center justify-between rounded-lg border px-2 py-2 text-sm transition-colors',
-                  isDarkMode
+            <Link
+              href={newChatHref}
+              aria-current={currentChat?.isBlankChat ? 'page' : undefined}
+              onClick={(e) => {
+                if (!isPlainPrimaryClick(e)) return
+                e.preventDefault()
+                if (currentChat?.isBlankChat) return
+                createNewChat(activeTab === 'local', true)
+              }}
+              className={cn(
+                'flex w-full items-center justify-between rounded-lg border px-2 py-2 text-sm transition-colors',
+                currentChat?.isBlankChat
+                  ? 'cursor-default border-transparent bg-transparent text-content-muted'
+                  : isDarkMode
                     ? 'border-border-strong bg-surface-chat text-content-primary hover:bg-surface-chat/80'
                     : 'border-border-subtle bg-white text-content-primary hover:bg-gray-50',
-                )}
-              >
-                <span className="flex items-center gap-2">
-                  <PiNotePencilLight className="h-4 w-4" />
-                  <span className="font-aeonik font-medium">New chat</span>
-                </span>
-                <span className="text-xs text-content-muted">
-                  {modKey}
-                  {isMac ? '⇧' : 'Shift+'}O
-                </span>
-              </Link>
-            )}
+              )}
+            >
+              <span className="flex items-center gap-2">
+                <PiNotePencilLight className="h-4 w-4" />
+                <span className="font-aeonik font-medium">New chat</span>
+              </span>
+              <span className="text-xs text-content-muted">
+                {modKey}
+                {isMac ? '⇧' : 'Shift+'}O
+              </span>
+            </Link>
           </div>
 
           {/* Projects dropdown - show for premium users */}
@@ -1577,7 +1568,9 @@ export function ChatSidebar({
                                 return (
                                   <Link
                                     key={project.id}
-                                    href={getNewChatPath(project.id)}
+                                    href={getNewChatPath({
+                                      projectId: project.id,
+                                    })}
                                     prefetch={false}
                                     draggable={false}
                                     onClick={(e) => {
@@ -2068,7 +2061,9 @@ export function ChatSidebar({
                       }
                       getChatHref={(chat) =>
                         chat.isBlankChat
-                          ? undefined
+                          ? getNewChatPath({
+                              isLocalOnly: chat.isLocalOnly,
+                            })
                           : getChatPath(chat.id, {
                               isLocalOnly: chat.isLocalOnly,
                             })

--- a/src/components/chat/chat-sidebar.tsx
+++ b/src/components/chat/chat-sidebar.tsx
@@ -295,6 +295,10 @@ export function ChatSidebar({
   }, [])
   const modKey = isMac ? '⌘' : 'Ctrl+'
   const newChatHref = getNewChatPath({ isLocalOnly: activeTab === 'local' })
+  const isCurrentNewChat =
+    currentChat?.isBlankChat &&
+    !currentChat.isTemporary &&
+    Boolean(currentChat.isLocalOnly) === (activeTab === 'local')
 
   const {
     projects,
@@ -1169,16 +1173,16 @@ export function ChatSidebar({
           <div className="relative z-10 flex-none px-2 py-2">
             <Link
               href={newChatHref}
-              aria-current={currentChat?.isBlankChat ? 'page' : undefined}
+              aria-current={isCurrentNewChat ? 'page' : undefined}
               onClick={(e) => {
                 if (!isPlainPrimaryClick(e)) return
                 e.preventDefault()
-                if (currentChat?.isBlankChat) return
+                if (isCurrentNewChat) return
                 createNewChat(activeTab === 'local', true)
               }}
               className={cn(
                 'flex w-full items-center justify-between rounded-lg border px-2 py-2 text-sm transition-colors',
-                currentChat?.isBlankChat
+                isCurrentNewChat
                   ? 'cursor-default border-transparent bg-transparent text-content-muted'
                   : isDarkMode
                     ? 'border-border-strong bg-surface-chat text-content-primary hover:bg-surface-chat/80'

--- a/src/components/chat/genui/widgets/ArtifactPreview.tsx
+++ b/src/components/chat/genui/widgets/ArtifactPreview.tsx
@@ -389,9 +389,8 @@ export function ArtifactPreviewPanel({
 
 /**
  * Full-width inline card shown in the chat scroll. The row itself is a
- * single click target that toggles the artifact sidebar. The download
- * button lives inside the row but stops propagation so the sidebar
- * doesn't toggle when the user just wants to save the file.
+ * single click target that toggles the artifact sidebar, with a separate
+ * download action beside it.
  */
 function ArtifactPreviewInlineCard({
   title,
@@ -408,36 +407,29 @@ function ArtifactPreviewInlineCard({
   const displayTitle = title ?? getSourceLabel(source)
   const subtitle = description ?? getSourceLabel(source)
   return (
-    <div
-      role="button"
-      tabIndex={0}
-      onClick={() => openArtifactPreviewSidebar(detail)}
-      onKeyDown={(e) => {
-        if (e.target !== e.currentTarget) return
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault()
-          openArtifactPreviewSidebar(detail)
-        }
-      }}
-      className="my-3 flex w-full cursor-pointer items-center gap-4 rounded-lg border border-border-subtle bg-surface-card px-4 py-4 text-left transition-colors hover:bg-surface-chat-background"
-    >
-      <FileText
-        className="h-6 w-6 flex-shrink-0 text-content-muted"
-        aria-hidden
-      />
-      <div className="flex min-w-0 flex-1 flex-col">
-        <span className="truncate text-sm font-medium text-content-primary">
-          {displayTitle}
-        </span>
-        <span className="truncate text-xs text-content-muted">{subtitle}</span>
-      </div>
+    <div className="my-3 flex w-full items-center rounded-lg border border-border-subtle bg-surface-card text-left transition-colors hover:bg-surface-chat-background">
       <button
         type="button"
-        onClick={(e) => {
-          e.stopPropagation()
-          downloadArtifact(source, title)
-        }}
-        className="inline-flex flex-shrink-0 items-center gap-1.5 rounded-md border border-border-subtle bg-surface-chat-background px-3 py-1.5 text-xs font-medium text-content-primary transition-colors hover:bg-surface-card"
+        onClick={() => openArtifactPreviewSidebar(detail)}
+        className="flex min-w-0 flex-1 cursor-pointer items-center gap-4 self-stretch px-4 py-4 text-left"
+      >
+        <FileText
+          className="h-6 w-6 flex-shrink-0 text-content-muted"
+          aria-hidden
+        />
+        <span className="flex min-w-0 flex-1 flex-col">
+          <span className="truncate text-sm font-medium text-content-primary">
+            {displayTitle}
+          </span>
+          <span className="truncate text-xs text-content-muted">
+            {subtitle}
+          </span>
+        </span>
+      </button>
+      <button
+        type="button"
+        onClick={() => downloadArtifact(source, title)}
+        className="mr-4 inline-flex flex-shrink-0 items-center gap-1.5 rounded-md border border-border-subtle bg-surface-chat-background px-3 py-1.5 text-xs font-medium text-content-primary transition-colors hover:bg-surface-card"
         aria-label="Download artifact"
       >
         <Download className="h-3.5 w-3.5" />

--- a/src/components/chat/hooks/use-chat-state.ts
+++ b/src/components/chat/hooks/use-chat-state.ts
@@ -97,6 +97,7 @@ export function useChatState({
   thinkingEnabled,
   initialChatId,
   isLocalChatUrl = false,
+  initialNewChatIsLocalOnly = false,
   webSearchAvailable,
   canUseCodeExecution = false,
   codeExecutionEnabled,
@@ -112,6 +113,7 @@ export function useChatState({
   thinkingEnabled?: boolean
   initialChatId?: string | null
   isLocalChatUrl?: boolean
+  initialNewChatIsLocalOnly?: boolean
   webSearchAvailable?: boolean
   // Feature flag: when false, useExecSnapshot stays a no-op and no
   // key material is derived. Distinct from `codeExecutionEnabled`,
@@ -164,6 +166,7 @@ export function useChatState({
     scrollToBottom,
     initialChatId,
     isLocalChatUrl,
+    initialNewChatIsLocalOnly,
   })
 
   // Model Management - the hook owns model validation, the device-local

--- a/src/components/chat/hooks/use-chat-storage.ts
+++ b/src/components/chat/hooks/use-chat-storage.ts
@@ -22,6 +22,7 @@ interface UseChatStorageProps {
   scrollToBottom?: () => void
   initialChatId?: string | null
   isLocalChatUrl?: boolean
+  initialNewChatIsLocalOnly?: boolean
 }
 
 interface UseChatStorageReturn {
@@ -51,6 +52,7 @@ export function useChatStorage({
   storeHistory,
   initialChatId,
   isLocalChatUrl = false,
+  initialNewChatIsLocalOnly = false,
 }: UseChatStorageProps): UseChatStorageReturn {
   const { isSignedIn } = useAuth()
   const [isInitialLoad, setIsInitialLoad] = useState(true)
@@ -69,7 +71,9 @@ export function useChatStorage({
     return [createBlankChat(false), createBlankChat(true)]
   })
 
-  const [currentChat, setCurrentChat] = useState<Chat>(chats[0])
+  const [currentChat, setCurrentChat] = useState<Chat>(
+    () => getBlankChat(chats, initialNewChatIsLocalOnly) ?? chats[0],
+  )
 
   // Create persistence manager
   const persistenceManager = useMemo(
@@ -198,6 +202,10 @@ export function useChatStorage({
 
         // Combine and sort
         const finalChats = sortChats([cloudBlank, localBlank, ...nonBlankChats])
+        const initialBlankChat = getBlankChat(
+          finalChats,
+          initialNewChatIsLocalOnly,
+        )
 
         setChats(finalChats)
 
@@ -206,7 +214,7 @@ export function useChatStorage({
         setCurrentChat((prev) =>
           isSwitchingChatRef.current || !prev.isBlankChat
             ? prev
-            : finalChats[0],
+            : (initialBlankChat ?? finalChats[0]),
         )
       } catch (error) {
         logError('Failed to load initial chats', error, {
@@ -224,7 +232,7 @@ export function useChatStorage({
     return () => {
       mounted = false
     }
-  }, [storeHistory, isSignedIn])
+  }, [storeHistory, isSignedIn, initialNewChatIsLocalOnly])
 
   // Create new chat (switch to the appropriate blank chat)
   const createNewChat = useCallback(

--- a/src/components/chat/prompt-library-modal.tsx
+++ b/src/components/chat/prompt-library-modal.tsx
@@ -497,30 +497,23 @@ function PresetDetail({
                 className="w-full rounded-md border border-border-subtle bg-surface-chat-background px-2 py-0.5 text-base font-semibold text-content-primary outline-none focus:border-brand-accent-dark/40 dark:focus:border-brand-accent-light/40"
               />
             ) : (
-              <h3
-                className={cn(
-                  'line-clamp-2 rounded-md px-1.5 py-0.5 text-base font-semibold text-content-primary md:truncate',
-                  !preset.isBuiltIn && 'cursor-text hover:bg-surface-chat',
+              <h3 className="line-clamp-2 rounded-md px-1.5 py-0.5 text-base font-semibold text-content-primary md:truncate">
+                {preset.isBuiltIn ? (
+                  preset.name
+                ) : (
+                  <button
+                    type="button"
+                    aria-label="Rename prompt"
+                    title="Click to rename"
+                    onClick={() => {
+                      setNameDraft(preset.name)
+                      setIsEditingName(true)
+                    }}
+                    className="max-w-full cursor-text rounded-md text-left hover:bg-surface-chat"
+                  >
+                    {preset.name}
+                  </button>
                 )}
-                title={preset.isBuiltIn ? undefined : 'Click to rename'}
-                role={preset.isBuiltIn ? undefined : 'button'}
-                tabIndex={preset.isBuiltIn ? undefined : 0}
-                aria-label={preset.isBuiltIn ? undefined : 'Rename prompt'}
-                onClick={() => {
-                  if (preset.isBuiltIn) return
-                  setNameDraft(preset.name)
-                  setIsEditingName(true)
-                }}
-                onKeyDown={(e) => {
-                  if (preset.isBuiltIn) return
-                  if (e.key === 'Enter' || e.key === ' ') {
-                    e.preventDefault()
-                    setNameDraft(preset.name)
-                    setIsEditingName(true)
-                  }
-                }}
-              >
-                {preset.name}
               </h3>
             )}
             {preset.description && (

--- a/src/components/chat/prompt-library-modal.tsx
+++ b/src/components/chat/prompt-library-modal.tsx
@@ -503,7 +503,7 @@ function PresetDetail({
                 ) : (
                   <button
                     type="button"
-                    aria-label="Rename prompt"
+                    aria-label={`Rename ${preset.name}`}
                     title="Click to rename"
                     onClick={() => {
                       setNameDraft(preset.name)

--- a/src/components/chat/quote-selection-popover.tsx
+++ b/src/components/chat/quote-selection-popover.tsx
@@ -141,7 +141,7 @@ export function QuoteSelectionPopover({
   return (
     <div
       ref={popoverRef}
-      role="dialog"
+      role="toolbar"
       aria-label="Selection actions"
       style={{
         position: 'fixed',

--- a/src/components/chat/renderers/components/DocumentList.tsx
+++ b/src/components/chat/renderers/components/DocumentList.tsx
@@ -290,34 +290,27 @@ export const DocumentList = memo(function DocumentList({
               : getPreviewForDocument(documentContent, attachment.fileName)
 
             return (
-              <div
+              <button
                 key={attachment.id}
-                role="button"
-                tabIndex={0}
+                type="button"
                 onClick={() => openModal(attachment)}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter' || e.key === ' ') {
-                    e.preventDefault()
-                    openModal(attachment)
-                  }
-                }}
-                className="flex min-w-[200px] max-w-[300px] cursor-pointer flex-col rounded-lg bg-surface-message-user/90 p-3 shadow-sm backdrop-blur-sm transition-colors hover:bg-surface-message-user"
+                className="flex min-w-[200px] max-w-[300px] cursor-pointer flex-col rounded-lg bg-surface-message-user/90 p-3 text-left shadow-sm backdrop-blur-sm transition-colors hover:bg-surface-message-user"
               >
-                <div className="flex items-center gap-2">
-                  <div className="flex items-center justify-center p-1">
+                <span className="flex items-center gap-2">
+                  <span className="flex items-center justify-center p-1">
                     {getFileIcon(attachment.fileName, 20)}
-                  </div>
+                  </span>
                   <span className="truncate text-sm font-medium text-content-primary">
                     {attachment.fileName}
                   </span>
-                </div>
+                </span>
 
                 {preview && (
-                  <div className="mt-2 line-clamp-2 text-xs text-content-muted">
+                  <span className="mt-2 line-clamp-2 text-xs text-content-muted">
                     {preview}
-                  </div>
+                  </span>
                 )}
-              </div>
+              </button>
             )
           })}
         </div>

--- a/src/components/chat/renderers/components/ThoughtProcess.tsx
+++ b/src/components/chat/renderers/components/ThoughtProcess.tsx
@@ -398,9 +398,12 @@ export const ThoughtProcess = memo(function ThoughtProcess({
                     )
                   }
                 }
+                if (!href) {
+                  return <span>{children}</span>
+                }
                 return (
                   <a
-                    href={href ? sanitizeUrl(href) : undefined}
+                    href={sanitizeUrl(href)}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="text-blue-500 underline hover:text-blue-600"

--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -2138,6 +2138,7 @@ ${encryptionKey.replace('key_', '')}
                 isUsingPersonalization &&
                 hasUnsavedPersonalization && (
                   <button
+                    type="button"
                     onClick={handleSavePersonalization}
                     className="rounded-lg bg-brand-accent-dark px-3 py-1 text-sm font-medium text-white transition-colors hover:bg-brand-accent-dark/90"
                   >
@@ -2145,7 +2146,9 @@ ${encryptionKey.replace('key_', '')}
                   </button>
                 )}
               <button
+                type="button"
                 onClick={() => setIsOpen(false)}
+                aria-label="Close settings"
                 className="rounded-lg p-1.5 text-content-secondary transition-colors hover:bg-surface-chat"
               >
                 <XMarkIcon className="h-5 w-5" />
@@ -2194,7 +2197,9 @@ ${encryptionKey.replace('key_', '')}
           {/* Close button */}
           <div className="flex h-14 items-center px-4">
             <button
+              type="button"
               onClick={() => setIsOpen(false)}
+              aria-label="Close settings"
               className="rounded-lg p-1.5 text-content-secondary transition-colors hover:bg-surface-chat"
             >
               <XMarkIcon className="h-5 w-5" />

--- a/src/components/project/project-sidebar.tsx
+++ b/src/components/project/project-sidebar.tsx
@@ -19,6 +19,11 @@ import { UI_EXPAND_PROJECT_DOCUMENTS } from '@/constants/storage-keys'
 import { toast } from '@/hooks/use-toast'
 import type { Fact } from '@/types/memory'
 import type { Project } from '@/types/project'
+import {
+  getChatPath,
+  getNewChatPath,
+  isPlainPrimaryClick,
+} from '@/utils/navigation'
 import { useAuth } from '@clerk/nextjs'
 import {
   ArrowLeftIcon,
@@ -34,13 +39,7 @@ import {
   TrashIcon,
 } from '@heroicons/react/24/outline'
 import { AnimatePresence, motion } from 'framer-motion'
-import {
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-  type MouseEvent as ReactMouseEvent,
-} from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import {
   BsFile,
   BsFiletypeCss,
@@ -609,36 +608,7 @@ export function ProjectSidebar({
     }
   }, [onNewChat, windowWidth, setIsOpen])
 
-  const newChatHref = projectId ? `/project/${projectId}` : '/newchat'
-
-  const openNewChatInNewTab = useCallback(() => {
-    window.open(newChatHref, '_blank', 'noopener,noreferrer')
-  }, [newChatHref])
-
-  // The New chat control is a button for parity with the other sidebar
-  // actions; modifier clicks still open a new tab so the link affordance is
-  // preserved, otherwise the plain click runs the in-app handler.
-  const handleNewChatButtonClick = useCallback(
-    (e: ReactMouseEvent<HTMLButtonElement>, action: () => void) => {
-      if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) {
-        openNewChatInNewTab()
-        return
-      }
-      action()
-    },
-    [openNewChatInNewTab],
-  )
-
-  // onClick never fires for the middle button, so open the new tab
-  // explicitly to guarantee middle-click "open in new tab" works.
-  const handleNewChatAuxClick = useCallback(
-    (e: ReactMouseEvent<HTMLButtonElement>) => {
-      if (e.button !== 1) return
-      e.preventDefault()
-      openNewChatInNewTab()
-    },
-    [openNewChatInNewTab],
-  )
+  const newChatHref = getNewChatPath(projectId)
 
   const handleRemoveDocument = useCallback(
     async (docId: string) => {
@@ -744,10 +714,13 @@ export function ProjectSidebar({
           <div className="flex flex-col items-center gap-1 px-2">
             {/* New chat button */}
             <div className="group relative">
-              <button
-                type="button"
-                onClick={(e) => handleNewChatButtonClick(e, onNewChat)}
-                onAuxClick={handleNewChatAuxClick}
+              <Link
+                href={newChatHref}
+                onClick={(e) => {
+                  if (!isPlainPrimaryClick(e)) return
+                  e.preventDefault()
+                  onNewChat()
+                }}
                 className={cn(
                   'flex h-10 w-10 items-center justify-center rounded-lg transition-colors',
                   'text-content-secondary hover:bg-surface-chat hover:text-content-primary',
@@ -755,7 +728,7 @@ export function ProjectSidebar({
                 aria-label="New chat"
               >
                 <PiNotePencilLight className="h-5 w-5" />
-              </button>
+              </Link>
               <span className="pointer-events-none absolute left-full top-1/2 z-50 ml-2 -translate-y-1/2 whitespace-nowrap rounded border border-border-subtle bg-surface-chat-background px-2 py-1 text-xs text-content-primary opacity-0 shadow-sm transition-opacity group-hover:opacity-100">
                 New chat{' '}
                 <span className="text-content-muted">
@@ -784,16 +757,7 @@ export function ProjectSidebar({
         {/* Header */}
         <div className="flex h-16 flex-none items-center justify-between border-b border-border-subtle p-4">
           <div className="flex items-center gap-3">
-            <Link
-              href="/"
-              title="Home"
-              className="flex items-center"
-              onAuxClick={(e) => {
-                if (e.button !== 1) return
-                e.preventDefault()
-                window.open('/', '_blank', 'noopener,noreferrer')
-              }}
-            >
+            <Link href="/" title="Home" className="flex items-center">
               <Logo className="h-6 w-auto" dark={isDarkMode} />
             </Link>
             {/* Settings button */}
@@ -801,6 +765,7 @@ export function ProjectSidebar({
               <button
                 type="button"
                 onClick={onSettingsClick}
+                aria-label="Settings"
                 className="rounded p-1.5 text-content-muted transition-all duration-200 hover:text-content-secondary"
               >
                 <Cog6ToothIcon className="h-5 w-5" />
@@ -919,23 +884,26 @@ export function ProjectSidebar({
                 </form>
               ) : project ? (
                 <>
-                  <div
-                    className="group flex cursor-pointer items-center gap-2"
-                    onClick={() => setIsEditingProjectName(true)}
-                  >
-                    <h2 className="truncate font-aeonik text-lg font-semibold text-content-primary">
-                      {isAnimatingName ? (
-                        <TypingAnimation
-                          fromText={animationFromName}
-                          toText={animationToName}
-                          onComplete={handleNameAnimationComplete}
-                        />
-                      ) : (
-                        displayProjectName
-                      )}
-                    </h2>
-                    <PencilSquareIcon className="h-4 w-4 text-content-muted opacity-0 transition-opacity group-hover:opacity-100" />
-                  </div>
+                  <h2 className="font-aeonik text-lg font-semibold text-content-primary">
+                    <button
+                      type="button"
+                      onClick={() => setIsEditingProjectName(true)}
+                      className="group flex max-w-full items-center gap-2 text-left"
+                    >
+                      <span className="truncate">
+                        {isAnimatingName ? (
+                          <TypingAnimation
+                            fromText={animationFromName}
+                            toText={animationToName}
+                            onComplete={handleNameAnimationComplete}
+                          />
+                        ) : (
+                          displayProjectName
+                        )}
+                      </span>
+                      <PencilSquareIcon className="h-4 w-4 shrink-0 text-content-muted opacity-0 transition-opacity group-hover:opacity-100" />
+                    </button>
+                  </h2>
                   <p className="mt-0.5 font-aeonik-fono text-xs text-content-muted">
                     Updated {formatRelativeTime(new Date(project.updatedAt))}
                   </p>
@@ -946,34 +914,46 @@ export function ProjectSidebar({
 
           {/* New Chat button */}
           <div className="relative z-10 mt-3 flex-none px-2 py-2">
-            <button
-              type="button"
-              aria-disabled={!currentChatId}
-              onClick={(e) =>
-                handleNewChatButtonClick(e, () => {
-                  if (!currentChatId) return
+            {!currentChatId ? (
+              <button
+                type="button"
+                disabled
+                className="flex w-full cursor-default items-center justify-between rounded-lg border border-transparent bg-transparent px-2 py-2 text-sm text-content-muted"
+              >
+                <span className="flex items-center gap-2">
+                  <PiNotePencilLight className="h-4 w-4" />
+                  <span className="font-aeonik font-medium">New chat</span>
+                </span>
+                <span className="text-xs text-content-muted">
+                  {modKey}
+                  {isMac ? '⇧' : 'Shift+'}O
+                </span>
+              </button>
+            ) : (
+              <Link
+                href={newChatHref}
+                onClick={(e) => {
+                  if (!isPlainPrimaryClick(e)) return
+                  e.preventDefault()
                   handleNewChat()
-                })
-              }
-              onAuxClick={handleNewChatAuxClick}
-              className={cn(
-                'flex w-full items-center justify-between rounded-lg border px-2 py-2 text-sm transition-colors',
-                !currentChatId
-                  ? 'cursor-default border-transparent bg-transparent text-content-muted'
-                  : isDarkMode
+                }}
+                className={cn(
+                  'flex w-full items-center justify-between rounded-lg border px-2 py-2 text-sm transition-colors',
+                  isDarkMode
                     ? 'border-border-strong bg-surface-chat text-content-primary hover:bg-surface-chat/80'
                     : 'border-border-subtle bg-white text-content-primary hover:bg-gray-50',
-              )}
-            >
-              <span className="flex items-center gap-2">
-                <PiNotePencilLight className="h-4 w-4" />
-                <span className="font-aeonik font-medium">New chat</span>
-              </span>
-              <span className="text-xs text-content-muted">
-                {modKey}
-                {isMac ? '⇧' : 'Shift+'}O
-              </span>
-            </button>
+                )}
+              >
+                <span className="flex items-center gap-2">
+                  <PiNotePencilLight className="h-4 w-4" />
+                  <span className="font-aeonik font-medium">New chat</span>
+                </span>
+                <span className="text-xs text-content-muted">
+                  {modKey}
+                  {isMac ? '⇧' : 'Shift+'}O
+                </span>
+              </Link>
+            )}
           </div>
 
           {/* Project Settings Dropdown */}
@@ -1231,12 +1211,14 @@ export function ProjectSidebar({
                     )}
                   >
                     {/* Drag and drop zone - at top */}
-                    <div
+                    <button
+                      type="button"
                       onClick={() =>
                         !contextLoading && fileInputRef.current?.click()
                       }
+                      disabled={contextLoading}
                       className={cn(
-                        'flex flex-col items-center justify-center rounded-lg border-2 border-dashed px-4 transition-colors',
+                        'flex w-full flex-col items-center justify-center rounded-lg border-2 border-dashed px-4 transition-colors',
                         contextLoading
                           ? 'cursor-not-allowed opacity-50'
                           : 'cursor-pointer',
@@ -1263,15 +1245,15 @@ export function ProjectSidebar({
                       {projectDocuments.length === 0 &&
                         contextUploadingFiles.length === 0 && (
                           <>
-                            <p className="text-center font-aeonik-fono text-xs text-content-muted">
+                            <span className="text-center font-aeonik-fono text-xs text-content-muted">
                               Click to upload
-                            </p>
-                            <p className="mt-1 text-center font-aeonik-fono text-[10px] text-content-muted">
+                            </span>
+                            <span className="mt-1 text-center font-aeonik-fono text-[10px] text-content-muted">
                               PDF, TXT, MD, DOCX, XLSX, PPTX, HTML, CSV, images
-                            </p>
+                            </span>
                           </>
                         )}
-                    </div>
+                    </button>
 
                     {/* Document list */}
                     {(projectDocuments.length > 0 ||
@@ -1335,8 +1317,10 @@ export function ProjectSidebar({
                               </div>
                             </div>
                             <button
+                              type="button"
                               onClick={() => handleRemoveDocument(doc.id)}
                               disabled={contextLoading}
+                              aria-label={`Remove ${doc.filename}`}
                               className={cn(
                                 'rounded p-0.5 transition-colors',
                                 isDarkMode
@@ -1416,6 +1400,11 @@ export function ProjectSidebar({
               isDraggable={!!onRemoveChatFromProject}
               showMoveToProject={!!onMoveChatToProject && projects.length > 0}
               projects={projects.filter((p) => p.id !== project?.id)}
+              getChatHref={(chat) =>
+                chat.isBlankChat || !projectId
+                  ? undefined
+                  : getChatPath(chat.id, { projectId })
+              }
               onSelectChat={(chatId) => {
                 if (chatId.startsWith('blank-') || chatId === '') {
                   handleNewChat()

--- a/src/components/project/project-sidebar.tsx
+++ b/src/components/project/project-sidebar.tsx
@@ -92,6 +92,7 @@ interface ProjectSidebarProps {
   isOpen: boolean
   setIsOpen: (isOpen: boolean) => void
   project: Project | null
+  loadingProjectId?: string
   projectName?: string
   isLoading?: boolean
   isDarkMode: boolean
@@ -260,6 +261,7 @@ export function ProjectSidebar({
   isOpen,
   setIsOpen,
   project,
+  loadingProjectId,
   projectName,
   isLoading,
   isDarkMode,
@@ -608,7 +610,8 @@ export function ProjectSidebar({
     }
   }, [onNewChat, windowWidth, setIsOpen])
 
-  const newChatHref = getNewChatPath(projectId)
+  const resolvedProjectId = project?.id ?? loadingProjectId
+  const newChatHref = getNewChatPath({ projectId: resolvedProjectId })
 
   const handleRemoveDocument = useCallback(
     async (docId: string) => {
@@ -914,46 +917,33 @@ export function ProjectSidebar({
 
           {/* New Chat button */}
           <div className="relative z-10 mt-3 flex-none px-2 py-2">
-            {!currentChatId ? (
-              <button
-                type="button"
-                disabled
-                className="flex w-full cursor-default items-center justify-between rounded-lg border border-transparent bg-transparent px-2 py-2 text-sm text-content-muted"
-              >
-                <span className="flex items-center gap-2">
-                  <PiNotePencilLight className="h-4 w-4" />
-                  <span className="font-aeonik font-medium">New chat</span>
-                </span>
-                <span className="text-xs text-content-muted">
-                  {modKey}
-                  {isMac ? '⇧' : 'Shift+'}O
-                </span>
-              </button>
-            ) : (
-              <Link
-                href={newChatHref}
-                onClick={(e) => {
-                  if (!isPlainPrimaryClick(e)) return
-                  e.preventDefault()
-                  handleNewChat()
-                }}
-                className={cn(
-                  'flex w-full items-center justify-between rounded-lg border px-2 py-2 text-sm transition-colors',
-                  isDarkMode
+            <Link
+              href={newChatHref}
+              aria-current={!currentChatId ? 'page' : undefined}
+              onClick={(e) => {
+                if (!isPlainPrimaryClick(e)) return
+                e.preventDefault()
+                if (!currentChatId) return
+                handleNewChat()
+              }}
+              className={cn(
+                'flex w-full items-center justify-between rounded-lg border px-2 py-2 text-sm transition-colors',
+                !currentChatId
+                  ? 'cursor-default border-transparent bg-transparent text-content-muted'
+                  : isDarkMode
                     ? 'border-border-strong bg-surface-chat text-content-primary hover:bg-surface-chat/80'
                     : 'border-border-subtle bg-white text-content-primary hover:bg-gray-50',
-                )}
-              >
-                <span className="flex items-center gap-2">
-                  <PiNotePencilLight className="h-4 w-4" />
-                  <span className="font-aeonik font-medium">New chat</span>
-                </span>
-                <span className="text-xs text-content-muted">
-                  {modKey}
-                  {isMac ? '⇧' : 'Shift+'}O
-                </span>
-              </Link>
-            )}
+              )}
+            >
+              <span className="flex items-center gap-2">
+                <PiNotePencilLight className="h-4 w-4" />
+                <span className="font-aeonik font-medium">New chat</span>
+              </span>
+              <span className="text-xs text-content-muted">
+                {modKey}
+                {isMac ? '⇧' : 'Shift+'}O
+              </span>
+            </Link>
           </div>
 
           {/* Project Settings Dropdown */}
@@ -1401,9 +1391,11 @@ export function ProjectSidebar({
               showMoveToProject={!!onMoveChatToProject && projects.length > 0}
               projects={projects.filter((p) => p.id !== project?.id)}
               getChatHref={(chat) =>
-                chat.isBlankChat || !projectId
-                  ? undefined
-                  : getChatPath(chat.id, { projectId })
+                chat.isBlankChat
+                  ? newChatHref
+                  : resolvedProjectId
+                    ? getChatPath(chat.id, { projectId: resolvedProjectId })
+                    : undefined
               }
               onSelectChat={(chatId) => {
                 if (chatId.startsWith('blank-') || chatId === '') {

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -81,6 +81,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       back = false,
       chevron = false,
       children,
+      type,
       ...props
     },
     ref,
@@ -93,6 +94,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
           chevron && 'group/button',
         )}
         ref={ref}
+        type={asChild ? type : (type ?? 'button')}
         {...props}
       >
         {chevron ? (

--- a/src/hooks/use-chat-router.ts
+++ b/src/hooks/use-chat-router.ts
@@ -1,3 +1,4 @@
+import { getChatPath, getNewChatPath } from '@/utils/navigation'
 import { useRouter } from 'next/router'
 import { useCallback, useEffect, useState } from 'react'
 
@@ -39,9 +40,7 @@ export function useChatRouter(): UseChatRouterReturn {
   const updateUrlForChat = useCallback((chatId: string, projectId?: string) => {
     if (typeof window === 'undefined') return
 
-    const newPath = projectId
-      ? `/project/${projectId}/chat/${chatId}`
-      : `/chat/${chatId}`
+    const newPath = getChatPath(chatId, { projectId })
 
     if (window.location.pathname !== newPath) {
       window.history.replaceState(
@@ -55,7 +54,7 @@ export function useChatRouter(): UseChatRouterReturn {
   const updateUrlForLocalChat = useCallback((chatId: string) => {
     if (typeof window === 'undefined') return
 
-    const newPath = `/chat/local/${chatId}`
+    const newPath = getChatPath(chatId, { isLocalOnly: true })
 
     if (window.location.pathname !== newPath) {
       window.history.replaceState(
@@ -69,7 +68,7 @@ export function useChatRouter(): UseChatRouterReturn {
   const updateUrlForProject = useCallback((projectId: string) => {
     if (typeof window === 'undefined') return
 
-    const newPath = `/project/${projectId}`
+    const newPath = getNewChatPath(projectId)
 
     if (window.location.pathname !== newPath) {
       window.history.replaceState(

--- a/src/hooks/use-chat-router.ts
+++ b/src/hooks/use-chat-router.ts
@@ -68,7 +68,7 @@ export function useChatRouter(): UseChatRouterReturn {
   const updateUrlForProject = useCallback((projectId: string) => {
     if (typeof window === 'undefined') return
 
-    const newPath = getNewChatPath(projectId)
+    const newPath = getNewChatPath({ projectId })
 
     if (window.location.pathname !== newPath) {
       window.history.replaceState(

--- a/src/pages/newchat.tsx
+++ b/src/pages/newchat.tsx
@@ -2,6 +2,11 @@
 
 import { ChatInterface } from '@/components/chat'
 import { ProjectProvider } from '@/components/project'
+import {
+  isLocalNewChatStorage,
+  NEW_CHAT_STORAGE_QUERY_KEY,
+} from '@/utils/navigation'
+import { useRouter } from 'next/router'
 
 /**
  * Entry point for starting a new chat without any auto-opening intro/setup
@@ -9,10 +14,21 @@ import { ProjectProvider } from '@/components/project'
  * message immediately (e.g. /newchat?q=hello+world).
  */
 export default function NewChatPage() {
+  const router = useRouter()
+
+  if (!router.isReady) return null
+
+  const initialNewChatIsLocalOnly = isLocalNewChatStorage(
+    router.query[NEW_CHAT_STORAGE_QUERY_KEY],
+  )
+
   return (
     <div className="h-screen font-aeonik">
       <ProjectProvider>
-        <ChatInterface suppressIntroModals />
+        <ChatInterface
+          initialNewChatIsLocalOnly={initialNewChatIsLocalOnly}
+          suppressIntroModals
+        />
       </ProjectProvider>
     </div>
   )

--- a/src/utils/navigation.ts
+++ b/src/utils/navigation.ts
@@ -1,0 +1,34 @@
+import type { MouseEvent } from 'react'
+
+type LinkClick = Pick<
+  MouseEvent<HTMLAnchorElement>,
+  'altKey' | 'button' | 'ctrlKey' | 'metaKey' | 'shiftKey'
+>
+
+interface ChatPathOptions {
+  isLocalOnly?: boolean
+  projectId?: string
+}
+
+export function isPlainPrimaryClick(event: LinkClick): boolean {
+  return (
+    event.button === 0 &&
+    !event.metaKey &&
+    !event.ctrlKey &&
+    !event.shiftKey &&
+    !event.altKey
+  )
+}
+
+export function getChatPath(
+  chatId: string,
+  { isLocalOnly = false, projectId }: ChatPathOptions = {},
+): string {
+  if (projectId) return `/project/${projectId}/chat/${chatId}`
+  if (isLocalOnly) return `/chat/local/${chatId}`
+  return `/chat/${chatId}`
+}
+
+export function getNewChatPath(projectId?: string): string {
+  return projectId ? `/project/${projectId}` : '/newchat'
+}

--- a/src/utils/navigation.ts
+++ b/src/utils/navigation.ts
@@ -10,11 +10,6 @@ interface ChatPathOptions {
   projectId?: string
 }
 
-interface NewChatPathOptions {
-  isLocalOnly?: boolean
-  projectId?: string
-}
-
 export const NEW_CHAT_STORAGE_QUERY_KEY = 'storage'
 export const LOCAL_NEW_CHAT_STORAGE = 'local'
 
@@ -40,7 +35,7 @@ export function getChatPath(
 export function getNewChatPath({
   isLocalOnly = false,
   projectId,
-}: NewChatPathOptions = {}): string {
+}: ChatPathOptions = {}): string {
   if (projectId) return `/project/${projectId}`
   if (isLocalOnly) {
     return `/newchat?${NEW_CHAT_STORAGE_QUERY_KEY}=${LOCAL_NEW_CHAT_STORAGE}`

--- a/src/utils/navigation.ts
+++ b/src/utils/navigation.ts
@@ -10,6 +10,14 @@ interface ChatPathOptions {
   projectId?: string
 }
 
+interface NewChatPathOptions {
+  isLocalOnly?: boolean
+  projectId?: string
+}
+
+export const NEW_CHAT_STORAGE_QUERY_KEY = 'storage'
+export const LOCAL_NEW_CHAT_STORAGE = 'local'
+
 export function isPlainPrimaryClick(event: LinkClick): boolean {
   return (
     event.button === 0 &&
@@ -29,6 +37,19 @@ export function getChatPath(
   return `/chat/${chatId}`
 }
 
-export function getNewChatPath(projectId?: string): string {
-  return projectId ? `/project/${projectId}` : '/newchat'
+export function getNewChatPath({
+  isLocalOnly = false,
+  projectId,
+}: NewChatPathOptions = {}): string {
+  if (projectId) return `/project/${projectId}`
+  if (isLocalOnly) {
+    return `/newchat?${NEW_CHAT_STORAGE_QUERY_KEY}=${LOCAL_NEW_CHAT_STORAGE}`
+  }
+  return '/newchat'
+}
+
+export function isLocalNewChatStorage(
+  storage: string | string[] | undefined,
+): boolean {
+  return storage === LOCAL_NEW_CHAT_STORAGE
 }

--- a/tests/components/button.test.tsx
+++ b/tests/components/button.test.tsx
@@ -1,0 +1,20 @@
+import { Button } from '@/components/ui/button'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+describe('Button', () => {
+  it('does not submit a form unless explicitly configured to submit', () => {
+    const onSubmit = vi.fn((event: React.FormEvent) => event.preventDefault())
+
+    render(
+      <form onSubmit={onSubmit}>
+        <Button>Open settings</Button>
+      </form>,
+    )
+
+    const button = screen.getByRole('button', { name: 'Open settings' })
+    expect(button).toHaveAttribute('type', 'button')
+    fireEvent.click(button)
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+})

--- a/tests/components/chat/chat-list-item.test.tsx
+++ b/tests/components/chat/chat-list-item.test.tsx
@@ -1,0 +1,64 @@
+import {
+  ChatListItem,
+  type ChatItemData,
+} from '@/components/chat/chat-list-item'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+const chat: ChatItemData = {
+  id: 'chat-123',
+  title: 'Trip planning',
+  messageCount: 2,
+}
+
+function renderChatListItem({
+  href,
+  onSelect = vi.fn(),
+}: {
+  href?: string
+  onSelect?: () => void
+} = {}) {
+  render(
+    <ChatListItem
+      chat={chat}
+      href={href}
+      isSelected={false}
+      isEditing={false}
+      editingTitle=""
+      isDarkMode={false}
+      onSelect={onSelect}
+      onStartEdit={vi.fn()}
+      onTitleChange={vi.fn()}
+      onSaveTitle={vi.fn()}
+      onCancelEdit={vi.fn()}
+      onRequestDelete={vi.fn()}
+    />,
+  )
+  return onSelect
+}
+
+describe('ChatListItem navigation semantics', () => {
+  it('renders persistent chats as links and handles ordinary clicks in place', () => {
+    const onSelect = renderChatListItem({ href: '/chat/chat-123' })
+    const link = screen.getByRole('link', { name: /Trip planning/ })
+
+    expect(link).toHaveAttribute('href', '/chat/chat-123')
+    fireEvent.click(link)
+    expect(onSelect).toHaveBeenCalledOnce()
+  })
+
+  it('preserves modified-click link behavior', () => {
+    const onSelect = renderChatListItem({ href: '/chat/chat-123' })
+
+    fireEvent.click(screen.getByRole('link'), { ctrlKey: true })
+    expect(onSelect).not.toHaveBeenCalled()
+  })
+
+  it('renders chats without destinations as buttons', () => {
+    const onSelect = renderChatListItem()
+
+    fireEvent.click(screen.getByRole('button', { name: /Trip planning/ }))
+    expect(onSelect).toHaveBeenCalledOnce()
+    expect(screen.queryByRole('link')).not.toBeInTheDocument()
+  })
+})

--- a/tests/components/chat/chat-list-item.test.tsx
+++ b/tests/components/chat/chat-list-item.test.tsx
@@ -47,10 +47,12 @@ describe('ChatListItem navigation semantics', () => {
     expect(onSelect).toHaveBeenCalledOnce()
   })
 
-  it('preserves modified-click link behavior', () => {
+  it('preserves modified- and middle-click link behavior', () => {
     const onSelect = renderChatListItem({ href: '/chat/chat-123' })
+    const link = screen.getByRole('link')
 
-    fireEvent.click(screen.getByRole('link'), { ctrlKey: true })
+    fireEvent.click(link, { ctrlKey: true })
+    fireEvent(link, new MouseEvent('auxclick', { bubbles: true, button: 1 }))
     expect(onSelect).not.toHaveBeenCalled()
   })
 

--- a/tests/components/chat/use-chat-storage.reloadChats.test.tsx
+++ b/tests/components/chat/use-chat-storage.reloadChats.test.tsx
@@ -26,6 +26,25 @@ describe('useChatStorage.reloadChats', () => {
     vi.clearAllMocks()
   })
 
+  it('keeps a routed local new chat selected after loading storage', async () => {
+    const { result } = renderHook(() =>
+      useChatStorage({
+        storeHistory: true,
+        initialNewChatIsLocalOnly: true,
+      }),
+    )
+
+    expect(result.current.currentChat.isBlankChat).toBe(true)
+    expect(result.current.currentChat.isLocalOnly).toBe(true)
+
+    await waitFor(() => {
+      expect(result.current.isInitialLoad).toBe(false)
+    })
+
+    expect(result.current.currentChat.isBlankChat).toBe(true)
+    expect(result.current.currentChat.isLocalOnly).toBe(true)
+  })
+
   it('does not reset currentChat to blank during temp-id window', async () => {
     const { result } = renderHook(() =>
       useChatStorage({

--- a/tests/pages/newchat.test.tsx
+++ b/tests/pages/newchat.test.tsx
@@ -1,0 +1,53 @@
+import NewChatPage from '@/pages/newchat'
+import { render } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  chatInterface: vi.fn(),
+  router: {
+    isReady: true,
+    query: {} as Record<string, string | string[] | undefined>,
+  },
+}))
+
+vi.mock('next/router', () => ({
+  useRouter: () => mocks.router,
+}))
+
+vi.mock('@/components/chat', () => ({
+  ChatInterface: (props: Record<string, unknown>) => {
+    mocks.chatInterface(props)
+    return null
+  },
+}))
+
+vi.mock('@/components/project', () => ({
+  ProjectProvider: ({ children }: { children: ReactNode }) => children,
+}))
+
+describe('NewChatPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.router.isReady = true
+    mocks.router.query = {}
+  })
+
+  it('starts a routed local new chat in local-only mode', () => {
+    mocks.router.query = { storage: 'local' }
+
+    render(<NewChatPage />)
+
+    expect(mocks.chatInterface).toHaveBeenCalledWith(
+      expect.objectContaining({ initialNewChatIsLocalOnly: true }),
+    )
+  })
+
+  it('uses cloud mode for the default new-chat destination', () => {
+    render(<NewChatPage />)
+
+    expect(mocks.chatInterface).toHaveBeenCalledWith(
+      expect.objectContaining({ initialNewChatIsLocalOnly: false }),
+    )
+  })
+})

--- a/tests/utils/navigation.test.ts
+++ b/tests/utils/navigation.test.ts
@@ -30,5 +30,8 @@ describe('navigation utilities', () => {
     expect(isPlainPrimaryClick(primaryClick)).toBe(true)
     expect(isPlainPrimaryClick({ ...primaryClick, button: 1 })).toBe(false)
     expect(isPlainPrimaryClick({ ...primaryClick, ctrlKey: true })).toBe(false)
+    expect(isPlainPrimaryClick({ ...primaryClick, metaKey: true })).toBe(false)
+    expect(isPlainPrimaryClick({ ...primaryClick, shiftKey: true })).toBe(false)
+    expect(isPlainPrimaryClick({ ...primaryClick, altKey: true })).toBe(false)
   })
 })

--- a/tests/utils/navigation.test.ts
+++ b/tests/utils/navigation.test.ts
@@ -1,0 +1,34 @@
+import {
+  getChatPath,
+  getNewChatPath,
+  isPlainPrimaryClick,
+} from '@/utils/navigation'
+import { describe, expect, it } from 'vitest'
+
+describe('navigation utilities', () => {
+  it('builds chat destinations for each storage context', () => {
+    expect(getChatPath('chat-1')).toBe('/chat/chat-1')
+    expect(getChatPath('chat-1', { isLocalOnly: true })).toBe(
+      '/chat/local/chat-1',
+    )
+    expect(getChatPath('chat-1', { projectId: 'project-1' })).toBe(
+      '/project/project-1/chat/chat-1',
+    )
+    expect(getNewChatPath()).toBe('/newchat')
+    expect(getNewChatPath('project-1')).toBe('/project/project-1')
+  })
+
+  it('only classifies unmodified primary clicks as in-place navigation', () => {
+    const primaryClick = {
+      altKey: false,
+      button: 0,
+      ctrlKey: false,
+      metaKey: false,
+      shiftKey: false,
+    }
+
+    expect(isPlainPrimaryClick(primaryClick)).toBe(true)
+    expect(isPlainPrimaryClick({ ...primaryClick, button: 1 })).toBe(false)
+    expect(isPlainPrimaryClick({ ...primaryClick, ctrlKey: true })).toBe(false)
+  })
+})

--- a/tests/utils/navigation.test.ts
+++ b/tests/utils/navigation.test.ts
@@ -1,6 +1,7 @@
 import {
   getChatPath,
   getNewChatPath,
+  isLocalNewChatStorage,
   isPlainPrimaryClick,
 } from '@/utils/navigation'
 import { describe, expect, it } from 'vitest'
@@ -15,7 +16,17 @@ describe('navigation utilities', () => {
       '/project/project-1/chat/chat-1',
     )
     expect(getNewChatPath()).toBe('/newchat')
-    expect(getNewChatPath('project-1')).toBe('/project/project-1')
+    expect(getNewChatPath({ isLocalOnly: true })).toBe('/newchat?storage=local')
+    expect(getNewChatPath({ projectId: 'project-1' })).toBe(
+      '/project/project-1',
+    )
+  })
+
+  it('recognizes local new-chat destinations', () => {
+    expect(isLocalNewChatStorage('local')).toBe(true)
+    expect(isLocalNewChatStorage('cloud')).toBe(false)
+    expect(isLocalNewChatStorage(['local'])).toBe(false)
+    expect(isLocalNewChatStorage(undefined)).toBe(false)
   })
 
   it('only classifies unmodified primary clicks as in-place navigation', () => {


### PR DESCRIPTION
## Summary
- render persistent chat, project, and new-chat destinations as links with native modified-click behavior
- use native buttons for fixed-context actions, remove nested interactive controls, and improve accessible labels
- centralize chat route and link-click helpers and add semantic control tests

## Validation
- `npm run lint`
- `npx tsc --noEmit`
- `npx vitest run` (1,154 tests passed)

Playwright was not run because its configuration starts the development server, which project instructions prohibit.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized navigation and actions across chat and project UIs using real links and buttons to improve accessibility and preserve native modified-click behavior. New chat and chat links now carry storage context (local/cloud) and project across tabs, with centralized path helpers.

- **Refactors**
  - Added `utils/navigation` with `getChatPath`, `getNewChatPath`, and `isPlainPrimaryClick`; updated `use-chat-router` and UI to use them.
  - New chat controls are links that preserve local/cloud and project context; plain clicks run in-app handlers.
  - `ChatListItem` supports `href`; `ChatList` accepts `getChatHref` to supply destinations.
  - Projects list items link to project new chat (encrypted projects render non-links with a delete button).
  - `newchat` reads `?storage=local`; `ChatInterface` passes `initialNewChatIsLocalOnly` and storage selects the correct blank chat. Converted several controls to semantic buttons/links (Artifact card, Document list, Chats/Projects headers, project rename, settings/close).

- **Bug Fixes**
  - Default `Button` uses `type="button"`; added missing `type="button"` on action buttons.
  - Preserved modified- and middle-click behavior for links; marked current new chat with `aria-current`.
  - Routed local new chats stay selected after storage loads; new chat context persists across tabs/windows.
  - Accessibility: selection popover uses `role="toolbar"`, avoided anchors without `href`, added labels for close/settings.
  - Tests: navigation helpers, chat list link semantics, `newchat` local routing, button default type, and storage selection after reload.

<sup>Written for commit ef377aa59ffd7297de25d2ff3c5ccd85789600b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/450?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

