### PR TITLE
Fix active stream recovery and Firefox requests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
         "remark-math": "^6.0.0",
         "tailwind-merge": "^2.6.0",
         "tailwindcss-animate": "^1.0.7",
-        "tinfoil": "^1.1.12",
+        "tinfoil": "^1.1.13",
         "uuid": "^11.1.1",
         "yet-another-react-lightbox": "^3.32.0",
         "zod": "^3.25.76",
@@ -3363,9 +3363,9 @@
       }
     },
     "node_modules/@tinfoilsh/verifier": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/@tinfoilsh/verifier/-/verifier-1.1.12.tgz",
-      "integrity": "sha512-O8MueAaGiCjKD2V0aTPJd0XXChKLeUmXREzfzNJ2BVB/EQtmmwrGmAZ52trU3wgWZsQuUUBsOzW+Xb85iPmbzw==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@tinfoilsh/verifier/-/verifier-1.1.13.tgz",
+      "integrity": "sha512-0QEQpLCtBe1F8MbwIs8m6VTH3aFPdAObVcfRsjxOqCnOlJkqNWCcvlfOG4Z3sJM9jvTu/T4bfed9txTVPWgJIw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@freedomofpress/crypto-browser": "^0.1.7",
@@ -6586,9 +6586,9 @@
       }
     },
     "node_modules/ehbp": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/ehbp/-/ehbp-0.3.1.tgz",
-      "integrity": "sha512-Y0g5OWSBWis5rJgw3mEftnvJtW5vD+5LSuzYwAy39HlmMWHm6KFBtw+Wr50IrCKWyRVW2VdxkMMwA8yAnBmkag==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/ehbp/-/ehbp-0.3.2.tgz",
+      "integrity": "sha512-t6aIXrztsQC7jGypZ4Mvc7oMP2LN1q5zAWRKZUcVbgEZgXq/OoD9MAQGFOaCv5LMexx6BOKYpEfIhM/kaRMrtg==",
       "license": "MIT",
       "dependencies": {
         "@panva/hpke-noble": "^1.0.3",
@@ -13814,16 +13814,16 @@
       }
     },
     "node_modules/tinfoil": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/tinfoil/-/tinfoil-1.1.12.tgz",
-      "integrity": "sha512-fBNAKvGS9zTbzOicCm5Bv1UfICB4vWHza0S4FavvhtIU7I8KhUa1407CqFDTKTYdJUjHH8fAPMbdvkaW1bFecA==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/tinfoil/-/tinfoil-1.1.13.tgz",
+      "integrity": "sha512-C3u7jy07eSmgs5spcuG2jn6I2Gj5nD++x9dFok+qi7LKv9Qc0hrOAVyKRXsO5lHVIPPEHvOeWVgcjf2159A1hw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/openai-compatible": "^3.0.7",
         "@freedomofpress/sigstore-browser": "^0.1.14",
-        "@tinfoilsh/verifier": "1.1.12",
+        "@tinfoilsh/verifier": "1.1.13",
         "@types/ws": "^8.18.1",
-        "ehbp": "^0.3.1",
+        "ehbp": "^0.3.2",
         "openai": "^6.46.0",
         "ws": "^8.21.0"
       },

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "remark-math": "^6.0.0",
     "tailwind-merge": "^2.6.0",
     "tailwindcss-animate": "^1.0.7",
-    "tinfoil": "^1.1.12",
+    "tinfoil": "^1.1.13",
     "uuid": "^11.1.1",
     "yet-another-react-lightbox": "^3.32.0",
     "zod": "^3.25.76",

--- a/src/components/chat/hooks/streaming/process-stream.ts
+++ b/src/components/chat/hooks/streaming/process-stream.ts
@@ -296,15 +296,17 @@ export async function processStreamingResponse(
   } finally {
     // Drop any pending trailing flush so it can't fire after teardown.
     clearTrailingFlush()
-    ctx.setLoadingState('idle')
-    ctx.setIsStreaming(false)
-    if (streamingChatId) streamingTracker.endStreaming(streamingChatId)
-    // The backend may have swapped the id mid-stream; clear that too.
-    if (
-      ctx.streamChatIdRef.current &&
-      ctx.streamChatIdRef.current !== streamingChatId
-    ) {
-      streamingTracker.endStreaming(ctx.streamChatIdRef.current)
+    if (!ctx.deferStreamCleanup) {
+      ctx.setLoadingState('idle')
+      ctx.setIsStreaming(false)
+      if (streamingChatId) streamingTracker.endStreaming(streamingChatId)
+      // The backend may have swapped the id mid-stream; clear that too.
+      if (
+        ctx.streamChatIdRef.current &&
+        ctx.streamChatIdRef.current !== streamingChatId
+      ) {
+        streamingTracker.endStreaming(ctx.streamChatIdRef.current)
+      }
     }
     ctx.setIsThinking(false)
     ctx.thinkingStartTimeRef.current = null

--- a/src/components/chat/hooks/streaming/types.ts
+++ b/src/components/chat/hooks/streaming/types.ts
@@ -126,6 +126,7 @@ export interface StreamingContext {
   setLoadingState: (s: 'idle' | 'loading') => void
   storeHistory: boolean
   startingChatId: string
+  deferStreamCleanup?: boolean
 }
 
 export interface StreamingHandlers {

--- a/src/components/chat/hooks/use-chat-messaging.ts
+++ b/src/components/chat/hooks/use-chat-messaging.ts
@@ -859,6 +859,7 @@ export function useChatMessaging({
           setLoadingState: setLoadingStateFor,
           storeHistory,
           startingChatId,
+          deferStreamCleanup: recoveryEnabled,
         })
         if (assistantMessage && turnId) {
           assistantMessage.turnId = turnId

--- a/tests/components/chat/streaming/process-stream.test.ts
+++ b/tests/components/chat/streaming/process-stream.test.ts
@@ -1,0 +1,84 @@
+import { processStreamingResponse } from '@/components/chat/hooks/streaming/process-stream'
+import type { StreamingContext } from '@/components/chat/hooks/streaming/types'
+import type { Chat } from '@/components/chat/types'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { endStreamingMock, startStreamingMock } = vi.hoisted(() => ({
+  endStreamingMock: vi.fn(),
+  startStreamingMock: vi.fn(),
+}))
+
+vi.mock('@/services/cloud/streaming-tracker', () => ({
+  streamingTracker: {
+    endStreaming: endStreamingMock,
+    startStreaming: startStreamingMock,
+  },
+}))
+
+function createResponse(): Response {
+  const events = [
+    { choices: [{ delta: { content: 'Hello' } }] },
+    { choices: [{ index: 0, delta: {}, finish_reason: 'stop' }] },
+  ]
+  const body = events
+    .map((event) => `data: ${JSON.stringify(event)}\n\n`)
+    .join('')
+  return new Response(`${body}data: [DONE]\n\n`)
+}
+
+function createContext(): StreamingContext {
+  const chat: Chat = {
+    id: 'chat-1',
+    title: 'Chat',
+    messages: [],
+    createdAt: new Date(),
+  }
+
+  return {
+    updatedChat: chat,
+    updatedMessages: [],
+    isFirstMessage: true,
+    modelsLength: 1,
+    streamChatIdRef: { current: chat.id },
+    thinkingStartTimeRef: { current: null },
+    setIsThinking: vi.fn(),
+    setIsWaitingForResponse: vi.fn(),
+    setIsStreaming: vi.fn(),
+    updateChatWithHistoryCheck: vi.fn(),
+    setChats: vi.fn(),
+    setCurrentChat: vi.fn(),
+    setLoadingState: vi.fn(),
+    storeHistory: true,
+    startingChatId: chat.id,
+  }
+}
+
+describe('processStreamingResponse lifecycle', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('cleans up the stream by default', async () => {
+    const context = createContext()
+
+    await processStreamingResponse(createResponse(), context)
+
+    expect(context.setLoadingState).toHaveBeenCalledWith('idle')
+    expect(context.setIsStreaming).toHaveBeenCalledWith(false)
+    expect(endStreamingMock).toHaveBeenCalledWith('chat-1')
+  })
+
+  it('keeps the stream active when the caller has recovery to finalize', async () => {
+    const context = {
+      ...createContext(),
+      deferStreamCleanup: true,
+    }
+
+    await processStreamingResponse(createResponse(), context)
+
+    expect(startStreamingMock).toHaveBeenCalledWith('chat-1')
+    expect(context.setLoadingState).not.toHaveBeenCalled()
+    expect(context.setIsStreaming).not.toHaveBeenCalled()
+    expect(endStreamingMock).not.toHaveBeenCalled()
+  })
+})

--- a/tests/services/cloud/upload-coalescer.test.ts
+++ b/tests/services/cloud/upload-coalescer.test.ts
@@ -193,20 +193,31 @@ describe('UploadCoalescer', () => {
   describe('Coalescing behavior', () => {
     it('waits for an existing upload without scheduling another write', async () => {
       let resolveUpload: (() => void) | undefined
-      const uploadFn = vi.fn(
+      const attemptFn = vi.fn(
         () =>
           new Promise<void>((resolve) => {
             resolveUpload = resolve
           }),
       )
-      const coalescer = new UploadCoalescer(uploadFn)
+      const prepareFn = prepareWith(attemptFn)
+      const coalescer = new UploadCoalescer(prepareFn)
       coalescer.enqueue('chat-1')
+      await vi.advanceTimersByTimeAsync(0)
 
       const ensured = coalescer.ensureUploadAndWait('chat-1')
-      resolveUpload?.()
+      let settled = false
+      void ensured.then(() => {
+        settled = true
+      })
+      await Promise.resolve()
+      expect(settled).toBe(false)
+
+      resolveUpload!()
       await ensured
 
-      expect(uploadFn).toHaveBeenCalledOnce()
+      expect(settled).toBe(true)
+      expect(prepareFn).toHaveBeenCalledOnce()
+      expect(attemptFn).toHaveBeenCalledOnce()
     })
 
     it('coalesces rapid enqueues for the same chat', async () => {


### PR DESCRIPTION
## Summary
- keep recoverable chats actively streaming until live recovery finalization finishes
- update to Tinfoil JS v1.1.13 and EHBP v0.3.2 so Firefox preserves encrypted request payloads
- fix the stale upload coalescer test to use the current prepare-and-attempt contract
- add regression coverage for deferred and default stream cleanup

## Testing
- `npx tsc --noEmit`
- `npx vitest run` (1354 tests)
- `npm run build`