### PR TITLE
Avoid metadata requests for favicon-only UI

### DIFF
--- a/src/components/ui/favicon.tsx
+++ b/src/components/ui/favicon.tsx
@@ -13,6 +13,19 @@ const RESOLVED_FAVICON_DATA_URLS = new Map<string, string>()
 // every re-render; the TTL still allows retries after transient outages.
 const FAILED_FAVICON_EXPIRY = new Map<string, number>()
 const FAILED_FAVICON_TTL_MS = 60_000
+const FAVICON_CACHE_MAX_ENTRIES = 200
+
+function setBoundedCacheEntry<Value>(
+  cache: Map<string, Value>,
+  key: string,
+  value: Value,
+): void {
+  if (!cache.has(key) && cache.size >= FAVICON_CACHE_MAX_ENTRIES) {
+    const oldestKey = cache.keys().next().value
+    if (oldestKey !== undefined) cache.delete(oldestKey)
+  }
+  cache.set(key, value)
+}
 
 function isFailureCached(key: string): boolean {
   const expiry = FAILED_FAVICON_EXPIRY.get(key)
@@ -25,7 +38,11 @@ function isFailureCached(key: string): boolean {
 }
 
 function cacheFailure(key: string): void {
-  FAILED_FAVICON_EXPIRY.set(key, Date.now() + FAILED_FAVICON_TTL_MS)
+  setBoundedCacheEntry(
+    FAILED_FAVICON_EXPIRY,
+    key,
+    Date.now() + FAILED_FAVICON_TTL_MS,
+  )
 }
 
 type FaviconState = 'loading' | 'ready' | 'error'
@@ -114,7 +131,11 @@ function FaviconForHost({
             return
           }
           FAILED_FAVICON_EXPIRY.delete(cacheKey)
-          RESOLVED_FAVICON_DATA_URLS.set(cacheKey, faviconDataUrl)
+          setBoundedCacheEntry(
+            RESOLVED_FAVICON_DATA_URLS,
+            cacheKey,
+            faviconDataUrl,
+          )
           if (!cancelled) {
             setResolved({ src: faviconDataUrl, state: 'ready' })
           }

--- a/src/components/ui/favicon.tsx
+++ b/src/components/ui/favicon.tsx
@@ -8,6 +8,26 @@ import { useEffect, useState } from 'react'
 // fetched.
 const RESOLVED_FAVICON_DATA_URLS = new Map<string, string>()
 
+// Hostnames whose favicon lookup recently failed, with the time the failure
+// expires. Streaming remounts would otherwise re-request a failing host on
+// every re-render; the TTL still allows retries after transient outages.
+const FAILED_FAVICON_EXPIRY = new Map<string, number>()
+const FAILED_FAVICON_TTL_MS = 60_000
+
+function isFailureCached(key: string): boolean {
+  const expiry = FAILED_FAVICON_EXPIRY.get(key)
+  if (expiry === undefined) return false
+  if (Date.now() > expiry) {
+    FAILED_FAVICON_EXPIRY.delete(key)
+    return false
+  }
+  return true
+}
+
+function cacheFailure(key: string): void {
+  FAILED_FAVICON_EXPIRY.set(key, Date.now() + FAILED_FAVICON_TTL_MS)
+}
+
 type FaviconState = 'loading' | 'ready' | 'error'
 
 interface ResolvedFavicon {
@@ -18,6 +38,7 @@ interface ResolvedFavicon {
 function initialResolved(key: string): ResolvedFavicon {
   const existing = RESOLVED_FAVICON_DATA_URLS.get(key)
   if (existing) return { src: existing, state: 'ready' }
+  if (isFailureCached(key)) return { src: '', state: 'error' }
   return { src: '', state: 'loading' }
 }
 
@@ -79,7 +100,15 @@ function FaviconForHost({
   useEffect(() => {
     let cancelled = false
 
-    if (RESOLVED_FAVICON_DATA_URLS.has(cacheKey)) {
+    const cached = RESOLVED_FAVICON_DATA_URLS.get(cacheKey)
+    if (cached) {
+      setResolved({ src: cached, state: 'ready' })
+      return () => {
+        cancelled = true
+      }
+    }
+    if (isFailureCached(cacheKey)) {
+      setResolved({ src: '', state: 'error' })
       return () => {
         cancelled = true
       }
@@ -89,6 +118,7 @@ function FaviconForHost({
       .then((faviconDataUrl) => {
         if (cancelled) return
         if (!faviconDataUrl) {
+          cacheFailure(cacheKey)
           setResolved({ src: '', state: 'error' })
           return
         }
@@ -97,6 +127,7 @@ function FaviconForHost({
       })
       .catch(() => {
         if (cancelled) return
+        cacheFailure(cacheKey)
         setResolved({ src: '', state: 'error' })
       })
 

--- a/src/components/ui/favicon.tsx
+++ b/src/components/ui/favicon.tsx
@@ -118,7 +118,9 @@ function FaviconForHost({
         onResolve?.()
       }}
       onError={() => {
-        RESOLVED_FAVICON_DATA_URLS.delete(cacheKey)
+        if (RESOLVED_FAVICON_DATA_URLS.get(cacheKey) === resolved.src) {
+          RESOLVED_FAVICON_DATA_URLS.delete(cacheKey)
+        }
         setResolved({ src: '', state: 'error' })
         onResolveError?.()
       }}

--- a/src/components/ui/favicon.tsx
+++ b/src/components/ui/favicon.tsx
@@ -103,33 +103,27 @@ function FaviconForHost({
     const cached = RESOLVED_FAVICON_DATA_URLS.get(cacheKey)
     if (cached) {
       setResolved({ src: cached, state: 'ready' })
-      return () => {
-        cancelled = true
-      }
-    }
-    if (isFailureCached(cacheKey)) {
+    } else if (isFailureCached(cacheKey)) {
       setResolved({ src: '', state: 'error' })
-      return () => {
-        cancelled = true
-      }
-    }
-
-    fetchFavicon(url)
-      .then((faviconDataUrl) => {
-        if (cancelled) return
-        if (!faviconDataUrl) {
+    } else {
+      fetchFavicon(url)
+        .then((faviconDataUrl) => {
+          if (!faviconDataUrl) {
+            cacheFailure(cacheKey)
+            if (!cancelled) setResolved({ src: '', state: 'error' })
+            return
+          }
+          FAILED_FAVICON_EXPIRY.delete(cacheKey)
+          RESOLVED_FAVICON_DATA_URLS.set(cacheKey, faviconDataUrl)
+          if (!cancelled) {
+            setResolved({ src: faviconDataUrl, state: 'ready' })
+          }
+        })
+        .catch(() => {
           cacheFailure(cacheKey)
-          setResolved({ src: '', state: 'error' })
-          return
-        }
-        RESOLVED_FAVICON_DATA_URLS.set(cacheKey, faviconDataUrl)
-        setResolved({ src: faviconDataUrl, state: 'ready' })
-      })
-      .catch(() => {
-        if (cancelled) return
-        cacheFailure(cacheKey)
-        setResolved({ src: '', state: 'error' })
-      })
+          if (!cancelled) setResolved({ src: '', state: 'error' })
+        })
+    }
 
     return () => {
       cancelled = true
@@ -151,6 +145,7 @@ function FaviconForHost({
       onError={() => {
         if (RESOLVED_FAVICON_DATA_URLS.get(cacheKey) === resolved.src) {
           RESOLVED_FAVICON_DATA_URLS.delete(cacheKey)
+          cacheFailure(cacheKey)
         }
         setResolved({ src: '', state: 'error' })
         onResolveError?.()

--- a/src/components/ui/favicon.tsx
+++ b/src/components/ui/favicon.tsx
@@ -1,13 +1,12 @@
-import { fetchLinkMetadata } from '@/services/inference/metadata-client'
+import { fetchFavicon } from '@/services/inference/metadata-client'
 import { useEffect, useState } from 'react'
 
-// Module-level cache of resolved favicon data URLs keyed by page URL.
+// Module-level cache of resolved favicon data URLs keyed by hostname.
 // Keeps remounts — for example, when react-markdown re-parses a
 // streaming message and recreates citation pills — from flashing back
 // through the loading placeholder once the icon has already been
 // fetched.
 const RESOLVED_FAVICON_DATA_URLS = new Map<string, string>()
-const FAILED_FAVICONS = new Set<string>()
 
 type FaviconState = 'loading' | 'ready' | 'error'
 
@@ -16,16 +15,23 @@ interface ResolvedFavicon {
   state: FaviconState
 }
 
-function initialResolved(url: string): ResolvedFavicon {
-  const existing = RESOLVED_FAVICON_DATA_URLS.get(url)
+function initialResolved(key: string): ResolvedFavicon {
+  const existing = RESOLVED_FAVICON_DATA_URLS.get(key)
   if (existing) return { src: existing, state: 'ready' }
-  if (FAILED_FAVICONS.has(url)) return { src: '', state: 'error' }
   return { src: '', state: 'loading' }
+}
+
+function faviconCacheKey(url: string): string {
+  try {
+    return new URL(url).hostname.toLowerCase()
+  } catch {
+    return url
+  }
 }
 
 /**
  * Favicon <img> that loads the icon through the attested metadata
- * enclave. The bytes come back inlined in the `/metadata` response and
+ * enclave. The bytes come back inlined in the `/favicon` response and
  * are rendered as a `data:` URL so the browser never reaches an
  * external icon host directly. Using a `data:` URL keeps the lifecycle
  * trivial: there's no Blob to allocate and no `URL.createObjectURL`
@@ -36,7 +42,7 @@ interface FaviconProps extends Omit<
   React.ImgHTMLAttributes<HTMLImageElement>,
   'src' | 'onError' | 'onLoad'
 > {
-  /** Page URL; metadata is fetched against this. */
+  /** Page URL used to identify the favicon hostname. */
   url: string
   /** Rendered until the favicon bytes resolve. */
   placeholder?: React.ReactNode
@@ -48,8 +54,16 @@ interface FaviconProps extends Omit<
   onResolveError?: () => void
 }
 
-export function Favicon({
+export function Favicon({ url, ...props }: FaviconProps) {
+  const cacheKey = faviconCacheKey(url)
+  return (
+    <FaviconForHost key={cacheKey} url={url} cacheKey={cacheKey} {...props} />
+  )
+}
+
+function FaviconForHost({
   url,
+  cacheKey,
   placeholder = null,
   fallback = null,
   onResolve,
@@ -57,42 +71,39 @@ export function Favicon({
   alt = '',
   className,
   ...imgProps
-}: FaviconProps) {
+}: FaviconProps & { cacheKey: string }) {
   const [resolved, setResolved] = useState<ResolvedFavicon>(() =>
-    initialResolved(url),
+    initialResolved(cacheKey),
   )
 
   useEffect(() => {
     let cancelled = false
-    setResolved(initialResolved(url))
 
-    if (RESOLVED_FAVICON_DATA_URLS.has(url) || FAILED_FAVICONS.has(url)) {
+    if (RESOLVED_FAVICON_DATA_URLS.has(cacheKey)) {
       return () => {
         cancelled = true
       }
     }
 
-    fetchLinkMetadata(url)
-      .then((metadata) => {
+    fetchFavicon(url)
+      .then((faviconDataUrl) => {
         if (cancelled) return
-        if (!metadata.faviconDataUrl) {
-          FAILED_FAVICONS.add(url)
+        if (!faviconDataUrl) {
           setResolved({ src: '', state: 'error' })
           return
         }
-        RESOLVED_FAVICON_DATA_URLS.set(url, metadata.faviconDataUrl)
-        setResolved({ src: metadata.faviconDataUrl, state: 'ready' })
+        RESOLVED_FAVICON_DATA_URLS.set(cacheKey, faviconDataUrl)
+        setResolved({ src: faviconDataUrl, state: 'ready' })
       })
       .catch(() => {
         if (cancelled) return
-        FAILED_FAVICONS.add(url)
         setResolved({ src: '', state: 'error' })
       })
 
     return () => {
       cancelled = true
     }
-  }, [url])
+  }, [cacheKey, url])
 
   if (resolved.state === 'error') return <>{fallback}</>
   if (resolved.state === 'loading') return <>{placeholder}</>
@@ -107,7 +118,7 @@ export function Favicon({
         onResolve?.()
       }}
       onError={() => {
-        FAILED_FAVICONS.add(url)
+        RESOLVED_FAVICON_DATA_URLS.delete(cacheKey)
         setResolved({ src: '', state: 'error' })
         onResolveError?.()
       }}

--- a/src/services/inference/metadata-client.ts
+++ b/src/services/inference/metadata-client.ts
@@ -4,12 +4,10 @@ import { SecureClient } from 'tinfoil'
 /**
  * Opengraph-metadata client.
  *
- * Fetches title/description/site_name/image/favicon-bytes for a URL
+ * Fetches title/description/site_name/image for a URL
  * from the attested `opengraph-metadata.tinfoil.sh` enclave. Used by
  * the GenUI link-preview widget to replace model-generated fields with
- * verified values scraped server-side inside a Tinfoil CVM. Favicon
- * bytes are inlined in the response so the browser never has to make a
- * follow-up GET to an external icon host.
+ * verified values scraped server-side inside a Tinfoil CVM.
  */
 
 const METADATA_ENCLAVE = 'https://opengraph-metadata.tinfoil.sh'
@@ -33,15 +31,6 @@ export interface LinkMetadata {
   description: string | null
   siteName: string | null
   image: string | null
-  /**
-   * `data:` URL for the page's favicon, already encoded so consumers can
-   * drop it straight into an `<img src>` without managing a Blob or
-   * object URL lifecycle. The bytes never leave the original base64
-   * envelope, which sidesteps the race conditions that come with
-   * `URL.createObjectURL` / `URL.revokeObjectURL` when the same icon is
-   * rendered by multiple components.
-   */
-  faviconDataUrl: string | null
   cached: boolean
 }
 
@@ -51,9 +40,12 @@ interface MetadataResponse {
   description: string | null
   site_name: string | null
   image: string | null
-  favicon_bytes?: string | null
-  favicon_content_type?: string | null
   cached: boolean
+}
+
+interface FaviconResponse {
+  favicon_bytes: string
+  favicon_content_type: string
 }
 
 /**
@@ -69,6 +61,7 @@ interface MetadataResponse {
  * data and grow unbounded over a session).
  */
 const metadataPromiseByUrl = new Map<string, Promise<LinkMetadata>>()
+const faviconPromiseByHost = new Map<string, Promise<string | null>>()
 
 /**
  * Fetch OpenGraph metadata for a URL from the Tinfoil enclave.
@@ -87,6 +80,19 @@ export function fetchLinkMetadata(url: string): Promise<LinkMetadata> {
     metadataPromiseByUrl.delete(url)
   })
   metadataPromiseByUrl.set(url, promise)
+  return promise
+}
+
+/** Fetch only a favicon without requesting the page through Zyte. */
+export function fetchFavicon(url: string): Promise<string | null> {
+  const key = faviconRequestKey(url)
+  const existing = faviconPromiseByHost.get(key)
+  if (existing) return existing
+
+  const promise = doFetchFavicon(url).finally(() => {
+    faviconPromiseByHost.delete(key)
+  })
+  faviconPromiseByHost.set(key, promise)
   return promise
 }
 
@@ -123,11 +129,39 @@ async function doFetchLinkMetadata(url: string): Promise<LinkMetadata> {
     description: data.description,
     siteName: data.site_name,
     image: data.image,
-    faviconDataUrl: buildFaviconDataUrl(
-      data.favicon_bytes,
-      data.favicon_content_type,
-    ),
     cached: data.cached,
+  }
+}
+
+async function doFetchFavicon(url: string): Promise<string | null> {
+  const response = await getClient().fetch(`${METADATA_ENCLAVE}/favicon`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ url }),
+  })
+
+  if (!response.ok) {
+    logError(
+      `Favicon fetch failed with status: ${response.status}`,
+      undefined,
+      {
+        component: 'metadata-client',
+        action: 'fetchFavicon',
+        metadata: { status: response.status },
+      },
+    )
+    throw new Error(`Favicon fetch failed: ${response.status}`)
+  }
+
+  const data: FaviconResponse = await response.json()
+  return buildFaviconDataUrl(data.favicon_bytes, data.favicon_content_type)
+}
+
+function faviconRequestKey(url: string): string {
+  try {
+    return new URL(url).hostname.toLowerCase()
+  } catch {
+    return url
   }
 }
 

--- a/src/services/inference/metadata-client.ts
+++ b/src/services/inference/metadata-client.ts
@@ -141,13 +141,14 @@ async function doFetchFavicon(url: string): Promise<string | null> {
   })
 
   if (!response.ok) {
+    const errorText = await response.text().catch(() => '')
     logError(
       `Favicon fetch failed with status: ${response.status}`,
       undefined,
       {
         component: 'metadata-client',
         action: 'fetchFavicon',
-        metadata: { status: response.status },
+        metadata: { status: response.status, error: errorText },
       },
     )
     throw new Error(`Favicon fetch failed: ${response.status}`)

--- a/tests/services/inference/metadata-client.test.ts
+++ b/tests/services/inference/metadata-client.test.ts
@@ -1,0 +1,49 @@
+import { fetchFavicon } from '@/services/inference/metadata-client'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockFetch } = vi.hoisted(() => ({
+  mockFetch: vi.fn<(input: string, init?: RequestInit) => Promise<Response>>(),
+}))
+
+vi.mock('tinfoil', () => ({
+  SecureClient: class {
+    fetch = mockFetch
+  },
+}))
+
+function faviconResponse(): Response {
+  return new Response(
+    JSON.stringify({
+      favicon_bytes: 'aWNvbg==',
+      favicon_content_type: 'image/x-icon',
+    }),
+    { status: 200, headers: { 'Content-Type': 'application/json' } },
+  )
+}
+
+describe('fetchFavicon', () => {
+  beforeEach(() => {
+    mockFetch.mockReset().mockResolvedValue(faviconResponse())
+  })
+
+  it('uses the favicon-only enclave endpoint', async () => {
+    await expect(fetchFavicon('https://example.com/page')).resolves.toBe(
+      'data:image/x-icon;base64,aWNvbg==',
+    )
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://opengraph-metadata.tinfoil.sh/favicon',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ url: 'https://example.com/page' }),
+      }),
+    )
+  })
+
+  it('deduplicates concurrent requests for the same hostname', async () => {
+    const first = fetchFavicon('https://example.org/one')
+    const second = fetchFavicon('https://example.org/two')
+
+    await Promise.all([first, second])
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## Summary
- fetch generic favicons through the new favicon-only enclave endpoint
- deduplicate and cache favicon requests by hostname without permanently caching transient failures
- keep full metadata requests limited to link previews

## Testing
- `npm run lint`
- `npm run test:unit -- --run`
- `npx tsc --noEmit`
- `npm run build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Load favicons through the new favicon-only enclave endpoint and cache by hostname to avoid full metadata requests. Failure handling now uses a short TTL and keeps icons in sync with a bounded shared cache to prevent stale renders, enable retries, and preserve outcomes across remounts.

- **Performance**
  - Switch `Favicon` to use `fetchFavicon` (`/favicon`) instead of `fetchLinkMetadata`.
  - Cache by hostname; deduplicate concurrent requests; initialize state from cache; bound session caches to 200 entries; add unit tests.
  - Cache failures for 60s; evict on image error to allow retry.
  - Limit full metadata fetches to link previews and remove `faviconDataUrl` from `LinkMetadata`.

<sup>Written for commit 51be4d6be263d761e5aa4a9cca541d5714c19f86. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/454?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

