### PR TITLE
Keep source favicons circular

### DIFF
--- a/src/components/chat/renderers/components/SourcesButton.tsx
+++ b/src/components/chat/renderers/components/SourcesButton.tsx
@@ -52,7 +52,8 @@ function FaviconBadge({
       url={url}
       width={size}
       height={size}
-      className={`shrink-0 rounded-full bg-white p-[1px] ${className ?? ''}`}
+      className={`shrink-0 rounded-full bg-white object-contain p-[1px] ${className ?? ''}`}
+      style={{ width: size, height: size }}
       placeholder={fallback}
       fallback={fallback}
     />


### PR DESCRIPTION
## Summary
- lock source favicon badges to square CSS dimensions
- contain non-square favicon artwork without stretching the badge
- apply the fix to both the chat Sources button and detailed source list

## Verification
- `npx eslint src/components/chat/renderers/components/SourcesButton.tsx`
- `npx prettier --check src/components/chat/renderers/components/SourcesButton.tsx`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep source favicon badges circular by locking icons to square dimensions and adding `object-contain` so non-square artwork doesn't stretch. Applies to the chat Sources button and the detailed source list.

<sup>Written for commit 49b4f911053f4bb1f73c54a9b323d375554fd061. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/456?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

