### PR TITLE
fix: preserve stopped assistant responses

### DIFF
--- a/src/components/chat/hooks/streaming/index.ts
+++ b/src/components/chat/hooks/streaming/index.ts
@@ -1,3 +1,8 @@
+export {
+  finalizeInterruptedMessage,
+  hasVisibleAssistantMessage,
+  mergeInterruptedAssistant,
+} from './interrupted-message'
 export { getThinkingDuration, processStreamingResponse } from './process-stream'
 export { parseRichStreamingResponse } from './rich-response-parser'
 export type { StreamingContext, StreamingHandlers } from './types'

--- a/src/components/chat/hooks/streaming/interrupted-message.ts
+++ b/src/components/chat/hooks/streaming/interrupted-message.ts
@@ -1,0 +1,95 @@
+import type { Message, TimelineBlock } from '../../types'
+
+function finalizeTimelineBlock(block: TimelineBlock): TimelineBlock {
+  switch (block.type) {
+    case 'thinking':
+      return block.isThinking ? { ...block, isThinking: false } : block
+    case 'web_search':
+      return block.state.status === 'searching'
+        ? { ...block, state: { ...block.state, status: 'failed' } }
+        : block
+    case 'url_fetches':
+      return {
+        ...block,
+        fetches: block.fetches.map((fetch) =>
+          fetch.status === 'fetching' ? { ...fetch, status: 'failed' } : fetch,
+        ),
+      }
+    case 'code_exec':
+      return {
+        ...block,
+        calls: block.calls.map((call) =>
+          call.status === 'running' ? { ...call, status: 'failed' } : call,
+        ),
+      }
+    default:
+      return block
+  }
+}
+
+export function hasVisibleAssistantMessage(message: Message): boolean {
+  return Boolean(
+    message.content ||
+    message.thoughts ||
+    message.webSearch ||
+    message.urlFetches?.length ||
+    message.annotations?.length ||
+    message.searchReasoning ||
+    message.toolCalls?.length ||
+    message.codeExecCalls?.length,
+  )
+}
+
+export function finalizeInterruptedMessage(
+  message: Message,
+  turnId?: string,
+): Message {
+  return {
+    ...message,
+    turnId: turnId ?? message.turnId,
+    isThinking: false,
+    webSearch:
+      message.webSearch?.status === 'searching'
+        ? { ...message.webSearch, status: 'failed' }
+        : message.webSearch,
+    urlFetches: message.urlFetches?.map((fetch) =>
+      fetch.status === 'fetching' ? { ...fetch, status: 'failed' } : fetch,
+    ),
+    codeExecCalls: message.codeExecCalls?.map((call) =>
+      call.status === 'running' ? { ...call, status: 'failed' } : call,
+    ),
+    timeline: message.timeline?.map(finalizeTimelineBlock),
+  }
+}
+
+export function mergeInterruptedAssistant(
+  messages: Message[],
+  turnId: string,
+  assistantMessage: Message | null,
+): Message[] {
+  const assistantIndex = messages.findIndex(
+    (message) => message.role === 'assistant' && message.turnId === turnId,
+  )
+  if (!assistantMessage) {
+    return assistantIndex < 0
+      ? messages
+      : messages.filter((_, index) => index !== assistantIndex)
+  }
+
+  const finalizedMessage = finalizeInterruptedMessage(assistantMessage, turnId)
+  if (assistantIndex >= 0) {
+    const merged = [...messages]
+    merged[assistantIndex] = finalizedMessage
+    return merged
+  }
+
+  const userIndex = messages.findIndex(
+    (message) => message.role === 'user' && message.turnId === turnId,
+  )
+  const insertAt = userIndex >= 0 ? userIndex + 1 : messages.length
+  return [
+    ...messages.slice(0, insertAt),
+    finalizedMessage,
+    ...messages.slice(insertAt),
+  ]
+}

--- a/src/components/chat/hooks/streaming/interrupted-message.ts
+++ b/src/components/chat/hooks/streaming/interrupted-message.ts
@@ -1,26 +1,38 @@
-import type { Message, TimelineBlock } from '../../types'
+import type {
+  Message,
+  TimelineBlock,
+  ToolCallState,
+  URLFetchState,
+  WebSearchState,
+} from '../../types'
+
+function finalizeWebSearchState(state: WebSearchState): WebSearchState {
+  return state.status === 'searching' ? { ...state, status: 'failed' } : state
+}
+
+function finalizeURLFetchState(state: URLFetchState): URLFetchState {
+  return state.status === 'fetching' ? { ...state, status: 'failed' } : state
+}
+
+function finalizeToolCallState(state: ToolCallState): ToolCallState {
+  return state.status === 'running' ? { ...state, status: 'failed' } : state
+}
 
 function finalizeTimelineBlock(block: TimelineBlock): TimelineBlock {
   switch (block.type) {
     case 'thinking':
       return block.isThinking ? { ...block, isThinking: false } : block
     case 'web_search':
-      return block.state.status === 'searching'
-        ? { ...block, state: { ...block.state, status: 'failed' } }
-        : block
+      return { ...block, state: finalizeWebSearchState(block.state) }
     case 'url_fetches':
       return {
         ...block,
-        fetches: block.fetches.map((fetch) =>
-          fetch.status === 'fetching' ? { ...fetch, status: 'failed' } : fetch,
-        ),
+        fetches: block.fetches.map(finalizeURLFetchState),
       }
     case 'code_exec':
       return {
         ...block,
-        calls: block.calls.map((call) =>
-          call.status === 'running' ? { ...call, status: 'failed' } : call,
-        ),
+        calls: block.calls.map(finalizeToolCallState),
       }
     default:
       return block
@@ -48,16 +60,11 @@ export function finalizeInterruptedMessage(
     ...message,
     turnId: turnId ?? message.turnId,
     isThinking: false,
-    webSearch:
-      message.webSearch?.status === 'searching'
-        ? { ...message.webSearch, status: 'failed' }
-        : message.webSearch,
-    urlFetches: message.urlFetches?.map((fetch) =>
-      fetch.status === 'fetching' ? { ...fetch, status: 'failed' } : fetch,
-    ),
-    codeExecCalls: message.codeExecCalls?.map((call) =>
-      call.status === 'running' ? { ...call, status: 'failed' } : call,
-    ),
+    webSearch: message.webSearch
+      ? finalizeWebSearchState(message.webSearch)
+      : undefined,
+    urlFetches: message.urlFetches?.map(finalizeURLFetchState),
+    codeExecCalls: message.codeExecCalls?.map(finalizeToolCallState),
     timeline: message.timeline?.map(finalizeTimelineBlock),
   }
 }

--- a/src/components/chat/hooks/streaming/process-stream.ts
+++ b/src/components/chat/hooks/streaming/process-stream.ts
@@ -22,6 +22,10 @@ import { CONSTANTS } from '../../constants'
 import type { Message, URLFetchState } from '../../types'
 import { createContentPreprocessor } from './content-preprocessor'
 import { createEventNormalizer } from './event-normalizer'
+import {
+  finalizeInterruptedMessage,
+  hasVisibleAssistantMessage,
+} from './interrupted-message'
 import { MessageAssembler } from './message-assembler'
 import { readSSEStream } from './sse-reader'
 import { TimelineBuilder } from './timeline-builder'
@@ -64,7 +68,10 @@ export async function processStreamingResponse(
   // background stream updates the list entry without disturbing the view.
   const flushToUI = () => {
     dirty = false
-    const message = assembler.toMessage(timeline.snapshot())
+    const message = {
+      ...assembler.toMessage(timeline.snapshot()),
+      turnId: ctx.turnId,
+    }
     const newMessages = [...ctx.updatedMessages, message]
     ctx.updateChatWithHistoryCheck(
       ctx.setChats,
@@ -89,7 +96,7 @@ export async function processStreamingResponse(
   // trailing timer guarantees the latest content still paints when the stream
   // pauses (e.g. before a tool call) instead of waiting for the next chunk.
   const flushThrottled = () => {
-    if (!dirty) return
+    if (!dirty || ctx.signal?.aborted) return
     const now = Date.now()
     const elapsed = now - lastFlushAt
     if (elapsed >= CONSTANTS.STREAM_FLUSH_INTERVAL_MS) {
@@ -251,10 +258,26 @@ export async function processStreamingResponse(
     }
   }
 
+  let interruptionPublished = false
+  const publishInterruption = () => {
+    if (interruptionPublished) return
+    interruptionPublished = true
+    clearTrailingFlush()
+    const message = finalizeInterruptedMessage(
+      assembler.toMessage(timeline.snapshot()),
+      ctx.turnId,
+    )
+    ctx.onInterrupted?.(hasVisibleAssistantMessage(message) ? message : null)
+  }
+
+  ctx.signal?.addEventListener('abort', publishInterruption, { once: true })
+  if (ctx.signal?.aborted) publishInterruption()
+
   try {
     if (streamingChatId) streamingTracker.startStreaming(streamingChatId)
 
     for await (const sseJson of readSSEStream(response, streamLogger)) {
+      if (ctx.signal?.aborted) break
       const events = normalizer.processChunk(
         sseJson,
         preprocessor,
@@ -264,9 +287,13 @@ export async function processStreamingResponse(
         applyEvent(event)
       }
 
+      if (ctx.signal?.aborted) break
       flushThrottled()
     }
 
+    if (ctx.signal?.aborted) {
+      throw new DOMException('Aborted', 'AbortError')
+    }
     normalizer.assertComplete()
 
     // Flush normalizer tail (buffered first-chunk or unclosed thinking)
@@ -292,11 +319,14 @@ export async function processStreamingResponse(
     if (dirty) flushToUI()
 
     streamLogger?.flush(streamingChatId)
-    return assembler.toMessage(timeline.snapshot())
+    return {
+      ...assembler.toMessage(timeline.snapshot()),
+      turnId: ctx.turnId,
+    }
   } finally {
     // Drop any pending trailing flush so it can't fire after teardown.
     clearTrailingFlush()
-    if (!ctx.deferStreamCleanup) {
+    if (!ctx.deferStreamCleanup && !ctx.signal?.aborted) {
       ctx.setLoadingState('idle')
       ctx.setIsStreaming(false)
       if (streamingChatId) streamingTracker.endStreaming(streamingChatId)
@@ -311,5 +341,6 @@ export async function processStreamingResponse(
     ctx.setIsThinking(false)
     ctx.thinkingStartTimeRef.current = null
     ctx.setIsWaitingForResponse(false)
+    ctx.signal?.removeEventListener('abort', publishInterruption)
   }
 }

--- a/src/components/chat/hooks/streaming/process-stream.ts
+++ b/src/components/chat/hooks/streaming/process-stream.ts
@@ -258,11 +258,22 @@ export async function processStreamingResponse(
     }
   }
 
+  const flushBufferedEvents = () => {
+    for (const event of normalizer.flush()) {
+      applyEvent(event)
+    }
+    const { text: tail } = preprocessor.flush()
+    if (tail) {
+      applyEvent({ type: 'content_delta', content: tail })
+    }
+  }
+
   let interruptionPublished = false
   const publishInterruption = () => {
     if (interruptionPublished) return
     interruptionPublished = true
     clearTrailingFlush()
+    flushBufferedEvents()
     const message = finalizeInterruptedMessage(
       assembler.toMessage(timeline.snapshot()),
       ctx.turnId,
@@ -296,16 +307,7 @@ export async function processStreamingResponse(
     }
     normalizer.assertComplete()
 
-    // Flush normalizer tail (buffered first-chunk or unclosed thinking)
-    for (const event of normalizer.flush()) {
-      applyEvent(event)
-    }
-
-    // Flush preprocessor tail (partial tinfoil/channel tags)
-    const { text: tail } = preprocessor.flush()
-    if (tail) {
-      applyEvent({ type: 'content_delta', content: tail })
-    }
+    flushBufferedEvents()
 
     // Finalize any open thinking block
     if (timeline.isThinkingOpen) {

--- a/src/components/chat/hooks/streaming/process-stream.ts
+++ b/src/components/chat/hooks/streaming/process-stream.ts
@@ -96,7 +96,7 @@ export async function processStreamingResponse(
   // trailing timer guarantees the latest content still paints when the stream
   // pauses (e.g. before a tool call) instead of waiting for the next chunk.
   const flushThrottled = () => {
-    if (!dirty || ctx.signal?.aborted) return
+    if (!dirty) return
     const now = Date.now()
     const elapsed = now - lastFlushAt
     if (elapsed >= CONSTANTS.STREAM_FLUSH_INTERVAL_MS) {

--- a/src/components/chat/hooks/streaming/types.ts
+++ b/src/components/chat/hooks/streaming/types.ts
@@ -127,6 +127,9 @@ export interface StreamingContext {
   storeHistory: boolean
   startingChatId: string
   deferStreamCleanup?: boolean
+  signal?: AbortSignal
+  turnId?: string
+  onInterrupted?: (message: Message | null) => void
 }
 
 export interface StreamingHandlers {

--- a/src/components/chat/hooks/use-chat-messaging.ts
+++ b/src/components/chat/hooks/use-chat-messaging.ts
@@ -126,7 +126,7 @@ type ActiveLiveGeneration = {
   chat: Chat
   messages: Message[]
   turnId?: string
-  interruptedMessage: Message | null
+  latestAssistantMessage: Message | null
   initialSave?: Promise<void>
 }
 
@@ -318,9 +318,9 @@ export function useChatMessaging({
 
         abort(targetId)
         const interruptedMessage =
-          activeGeneration?.interruptedMessage &&
-          hasVisibleAssistantMessage(activeGeneration.interruptedMessage)
-            ? activeGeneration.interruptedMessage
+          activeGeneration?.latestAssistantMessage &&
+          hasVisibleAssistantMessage(activeGeneration.latestAssistantMessage)
+            ? activeGeneration.latestAssistantMessage
             : null
         patchStatus(targetId, {
           loadingState: 'loading',
@@ -750,7 +750,7 @@ export function useChatMessaging({
         chat: updatedChat,
         messages: updatedMessages,
         turnId: turnId ?? undefined,
-        interruptedMessage: null,
+        latestAssistantMessage: null,
         initialSave: initialSavePromise,
       }
       activeLiveGenerationsRef.current.set(startingChatId, activeGeneration)
@@ -935,7 +935,7 @@ export function useChatMessaging({
           signal: controller.signal,
           turnId: turnId ?? undefined,
           onInterrupted: (message) => {
-            activeGeneration.interruptedMessage = message
+            activeGeneration.latestAssistantMessage = message
           },
         })
         if (assistantMessage && turnId) {
@@ -944,6 +944,9 @@ export function useChatMessaging({
 
         const hasAssistantMessageToSave =
           !!assistantMessage && hasVisibleAssistantMessage(assistantMessage)
+        if (assistantMessage && hasAssistantMessageToSave) {
+          activeGeneration.latestAssistantMessage = assistantMessage
+        }
 
         if (assistantMessage && hasAssistantMessageToSave) {
           // Use this stream's own id (already reflects any server id swap).

--- a/src/components/chat/hooks/use-chat-messaging.ts
+++ b/src/components/chat/hooks/use-chat-messaging.ts
@@ -34,6 +34,7 @@ import {
   scanPendingChatRecoveries,
   startChatRecoveryAttempt,
 } from '@/services/inference/chat-recovery'
+import { persistInterruptedAssistant } from '@/services/inference/chat-recovery-sync'
 import { sendChatStream } from '@/services/inference/inference-client'
 import {
   getRateLimitInfo,
@@ -58,7 +59,11 @@ import {
   sortChats,
 } from './chat-operations'
 import { createUpdateChatWithHistoryCheck } from './chat-persistence'
-import { processStreamingResponse } from './streaming'
+import {
+  hasVisibleAssistantMessage,
+  mergeInterruptedAssistant,
+  processStreamingResponse,
+} from './streaming'
 import {
   IDLE_STREAM_STATUS,
   useChatStreams,
@@ -115,6 +120,14 @@ interface UseChatMessagingReturn {
     resultText: string,
     resultData?: unknown,
   ) => void
+}
+
+type ActiveLiveGeneration = {
+  chat: Chat
+  messages: Message[]
+  turnId?: string
+  interruptedMessage: Message | null
+  initialSave?: Promise<void>
 }
 
 const CHAT_RECOVERY_POLL_INTERVAL_MS = 10_000
@@ -268,6 +281,11 @@ export function useChatMessaging({
   const chatsRef = useRef<Chat[]>(chats)
   chatsRef.current = chats
 
+  const activeLiveGenerationsRef = useRef(
+    new Map<string, ActiveLiveGeneration>(),
+  )
+  const cancellationPromisesRef = useRef(new Map<string, Promise<void>>())
+
   const dismissStreamError = useCallback(() => {
     patchStatus(viewedChatIdRef.current, { streamError: null })
   }, [patchStatus])
@@ -290,92 +308,131 @@ export function useChatMessaging({
   // Passing an explicit id lets callers stop a background stream without
   // first switching to it.
   const cancelGeneration = useCallback(
-    async (chatId?: string) => {
+    (chatId?: string) => {
       const targetId = chatId ?? viewedChatIdRef.current
+      const existingCancellation = cancellationPromisesRef.current.get(targetId)
+      if (existingCancellation) return existingCancellation
 
-      const recoveryCancellation = cancelChatRecovery(targetId)
-      abort(targetId)
-      patchStatus(targetId, {
-        loadingState: 'idle',
-        retryInfo: null,
-        isThinking: false,
-        isWaitingForResponse: false,
-        isStreaming: false,
-      })
+      const cancellation = (async () => {
+        const activeGeneration = activeLiveGenerationsRef.current.get(targetId)
 
-      // If a stream was mid-flight, drop a dangling "thinking" placeholder
-      // and persist the truncated transcript for the affected chat.
-      if (streamingTracker.isStreaming(targetId)) {
-        const stripThinking = (messages: Message[]): Message[] =>
-          messages.filter(
-            (msg, idx) => !(idx === messages.length - 1 && msg.isThinking),
-          )
-
-        setChats((prevChats) => {
-          const newChats = prevChats.map((chat) =>
-            chat.id === targetId
-              ? {
-                  ...chat,
-                  messages: stripThinking(chat.messages),
-                  pendingSave: false,
-                }
-              : chat,
-          )
-          const updatedChat = newChats.find((c) => c.id === targetId)
-          if (updatedChat && !updatedChat.isTemporary) {
-            if (storeHistory) {
-              chatStorage
-                .saveChatAndSync(updatedChat)
-                .then((savedChat) => {
-                  // Only update if the ID actually changed
-                  if (savedChat.id !== updatedChat.id) {
-                    moveStatus(updatedChat.id, savedChat.id)
-                    if (viewedChatIdRef.current === updatedChat.id) {
-                      viewedChatIdRef.current = savedChat.id
-                      setCurrentChat(savedChat)
-                    }
-                    setChats((prev) =>
-                      prev.map((c) =>
-                        c.id === updatedChat.id ? savedChat : c,
-                      ),
-                    )
-                  }
-                })
-                .catch((error) => {
-                  logError('Failed to save chat after cancellation', error, {
-                    component: 'useChatMessaging',
-                  })
-                })
-            } else {
-              // Save to session storage for non-signed-in users
-              sessionChatStorage.saveChat(updatedChat)
-            }
-          }
-          return newChats
+        abort(targetId)
+        const interruptedMessage =
+          activeGeneration?.interruptedMessage &&
+          hasVisibleAssistantMessage(activeGeneration.interruptedMessage)
+            ? activeGeneration.interruptedMessage
+            : null
+        patchStatus(targetId, {
+          loadingState: 'loading',
+          retryInfo: null,
+          isThinking: false,
+          isWaitingForResponse: false,
+          isStreaming: false,
         })
 
-        // Mirror the truncation into the active view if it's the same chat
-        setCurrentChat((prev) =>
-          prev.id === targetId
-            ? {
-                ...prev,
-                messages: stripThinking(prev.messages),
-                pendingSave: false,
-              }
-            : prev,
-        )
+        let stoppedChat: Chat | undefined
+        if (activeGeneration) {
+          const finalizeChat = (chat: Chat): Chat => {
+            const hasOriginatingUser = activeGeneration.turnId
+              ? chat.messages.some(
+                  (message) =>
+                    message.role === 'user' &&
+                    message.turnId === activeGeneration.turnId,
+                )
+              : false
+            const sourceMessages = hasOriginatingUser
+              ? chat.messages
+              : activeGeneration.messages
+            const messages = activeGeneration.turnId
+              ? mergeInterruptedAssistant(
+                  sourceMessages,
+                  activeGeneration.turnId,
+                  interruptedMessage,
+                )
+              : interruptedMessage
+                ? [...activeGeneration.messages, interruptedMessage]
+                : activeGeneration.messages
+            return {
+              ...chat,
+              messages,
+              pendingRecoveries: chat.pendingRecoveries?.filter(
+                (recovery) => recovery.turnId !== activeGeneration.turnId,
+              ),
+              pendingSave: false,
+            }
+          }
+          const latestChat =
+            chatsRef.current.find((chat) => chat.id === targetId) ??
+            activeGeneration.chat
+          const finalizedChat = finalizeChat(latestChat)
+          stoppedChat = finalizedChat
+          setChats((prevChats) =>
+            prevChats.map((chat) =>
+              chat.id === targetId ? finalizeChat(chat) : chat,
+            ),
+          )
+          setCurrentChat((prev) =>
+            prev.id === targetId ? finalizeChat(prev) : prev,
+          )
+        }
+
+        await activeGeneration?.initialSave
+
+        let assistantPersistedByRecovery = false
+        try {
+          assistantPersistedByRecovery = await cancelChatRecovery(
+            targetId,
+            interruptedMessage ?? undefined,
+          )
+        } catch (error) {
+          logError('Failed to cancel chat recovery', error, {
+            component: 'useChatMessaging',
+            action: 'cancelGeneration.recovery',
+            metadata: { chatId: targetId },
+          })
+        }
+
+        if (
+          interruptedMessage &&
+          stoppedChat &&
+          !stoppedChat.isTemporary &&
+          !assistantPersistedByRecovery
+        ) {
+          try {
+            if (storeHistory && activeGeneration?.turnId) {
+              await persistInterruptedAssistant(
+                targetId,
+                activeGeneration.turnId,
+                interruptedMessage,
+              )
+            } else if (storeHistory) {
+              await chatStorage.saveChatAndSync(stoppedChat)
+            } else {
+              sessionChatStorage.saveChat(stoppedChat)
+            }
+          } catch (error) {
+            logError('Failed to save chat after cancellation', error, {
+              component: 'useChatMessaging',
+              action: 'cancelGeneration.save',
+              metadata: { chatId: targetId },
+            })
+          }
+        }
 
         streamingTracker.endStreaming(targetId)
+        patchStatus(targetId, { loadingState: 'idle' })
+      })()
+
+      cancellationPromisesRef.current.set(targetId, cancellation)
+      const clearCancellation = () => {
+        if (cancellationPromisesRef.current.get(targetId) === cancellation) {
+          cancellationPromisesRef.current.delete(targetId)
+        }
       }
-
-      await recoveryCancellation
-
-      // Wait for any pending state updates
-      await new Promise((resolve) =>
-        setTimeout(resolve, CONSTANTS.ASYNC_STATE_DELAY_MS),
-      )
+      void cancellation.then(clearCancellation, clearCancellation)
+      return cancellation
     },
-    [abort, patchStatus, moveStatus, storeHistory, setChats, setCurrentChat],
+    [abort, patchStatus, storeHistory, setChats, setCurrentChat],
   )
 
   // Handle chat query
@@ -435,6 +492,7 @@ export function useChatMessaging({
         current: null,
       }
       let earlyTitlePromise: Promise<string> | null = null
+      let initialSavePromise: Promise<void> | undefined
 
       const setLoadingStateFor = (s: LoadingState) =>
         patchStatus(streamChatIdRef.current, { loadingState: s })
@@ -571,7 +629,7 @@ export function useChatMessaging({
         }
 
         // Save immediately (and sync if applicable). ID is already server-valid.
-        chatStorage
+        initialSavePromise = chatStorage
           .saveChatAndSync(updatedChat)
           .then(() => {
             setChats((prevChats) =>
@@ -686,6 +744,14 @@ export function useChatMessaging({
 
       // Capture the starting chat ID before any async operations that might change it
       const startingChatId = streamChatIdRef.current
+      const activeGeneration: ActiveLiveGeneration = {
+        chat: updatedChat,
+        messages: updatedMessages,
+        turnId: turnId ?? undefined,
+        interruptedMessage: null,
+        initialSave: initialSavePromise,
+      }
+      activeLiveGenerationsRef.current.set(startingChatId, activeGeneration)
 
       // Fire title generation in parallel with streaming (based on user's message).
       // The promise is awaited after streaming completes, before the final save.
@@ -860,20 +926,18 @@ export function useChatMessaging({
           storeHistory,
           startingChatId,
           deferStreamCleanup: recoveryEnabled,
+          signal: controller.signal,
+          turnId: turnId ?? undefined,
+          onInterrupted: (message) => {
+            activeGeneration.interruptedMessage = message
+          },
         })
         if (assistantMessage && turnId) {
           assistantMessage.turnId = turnId
         }
 
         const hasAssistantMessageToSave =
-          !!assistantMessage &&
-          (!!assistantMessage.content ||
-            !!assistantMessage.thoughts ||
-            !!assistantMessage.webSearch ||
-            !!assistantMessage.urlFetches?.length ||
-            !!assistantMessage.toolCalls?.length ||
-            !!assistantMessage.codeExecCalls?.length ||
-            !!assistantMessage.timeline?.length)
+          !!assistantMessage && hasVisibleAssistantMessage(assistantMessage)
 
         if (assistantMessage && hasAssistantMessageToSave) {
           // Use this stream's own id (already reflects any server id swap).
@@ -1067,20 +1131,25 @@ export function useChatMessaging({
           })
         }
       } catch (error) {
-        releaseActiveChatRecovery(streamChatIdRef.current)
-        if (
-          typeof userId === 'string' &&
-          canUseChatRecovery({ isSignedIn, userId, storeHistory })
-        ) {
-          void scanPendingChatRecoveries(userId)
+        const wasAborted =
+          controller.signal.aborted ||
+          (error instanceof DOMException && error.name === 'AbortError')
+        if (!wasAborted) {
+          releaseActiveChatRecovery(streamChatIdRef.current)
+          if (
+            typeof userId === 'string' &&
+            canUseChatRecovery({ isSignedIn, userId, storeHistory })
+          ) {
+            void scanPendingChatRecoveries(userId)
+          }
         }
         // Ensure UI loading flags are reset on pre-stream errors
         setIsWaitingForResponseFor(false)
         setIsStreamingFor(false)
-        setLoadingStateFor('idle')
+        if (!wasAborted) setLoadingStateFor('idle')
         setIsThinkingFor(false)
         thinkingStartTimeRef.current = null
-        if (!(error instanceof DOMException && error.name === 'AbortError')) {
+        if (!wasAborted) {
           logError('Chat query failed', error, {
             component: 'useChatMessaging',
             action: 'handleQuery',
@@ -1134,16 +1203,24 @@ export function useChatMessaging({
         // Settle this stream's status (preserving any streamError so the
         // banner can surface when the user returns to the chat).
         patchStatus(streamChatIdRef.current, {
-          loadingState: 'idle',
+          ...(controller.signal.aborted ? {} : { loadingState: 'idle' }),
           retryInfo: null,
           isWaitingForResponse: false,
           isStreaming: false,
           isThinking: false,
         })
         clearController(streamChatIdRef.current)
-        // Covers pre-stream failures where the processor (which normally
-        // ends streaming) never ran. Idempotent if already ended.
-        streamingTracker.endStreaming(streamChatIdRef.current)
+        if (
+          activeLiveGenerationsRef.current.get(startingChatId) ===
+          activeGeneration
+        ) {
+          activeLiveGenerationsRef.current.delete(startingChatId)
+        }
+        if (!controller.signal.aborted) {
+          // Covers pre-stream failures where the processor (which normally
+          // ends streaming) never ran. Idempotent if already ended.
+          streamingTracker.endStreaming(streamChatIdRef.current)
+        }
       }
     },
     [

--- a/src/components/chat/hooks/use-chat-messaging.ts
+++ b/src/components/chat/hooks/use-chat-messaging.ts
@@ -378,13 +378,14 @@ export function useChatMessaging({
 
         await activeGeneration?.initialSave
 
-        let assistantPersistedByRecovery = false
+        let recoveryHandled = false
         try {
-          assistantPersistedByRecovery = await cancelChatRecovery(
+          recoveryHandled = await cancelChatRecovery(
             targetId,
             interruptedMessage ?? undefined,
           )
         } catch (error) {
+          recoveryHandled = true
           logError('Failed to cancel chat recovery', error, {
             component: 'useChatMessaging',
             action: 'cancelGeneration.recovery',
@@ -396,7 +397,7 @@ export function useChatMessaging({
           interruptedMessage &&
           stoppedChat &&
           !stoppedChat.isTemporary &&
-          !assistantPersistedByRecovery
+          !recoveryHandled
         ) {
           try {
             if (storeHistory && activeGeneration?.turnId) {

--- a/src/components/chat/hooks/use-chat-messaging.ts
+++ b/src/components/chat/hooks/use-chat-messaging.ts
@@ -742,6 +742,8 @@ export function useChatMessaging({
         }
       }
 
+      if (controller.signal.aborted) return
+
       // Capture the starting chat ID before any async operations that might change it
       const startingChatId = streamChatIdRef.current
       const activeGeneration: ActiveLiveGeneration = {
@@ -858,6 +860,10 @@ export function useChatMessaging({
               },
             )
           }
+        }
+
+        if (controller.signal.aborted) {
+          throw new DOMException('Aborted', 'AbortError')
         }
 
         // Mark the chat as streaming up front (after the initial creation

--- a/src/services/inference/chat-recovery-sync.ts
+++ b/src/services/inference/chat-recovery-sync.ts
@@ -1,3 +1,4 @@
+import { mergeInterruptedAssistant } from '@/components/chat/hooks/streaming/interrupted-message'
 import type { Message } from '@/components/chat/types'
 import { cloudStorage } from '@/services/cloud/cloud-storage'
 import { nextClock } from '@/services/cloud/edit-clock'
@@ -317,6 +318,33 @@ export function removePendingRecovery(
     isCurrent,
     signal,
   )
+}
+
+export function persistInterruptedAssistant(
+  chatId: string,
+  turnId: string,
+  assistantMessage: Message,
+): Promise<StoredChat> {
+  return mutateSyncedChat(chatId, (chat) => {
+    const messages = mergeInterruptedAssistant(
+      chat.messages,
+      turnId,
+      assistantMessage,
+    )
+    const currentPending = chat.pendingRecoveries ?? []
+    const pending = currentPending.filter(
+      (recovery) => recovery.turnId !== turnId,
+    )
+    return {
+      chat: {
+        ...chat,
+        messages,
+        pendingRecoveries: pending.length > 0 ? pending : undefined,
+      },
+      changed:
+        messages !== chat.messages || pending.length !== currentPending.length,
+    }
+  })
 }
 
 export function sameRecoveredResponse(

--- a/src/services/inference/chat-recovery.ts
+++ b/src/services/inference/chat-recovery.ts
@@ -43,6 +43,7 @@ import {
 import {
   addPendingRecovery,
   completePendingRecovery,
+  persistInterruptedAssistant,
   removePendingRecovery,
   replacePendingRecovery,
   resetChatRecoverySyncState,
@@ -400,10 +401,14 @@ export async function cancelChatRecovery(
 
       let persisted = false
       if (stoppedMessage && hasVisibleAssistantMessage(stoppedMessage)) {
+        const finalizedMessage = finalizeInterruptedMessage(
+          stoppedMessage,
+          recovery.turnId,
+        )
         const completedChat = await completePendingRecovery(
           recovery.chatId,
           recovery.envelope,
-          finalizeInterruptedMessage(stoppedMessage, recovery.turnId),
+          finalizedMessage,
           {},
           isCurrent,
         )
@@ -413,7 +418,20 @@ export async function cancelChatRecovery(
             message.turnId === recovery.turnId &&
             hasVisibleAssistantMessage(message),
         )
-        await deleteRecoveryQuietly(recovery.sessionId)
+        if (!persisted) {
+          const fallbackChat = await persistInterruptedAssistant(
+            recovery.chatId,
+            recovery.turnId,
+            finalizedMessage,
+          )
+          persisted = fallbackChat.messages.some(
+            (message) =>
+              message.role === 'assistant' &&
+              message.turnId === recovery.turnId &&
+              hasVisibleAssistantMessage(message),
+          )
+        }
+        if (persisted) await deleteRecoveryQuietly(recovery.sessionId)
       } else {
         try {
           await removePendingRecovery(

--- a/src/services/inference/chat-recovery.ts
+++ b/src/services/inference/chat-recovery.ts
@@ -1,4 +1,8 @@
-import { parseRichStreamingResponse } from '@/components/chat/hooks/streaming'
+import {
+  finalizeInterruptedMessage,
+  hasVisibleAssistantMessage,
+  parseRichStreamingResponse,
+} from '@/components/chat/hooks/streaming'
 import type { Message } from '@/components/chat/types'
 import { retryDeferredAlternativesFinalization } from '@/services/cloud/legacy-blob-migration'
 import { encryptionService } from '@/services/encryption/encryption-service'
@@ -350,7 +354,10 @@ export async function completeLiveChatRecovery(args: {
   await deleteRecoveryQuietly(active.sessionId)
 }
 
-export async function cancelChatRecovery(chatId: string): Promise<void> {
+export async function cancelChatRecovery(
+  chatId: string,
+  assistantMessage?: Message,
+): Promise<boolean> {
   const active = [...activeRecoveries.values()].filter(
     (candidate) => candidate.chatId === chatId,
   )
@@ -368,20 +375,60 @@ export async function cancelChatRecovery(chatId: string): Promise<void> {
     setChatRecoveryActive(recovery.chatId, recovery.turnId, false)
   }
   const recoveries = [...active, ...scanned]
-  try {
-    await Promise.all(
-      recoveries.map((recovery) => {
-        const isCurrent = () => recovery.generation === recoveryGeneration
-        return isCurrent() && recovery.envelope
-          ? removePendingRecovery(recovery.chatId, recovery.envelope, isCurrent)
+  const persistedTurns = new Set<string>()
+  const results = await Promise.all(
+    recoveries.map(async (recovery) => {
+      const isCurrent = () => recovery.generation === recoveryGeneration
+      if (!isCurrent()) return false
+      if (!recovery.envelope) {
+        await deleteRecoveryQuietly(recovery.sessionId)
+        return false
+      }
+
+      const recoveryDraft = getChatRecoveryDraft(
+        recovery.chatId,
+        recovery.turnId,
+      )
+      const draftMessage =
+        recoveryDraft?.sessionId === recovery.sessionId
+          ? recoveryDraft.message
           : undefined
-      }),
-    )
-  } finally {
-    await Promise.all(
-      recoveries.map((recovery) => deleteRecoveryQuietly(recovery.sessionId)),
-    )
-  }
+      const stoppedMessage =
+        assistantMessage?.turnId === recovery.turnId
+          ? assistantMessage
+          : draftMessage
+
+      let persisted = false
+      if (stoppedMessage && hasVisibleAssistantMessage(stoppedMessage)) {
+        await completePendingRecovery(
+          recovery.chatId,
+          recovery.envelope,
+          finalizeInterruptedMessage(stoppedMessage, recovery.turnId),
+          {},
+          isCurrent,
+        )
+        persisted = true
+        await deleteRecoveryQuietly(recovery.sessionId)
+      } else {
+        try {
+          await removePendingRecovery(
+            recovery.chatId,
+            recovery.envelope,
+            isCurrent,
+          )
+        } finally {
+          await deleteRecoveryQuietly(recovery.sessionId)
+        }
+      }
+      return persisted
+    }),
+  )
+  results.forEach((persisted, index) => {
+    if (persisted) persistedTurns.add(recoveries[index].turnId)
+  })
+  return assistantMessage?.turnId
+    ? persistedTurns.has(assistantMessage.turnId)
+    : persistedTurns.size > 0
 }
 
 export function releaseActiveChatRecovery(chatId: string): void {

--- a/src/services/inference/chat-recovery.ts
+++ b/src/services/inference/chat-recovery.ts
@@ -400,14 +400,19 @@ export async function cancelChatRecovery(
 
       let persisted = false
       if (stoppedMessage && hasVisibleAssistantMessage(stoppedMessage)) {
-        await completePendingRecovery(
+        const completedChat = await completePendingRecovery(
           recovery.chatId,
           recovery.envelope,
           finalizeInterruptedMessage(stoppedMessage, recovery.turnId),
           {},
           isCurrent,
         )
-        persisted = true
+        persisted = completedChat.messages.some(
+          (message) =>
+            message.role === 'assistant' &&
+            message.turnId === recovery.turnId &&
+            hasVisibleAssistantMessage(message),
+        )
         await deleteRecoveryQuietly(recovery.sessionId)
       } else {
         try {

--- a/src/services/inference/chat-recovery.ts
+++ b/src/services/inference/chat-recovery.ts
@@ -43,7 +43,6 @@ import {
 import {
   addPendingRecovery,
   completePendingRecovery,
-  persistInterruptedAssistant,
   removePendingRecovery,
   replacePendingRecovery,
   resetChatRecoverySyncState,
@@ -376,14 +375,18 @@ export async function cancelChatRecovery(
     setChatRecoveryActive(recovery.chatId, recovery.turnId, false)
   }
   const recoveries = [...active, ...scanned]
-  const persistedTurns = new Set<string>()
-  const results = await Promise.all(
+  const envelopeTurns = new Set(
+    recoveries
+      .filter((recovery) => recovery.envelope !== undefined)
+      .map((recovery) => recovery.turnId),
+  )
+  await Promise.all(
     recoveries.map(async (recovery) => {
       const isCurrent = () => recovery.generation === recoveryGeneration
-      if (!isCurrent()) return false
+      if (!isCurrent()) return
       if (!recovery.envelope) {
         await deleteRecoveryQuietly(recovery.sessionId)
-        return false
+        return
       }
 
       const recoveryDraft = getChatRecoveryDraft(
@@ -399,7 +402,6 @@ export async function cancelChatRecovery(
           ? assistantMessage
           : draftMessage
 
-      let persisted = false
       if (stoppedMessage && hasVisibleAssistantMessage(stoppedMessage)) {
         const finalizedMessage = finalizeInterruptedMessage(
           stoppedMessage,
@@ -412,25 +414,12 @@ export async function cancelChatRecovery(
           {},
           isCurrent,
         )
-        persisted = completedChat.messages.some(
+        const persisted = completedChat.messages.some(
           (message) =>
             message.role === 'assistant' &&
             message.turnId === recovery.turnId &&
             hasVisibleAssistantMessage(message),
         )
-        if (!persisted) {
-          const fallbackChat = await persistInterruptedAssistant(
-            recovery.chatId,
-            recovery.turnId,
-            finalizedMessage,
-          )
-          persisted = fallbackChat.messages.some(
-            (message) =>
-              message.role === 'assistant' &&
-              message.turnId === recovery.turnId &&
-              hasVisibleAssistantMessage(message),
-          )
-        }
         if (persisted) await deleteRecoveryQuietly(recovery.sessionId)
       } else {
         try {
@@ -443,15 +432,11 @@ export async function cancelChatRecovery(
           await deleteRecoveryQuietly(recovery.sessionId)
         }
       }
-      return persisted
     }),
   )
-  results.forEach((persisted, index) => {
-    if (persisted) persistedTurns.add(recoveries[index].turnId)
-  })
   return assistantMessage?.turnId
-    ? persistedTurns.has(assistantMessage.turnId)
-    : persistedTurns.size > 0
+    ? envelopeTurns.has(assistantMessage.turnId)
+    : envelopeTurns.size > 0
 }
 
 export function releaseActiveChatRecovery(chatId: string): void {

--- a/tests/components/chat/streaming/process-stream.test.ts
+++ b/tests/components/chat/streaming/process-stream.test.ts
@@ -177,6 +177,40 @@ describe('processStreamingResponse interruption', () => {
     await expect(processing).rejects.toMatchObject({ name: 'AbortError' })
   })
 
+  it('includes content buffered for stream format detection', async () => {
+    const controller = new AbortController()
+    const stream = createOpenResponse()
+    const interrupted: Array<Message | null> = []
+    const context = createContext({
+      signal: controller.signal,
+      turnId: 'turn-1',
+      onInterrupted: (message) => interrupted.push(message),
+    })
+    const processing = processStreamingResponse(stream.response, context)
+
+    stream.send(
+      { choices: [{ delta: { content: 'Hi' } }] },
+      {
+        type: 'web_search_call',
+        status: 'in_progress',
+        action: { query: 'test query' },
+      },
+    )
+    await vi.waitFor(() =>
+      expect(context.setIsWaitingForResponse).toHaveBeenCalledWith(false),
+    )
+
+    controller.abort()
+
+    expect(interrupted[0]).toMatchObject({
+      content: 'Hi',
+      turnId: 'turn-1',
+    })
+
+    stream.close()
+    await expect(processing).rejects.toMatchObject({ name: 'AbortError' })
+  })
+
   it('does not publish an empty assistant placeholder', async () => {
     const controller = new AbortController()
     const stream = createOpenResponse()

--- a/tests/components/chat/streaming/process-stream.test.ts
+++ b/tests/components/chat/streaming/process-stream.test.ts
@@ -1,6 +1,6 @@
 import { processStreamingResponse } from '@/components/chat/hooks/streaming/process-stream'
 import type { StreamingContext } from '@/components/chat/hooks/streaming/types'
-import type { Chat } from '@/components/chat/types'
+import type { Chat, Message } from '@/components/chat/types'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const { endStreamingMock, startStreamingMock } = vi.hoisted(() => ({
@@ -26,7 +26,7 @@ function createResponse(): Response {
   return new Response(`${body}data: [DONE]\n\n`)
 }
 
-function createContext(): StreamingContext {
+function createContext(overrides: Partial<StreamingContext> = {}) {
   const chat: Chat = {
     id: 'chat-1',
     title: 'Chat',
@@ -50,6 +50,30 @@ function createContext(): StreamingContext {
     setLoadingState: vi.fn(),
     storeHistory: true,
     startingChatId: chat.id,
+    ...overrides,
+  } satisfies StreamingContext
+}
+
+function createOpenResponse() {
+  let streamController!: ReadableStreamDefaultController<Uint8Array>
+  const response = new Response(
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        streamController = controller
+      },
+    }),
+  )
+  const encoder = new TextEncoder()
+  return {
+    response,
+    close: () => streamController.close(),
+    send: (...events: Record<string, unknown>[]) => {
+      streamController.enqueue(
+        encoder.encode(
+          events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join(''),
+        ),
+      )
+    },
   }
 }
 
@@ -69,10 +93,7 @@ describe('processStreamingResponse lifecycle', () => {
   })
 
   it('keeps the stream active when the caller has recovery to finalize', async () => {
-    const context = {
-      ...createContext(),
-      deferStreamCleanup: true,
-    }
+    const context = createContext({ deferStreamCleanup: true })
 
     await processStreamingResponse(createResponse(), context)
 
@@ -80,5 +101,98 @@ describe('processStreamingResponse lifecycle', () => {
     expect(context.setLoadingState).not.toHaveBeenCalled()
     expect(context.setIsStreaming).not.toHaveBeenCalled()
     expect(endStreamingMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('processStreamingResponse interruption', () => {
+  it('publishes the latest content with its turn identity on abort', async () => {
+    const controller = new AbortController()
+    const stream = createOpenResponse()
+    const interrupted: Array<Message | null> = []
+    const context = createContext({
+      signal: controller.signal,
+      turnId: 'turn-1',
+      onInterrupted: (message) => interrupted.push(message),
+    })
+    const processing = processStreamingResponse(stream.response, context)
+
+    stream.send(
+      { choices: [{ delta: { content: 'Hello world' } }] },
+      { choices: [{ delta: { content: ' before stopping' } }] },
+    )
+    await vi.waitFor(() =>
+      expect(context.updateChatWithHistoryCheck).toHaveBeenCalled(),
+    )
+
+    controller.abort()
+
+    expect(interrupted).toEqual([
+      expect.objectContaining({
+        role: 'assistant',
+        content: 'Hello world before stopping',
+        turnId: 'turn-1',
+        isThinking: false,
+      }),
+    ])
+
+    stream.close()
+    await expect(processing).rejects.toMatchObject({ name: 'AbortError' })
+    expect(context.setLoadingState).not.toHaveBeenCalled()
+  })
+
+  it('preserves partial reasoning instead of dropping the message', async () => {
+    const controller = new AbortController()
+    const stream = createOpenResponse()
+    const interrupted: Array<Message | null> = []
+    const context = createContext({
+      signal: controller.signal,
+      turnId: 'turn-1',
+      onInterrupted: (message) => interrupted.push(message),
+    })
+    const processing = processStreamingResponse(stream.response, context)
+
+    stream.send({
+      choices: [{ delta: { reasoning_content: 'Keep this reasoning' } }],
+    })
+    await vi.waitFor(() =>
+      expect(context.updateChatWithHistoryCheck).toHaveBeenCalled(),
+    )
+
+    controller.abort()
+
+    expect(interrupted[0]).toMatchObject({
+      thoughts: 'Keep this reasoning',
+      isThinking: false,
+      turnId: 'turn-1',
+      timeline: [
+        expect.objectContaining({
+          type: 'thinking',
+          content: 'Keep this reasoning',
+          isThinking: false,
+        }),
+      ],
+    })
+
+    stream.close()
+    await expect(processing).rejects.toMatchObject({ name: 'AbortError' })
+  })
+
+  it('does not publish an empty assistant placeholder', async () => {
+    const controller = new AbortController()
+    const stream = createOpenResponse()
+    const interrupted: Array<Message | null> = []
+    const context = createContext({
+      signal: controller.signal,
+      turnId: 'turn-1',
+      onInterrupted: (message) => interrupted.push(message),
+    })
+    const processing = processStreamingResponse(stream.response, context)
+
+    controller.abort()
+
+    expect(interrupted).toEqual([null])
+
+    stream.close()
+    await expect(processing).rejects.toMatchObject({ name: 'AbortError' })
   })
 })

--- a/tests/components/chat/use-chat-messaging.cancel-generation.test.tsx
+++ b/tests/components/chat/use-chat-messaging.cancel-generation.test.tsx
@@ -21,16 +21,20 @@ const moveStatusMock = vi.fn()
 const registerControllerMock = vi.fn()
 const clearControllerMock = vi.fn()
 const streamStatuses: Record<string, object> = {}
-const { authState, cloudSyncState, scanPendingChatRecoveriesMock } = vi.hoisted(
-  () => ({
-    authState: {
-      isSignedIn: false,
-      userId: undefined as string | undefined,
-    },
-    cloudSyncState: { enabled: true },
-    scanPendingChatRecoveriesMock: vi.fn(),
-  }),
-)
+const {
+  authState,
+  cancelChatRecoveryMock,
+  cloudSyncState,
+  scanPendingChatRecoveriesMock,
+} = vi.hoisted(() => ({
+  authState: {
+    isSignedIn: false,
+    userId: undefined as string | undefined,
+  },
+  cancelChatRecoveryMock: vi.fn(async () => false),
+  cloudSyncState: { enabled: true },
+  scanPendingChatRecoveriesMock: vi.fn(),
+}))
 
 vi.mock('@clerk/nextjs', () => ({
   useAuth: () => authState,
@@ -66,7 +70,7 @@ vi.mock('@/utils/cloud-sync-settings', () => ({
 
 vi.mock('@/services/inference/chat-recovery', () => ({
   abandonChatRecoveryAttempt: vi.fn(),
-  cancelChatRecovery: vi.fn(async () => undefined),
+  cancelChatRecovery: cancelChatRecoveryMock,
   completeLiveChatRecovery: vi.fn(),
   persistChatRecoveryToken: vi.fn(),
   releaseActiveChatRecovery: vi.fn(),
@@ -151,7 +155,7 @@ describe('useChatMessaging cancelGeneration', () => {
     }
   })
 
-  it('targets the latest rendered chat during a chat switch', () => {
+  it('targets the latest rendered chat during a chat switch', async () => {
     const firstChat = createChat('chat-a')
     const secondChat = createChat('chat-b')
 
@@ -170,10 +174,17 @@ describe('useChatMessaging cancelGeneration', () => {
     })
 
     expect(abortMock).toHaveBeenCalledWith('chat-b')
+    await vi.waitFor(() =>
+      expect(patchStatusMock).toHaveBeenCalledWith(
+        'chat-b',
+        expect.objectContaining({
+          loadingState: 'idle',
+        }),
+      ),
+    )
     expect(patchStatusMock).toHaveBeenCalledWith(
       'chat-b',
       expect.objectContaining({
-        loadingState: 'idle',
         retryInfo: null,
         isThinking: false,
         isWaitingForResponse: false,
@@ -249,6 +260,55 @@ describe('useChatMessaging cancelGeneration', () => {
 
     expect(result.current.loadingState).toBe('loading')
     expect(result.current.isStreaming).toBe(true)
+  })
+
+  it('keeps recovery cancellation loading and deduplicates repeated stops', async () => {
+    let finishCancellation!: (persisted: boolean) => void
+    cancelChatRecoveryMock.mockImplementationOnce(
+      () =>
+        new Promise<boolean>((resolve) => {
+          finishCancellation = resolve
+        }),
+    )
+    const chat = createChat('chat-a')
+    const { result } = renderHook(useChatMessagingHarness, {
+      initialProps: {
+        currentChat: chat,
+        triggerCancelOnLayout: false,
+      },
+    })
+    act(() => {
+      setChatRecoveryActive('chat-a', 'turn-1', true)
+    })
+
+    let firstCancellation!: Promise<void>
+    let secondCancellation!: Promise<void>
+    act(() => {
+      firstCancellation = result.current.cancelGeneration()
+      secondCancellation = result.current.cancelGeneration()
+    })
+
+    expect(firstCancellation).toBe(secondCancellation)
+    expect(abortMock).toHaveBeenCalledTimes(1)
+    await vi.waitFor(() =>
+      expect(cancelChatRecoveryMock).toHaveBeenCalledTimes(1),
+    )
+    expect(patchStatusMock).toHaveBeenCalledWith(
+      'chat-a',
+      expect.objectContaining({ loadingState: 'loading' }),
+    )
+    expect(patchStatusMock).not.toHaveBeenCalledWith('chat-a', {
+      loadingState: 'idle',
+    })
+
+    finishCancellation(false)
+    await act(async () => {
+      await firstCancellation
+    })
+
+    expect(patchStatusMock).toHaveBeenCalledWith('chat-a', {
+      loadingState: 'idle',
+    })
   })
 
   it('rescans pending recoveries when cloud sync downloads a chat', () => {

--- a/tests/components/chat/use-chat-messaging.stop-stream.test.tsx
+++ b/tests/components/chat/use-chat-messaging.stop-stream.test.tsx
@@ -1,0 +1,315 @@
+import { useChatMessaging } from '@/components/chat/hooks/use-chat-messaging'
+import type { Chat } from '@/components/chat/types'
+import { act, renderHook } from '@testing-library/react'
+import { useState } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  cancelChatRecoveryMock,
+  initialSaveMock,
+  persistInterruptedAssistantMock,
+  sendChatStreamMock,
+  sessionSaveMock,
+  streamControllers,
+  streamingChats,
+} = vi.hoisted(() => ({
+  cancelChatRecoveryMock: vi.fn(async (..._args: unknown[]) => false),
+  initialSaveMock: vi.fn(async (chat: unknown) => chat),
+  persistInterruptedAssistantMock: vi.fn(
+    async (..._args: unknown[]) => undefined,
+  ),
+  sendChatStreamMock: vi.fn(),
+  sessionSaveMock: vi.fn(),
+  streamControllers: new Map<string, AbortController>(),
+  streamingChats: new Set<string>(),
+}))
+
+vi.mock('@clerk/nextjs', () => ({
+  useAuth: () => ({ isSignedIn: false, userId: undefined }),
+}))
+
+vi.mock('@/components/project', () => ({
+  useProject: () => ({ isProjectMode: false, activeProject: null }),
+}))
+
+vi.mock('@/config/models', () => ({
+  resolveModelSelection: () => ({
+    model: { modelName: 'test-model' },
+    autoCandidates: undefined,
+  }),
+}))
+
+vi.mock('@/services/cloud/streaming-tracker', () => ({
+  streamingTracker: {
+    startStreaming: (chatId: string) => streamingChats.add(chatId),
+    endStreaming: (chatId: string) => streamingChats.delete(chatId),
+    isStreaming: (chatId: string) => streamingChats.has(chatId),
+  },
+}))
+
+vi.mock('@/components/chat/hooks/use-chat-streams', async (importOriginal) => ({
+  ...(await importOriginal<
+    typeof import('@/components/chat/hooks/use-chat-streams')
+  >()),
+  useChatStreams: () => ({
+    statusByChat: {},
+    patchStatus: vi.fn(),
+    resetStatus: vi.fn(),
+    moveStatus: (fromId: string, toId: string) => {
+      const controller = streamControllers.get(fromId)
+      if (controller) {
+        streamControllers.delete(fromId)
+        streamControllers.set(toId, controller)
+      }
+    },
+    registerController: (chatId: string, controller: AbortController) => {
+      streamControllers.set(chatId, controller)
+    },
+    clearController: (chatId: string) => streamControllers.delete(chatId),
+    abort: (chatId: string) => streamControllers.get(chatId)?.abort(),
+  }),
+}))
+
+vi.mock('@/services/inference/chat-recovery', () => ({
+  abandonChatRecoveryAttempt: vi.fn(),
+  cancelChatRecovery: (...args: unknown[]) => cancelChatRecoveryMock(...args),
+  completeLiveChatRecovery: vi.fn(),
+  persistChatRecoveryToken: vi.fn(),
+  releaseActiveChatRecovery: vi.fn(),
+  scanPendingChatRecoveries: vi.fn(),
+  startChatRecoveryAttempt: vi.fn(),
+}))
+
+vi.mock('@/services/inference/inference-client', () => ({
+  sendChatStream: (...args: unknown[]) => sendChatStreamMock(...args),
+}))
+
+vi.mock('@/services/inference/chat-recovery-sync', () => ({
+  persistInterruptedAssistant: (...args: unknown[]) =>
+    persistInterruptedAssistantMock(...args),
+}))
+
+vi.mock('@/services/inference/tinfoil-client', () => ({
+  getRateLimitInfo: () => null,
+  isChatRecoveryAvailable: () => false,
+  refreshRateLimit: vi.fn(),
+}))
+
+vi.mock('@/services/inference/title', () => ({
+  generateTitle: vi.fn(async () => 'Untitled'),
+  getTitleContent: (message: { content: string }) => message.content,
+}))
+
+vi.mock('@/services/storage/chat-storage', () => ({
+  chatStorage: {
+    saveChat: vi.fn(async (chat) => chat),
+    saveChatAndSync: initialSaveMock,
+    saveChatAndWaitForSync: vi.fn(async (chat) => chat),
+  },
+}))
+
+vi.mock('@/services/storage/session-storage', () => ({
+  sessionChatStorage: { saveChat: sessionSaveMock },
+}))
+
+vi.mock('@/services/exec-snapshot/access-token', () => ({
+  generateCodeExecutionAccessToken: () => 'token',
+}))
+
+vi.mock('@/services/exec-snapshot/use-exec-snapshot', () => ({
+  getCodeExecutionContainerAuthTokenForChat: async () => null,
+}))
+
+vi.mock('@/utils/cloud-sync-settings', () => ({
+  isCloudSyncEnabled: () => false,
+}))
+
+vi.mock('@/utils/error-handling', () => ({
+  logError: vi.fn(),
+  logInfo: vi.fn(),
+  logWarning: vi.fn(),
+}))
+
+function createOpenResponse() {
+  let controller!: ReadableStreamDefaultController<Uint8Array>
+  const response = new Response(
+    new ReadableStream<Uint8Array>({
+      start(streamController) {
+        controller = streamController
+      },
+    }),
+  )
+  return {
+    response,
+    send: (event: Record<string, unknown>) => {
+      controller.enqueue(
+        new TextEncoder().encode(`data: ${JSON.stringify(event)}\n\n`),
+      )
+    },
+    close: () => controller.close(),
+  }
+}
+
+describe('useChatMessaging stopped streams', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    initialSaveMock.mockImplementation(async (chat: unknown) => chat)
+    persistInterruptedAssistantMock.mockResolvedValue(undefined)
+    streamControllers.clear()
+    streamingChats.clear()
+  })
+
+  it('keeps and persists the assistant response at the stop point', async () => {
+    const initialChat: Chat = {
+      id: 'chat-1',
+      title: 'Existing chat',
+      createdAt: new Date(),
+      messages: [
+        { role: 'user', content: 'Earlier', timestamp: new Date() },
+        { role: 'assistant', content: 'Earlier reply', timestamp: new Date() },
+      ],
+    }
+    const stream = createOpenResponse()
+    sendChatStreamMock.mockResolvedValue(stream.response)
+
+    const { result } = renderHook(() => {
+      const [currentChat, setCurrentChat] = useState(initialChat)
+      const [chats, setChats] = useState([initialChat])
+      const messaging = useChatMessaging({
+        systemPrompt: '',
+        storeHistory: false,
+        models: [{} as never],
+        selectedModel: 'test-model',
+        chats,
+        currentChat,
+        setChats,
+        setCurrentChat,
+        messagesEndRef: { current: null },
+      })
+      return { currentChat, messaging }
+    })
+
+    let query!: Promise<unknown>
+    act(() => {
+      query = result.current.messaging.handleQuery(
+        'New prompt',
+      ) as Promise<unknown>
+    })
+    await vi.waitFor(() => expect(sendChatStreamMock).toHaveBeenCalled())
+
+    stream.send({
+      choices: [{ delta: { reasoning_content: 'Partial reasoning' } }],
+    })
+    await vi.waitFor(() =>
+      expect(result.current.currentChat.messages.at(-1)?.thoughts).toBe(
+        'Partial reasoning',
+      ),
+    )
+
+    await act(async () => {
+      await result.current.messaging.cancelGeneration()
+    })
+    stream.close()
+    await act(async () => {
+      await query
+    })
+
+    const stoppedMessage = result.current.currentChat.messages.at(-1)
+    expect(stoppedMessage).toMatchObject({
+      role: 'assistant',
+      thoughts: 'Partial reasoning',
+      isThinking: false,
+      turnId: expect.any(String),
+    })
+    expect(sessionSaveMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        messages: expect.arrayContaining([
+          expect.objectContaining({
+            role: 'assistant',
+            thoughts: 'Partial reasoning',
+            isThinking: false,
+            turnId: expect.any(String),
+          }),
+        ]),
+      }),
+    )
+    expect(cancelChatRecoveryMock).toHaveBeenCalledWith(
+      'chat-1',
+      expect.objectContaining({ thoughts: 'Partial reasoning' }),
+    )
+  })
+
+  it('waits for first-turn persistence before saving the stopped response', async () => {
+    const initialChat: Chat = {
+      id: '',
+      title: 'New chat',
+      createdAt: new Date(),
+      messages: [],
+      isBlankChat: true,
+      isLocalOnly: true,
+    }
+    let finishInitialSave!: () => void
+    initialSaveMock.mockImplementationOnce(
+      (chat: unknown) =>
+        new Promise((resolve) => {
+          finishInitialSave = () => resolve(chat)
+        }),
+    )
+    const stream = createOpenResponse()
+    sendChatStreamMock.mockResolvedValue(stream.response)
+
+    const { result } = renderHook(() => {
+      const [currentChat, setCurrentChat] = useState(initialChat)
+      const [chats, setChats] = useState([initialChat])
+      const messaging = useChatMessaging({
+        systemPrompt: '',
+        storeHistory: true,
+        models: [{} as never],
+        selectedModel: 'test-model',
+        chats,
+        currentChat,
+        setChats,
+        setCurrentChat,
+        messagesEndRef: { current: null },
+      })
+      return { currentChat, messaging }
+    })
+
+    let query!: Promise<unknown>
+    act(() => {
+      query = result.current.messaging.handleQuery(
+        'First prompt',
+      ) as Promise<unknown>
+    })
+    await vi.waitFor(() => expect(sendChatStreamMock).toHaveBeenCalled())
+    stream.send({ choices: [{ delta: { content: 'Partial answer' } }] })
+    await vi.waitFor(() =>
+      expect(result.current.currentChat.messages.at(-1)?.content).toBe(
+        'Partial answer',
+      ),
+    )
+
+    let cancellation!: Promise<void>
+    act(() => {
+      cancellation = result.current.messaging.cancelGeneration()
+    })
+    await Promise.resolve()
+    expect(persistInterruptedAssistantMock).not.toHaveBeenCalled()
+
+    finishInitialSave()
+    await act(async () => {
+      await cancellation
+    })
+
+    expect(persistInterruptedAssistantMock).toHaveBeenCalledWith(
+      result.current.currentChat.id,
+      expect.any(String),
+      expect.objectContaining({ content: 'Partial answer' }),
+    )
+
+    stream.close()
+    await act(async () => {
+      await query
+    })
+  })
+})

--- a/tests/components/chat/use-chat-messaging.stop-stream.test.tsx
+++ b/tests/components/chat/use-chat-messaging.stop-stream.test.tsx
@@ -5,7 +5,9 @@ import { useState } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const {
+  authState,
   cancelChatRecoveryMock,
+  completeLiveChatRecoveryMock,
   containerAuthTokenMock,
   initialSaveMock,
   persistInterruptedAssistantMock,
@@ -13,8 +15,16 @@ const {
   sessionSaveMock,
   streamControllers,
   streamingChats,
+  recoveryAvailableState,
 } = vi.hoisted(() => ({
+  authState: {
+    isSignedIn: false,
+    userId: undefined as string | undefined,
+  },
   cancelChatRecoveryMock: vi.fn(async (..._args: unknown[]) => false),
+  completeLiveChatRecoveryMock: vi.fn(
+    async (..._args: unknown[]): Promise<void> => {},
+  ),
   containerAuthTokenMock: vi.fn(async (..._args: unknown[]) => null),
   initialSaveMock: vi.fn(async (chat: unknown) => chat),
   persistInterruptedAssistantMock: vi.fn(
@@ -24,10 +34,11 @@ const {
   sessionSaveMock: vi.fn(),
   streamControllers: new Map<string, AbortController>(),
   streamingChats: new Set<string>(),
+  recoveryAvailableState: { available: false },
 }))
 
 vi.mock('@clerk/nextjs', () => ({
-  useAuth: () => ({ isSignedIn: false, userId: undefined }),
+  useAuth: () => authState,
 }))
 
 vi.mock('@/components/project', () => ({
@@ -75,7 +86,8 @@ vi.mock('@/components/chat/hooks/use-chat-streams', async (importOriginal) => ({
 vi.mock('@/services/inference/chat-recovery', () => ({
   abandonChatRecoveryAttempt: vi.fn(),
   cancelChatRecovery: (...args: unknown[]) => cancelChatRecoveryMock(...args),
-  completeLiveChatRecovery: vi.fn(),
+  completeLiveChatRecovery: (...args: unknown[]) =>
+    completeLiveChatRecoveryMock(...args),
   persistChatRecoveryToken: vi.fn(),
   releaseActiveChatRecovery: vi.fn(),
   scanPendingChatRecoveries: vi.fn(),
@@ -93,7 +105,7 @@ vi.mock('@/services/inference/chat-recovery-sync', () => ({
 
 vi.mock('@/services/inference/tinfoil-client', () => ({
   getRateLimitInfo: () => null,
-  isChatRecoveryAvailable: () => false,
+  isChatRecoveryAvailable: () => recoveryAvailableState.available,
   refreshRateLimit: vi.fn(),
 }))
 
@@ -159,6 +171,10 @@ describe('useChatMessaging stopped streams', () => {
     initialSaveMock.mockImplementation(async (chat: unknown) => chat)
     persistInterruptedAssistantMock.mockResolvedValue(undefined)
     containerAuthTokenMock.mockResolvedValue(null)
+    completeLiveChatRecoveryMock.mockResolvedValue(undefined)
+    authState.isSignedIn = false
+    authState.userId = undefined
+    recoveryAvailableState.available = false
     streamControllers.clear()
     streamingChats.clear()
   })
@@ -371,5 +387,82 @@ describe('useChatMessaging stopped streams', () => {
 
     expect(sendChatStreamMock).not.toHaveBeenCalled()
     expect(streamingChats).toEqual(new Set())
+  })
+
+  it('keeps a completed response when stopped during recovery finalization', async () => {
+    authState.isSignedIn = true
+    authState.userId = 'user-1'
+    recoveryAvailableState.available = true
+    const initialChat: Chat = {
+      id: 'chat-1',
+      title: 'Existing chat',
+      createdAt: new Date(),
+      messages: [
+        { role: 'user', content: 'Earlier', timestamp: new Date() },
+        { role: 'assistant', content: 'Earlier reply', timestamp: new Date() },
+      ],
+      isLocalOnly: true,
+    }
+    const stream = createOpenResponse()
+    sendChatStreamMock.mockResolvedValue(stream.response)
+    let finishRecovery!: () => void
+    completeLiveChatRecoveryMock.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          finishRecovery = resolve
+        }),
+    )
+
+    const { result } = renderHook(() => {
+      const [currentChat, setCurrentChat] = useState(initialChat)
+      const [chats, setChats] = useState([initialChat])
+      const messaging = useChatMessaging({
+        systemPrompt: '',
+        storeHistory: true,
+        models: [{} as never],
+        selectedModel: 'test-model',
+        chats,
+        currentChat,
+        setChats,
+        setCurrentChat,
+        messagesEndRef: { current: null },
+      })
+      return { currentChat, messaging }
+    })
+
+    let query!: Promise<unknown>
+    act(() => {
+      query = result.current.messaging.handleQuery(
+        'New prompt',
+      ) as Promise<unknown>
+    })
+    await vi.waitFor(() => expect(sendChatStreamMock).toHaveBeenCalled())
+    stream.send({ choices: [{ delta: { content: 'Complete answer' } }] })
+    stream.send({
+      choices: [{ index: 0, delta: {}, finish_reason: 'stop' }],
+    })
+    stream.close()
+    await vi.waitFor(() =>
+      expect(completeLiveChatRecoveryMock).toHaveBeenCalled(),
+    )
+
+    await act(async () => {
+      await result.current.messaging.cancelGeneration()
+    })
+
+    expect(result.current.currentChat.messages.at(-1)).toMatchObject({
+      role: 'assistant',
+      content: 'Complete answer',
+      turnId: expect.any(String),
+    })
+    expect(cancelChatRecoveryMock).toHaveBeenCalledWith(
+      'chat-1',
+      expect.objectContaining({ content: 'Complete answer' }),
+    )
+
+    finishRecovery()
+    await act(async () => {
+      await query
+    })
   })
 })

--- a/tests/components/chat/use-chat-messaging.stop-stream.test.tsx
+++ b/tests/components/chat/use-chat-messaging.stop-stream.test.tsx
@@ -393,6 +393,9 @@ describe('useChatMessaging stopped streams', () => {
     authState.isSignedIn = true
     authState.userId = 'user-1'
     recoveryAvailableState.available = true
+    cancelChatRecoveryMock.mockRejectedValueOnce(
+      new Error('recovery state changed'),
+    )
     const initialChat: Chat = {
       id: 'chat-1',
       title: 'Existing chat',
@@ -459,6 +462,7 @@ describe('useChatMessaging stopped streams', () => {
       'chat-1',
       expect.objectContaining({ content: 'Complete answer' }),
     )
+    expect(persistInterruptedAssistantMock).not.toHaveBeenCalled()
 
     finishRecovery()
     await act(async () => {

--- a/tests/components/chat/use-chat-messaging.stop-stream.test.tsx
+++ b/tests/components/chat/use-chat-messaging.stop-stream.test.tsx
@@ -6,6 +6,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const {
   cancelChatRecoveryMock,
+  containerAuthTokenMock,
   initialSaveMock,
   persistInterruptedAssistantMock,
   sendChatStreamMock,
@@ -14,6 +15,7 @@ const {
   streamingChats,
 } = vi.hoisted(() => ({
   cancelChatRecoveryMock: vi.fn(async (..._args: unknown[]) => false),
+  containerAuthTokenMock: vi.fn(async (..._args: unknown[]) => null),
   initialSaveMock: vi.fn(async (chat: unknown) => chat),
   persistInterruptedAssistantMock: vi.fn(
     async (..._args: unknown[]) => undefined,
@@ -117,7 +119,8 @@ vi.mock('@/services/exec-snapshot/access-token', () => ({
 }))
 
 vi.mock('@/services/exec-snapshot/use-exec-snapshot', () => ({
-  getCodeExecutionContainerAuthTokenForChat: async () => null,
+  getCodeExecutionContainerAuthTokenForChat: (...args: unknown[]) =>
+    containerAuthTokenMock(...args),
 }))
 
 vi.mock('@/utils/cloud-sync-settings', () => ({
@@ -155,6 +158,7 @@ describe('useChatMessaging stopped streams', () => {
     vi.clearAllMocks()
     initialSaveMock.mockImplementation(async (chat: unknown) => chat)
     persistInterruptedAssistantMock.mockResolvedValue(undefined)
+    containerAuthTokenMock.mockResolvedValue(null)
     streamControllers.clear()
     streamingChats.clear()
   })
@@ -311,5 +315,61 @@ describe('useChatMessaging stopped streams', () => {
     await act(async () => {
       await query
     })
+  })
+
+  it('does not start stream tracking after pre-stream cancellation', async () => {
+    const initialChat: Chat = {
+      id: 'chat-1',
+      title: 'Existing chat',
+      createdAt: new Date(),
+      messages: [
+        { role: 'user', content: 'Earlier', timestamp: new Date() },
+        { role: 'assistant', content: 'Earlier reply', timestamp: new Date() },
+      ],
+    }
+    let finishContainerAuth!: () => void
+    containerAuthTokenMock.mockImplementationOnce(
+      () =>
+        new Promise<null>((resolve) => {
+          finishContainerAuth = () => resolve(null)
+        }),
+    )
+
+    const { result } = renderHook(() => {
+      const [currentChat, setCurrentChat] = useState(initialChat)
+      const [chats, setChats] = useState([initialChat])
+      const messaging = useChatMessaging({
+        systemPrompt: '',
+        storeHistory: false,
+        models: [{} as never],
+        selectedModel: 'test-model',
+        chats,
+        currentChat,
+        setChats,
+        setCurrentChat,
+        messagesEndRef: { current: null },
+        codeExecutionEnabled: true,
+      })
+      return { messaging }
+    })
+
+    let query!: Promise<unknown>
+    act(() => {
+      query = result.current.messaging.handleQuery(
+        'New prompt',
+      ) as Promise<unknown>
+    })
+    await vi.waitFor(() => expect(containerAuthTokenMock).toHaveBeenCalled())
+
+    await act(async () => {
+      await result.current.messaging.cancelGeneration()
+    })
+    finishContainerAuth()
+    await act(async () => {
+      await query
+    })
+
+    expect(sendChatStreamMock).not.toHaveBeenCalled()
+    expect(streamingChats).toEqual(new Set())
   })
 })

--- a/tests/services/inference/chat-recovery-sync.test.ts
+++ b/tests/services/inference/chat-recovery-sync.test.ts
@@ -93,6 +93,7 @@ vi.mock('@/services/sync-enclave/sync-api', () => ({
 import {
   addPendingRecovery,
   completePendingRecovery,
+  persistInterruptedAssistant,
   removePendingRecovery,
   replacePendingRecovery,
   resetChatRecoverySyncState,
@@ -303,6 +304,36 @@ describe('chat recovery sync mutations', () => {
     expect(remoteChat.messages[1].content).toBe('Recovered answer')
     expect(remoteChat.messages[1].isThinking).toBeUndefined()
     expect(remoteChat.pendingRecoveries).toBeUndefined()
+  })
+
+  it('persists only the interrupted turn without dropping later messages', async () => {
+    remoteChat.messages.push(
+      message('user', 'Later question', 'turn-2'),
+      message('assistant', 'Later answer', 'turn-2'),
+    )
+    remoteChat.pendingRecoveries = [envelope('turn-1'), envelope('turn-2')]
+    localChat = structuredClone(remoteChat)
+
+    await persistInterruptedAssistant(remoteChat.id, 'turn-1', {
+      ...message('assistant', '', 'turn-1'),
+      thoughts: 'Partial reasoning',
+      isThinking: false,
+    })
+
+    expect(remoteChat.messages.map((item) => item.turnId)).toEqual([
+      'turn-1',
+      'turn-1',
+      'turn-2',
+      'turn-2',
+    ])
+    expect(remoteChat.messages[1]).toMatchObject({
+      role: 'assistant',
+      thoughts: 'Partial reasoning',
+      isThinking: false,
+    })
+    expect(remoteChat.pendingRecoveries?.map((item) => item.turnId)).toEqual([
+      'turn-2',
+    ])
   })
 
   it('updates recovered search reasoning when response content is unchanged', async () => {

--- a/tests/services/inference/chat-recovery.test.ts
+++ b/tests/services/inference/chat-recovery.test.ts
@@ -83,7 +83,10 @@ vi.mock('@/services/cloud/legacy-blob-migration', () => ({
     retryDeferredAlternativesFinalization(),
 }))
 
-vi.mock('@/components/chat/hooks/streaming', () => ({
+vi.mock('@/components/chat/hooks/streaming', async (importOriginal) => ({
+  ...(await importOriginal<
+    typeof import('@/components/chat/hooks/streaming')
+  >()),
   parseRichStreamingResponse: (...args: unknown[]) =>
     parseRichStreamingResponse(...args),
 }))
@@ -190,6 +193,22 @@ describe('chat recovery lifecycle', () => {
     expect(encryptRecoveryEnvelope).not.toHaveBeenCalled()
     expect(addPendingRecovery).not.toHaveBeenCalled()
     expect(deleteChatRecovery).toHaveBeenCalledWith(SESSION_ID)
+  })
+
+  it('retains the recovery session when interrupted output cannot be saved', async () => {
+    await persistActiveRecovery()
+    completePendingRecovery.mockRejectedValueOnce(new Error('save failed'))
+
+    await expect(
+      cancelChatRecovery('chat-1', {
+        role: 'assistant',
+        content: 'Partial answer',
+        turnId: 'turn-1',
+        timestamp: new Date(),
+      }),
+    ).rejects.toThrow('save failed')
+
+    expect(deleteChatRecovery).not.toHaveBeenCalled()
   })
 
   it('stores a local recovery token without a cloud encryption key', async () => {
@@ -1038,7 +1057,7 @@ describe('chat recovery lifecycle', () => {
     await vi.waitFor(() => expect(getAllChats).toHaveBeenCalledTimes(2))
   })
 
-  it('cancels a recovery stream resumed by a scan', async () => {
+  it('saves the visible draft when cancelling a resumed recovery stream', async () => {
     getAllChats.mockResolvedValue([
       { id: 'chat-1', pendingRecoveries: [envelope] },
     ])
@@ -1071,16 +1090,26 @@ describe('chat recovery lifecycle', () => {
           }
         }),
     )
-    let finishRemoval: (() => void) | undefined
-    removePendingRecovery.mockImplementationOnce(
-      (_chatId: string, _turnId: string, isCurrent: () => boolean) =>
-        new Promise<void>((resolve) => {
-          finishRemoval = () => {
-            expect(isCurrent()).toBe(true)
-            resolve()
-          }
-        }),
-    )
+    getChatRecoveryDraft.mockReturnValue({
+      chatId: 'chat-1',
+      turnId: 'turn-1',
+      sessionId: SESSION_ID,
+      message: {
+        role: 'assistant',
+        content: '',
+        thoughts: 'Recovered reasoning so far',
+        isThinking: true,
+        timestamp: new Date(),
+        timeline: [
+          {
+            type: 'thinking',
+            id: 'thinking-0',
+            content: 'Recovered reasoning so far',
+            isThinking: true,
+          },
+        ],
+      },
+    })
 
     const scan = scanPendingChatRecoveries('user-1')
     await vi.waitFor(() => {
@@ -1091,24 +1120,35 @@ describe('chat recovery lifecycle', () => {
       )
     })
 
-    const cancellation = cancelChatRecovery('chat-1')
-    await vi.waitFor(() => expect(removePendingRecovery).toHaveBeenCalled())
-    await scanPendingChatRecoveries('user-1', true)
-    finishRemoval?.()
-    await cancellation
+    const result = await cancelChatRecovery('chat-1')
     await scan
 
+    expect(result).toBe(true)
     expect(recoverySignal?.aborted).toBe(true)
     expect(setChatRecoveryActive).toHaveBeenCalledWith(
       'chat-1',
       'turn-1',
       false,
     )
-    expect(removePendingRecovery).toHaveBeenCalledWith(
+    expect(completePendingRecovery).toHaveBeenCalledWith(
       'chat-1',
       expect.objectContaining({ turnId: 'turn-1' }),
+      expect.objectContaining({
+        turnId: 'turn-1',
+        thoughts: 'Recovered reasoning so far',
+        isThinking: false,
+        timeline: [
+          expect.objectContaining({
+            type: 'thinking',
+            content: 'Recovered reasoning so far',
+            isThinking: false,
+          }),
+        ],
+      }),
+      {},
       expect.any(Function),
     )
+    expect(removePendingRecovery).not.toHaveBeenCalled()
     expect(deleteChatRecovery).toHaveBeenCalledWith(SESSION_ID)
   })
 

--- a/tests/services/inference/chat-recovery.test.ts
+++ b/tests/services/inference/chat-recovery.test.ts
@@ -211,6 +211,23 @@ describe('chat recovery lifecycle', () => {
     expect(deleteChatRecovery).not.toHaveBeenCalled()
   })
 
+  it('reports a no-op completion without an assistant as unpersisted', async () => {
+    await persistActiveRecovery()
+    completePendingRecovery.mockResolvedValueOnce({
+      id: 'chat-1',
+      messages: [{ role: 'user', content: 'Question', turnId: 'turn-1' }],
+    })
+
+    const persisted = await cancelChatRecovery('chat-1', {
+      role: 'assistant',
+      content: 'Partial answer',
+      turnId: 'turn-1',
+      timestamp: new Date(),
+    })
+
+    expect(persisted).toBe(false)
+  })
+
   it('stores a local recovery token without a cloud encryption key', async () => {
     cloudSyncEnabled = false
     getChat.mockResolvedValue({ id: 'chat-1', isLocalOnly: true })
@@ -1109,6 +1126,18 @@ describe('chat recovery lifecycle', () => {
           },
         ],
       },
+    })
+    completePendingRecovery.mockResolvedValueOnce({
+      id: 'chat-1',
+      messages: [
+        {
+          role: 'assistant',
+          content: '',
+          thoughts: 'Recovered reasoning so far',
+          isThinking: false,
+          turnId: 'turn-1',
+        },
+      ],
     })
 
     const scan = scanPendingChatRecoveries('user-1')

--- a/tests/services/inference/chat-recovery.test.ts
+++ b/tests/services/inference/chat-recovery.test.ts
@@ -9,6 +9,7 @@ const fetchRecoveredChatResponse = vi.fn()
 const getChatRecoveryState = vi.fn()
 const addPendingRecovery = vi.fn()
 const completePendingRecovery = vi.fn()
+const persistInterruptedAssistant = vi.fn()
 const removePendingRecovery = vi.fn()
 const replacePendingRecovery = vi.fn()
 const resetChatRecoverySyncState = vi.fn()
@@ -58,6 +59,8 @@ vi.mock('@/services/inference/chat-recovery-sync', () => ({
   addPendingRecovery: (...args: unknown[]) => addPendingRecovery(...args),
   completePendingRecovery: (...args: unknown[]) =>
     completePendingRecovery(...args),
+  persistInterruptedAssistant: (...args: unknown[]) =>
+    persistInterruptedAssistant(...args),
   removePendingRecovery: (...args: unknown[]) => removePendingRecovery(...args),
   replacePendingRecovery: (...args: unknown[]) =>
     replacePendingRecovery(...args),
@@ -168,6 +171,7 @@ describe('chat recovery lifecycle', () => {
     removePendingRecovery.mockResolvedValue(undefined)
     addPendingRecovery.mockResolvedValue(undefined)
     completePendingRecovery.mockResolvedValue(undefined)
+    persistInterruptedAssistant.mockResolvedValue(undefined)
     replacePendingRecovery.mockResolvedValue(undefined)
     retryDeferredAlternativesFinalization.mockResolvedValue(undefined)
   })
@@ -211,21 +215,61 @@ describe('chat recovery lifecycle', () => {
     expect(deleteChatRecovery).not.toHaveBeenCalled()
   })
 
-  it('reports a no-op completion without an assistant as unpersisted', async () => {
+  it('falls back when completion does not retain the stopped assistant', async () => {
     await persistActiveRecovery()
     completePendingRecovery.mockResolvedValueOnce({
       id: 'chat-1',
       messages: [{ role: 'user', content: 'Question', turnId: 'turn-1' }],
     })
 
-    const persisted = await cancelChatRecovery('chat-1', {
-      role: 'assistant',
+    persistInterruptedAssistant.mockResolvedValueOnce({
+      id: 'chat-1',
+      messages: [
+        {
+          role: 'assistant',
+          content: 'Partial answer',
+          turnId: 'turn-1',
+        },
+      ],
+    })
+
+    const stoppedMessage = {
+      role: 'assistant' as const,
       content: 'Partial answer',
       turnId: 'turn-1',
       timestamp: new Date(),
-    })
+    }
+    const persisted = await cancelChatRecovery('chat-1', stoppedMessage)
 
-    expect(persisted).toBe(false)
+    expect(persistInterruptedAssistant).toHaveBeenCalledWith(
+      'chat-1',
+      'turn-1',
+      expect.objectContaining(stoppedMessage),
+    )
+    expect(persisted).toBe(true)
+    expect(deleteChatRecovery).toHaveBeenCalledWith(SESSION_ID)
+  })
+
+  it('retains the recovery session when no-op fallback persistence fails', async () => {
+    await persistActiveRecovery()
+    completePendingRecovery.mockResolvedValueOnce({
+      id: 'chat-1',
+      messages: [{ role: 'user', content: 'Question', turnId: 'turn-1' }],
+    })
+    persistInterruptedAssistant.mockRejectedValueOnce(
+      new Error('fallback failed'),
+    )
+
+    await expect(
+      cancelChatRecovery('chat-1', {
+        role: 'assistant',
+        content: 'Partial answer',
+        turnId: 'turn-1',
+        timestamp: new Date(),
+      }),
+    ).rejects.toThrow('fallback failed')
+
+    expect(deleteChatRecovery).not.toHaveBeenCalled()
   })
 
   it('stores a local recovery token without a cloud encryption key', async () => {

--- a/tests/services/inference/chat-recovery.test.ts
+++ b/tests/services/inference/chat-recovery.test.ts
@@ -9,7 +9,6 @@ const fetchRecoveredChatResponse = vi.fn()
 const getChatRecoveryState = vi.fn()
 const addPendingRecovery = vi.fn()
 const completePendingRecovery = vi.fn()
-const persistInterruptedAssistant = vi.fn()
 const removePendingRecovery = vi.fn()
 const replacePendingRecovery = vi.fn()
 const resetChatRecoverySyncState = vi.fn()
@@ -59,8 +58,6 @@ vi.mock('@/services/inference/chat-recovery-sync', () => ({
   addPendingRecovery: (...args: unknown[]) => addPendingRecovery(...args),
   completePendingRecovery: (...args: unknown[]) =>
     completePendingRecovery(...args),
-  persistInterruptedAssistant: (...args: unknown[]) =>
-    persistInterruptedAssistant(...args),
   removePendingRecovery: (...args: unknown[]) => removePendingRecovery(...args),
   replacePendingRecovery: (...args: unknown[]) =>
     replacePendingRecovery(...args),
@@ -171,7 +168,6 @@ describe('chat recovery lifecycle', () => {
     removePendingRecovery.mockResolvedValue(undefined)
     addPendingRecovery.mockResolvedValue(undefined)
     completePendingRecovery.mockResolvedValue(undefined)
-    persistInterruptedAssistant.mockResolvedValue(undefined)
     replacePendingRecovery.mockResolvedValue(undefined)
     retryDeferredAlternativesFinalization.mockResolvedValue(undefined)
   })
@@ -192,7 +188,7 @@ describe('chat recovery lifecycle', () => {
         },
       }),
     ).rejects.toMatchObject({ name: 'AbortError' })
-    await cancellation
+    await expect(cancellation).resolves.toBe(false)
 
     expect(encryptRecoveryEnvelope).not.toHaveBeenCalled()
     expect(addPendingRecovery).not.toHaveBeenCalled()
@@ -215,60 +211,21 @@ describe('chat recovery lifecycle', () => {
     expect(deleteChatRecovery).not.toHaveBeenCalled()
   })
 
-  it('falls back when completion does not retain the stopped assistant', async () => {
+  it('does not overwrite a concurrently removed recovery', async () => {
     await persistActiveRecovery()
     completePendingRecovery.mockResolvedValueOnce({
       id: 'chat-1',
       messages: [{ role: 'user', content: 'Question', turnId: 'turn-1' }],
     })
 
-    persistInterruptedAssistant.mockResolvedValueOnce({
-      id: 'chat-1',
-      messages: [
-        {
-          role: 'assistant',
-          content: 'Partial answer',
-          turnId: 'turn-1',
-        },
-      ],
-    })
-
-    const stoppedMessage = {
-      role: 'assistant' as const,
+    const handled = await cancelChatRecovery('chat-1', {
+      role: 'assistant',
       content: 'Partial answer',
       turnId: 'turn-1',
       timestamp: new Date(),
-    }
-    const persisted = await cancelChatRecovery('chat-1', stoppedMessage)
-
-    expect(persistInterruptedAssistant).toHaveBeenCalledWith(
-      'chat-1',
-      'turn-1',
-      expect.objectContaining(stoppedMessage),
-    )
-    expect(persisted).toBe(true)
-    expect(deleteChatRecovery).toHaveBeenCalledWith(SESSION_ID)
-  })
-
-  it('retains the recovery session when no-op fallback persistence fails', async () => {
-    await persistActiveRecovery()
-    completePendingRecovery.mockResolvedValueOnce({
-      id: 'chat-1',
-      messages: [{ role: 'user', content: 'Question', turnId: 'turn-1' }],
     })
-    persistInterruptedAssistant.mockRejectedValueOnce(
-      new Error('fallback failed'),
-    )
 
-    await expect(
-      cancelChatRecovery('chat-1', {
-        role: 'assistant',
-        content: 'Partial answer',
-        turnId: 'turn-1',
-        timestamp: new Date(),
-      }),
-    ).rejects.toThrow('fallback failed')
-
+    expect(handled).toBe(true)
     expect(deleteChatRecovery).not.toHaveBeenCalled()
   })
 


### PR DESCRIPTION
## Summary
- capture and finalize the exact assistant draft when a live stream is stopped
- persist stopped normal and recovered turns atomically without overwriting newer messages
- serialize repeated cancellation, recovery cleanup, and first-turn persistence

## Testing
- `npx vitest run tests/components/chat/streaming/process-stream.test.ts tests/components/chat/use-chat-messaging.stop-stream.test.tsx tests/components/chat/use-chat-messaging.cancel-generation.test.tsx tests/services/inference/chat-recovery.test.ts tests/services/inference/chat-recovery-sync.test.ts`
- `npx tsc --noEmit`
- `npm run lint`
- `npm run build`
- Full unit suite: 1,359 passed; one unrelated existing timeout remains in `tests/services/cloud/upload-coalescer.test.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves assistant output when a live stream is stopped or a recovered stream is cancelled, finalizing the exact draft (with its `turnId`) without dropping partial reasoning or overwriting newer messages. Also respects concurrent recovery cancellation to avoid double-saves or session loss.

- **New Features**
  - Abort-aware streaming: `processStreamingResponse` accepts a `signal`, flushes buffered content, tags `turnId` on UI/return, and publishes one interruption via `onInterrupted`.
  - Turn-aware persistence: `persistInterruptedAssistant` updates only the interrupted turn and clears its recovery; `cancelChatRecovery` accepts the visible draft and returns a handled flag.
  - `useChatMessaging` tracks active generations (with `turnId`, latest draft, and an initial-save promise), waits for the first-turn save, persists the stopped message (cloud or session), deduplicates repeated stops, and keeps loading until recovery cancellation finishes.

- **Bug Fixes**
  - No empty assistant placeholders; keep partial reasoning and mark it not-thinking. Finalize timeline blocks (search/fetch/exec → failed).
  - Abort-safe streaming: stop trailing flushes/UI updates and avoid cleanup that would reset loading state; don’t start stream tracking when pre-stream cancelled.
  - Respect concurrent recovery cancellation: don’t overwrite or delete recoveries already removed by another actor; when cancelling a resumed recovery, save the visible draft if present and keep the session if persisting fails.

<sup>Written for commit 20cb49041512269bfa30e35eb80a0c53cc71e505. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/457?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

