### PR TITLE
fix: allow recovery key selection in Orion

### DIFF
--- a/src/components/modals/cloud-sync-setup-modal.tsx
+++ b/src/components/modals/cloud-sync-setup-modal.tsx
@@ -712,7 +712,6 @@ ${generatedKey.replace('key_', '')}
           <input
             ref={fileInputRef}
             type="file"
-            accept=".pem"
             onChange={handleFileSelect}
             className="hidden"
           />

--- a/tests/components/cloud-sync-setup-modal.test.tsx
+++ b/tests/components/cloud-sync-setup-modal.test.tsx
@@ -247,4 +247,17 @@ describe('CloudSyncSetupModal onboarding', () => {
       screen.queryByRole('heading', { name: 'Encrypted Backups & Sync' }),
     ).not.toBeInTheDocument()
   })
+
+  it('does not restrict the native recovery-key file picker', async () => {
+    render(<CloudSyncSetupModal {...baseProps} manualRecoveryNeeded />)
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Restore Encryption Key' }),
+    )
+    await screen.findByRole('heading', { name: 'Restore Encryption Key' })
+
+    const fileInput =
+      document.querySelector<HTMLInputElement>('input[type="file"]')
+    expect(fileInput?.accept).toBe('')
+  })
 })


### PR DESCRIPTION
## Summary
- allow Orion users to select recovery key files without WebKit's unsupported PEM picker restriction
- continue validating the selected file's PEM contents before restoring the key
- add regression coverage for the unrestricted native file picker

## Testing
- `npm run test:unit -- --run tests/components/cloud-sync-setup-modal.test.tsx`
- `npx eslint src/components/modals/cloud-sync-setup-modal.tsx tests/components/cloud-sync-setup-modal.test.tsx`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows Orion users to select recovery key files by removing the `.pem` file filter that WebKit doesn’t support. We still validate the file’s PEM contents before restoring the key.

- **Bug Fixes**
  - Removed the `accept=".pem"` restriction from the recovery-key file input to use the native picker.
  - Added a test to assert the file input `accept` is empty.

<sup>Written for commit 18173b1d125033e39cbff2f6afd5013efeef0a6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/452?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

