### PR TITLE
fix: finish pending sync retries

### DIFF
--- a/src/services/cloud/upload-coalescer.ts
+++ b/src/services/cloud/upload-coalescer.ts
@@ -172,12 +172,7 @@ export class UploadCoalescer {
         const idempotencyKey = newIdempotencyKey()
 
         try {
-          await this.uploadWithRetry(
-            chatId,
-            state,
-            idempotencyKey,
-            workerGeneration,
-          )
+          await this.uploadWithRetry(chatId, idempotencyKey, workerGeneration)
           // Success - reset failure count
           state.failureCount = 0
           state.lastError = null
@@ -249,7 +244,6 @@ export class UploadCoalescer {
    */
   private async uploadWithRetry(
     chatId: string,
-    state: ChatUploadState,
     idempotencyKey: string,
     workerGeneration: number,
   ): Promise<void> {
@@ -303,12 +297,6 @@ export class UploadCoalescer {
 
         await this.scheduler.sleep(delay)
         if (workerGeneration !== this.generation) return
-
-        // Check if new changes came in during wait
-        if (state.dirty) {
-          // New changes - let the outer loop handle it with fresh data
-          return
-        }
       }
     }
 

--- a/tests/services/cloud/upload-coalescer.test.ts
+++ b/tests/services/cloud/upload-coalescer.test.ts
@@ -452,12 +452,18 @@ describe('UploadCoalescer', () => {
       expect(coalescer.hasPendingUpload('chat-1')).toBe(false)
     })
 
-    it('handles enqueue during retry backoff', async () => {
-      const attemptFn = vi
-        .fn()
-        .mockRejectedValueOnce(new Error('Fail'))
-        .mockResolvedValue(undefined)
-      const prepareFn = prepareWith(attemptFn)
+    it('finishes a frozen retry before uploading newer dirty state', async () => {
+      let source = 'v1'
+      const attempts: Array<{ payload: string; idempotencyKey: string }> = []
+      const prepareFn = vi.fn(
+        async (_chatId: string, idempotencyKey: string) => {
+          const payload = source
+          return async () => {
+            attempts.push({ payload, idempotencyKey })
+            if (attempts.length === 1) throw new Error('Fail')
+          }
+        },
+      )
 
       // Pin the jitter to its upper bound so the backoff window is
       // deterministic. A random delay of 0 would let the first retry
@@ -477,18 +483,22 @@ describe('UploadCoalescer', () => {
       await vi.advanceTimersByTimeAsync(0) // First attempt fails
 
       // Enqueue during backoff
+      source = 'v2'
       coalescer.enqueue('chat-1')
 
       // Advance to trigger retry
       await vi.advanceTimersByTimeAsync(1000)
 
-      // Should succeed (dirty flag causes fresh data)
       await vi.runAllTimersAsync()
 
-      expect(attemptFn).toHaveBeenCalledTimes(2)
-      // The abandoned first write plus the new logical write each
-      // prepared once
+      expect(attempts.map((attempt) => attempt.payload)).toEqual([
+        'v1',
+        'v1',
+        'v2',
+      ])
       expect(prepareFn).toHaveBeenCalledTimes(2)
+      expect(attempts[0].idempotencyKey).toBe(attempts[1].idempotencyKey)
+      expect(attempts[2].idempotencyKey).not.toBe(attempts[1].idempotencyKey)
     })
   })
 })


### PR DESCRIPTION
## Summary
- finish replaying a frozen sync operation before processing edits received during backoff
- preserve generation cancellation while giving newer edits a fresh idempotency key
- replace the obsolete retry-abandonment expectation with ordering coverage

## Testing
- `npm run test:unit -- --run tests/services/cloud/upload-coalescer.test.ts`
- `npx eslint src/services/cloud/upload-coalescer.ts tests/services/cloud/upload-coalescer.test.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures the upload coalescer finishes an in-flight retry before sending newer edits, preserving write ordering and idempotency. Keeps generation cancellation intact and assigns fresh idempotency keys to new edits.

- **Bug Fixes**
  - Complete the pending retry with the original payload and idempotency key; upload newer dirty state afterward with a new idempotency key.
  - Keep generation-based cancellation checks.
  - Replace the old “abandon retry on dirty” logic and update tests to assert ordering and idempotency key behavior.

<sup>Written for commit 8ffe8279091580f4af235552ac6957e9cda0a406. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/453?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

