### PR TITLE
fix: stop chat edits during retries from breaking sync

### DIFF
--- a/src/services/cloud/cloud-sync.ts
+++ b/src/services/cloud/cloud-sync.ts
@@ -46,7 +46,7 @@ import {
 } from './sync-health'
 import { isUploadableChat, remoteWins } from './sync-predicates'
 import { SyncStatusCache } from './sync-status-cache'
-import { UploadCoalescer } from './upload-coalescer'
+import { UploadCoalescer, type UploadAttempt } from './upload-coalescer'
 
 export interface SyncResult {
   uploaded: number
@@ -96,7 +96,7 @@ export class CloudSyncService {
   private projectSyncCaches = new Map<string, SyncStatusCache<ChatSyncStatus>>()
 
   constructor() {
-    // Initialize upload coalescer with doBackupChat as the upload function
+    // Initialize upload coalescer with doBackupChat as the prepare function
     this.uploadCoalescer = new UploadCoalescer(
       (chatId, idempotencyKey) => this.doBackupChat(chatId, idempotencyKey),
       {
@@ -728,17 +728,27 @@ export class CloudSyncService {
     })
   }
 
+  /**
+   * Prepare one logical chat upload for the coalescer. Runs the
+   * eligibility checks, snapshots the chat, and returns a frozen
+   * attempt closure; the coalescer replays that closure on every
+   * retry so the enclave sees byte-identical plaintext under the
+   * same idempotency key (§9.6 R1). Re-reading the chat per retry
+   * instead would replay different bytes whenever the chat was
+   * edited between attempts, turning a committed-but-lost write
+   * into a 409 IDEMPOTENCY_CONFLICT. Returns null when there is
+   * nothing to upload.
+   */
   private async doBackupChat(
     chatId: string,
     idempotencyKey: string,
-  ): Promise<void> {
+  ): Promise<UploadAttempt | null> {
     const generation = this.accountGeneration
-    const startedAt = Date.now()
     try {
       if (!(await canWriteToCloud())) {
-        return
+        return null
       }
-      if (!this.isCurrentGeneration(generation)) return
+      if (!this.isCurrentGeneration(generation)) return null
 
       // Check if chat is currently streaming
       if (streamingTracker.isStreaming(chatId)) {
@@ -749,7 +759,7 @@ export class CloudSyncService {
             action: 'backupChat',
             metadata: { chatId },
           })
-          return
+          return null
         }
 
         logInfo('Chat is streaming, registering for sync after stream ends', {
@@ -777,13 +787,13 @@ export class CloudSyncService {
           this.backupChat(chatId)
         })
 
-        return
+        return null
       }
 
       const chat = await indexedDBStorage.getChat(chatId)
-      if (!this.isCurrentGeneration(generation)) return
+      if (!this.isCurrentGeneration(generation)) return null
       if (!chat) {
-        return // Chat might have been deleted
+        return null // Chat might have been deleted
       }
 
       // Use centralized predicate for upload eligibility
@@ -799,7 +809,7 @@ export class CloudSyncService {
             decryptionFailed: chat.decryptionFailed,
           },
         })
-        return
+        return null
       }
 
       // Double-check streaming status right before upload (in case it started during async ops)
@@ -809,91 +819,113 @@ export class CloudSyncService {
           action: 'backupChat',
           metadata: { chatId },
         })
-        return
+        return null
       }
 
       const preUploadUpdatedAt = chat.updatedAt
       const preUploadVersion = chat.syncVersion ?? 0
-      if (!this.isCurrentGeneration(generation)) return
-      const { syncVersion, rewrites } = await cloudStorage.uploadChat(chat, {
-        idempotencyKey,
-      })
-      if (!this.isCurrentGeneration(generation)) return
+      if (!this.isCurrentGeneration(generation)) return null
+      return async () => {
+        try {
+          const { syncVersion, rewrites } = await cloudStorage.uploadChat(
+            chat,
+            { idempotencyKey },
+          )
+          if (!this.isCurrentGeneration(generation)) return
 
-      await indexedDBStorage.finalizeUpload({
-        chatId,
-        rewrites,
-        preUploadUpdatedAt,
-        syncVersion: syncVersion ?? preUploadVersion + 1,
-      })
-      reportChatSynced(chatId)
-    } catch (error) {
-      if (!this.isCurrentGeneration(generation)) return
-      // Silently fail if no auth token set
-      if (
-        error instanceof Error &&
-        error.message.includes('Authentication token not set')
-      ) {
-        return
-      }
-      // §9.6 R4 — surface the typed decision and ACT on the codes
-      // that have a defined client-side recovery (§C5). For STALE_BLOB
-      // / SYNC_CONFLICT, last-write-wins by pulling the remote and
-      // replacing the local row so the chat exits `locallyModified`
-      // and stops re-attempting. Terminal failures report into the
-      // sync-health store so the settings status row and the sidebar
-      // badge surface them. Other codes still bubble up so the
-      // coalescer can retry where the recovery table says transient.
-      const decision = decideRecovery(error)
-      logInfo('upload-chat recovery decision', {
-        component: 'CloudSync',
-        action: 'backupChat',
-        metadata: {
-          chatId,
-          action: decision.action.type,
-          code: decision.classification.code ?? null,
-          kind: decision.classification.kind,
-        },
-      })
-      if (decision.action.type === 'surface-conflict') {
-        await this.resolveConflictByPullingRemote(chatId, generation)
-        return
-      }
-      if (decision.action.type === 'refresh-current-key-and-retry') {
-        reportKeyActionRequired('key-mismatch')
-        return
-      }
-      if (decision.action.type === 'trigger-recovery-wizard') {
-        reportKeyActionRequired('key-recovery')
-        return
-      }
-      if (decision.action.type === 'block-all-sync') {
-        reportSyncPaused('attestation')
-        return
-      }
-      if (decision.action.type === 'surface-existing-data-under-other-key') {
-        reportKeyActionRequired('key-conflict')
-        return
-      }
-      if (decision.action.type === 'surface-not-found') {
-        reportChatSyncFailed(chatId, 'This chat no longer exists in the cloud')
-        return
-      }
-      if (decision.action.type === 'migrate-legacy-and-retry') {
-        // Handled out-of-band by the migration kick on the next sync
-        // pass; nothing for the user to act on.
-        return
-      }
-      if (decision.action.type === 'abort') {
-        if (decision.action.reason === 'FORBIDDEN') {
-          reportKeyActionRequired('account-blocked')
-        } else {
-          reportChatSyncFailed(chatId, "This chat couldn't be synced")
+          await indexedDBStorage.finalizeUpload({
+            chatId,
+            rewrites,
+            preUploadUpdatedAt,
+            syncVersion: syncVersion ?? preUploadVersion + 1,
+          })
+          reportChatSynced(chatId)
+        } catch (error) {
+          await this.recoverFromChatUploadError(chatId, generation, error)
         }
-        return
       }
-      throw error
+    } catch (error) {
+      await this.recoverFromChatUploadError(chatId, generation, error)
+      return null
     }
+  }
+
+  /**
+   * Shared error dispatch for both phases of a coalesced chat upload
+   * (prepare and the frozen attempt). Handles the codes that have a
+   * defined client-side recovery and swallows them; rethrows anything
+   * the recovery table marks transient so the coalescer retries it.
+   */
+  private async recoverFromChatUploadError(
+    chatId: string,
+    generation: number,
+    error: unknown,
+  ): Promise<void> {
+    if (!this.isCurrentGeneration(generation)) return
+    // Silently fail if no auth token set
+    if (
+      error instanceof Error &&
+      error.message.includes('Authentication token not set')
+    ) {
+      return
+    }
+    // §9.6 R4 — surface the typed decision and ACT on the codes
+    // that have a defined client-side recovery (§C5). For STALE_BLOB
+    // / SYNC_CONFLICT, last-write-wins by pulling the remote and
+    // replacing the local row so the chat exits `locallyModified`
+    // and stops re-attempting. Terminal failures report into the
+    // sync-health store so the settings status row and the sidebar
+    // badge surface them. Other codes still bubble up so the
+    // coalescer can retry where the recovery table says transient.
+    const decision = decideRecovery(error)
+    logInfo('upload-chat recovery decision', {
+      component: 'CloudSync',
+      action: 'backupChat',
+      metadata: {
+        chatId,
+        action: decision.action.type,
+        code: decision.classification.code ?? null,
+        kind: decision.classification.kind,
+      },
+    })
+    if (decision.action.type === 'surface-conflict') {
+      await this.resolveConflictByPullingRemote(chatId, generation)
+      return
+    }
+    if (decision.action.type === 'refresh-current-key-and-retry') {
+      reportKeyActionRequired('key-mismatch')
+      return
+    }
+    if (decision.action.type === 'trigger-recovery-wizard') {
+      reportKeyActionRequired('key-recovery')
+      return
+    }
+    if (decision.action.type === 'block-all-sync') {
+      reportSyncPaused('attestation')
+      return
+    }
+    if (decision.action.type === 'surface-existing-data-under-other-key') {
+      reportKeyActionRequired('key-conflict')
+      return
+    }
+    if (decision.action.type === 'surface-not-found') {
+      reportChatSyncFailed(chatId, 'This chat no longer exists in the cloud')
+      return
+    }
+    if (decision.action.type === 'migrate-legacy-and-retry') {
+      // Handled out-of-band by the migration kick on the next sync
+      // pass; nothing for the user to act on.
+      return
+    }
+    if (decision.action.type === 'abort') {
+      if (decision.action.reason === 'FORBIDDEN') {
+        reportKeyActionRequired('account-blocked')
+      } else {
+        reportChatSyncFailed(chatId, "This chat couldn't be synced")
+      }
+      return
+    }
+    throw error
   }
 
   /**

--- a/src/services/cloud/upload-coalescer.ts
+++ b/src/services/cloud/upload-coalescer.ts
@@ -61,12 +61,27 @@ interface ChatUploadState {
 }
 
 /**
- * Upload function signature. The coalescer owns the idempotency key
- * (§9.6 R1): it mints one per logical write and passes the same value
- * into every retry of that write, so the enclave can de-duplicate
- * replays into a single committed effect.
+ * One frozen upload attempt. The prepare function captures the chat
+ * snapshot and returns this closure; every retry replays it, so the
+ * bytes pushed to the enclave are identical across attempts and the
+ * enclave can de-duplicate them into a single committed effect.
  */
-type UploadFn = (chatId: string, idempotencyKey: string) => Promise<void>
+export type UploadAttempt = () => Promise<void>
+
+/**
+ * Prepare function signature. The coalescer owns the idempotency key
+ * (§9.6 R1): it mints one per logical write and calls prepare once to
+ * freeze that write's payload; `null` means there is nothing to
+ * upload (deleted/ineligible/streaming chat). Retries re-run the
+ * returned attempt, never prepare — the enclave's operation hash
+ * covers the plaintext, so a retry that re-read a chat edited between
+ * attempts would replay different bytes under the same key and fail
+ * with 409 IDEMPOTENCY_CONFLICT instead of deduping.
+ */
+type PrepareUploadFn = (
+  chatId: string,
+  idempotencyKey: string,
+) => Promise<UploadAttempt | null>
 
 /**
  * UploadCoalescer - manages coalescing upload queue for chat backups
@@ -74,7 +89,11 @@ type UploadFn = (chatId: string, idempotencyKey: string) => Promise<void>
  * Usage:
  * ```typescript
  * const coalescer = new UploadCoalescer(
- *   (chatId) => cloudStorage.uploadChat(chatId),
+ *   async (chatId, idempotencyKey) => {
+ *     const chat = await readChat(chatId)
+ *     if (!chat) return null
+ *     return () => cloudStorage.uploadChat(chat, { idempotencyKey })
+ *   },
  * )
  *
  * // Enqueue uploads - rapid calls for same chat are coalesced
@@ -85,13 +104,16 @@ type UploadFn = (chatId: string, idempotencyKey: string) => Promise<void>
  */
 export class UploadCoalescer {
   private states: Map<string, ChatUploadState> = new Map()
-  private uploadFn: UploadFn
+  private prepareUpload: PrepareUploadFn
   private config: Required<Omit<UploadCoalescerConfig, 'scheduler'>>
   private scheduler: RetryScheduler
   private generation = 0
 
-  constructor(uploadFn: UploadFn, config: UploadCoalescerConfig = {}) {
-    this.uploadFn = uploadFn
+  constructor(
+    prepareUpload: PrepareUploadFn,
+    config: UploadCoalescerConfig = {},
+  ) {
+    this.prepareUpload = prepareUpload
     this.config = {
       baseDelayMs: config.baseDelayMs ?? DEFAULT_BASE_DELAY_MS,
       maxDelayMs: config.maxDelayMs ?? DEFAULT_MAX_DELAY_MS,
@@ -232,11 +254,21 @@ export class UploadCoalescer {
     workerGeneration: number,
   ): Promise<void> {
     let lastError: Error | null = null
+    // Frozen on the first successful prepare so every retry replays
+    // the exact payload the enclave may have already committed. Only
+    // a failed prepare re-runs; a failed attempt never re-reads the
+    // chat. Edits that land mid-write set `dirty` and go out as the
+    // next logical write under a fresh key.
+    let preparedAttempt: UploadAttempt | null | undefined
 
     for (let attempt = 0; attempt <= this.config.maxRetries; attempt++) {
       if (workerGeneration !== this.generation) return
       try {
-        await this.uploadFn(chatId, idempotencyKey)
+        if (preparedAttempt === undefined) {
+          preparedAttempt = await this.prepareUpload(chatId, idempotencyKey)
+        }
+        if (preparedAttempt === null) return // Nothing to upload
+        await preparedAttempt()
         return // Success
       } catch (error) {
         lastError = error instanceof Error ? error : new Error(String(error))
@@ -384,11 +416,11 @@ function shouldRetryUploadError(error: Error): boolean {
 }
 
 /**
- * Create a singleton upload coalescer for a given upload function.
+ * Create a singleton upload coalescer for a given prepare function.
  */
 export function createUploadCoalescer(
-  uploadFn: UploadFn,
+  prepareUpload: PrepareUploadFn,
   config?: UploadCoalescerConfig,
 ): UploadCoalescer {
-  return new UploadCoalescer(uploadFn, config)
+  return new UploadCoalescer(prepareUpload, config)
 }

--- a/src/services/cloud/upload-coalescer.ts
+++ b/src/services/cloud/upload-coalescer.ts
@@ -266,6 +266,7 @@ export class UploadCoalescer {
       try {
         if (preparedAttempt === undefined) {
           preparedAttempt = await this.prepareUpload(chatId, idempotencyKey)
+          if (workerGeneration !== this.generation) return
         }
         if (preparedAttempt === null) return // Nothing to upload
         await preparedAttempt()

--- a/tests/services/cloud/upload-coalescer.test.ts
+++ b/tests/services/cloud/upload-coalescer.test.ts
@@ -107,6 +107,34 @@ describe('UploadCoalescer', () => {
       expect(prepareFn).toHaveBeenCalledTimes(1)
     })
 
+    it('replays the frozen snapshot even when the source changes between retries', async () => {
+      let source = 'v1'
+      const seenPayloads: string[] = []
+      const prepareFn = vi.fn(async () => {
+        const snapshot = source
+        return async () => {
+          seenPayloads.push(snapshot)
+          if (seenPayloads.length === 1) throw new Error('flake')
+        }
+      })
+
+      const coalescer = new UploadCoalescer(prepareFn, {
+        baseDelayMs: 10,
+        maxRetries: 2,
+      })
+
+      coalescer.enqueue('chat-1')
+      await vi.advanceTimersByTimeAsync(0) // First attempt fails
+      source = 'v2' // An edit lands between attempts
+      await vi.runAllTimersAsync()
+
+      // The retry replays the snapshot captured at prepare time, not
+      // the mutated source — that byte-identity is what lets the
+      // enclave replay a committed-but-lost write instead of failing
+      // with IDEMPOTENCY_CONFLICT.
+      expect(seenPayloads).toEqual(['v1', 'v1'])
+    })
+
     it('re-runs prepare when prepare itself fails before freezing a payload', async () => {
       const attemptFn = vi.fn().mockResolvedValue(undefined)
       const prepareFn = vi

--- a/tests/services/cloud/upload-coalescer.test.ts
+++ b/tests/services/cloud/upload-coalescer.test.ts
@@ -12,6 +12,19 @@ vi.mock('@/utils/error-handling', () => ({
   logError: vi.fn(),
 }))
 
+type AttemptImpl = (chatId: string, idempotencyKey: string) => Promise<void>
+
+// Adapts a per-attempt mock to the coalescer's prepare contract: the
+// prepare mock resolves to a frozen attempt closure delegating to
+// `attemptFn`, mirroring how cloud-sync snapshots a chat once and
+// returns an attempt bound to that snapshot.
+function prepareWith(attemptFn: AttemptImpl) {
+  return vi.fn(
+    async (chatId: string, idempotencyKey: string) => () =>
+      attemptFn(chatId, idempotencyKey),
+  )
+}
+
 describe('UploadCoalescer', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -23,22 +36,25 @@ describe('UploadCoalescer', () => {
   })
 
   describe('Basic enqueue behavior', () => {
-    it('calls upload function when enqueued', async () => {
-      const uploadFn = vi.fn().mockResolvedValue(undefined)
-      const coalescer = new UploadCoalescer(uploadFn)
+    it('prepares and runs the upload attempt when enqueued', async () => {
+      const attemptFn = vi.fn().mockResolvedValue(undefined)
+      const prepareFn = prepareWith(attemptFn)
+      const coalescer = new UploadCoalescer(prepareFn)
 
       coalescer.enqueue('chat-1')
 
       // Let the async worker run
       await vi.runAllTimersAsync()
 
-      expect(uploadFn).toHaveBeenCalledWith('chat-1', expect.any(String))
-      expect(uploadFn).toHaveBeenCalledTimes(1)
+      expect(prepareFn).toHaveBeenCalledWith('chat-1', expect.any(String))
+      expect(prepareFn).toHaveBeenCalledTimes(1)
+      expect(attemptFn).toHaveBeenCalledTimes(1)
     })
 
     it('handles multiple different chats in parallel', async () => {
-      const uploadFn = vi.fn().mockResolvedValue(undefined)
-      const coalescer = new UploadCoalescer(uploadFn)
+      const attemptFn = vi.fn().mockResolvedValue(undefined)
+      const prepareFn = prepareWith(attemptFn)
+      const coalescer = new UploadCoalescer(prepareFn)
 
       coalescer.enqueue('chat-1')
       coalescer.enqueue('chat-2')
@@ -46,22 +62,34 @@ describe('UploadCoalescer', () => {
 
       await vi.runAllTimersAsync()
 
-      expect(uploadFn).toHaveBeenCalledTimes(3)
-      expect(uploadFn).toHaveBeenCalledWith('chat-1', expect.any(String))
-      expect(uploadFn).toHaveBeenCalledWith('chat-2', expect.any(String))
-      expect(uploadFn).toHaveBeenCalledWith('chat-3', expect.any(String))
+      expect(attemptFn).toHaveBeenCalledTimes(3)
+      expect(prepareFn).toHaveBeenCalledWith('chat-1', expect.any(String))
+      expect(prepareFn).toHaveBeenCalledWith('chat-2', expect.any(String))
+      expect(prepareFn).toHaveBeenCalledWith('chat-3', expect.any(String))
+    })
+
+    it('completes without an attempt when prepare returns null', async () => {
+      const prepareFn = vi.fn().mockResolvedValue(null)
+      const coalescer = new UploadCoalescer(prepareFn)
+
+      const wait = coalescer.enqueueAndWait('chat-1')
+      await vi.runAllTimersAsync()
+
+      await expect(wait).resolves.toBeUndefined()
+      expect(prepareFn).toHaveBeenCalledTimes(1)
     })
   })
 
   describe('§9.6 R1 — idempotency key ownership', () => {
-    it('reuses the same idempotency key across retries of one logical write', async () => {
-      const uploadFn = vi
+    it('reuses the same idempotency key and frozen payload across retries of one logical write', async () => {
+      const attemptFn = vi
         .fn()
         .mockRejectedValueOnce(new Error('flake'))
         .mockRejectedValueOnce(new Error('flake'))
         .mockResolvedValueOnce(undefined)
+      const prepareFn = prepareWith(attemptFn)
 
-      const coalescer = new UploadCoalescer(uploadFn, {
+      const coalescer = new UploadCoalescer(prepareFn, {
         baseDelayMs: 10,
         maxDelayMs: 40,
         maxRetries: 3,
@@ -70,14 +98,42 @@ describe('UploadCoalescer', () => {
       coalescer.enqueue('chat-1')
       await vi.runAllTimersAsync()
 
-      expect(uploadFn).toHaveBeenCalledTimes(3)
-      const keys = uploadFn.mock.calls.map((c) => c[1])
+      expect(attemptFn).toHaveBeenCalledTimes(3)
+      const keys = attemptFn.mock.calls.map((c) => c[1])
       expect(new Set(keys).size).toBe(1)
+      // The payload is prepared once and every retry replays it, so
+      // the enclave sees byte-identical bytes under the same key
+      // instead of a re-read snapshot that could have changed.
+      expect(prepareFn).toHaveBeenCalledTimes(1)
+    })
+
+    it('re-runs prepare when prepare itself fails before freezing a payload', async () => {
+      const attemptFn = vi.fn().mockResolvedValue(undefined)
+      const prepareFn = vi
+        .fn()
+        .mockRejectedValueOnce(new Error('flake'))
+        .mockImplementation(
+          async (chatId: string, idempotencyKey: string) => () =>
+            attemptFn(chatId, idempotencyKey),
+        )
+
+      const coalescer = new UploadCoalescer(prepareFn, {
+        baseDelayMs: 10,
+        maxRetries: 3,
+      })
+
+      coalescer.enqueue('chat-1')
+      await vi.runAllTimersAsync()
+
+      expect(prepareFn).toHaveBeenCalledTimes(2)
+      expect(attemptFn).toHaveBeenCalledTimes(1)
+      // Still one logical write: both prepare calls carry the same key
+      expect(prepareFn.mock.calls[0][1]).toBe(prepareFn.mock.calls[1][1])
     })
 
     it('mints a fresh idempotency key for each new logical write', async () => {
       let resolveFirst: () => void
-      const uploadFn = vi
+      const attemptFn = vi
         .fn()
         .mockImplementationOnce(
           () =>
@@ -86,19 +142,22 @@ describe('UploadCoalescer', () => {
             }),
         )
         .mockResolvedValueOnce(undefined)
+      const prepareFn = prepareWith(attemptFn)
 
-      const coalescer = new UploadCoalescer(uploadFn)
+      const coalescer = new UploadCoalescer(prepareFn)
 
       coalescer.enqueue('chat-1')
+      // Let prepare resolve so the first attempt is in flight
+      await vi.advanceTimersByTimeAsync(0)
       // Dirty during in-flight — second logical write.
       coalescer.enqueue('chat-1')
 
       resolveFirst!()
       await vi.runAllTimersAsync()
 
-      expect(uploadFn).toHaveBeenCalledTimes(2)
-      const firstKey = uploadFn.mock.calls[0][1]
-      const secondKey = uploadFn.mock.calls[1][1]
+      expect(attemptFn).toHaveBeenCalledTimes(2)
+      const firstKey = attemptFn.mock.calls[0][1]
+      const secondKey = attemptFn.mock.calls[1][1]
       expect(firstKey).not.toBe(secondKey)
     })
   })
@@ -109,11 +168,13 @@ describe('UploadCoalescer', () => {
       const uploadPromise = new Promise<void>((resolve) => {
         resolveUpload = resolve
       })
-      const uploadFn = vi.fn().mockReturnValue(uploadPromise)
-      const coalescer = new UploadCoalescer(uploadFn)
+      const attemptFn = vi.fn().mockReturnValue(uploadPromise)
+      const prepareFn = prepareWith(attemptFn)
+      const coalescer = new UploadCoalescer(prepareFn)
 
       // First enqueue starts upload
       coalescer.enqueue('chat-1')
+      await vi.advanceTimersByTimeAsync(0)
 
       // These should be coalesced since upload is in progress
       coalescer.enqueue('chat-1')
@@ -121,7 +182,7 @@ describe('UploadCoalescer', () => {
       coalescer.enqueue('chat-1')
 
       // Still only one upload started
-      expect(uploadFn).toHaveBeenCalledTimes(1)
+      expect(attemptFn).toHaveBeenCalledTimes(1)
       expect(coalescer.isUploading('chat-1')).toBe(true)
 
       // Complete first upload
@@ -129,14 +190,14 @@ describe('UploadCoalescer', () => {
       await vi.runAllTimersAsync()
 
       // Dirty flag was set, so one more upload
-      expect(uploadFn).toHaveBeenCalledTimes(2)
+      expect(attemptFn).toHaveBeenCalledTimes(2)
     })
 
     it('re-uploads after dirty flag set during upload', async () => {
       let resolveFirst: () => void
       let resolveSecond: () => void
 
-      const uploadFn = vi
+      const attemptFn = vi
         .fn()
         .mockImplementationOnce(
           () =>
@@ -150,46 +211,49 @@ describe('UploadCoalescer', () => {
               resolveSecond = resolve
             }),
         )
+      const prepareFn = prepareWith(attemptFn)
 
-      const coalescer = new UploadCoalescer(uploadFn)
+      const coalescer = new UploadCoalescer(prepareFn)
 
       // Start first upload
       coalescer.enqueue('chat-1')
-      expect(uploadFn).toHaveBeenCalledTimes(1)
+      await vi.advanceTimersByTimeAsync(0)
+      expect(attemptFn).toHaveBeenCalledTimes(1)
 
       // Enqueue during upload - sets dirty flag
       coalescer.enqueue('chat-1')
-      expect(uploadFn).toHaveBeenCalledTimes(1) // Still just one
+      expect(attemptFn).toHaveBeenCalledTimes(1) // Still just one
 
       // Complete first upload
       resolveFirst!()
       await vi.runAllTimersAsync()
 
       // Second upload should have started
-      expect(uploadFn).toHaveBeenCalledTimes(2)
+      expect(attemptFn).toHaveBeenCalledTimes(2)
 
       // Complete second upload
       resolveSecond!()
       await vi.runAllTimersAsync()
 
       // No more uploads (dirty flag was clear)
-      expect(uploadFn).toHaveBeenCalledTimes(2)
+      expect(attemptFn).toHaveBeenCalledTimes(2)
     })
   })
 
   describe('Retry behavior', () => {
     it('retries failed uploads with exponential backoff', async () => {
-      const uploadFn = vi
+      const attemptFn = vi
         .fn()
         .mockRejectedValueOnce(new Error('Network error'))
         .mockRejectedValueOnce(new Error('Network error'))
         .mockResolvedValueOnce(undefined)
+      const prepareFn = prepareWith(attemptFn)
 
       // Pin the jitter to its upper bound so the retry windows are
       // deterministic. With full-jitter exponential backoff
       // delay = floor(random() * min(maxDelay, baseDelay * 2**attempt)),
       // random()=0.9999 gives the worst-case wait per attempt.
-      const coalescer = new UploadCoalescer(uploadFn, {
+      const coalescer = new UploadCoalescer(prepareFn, {
         baseDelayMs: 100,
         maxDelayMs: 400,
         maxRetries: 3,
@@ -203,25 +267,28 @@ describe('UploadCoalescer', () => {
 
       // First attempt fails immediately
       await vi.advanceTimersByTimeAsync(0)
-      expect(uploadFn).toHaveBeenCalledTimes(1)
+      expect(attemptFn).toHaveBeenCalledTimes(1)
 
       // Wait for first retry: max delay window = baseDelay * 2**0 = 100ms.
       await vi.advanceTimersByTimeAsync(100)
-      expect(uploadFn).toHaveBeenCalledTimes(2)
+      expect(attemptFn).toHaveBeenCalledTimes(2)
 
       // Wait for second retry: max delay window = baseDelay * 2**1 = 200ms.
       await vi.advanceTimersByTimeAsync(200)
-      expect(uploadFn).toHaveBeenCalledTimes(3)
+      expect(attemptFn).toHaveBeenCalledTimes(3)
 
       // All done
       await vi.runAllTimersAsync()
-      expect(uploadFn).toHaveBeenCalledTimes(3)
+      expect(attemptFn).toHaveBeenCalledTimes(3)
     })
 
     it('gives up after max retries', async () => {
-      const uploadFn = vi.fn().mockRejectedValue(new Error('Permanent failure'))
+      const attemptFn = vi
+        .fn()
+        .mockRejectedValue(new Error('Permanent failure'))
+      const prepareFn = prepareWith(attemptFn)
 
-      const coalescer = new UploadCoalescer(uploadFn, {
+      const coalescer = new UploadCoalescer(prepareFn, {
         baseDelayMs: 100,
         maxRetries: 2,
       })
@@ -231,12 +298,14 @@ describe('UploadCoalescer', () => {
       await vi.runAllTimersAsync()
 
       // 1 initial + 2 retries = 3 total attempts
-      expect(uploadFn).toHaveBeenCalledTimes(3)
+      expect(attemptFn).toHaveBeenCalledTimes(3)
     })
 
     it('rejects enqueueAndWait after retries are exhausted', async () => {
-      const uploadFn = vi.fn().mockRejectedValue(new Error('Permanent failure'))
-      const coalescer = new UploadCoalescer(uploadFn, {
+      const attemptFn = vi
+        .fn()
+        .mockRejectedValue(new Error('Permanent failure'))
+      const coalescer = new UploadCoalescer(prepareWith(attemptFn), {
         baseDelayMs: 100,
         maxRetries: 1,
       })
@@ -250,12 +319,12 @@ describe('UploadCoalescer', () => {
     })
 
     it('surfaces sync conflicts without retrying under the same idempotency key', async () => {
-      const uploadFn = vi
+      const attemptFn = vi
         .fn()
         .mockRejectedValue(
           new SyncEnclaveError('SYNC_CONFLICT', 409, 'SYNC_CONFLICT'),
         )
-      const coalescer = new UploadCoalescer(uploadFn, {
+      const coalescer = new UploadCoalescer(prepareWith(attemptFn), {
         baseDelayMs: 100,
         maxRetries: 3,
       })
@@ -267,15 +336,14 @@ describe('UploadCoalescer', () => {
       await vi.runAllTimersAsync()
 
       await expectation
-      expect(uploadFn).toHaveBeenCalledTimes(1)
+      expect(attemptFn).toHaveBeenCalledTimes(1)
     })
   })
 
   describe('State tracking', () => {
     it('tracks pending uploads correctly', async () => {
-      const uploadFn = vi.fn().mockResolvedValue(undefined)
-
-      const coalescer = new UploadCoalescer(uploadFn)
+      const attemptFn = vi.fn().mockResolvedValue(undefined)
+      const coalescer = new UploadCoalescer(prepareWith(attemptFn))
 
       expect(coalescer.hasPendingUpload('chat-1')).toBe(false)
 
@@ -293,9 +361,8 @@ describe('UploadCoalescer', () => {
     })
 
     it('returns pending chat IDs', async () => {
-      const uploadFn = vi.fn().mockReturnValue(new Promise(() => {})) // Never resolves
-
-      const coalescer = new UploadCoalescer(uploadFn)
+      const attemptFn = vi.fn().mockReturnValue(new Promise(() => {})) // Never resolves
+      const coalescer = new UploadCoalescer(prepareWith(attemptFn))
 
       coalescer.enqueue('chat-1')
       coalescer.enqueue('chat-2')
@@ -308,9 +375,8 @@ describe('UploadCoalescer', () => {
     })
 
     it('clears all state', async () => {
-      const uploadFn = vi.fn().mockReturnValue(new Promise(() => {}))
-
-      const coalescer = new UploadCoalescer(uploadFn)
+      const attemptFn = vi.fn().mockReturnValue(new Promise(() => {}))
+      const coalescer = new UploadCoalescer(prepareWith(attemptFn))
 
       coalescer.enqueue('chat-1')
       coalescer.enqueue('chat-2')
@@ -324,8 +390,8 @@ describe('UploadCoalescer', () => {
     })
 
     it('cancels waiters and retries when cleared during backoff', async () => {
-      const uploadFn = vi.fn().mockRejectedValue(new Error('Network error'))
-      const coalescer = new UploadCoalescer(uploadFn, {
+      const attemptFn = vi.fn().mockRejectedValue(new Error('Network error'))
+      const coalescer = new UploadCoalescer(prepareWith(attemptFn), {
         baseDelayMs: 1000,
         maxRetries: 3,
         scheduler: {
@@ -336,40 +402,41 @@ describe('UploadCoalescer', () => {
 
       const upload = coalescer.enqueueAndWait('chat-1')
       await vi.advanceTimersByTimeAsync(0)
-      expect(uploadFn).toHaveBeenCalledTimes(1)
+      expect(attemptFn).toHaveBeenCalledTimes(1)
 
       coalescer.clear()
       await expect(upload).rejects.toThrow('account change')
       await vi.advanceTimersByTimeAsync(1000)
 
-      expect(uploadFn).toHaveBeenCalledTimes(1)
+      expect(attemptFn).toHaveBeenCalledTimes(1)
     })
   })
 
   describe('Edge cases', () => {
     it('handles synchronous upload success', async () => {
-      const uploadFn = vi.fn().mockResolvedValue(undefined)
-      const coalescer = new UploadCoalescer(uploadFn)
+      const attemptFn = vi.fn().mockResolvedValue(undefined)
+      const coalescer = new UploadCoalescer(prepareWith(attemptFn))
 
       coalescer.enqueue('chat-1')
       await vi.runAllTimersAsync()
 
-      expect(uploadFn).toHaveBeenCalledTimes(1)
+      expect(attemptFn).toHaveBeenCalledTimes(1)
       expect(coalescer.hasPendingUpload('chat-1')).toBe(false)
     })
 
     it('handles enqueue during retry backoff', async () => {
-      const uploadFn = vi
+      const attemptFn = vi
         .fn()
         .mockRejectedValueOnce(new Error('Fail'))
         .mockResolvedValue(undefined)
+      const prepareFn = prepareWith(attemptFn)
 
       // Pin the jitter to its upper bound so the backoff window is
       // deterministic. A random delay of 0 would let the first retry
       // fire inside advanceTimersByTimeAsync(0) below — before the
       // enqueue during backoff — completing the worker and triggering
       // an extra upload.
-      const coalescer = new UploadCoalescer(uploadFn, {
+      const coalescer = new UploadCoalescer(prepareFn, {
         baseDelayMs: 1000,
         maxRetries: 3,
         scheduler: {
@@ -390,7 +457,10 @@ describe('UploadCoalescer', () => {
       // Should succeed (dirty flag causes fresh data)
       await vi.runAllTimersAsync()
 
-      expect(uploadFn).toHaveBeenCalledTimes(2)
+      expect(attemptFn).toHaveBeenCalledTimes(2)
+      // The abandoned first write plus the new logical write each
+      // prepared once
+      expect(prepareFn).toHaveBeenCalledTimes(2)
     })
   })
 })


### PR DESCRIPTION
## Problem

Users report waves of 500s followed by 409s on `POST /v1/sync/push` during active chatting. Controlplane logs confirm the 409s are `IDEMPOTENCY_CONFLICT` on `PUT /api/sync/blob/chat/...`.

## Root cause

The upload coalescer correctly reuses one idempotency key across all HTTP retries of a logical write (§9.6 R1), but `doBackupChat` re-read the chat from IndexedDB and re-serialized it on **every attempt**. The enclave's operation hash covers the plaintext, so when a chat was edited between attempts (streaming, title generation, `updatedAt` bumps), the retry replayed different bytes under the same key. If the first attempt had committed server-side but the response was lost (enclave 500/timeout, network flake), the retry then failed with `409 IDEMPOTENCY_CONFLICT` instead of replaying the committed 200 - and the local `syncVersion` never advanced, cascading into `409 SYNC_CONFLICT` on subsequent writes.

## Fix

- `UploadCoalescer` now takes a prepare function that runs once per logical write and returns a frozen attempt closure; `uploadWithRetry` replays that closure, so every retry is byte-identical and the controlplane's idempotency cache replays the committed result.
- Only a failed prepare re-runs; a failed attempt never re-reads the chat. Edits landing mid-write still set `dirty` and go out as the next logical write under a fresh key.
- `doBackupChat` split into prepare (eligibility checks + chat snapshot) and the frozen attempt (push + finalize), with the §9.6 R4 recovery dispatch extracted into `recoverFromChatUploadError`, shared by both phases. Behavior otherwise unchanged.

## Testing

- Full vitest suite passes (1156 tests).
- Coalescer tests updated to the prepare/attempt contract, with new coverage: payload frozen across retries (prepare called once), prepare re-runs when prepare itself fails, prepare returning null completes the write.

Companion iOS PR ports the same fix to `CloudSyncService.swift`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes sync conflicts caused by chat edits during retries by freezing each upload’s payload and replaying the same bytes under the same idempotency key. Also skips uploads prepared just before an account switch to avoid cross-account writes and flaky 409s.

- **Bug Fixes**
  - `UploadCoalescer` prepares once per logical write and replays a frozen attempt on retries, so the enclave sees identical bytes and replays the committed result instead of returning `409 IDEMPOTENCY_CONFLICT`.
  - Only a failed prepare re-runs; a failed attempt never re-reads the chat. Edits mid-write set `dirty` and go out as a new logical write with a fresh key.
  - Skips stale attempts when the account switches after prepare (checked in both prepare and attempt), preventing uploads under the wrong account.
  - Stops cascading `409 SYNC_CONFLICT` by ensuring successful server commits advance `syncVersion` locally.

- **Refactors**
  - `UploadCoalescer` API now takes a prepare function that returns `UploadAttempt | null`; `createUploadCoalescer` updated to match.
  - `CloudSyncService.doBackupChat` split into prepare (eligibility + snapshot) and frozen attempt (push + finalize). New `recoverFromChatUploadError` centralizes recovery handling.

<sup>Written for commit e419813e57fa2385a9b2b233b8a073648bcf45da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/451?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

