### PR TITLE
Pixelate sidebar chat titles until hover

### DIFF
--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -5,12 +5,12 @@ import {
   type BaseModel,
 } from '@/config/models'
 import {
+  SETTINGS_BLUR_SIDEBAR_CHAT_TITLES,
   SETTINGS_CODE_EXECUTION_ENABLED,
   SETTINGS_GENUI_ENABLED,
   SETTINGS_HAS_SEEN_ONBOARDING,
   SETTINGS_HAS_SEEN_WEB_SEARCH_INTRO,
   SETTINGS_PII_CHECK_ENABLED,
-  SETTINGS_PIXELATE_SIDEBAR_CHAT_TITLES,
   SETTINGS_WEB_SEARCH_AVAILABLE,
   UI_EXPAND_PROJECT_DOCUMENTS,
 } from '@/constants/storage-keys'
@@ -496,13 +496,11 @@ export function ChatInterface({
     return saved === null ? true : saved === 'true'
   })
 
-  const [pixelateSidebarChatTitles, setPixelateSidebarChatTitles] = useState(
-    () => {
-      if (typeof window === 'undefined') return true
-      const saved = localStorage.getItem(SETTINGS_PIXELATE_SIDEBAR_CHAT_TITLES)
-      return saved === null ? true : saved === 'true'
-    },
-  )
+  const [blurSidebarChatTitles, setBlurSidebarChatTitles] = useState(() => {
+    if (typeof window === 'undefined') return true
+    const saved = localStorage.getItem(SETTINGS_BLUR_SIDEBAR_CHAT_TITLES)
+    return saved === null ? true : saved === 'true'
+  })
 
   // Generative UI setting (controlled from settings modal, defaults to on)
   const [genUIEnabled, setGenUIEnabled] = useState(() => {
@@ -1180,16 +1178,14 @@ export function ChatInterface({
     const handlePiiCheckChange = (event: CustomEvent<{ enabled: boolean }>) => {
       setPiiCheckEnabled(event.detail.enabled)
     }
-    const handlePixelateSidebarChatTitlesChange = (
+    const handleBlurSidebarChatTitlesChange = (
       event: CustomEvent<{ enabled: boolean }>,
     ) => {
-      setPixelateSidebarChatTitles(event.detail.enabled)
+      setBlurSidebarChatTitles(event.detail.enabled)
     }
-    const handlePixelateSidebarChatTitlesStorageChange = (
-      event: StorageEvent,
-    ) => {
-      if (event.key !== SETTINGS_PIXELATE_SIDEBAR_CHAT_TITLES) return
-      setPixelateSidebarChatTitles(
+    const handleBlurSidebarChatTitlesStorageChange = (event: StorageEvent) => {
+      if (event.key !== SETTINGS_BLUR_SIDEBAR_CHAT_TITLES) return
+      setBlurSidebarChatTitles(
         event.newValue === null ? true : event.newValue === 'true',
       )
     }
@@ -1199,13 +1195,10 @@ export function ChatInterface({
       handlePiiCheckChange as EventListener,
     )
     window.addEventListener(
-      'pixelateSidebarChatTitlesChanged',
-      handlePixelateSidebarChatTitlesChange as EventListener,
+      'blurSidebarChatTitlesChanged',
+      handleBlurSidebarChatTitlesChange as EventListener,
     )
-    window.addEventListener(
-      'storage',
-      handlePixelateSidebarChatTitlesStorageChange,
-    )
+    window.addEventListener('storage', handleBlurSidebarChatTitlesStorageChange)
 
     return () => {
       window.removeEventListener(
@@ -1213,12 +1206,12 @@ export function ChatInterface({
         handlePiiCheckChange as EventListener,
       )
       window.removeEventListener(
-        'pixelateSidebarChatTitlesChanged',
-        handlePixelateSidebarChatTitlesChange as EventListener,
+        'blurSidebarChatTitlesChanged',
+        handleBlurSidebarChatTitlesChange as EventListener,
       )
       window.removeEventListener(
         'storage',
-        handlePixelateSidebarChatTitlesStorageChange,
+        handleBlurSidebarChatTitlesStorageChange,
       )
     }
   }, [])
@@ -3079,7 +3072,7 @@ export function ChatInterface({
                   setIsOpen={setIsSidebarOpen}
                   project={activeProject}
                   isDarkMode={isDarkMode}
-                  pixelateSidebarChatTitles={pixelateSidebarChatTitles}
+                  blurSidebarChatTitles={blurSidebarChatTitles}
                   onExitProject={handleExitProject}
                   onExitProjectWhileDragging={handleExitProjectWhileDragging}
                   onNewChat={() => createNewChat(false, true)}
@@ -3123,7 +3116,7 @@ export function ChatInterface({
                   projectName={loadingProject?.name}
                   isLoading={true}
                   isDarkMode={isDarkMode}
-                  pixelateSidebarChatTitles={pixelateSidebarChatTitles}
+                  blurSidebarChatTitles={blurSidebarChatTitles}
                   onExitProject={handleExitProject}
                   onExitProjectWhileDragging={handleExitProjectWhileDragging}
                   onNewChat={() => {}}
@@ -3149,7 +3142,7 @@ export function ChatInterface({
                 chats={chats}
                 currentChat={currentChat}
                 isDarkMode={isDarkMode}
-                pixelateSidebarChatTitles={pixelateSidebarChatTitles}
+                blurSidebarChatTitles={blurSidebarChatTitles}
                 createNewChat={createNewChat}
                 handleChatSelect={handleChatSelect}
                 onOpenChatById={(chatId) => loadChatById(chatId, false)}

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -1191,7 +1191,12 @@ export function ChatInterface({
     const handlePixelateSidebarChatTitlesStorageChange = (
       event: StorageEvent,
     ) => {
-      if (event.key !== SETTINGS_PIXELATE_SIDEBAR_CHAT_TITLES_ENABLED) return
+      if (
+        event.key !== null &&
+        event.key !== SETTINGS_PIXELATE_SIDEBAR_CHAT_TITLES_ENABLED
+      ) {
+        return
+      }
       setPixelateSidebarChatTitles(
         event.newValue === null ? true : event.newValue === 'true',
       )

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -4,8 +4,9 @@ import {
   getSystemPromptAndRules,
   type BaseModel,
 } from '@/config/models'
+import { BLUR_SIDEBAR_CHAT_TITLES_CHANGED_EVENT } from '@/constants/settings-events'
 import {
-  SETTINGS_BLUR_SIDEBAR_CHAT_TITLES,
+  SETTINGS_BLUR_SIDEBAR_CHAT_TITLES_ENABLED,
   SETTINGS_CODE_EXECUTION_ENABLED,
   SETTINGS_GENUI_ENABLED,
   SETTINGS_HAS_SEEN_ONBOARDING,
@@ -498,7 +499,9 @@ export function ChatInterface({
 
   const [blurSidebarChatTitles, setBlurSidebarChatTitles] = useState(() => {
     if (typeof window === 'undefined') return true
-    const saved = localStorage.getItem(SETTINGS_BLUR_SIDEBAR_CHAT_TITLES)
+    const saved = localStorage.getItem(
+      SETTINGS_BLUR_SIDEBAR_CHAT_TITLES_ENABLED,
+    )
     return saved === null ? true : saved === 'true'
   })
 
@@ -1184,7 +1187,7 @@ export function ChatInterface({
       setBlurSidebarChatTitles(event.detail.enabled)
     }
     const handleBlurSidebarChatTitlesStorageChange = (event: StorageEvent) => {
-      if (event.key !== SETTINGS_BLUR_SIDEBAR_CHAT_TITLES) return
+      if (event.key !== SETTINGS_BLUR_SIDEBAR_CHAT_TITLES_ENABLED) return
       setBlurSidebarChatTitles(
         event.newValue === null ? true : event.newValue === 'true',
       )
@@ -1195,7 +1198,7 @@ export function ChatInterface({
       handlePiiCheckChange as EventListener,
     )
     window.addEventListener(
-      'blurSidebarChatTitlesChanged',
+      BLUR_SIDEBAR_CHAT_TITLES_CHANGED_EVENT,
       handleBlurSidebarChatTitlesChange as EventListener,
     )
     window.addEventListener('storage', handleBlurSidebarChatTitlesStorageChange)
@@ -1206,7 +1209,7 @@ export function ChatInterface({
         handlePiiCheckChange as EventListener,
       )
       window.removeEventListener(
-        'blurSidebarChatTitlesChanged',
+        BLUR_SIDEBAR_CHAT_TITLES_CHANGED_EVENT,
         handleBlurSidebarChatTitlesChange as EventListener,
       )
       window.removeEventListener(

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -10,6 +10,7 @@ import {
   SETTINGS_HAS_SEEN_ONBOARDING,
   SETTINGS_HAS_SEEN_WEB_SEARCH_INTRO,
   SETTINGS_PII_CHECK_ENABLED,
+  SETTINGS_PIXELATE_SIDEBAR_CHAT_TITLES,
   SETTINGS_WEB_SEARCH_AVAILABLE,
   UI_EXPAND_PROJECT_DOCUMENTS,
 } from '@/constants/storage-keys'
@@ -494,6 +495,14 @@ export function ChatInterface({
     const saved = localStorage.getItem(SETTINGS_PII_CHECK_ENABLED)
     return saved === null ? true : saved === 'true'
   })
+
+  const [pixelateSidebarChatTitles, setPixelateSidebarChatTitles] = useState(
+    () => {
+      if (typeof window === 'undefined') return true
+      const saved = localStorage.getItem(SETTINGS_PIXELATE_SIDEBAR_CHAT_TITLES)
+      return saved === null ? true : saved === 'true'
+    },
+  )
 
   // Generative UI setting (controlled from settings modal, defaults to on)
   const [genUIEnabled, setGenUIEnabled] = useState(() => {
@@ -1166,21 +1175,50 @@ export function ChatInterface({
     }
   }, [])
 
-  // Listen for PII check setting changes from settings modal
+  // Listen for privacy setting changes from settings modal
   useEffect(() => {
     const handlePiiCheckChange = (event: CustomEvent<{ enabled: boolean }>) => {
       setPiiCheckEnabled(event.detail.enabled)
+    }
+    const handlePixelateSidebarChatTitlesChange = (
+      event: CustomEvent<{ enabled: boolean }>,
+    ) => {
+      setPixelateSidebarChatTitles(event.detail.enabled)
+    }
+    const handlePixelateSidebarChatTitlesStorageChange = (
+      event: StorageEvent,
+    ) => {
+      if (event.key !== SETTINGS_PIXELATE_SIDEBAR_CHAT_TITLES) return
+      setPixelateSidebarChatTitles(
+        event.newValue === null ? true : event.newValue === 'true',
+      )
     }
 
     window.addEventListener(
       'piiCheckEnabledChanged',
       handlePiiCheckChange as EventListener,
     )
+    window.addEventListener(
+      'pixelateSidebarChatTitlesChanged',
+      handlePixelateSidebarChatTitlesChange as EventListener,
+    )
+    window.addEventListener(
+      'storage',
+      handlePixelateSidebarChatTitlesStorageChange,
+    )
 
     return () => {
       window.removeEventListener(
         'piiCheckEnabledChanged',
         handlePiiCheckChange as EventListener,
+      )
+      window.removeEventListener(
+        'pixelateSidebarChatTitlesChanged',
+        handlePixelateSidebarChatTitlesChange as EventListener,
+      )
+      window.removeEventListener(
+        'storage',
+        handlePixelateSidebarChatTitlesStorageChange,
       )
     }
   }, [])
@@ -3041,6 +3079,7 @@ export function ChatInterface({
                   setIsOpen={setIsSidebarOpen}
                   project={activeProject}
                   isDarkMode={isDarkMode}
+                  pixelateSidebarChatTitles={pixelateSidebarChatTitles}
                   onExitProject={handleExitProject}
                   onExitProjectWhileDragging={handleExitProjectWhileDragging}
                   onNewChat={() => createNewChat(false, true)}
@@ -3084,6 +3123,7 @@ export function ChatInterface({
                   projectName={loadingProject?.name}
                   isLoading={true}
                   isDarkMode={isDarkMode}
+                  pixelateSidebarChatTitles={pixelateSidebarChatTitles}
                   onExitProject={handleExitProject}
                   onExitProjectWhileDragging={handleExitProjectWhileDragging}
                   onNewChat={() => {}}
@@ -3109,6 +3149,7 @@ export function ChatInterface({
                 chats={chats}
                 currentChat={currentChat}
                 isDarkMode={isDarkMode}
+                pixelateSidebarChatTitles={pixelateSidebarChatTitles}
                 createNewChat={createNewChat}
                 handleChatSelect={handleChatSelect}
                 onOpenChatById={(chatId) => loadChatById(chatId, false)}

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -4,14 +4,14 @@ import {
   getSystemPromptAndRules,
   type BaseModel,
 } from '@/config/models'
-import { BLUR_SIDEBAR_CHAT_TITLES_CHANGED_EVENT } from '@/constants/settings-events'
+import { PIXELATE_SIDEBAR_CHAT_TITLES_CHANGED_EVENT } from '@/constants/settings-events'
 import {
-  SETTINGS_BLUR_SIDEBAR_CHAT_TITLES_ENABLED,
   SETTINGS_CODE_EXECUTION_ENABLED,
   SETTINGS_GENUI_ENABLED,
   SETTINGS_HAS_SEEN_ONBOARDING,
   SETTINGS_HAS_SEEN_WEB_SEARCH_INTRO,
   SETTINGS_PII_CHECK_ENABLED,
+  SETTINGS_PIXELATE_SIDEBAR_CHAT_TITLES_ENABLED,
   SETTINGS_WEB_SEARCH_AVAILABLE,
   UI_EXPAND_PROJECT_DOCUMENTS,
 } from '@/constants/storage-keys'
@@ -497,13 +497,15 @@ export function ChatInterface({
     return saved === null ? true : saved === 'true'
   })
 
-  const [blurSidebarChatTitles, setBlurSidebarChatTitles] = useState(() => {
-    if (typeof window === 'undefined') return true
-    const saved = localStorage.getItem(
-      SETTINGS_BLUR_SIDEBAR_CHAT_TITLES_ENABLED,
-    )
-    return saved === null ? true : saved === 'true'
-  })
+  const [pixelateSidebarChatTitles, setPixelateSidebarChatTitles] = useState(
+    () => {
+      if (typeof window === 'undefined') return true
+      const saved = localStorage.getItem(
+        SETTINGS_PIXELATE_SIDEBAR_CHAT_TITLES_ENABLED,
+      )
+      return saved === null ? true : saved === 'true'
+    },
+  )
 
   // Generative UI setting (controlled from settings modal, defaults to on)
   const [genUIEnabled, setGenUIEnabled] = useState(() => {
@@ -1181,14 +1183,16 @@ export function ChatInterface({
     const handlePiiCheckChange = (event: CustomEvent<{ enabled: boolean }>) => {
       setPiiCheckEnabled(event.detail.enabled)
     }
-    const handleBlurSidebarChatTitlesChange = (
+    const handlePixelateSidebarChatTitlesChange = (
       event: CustomEvent<{ enabled: boolean }>,
     ) => {
-      setBlurSidebarChatTitles(event.detail.enabled)
+      setPixelateSidebarChatTitles(event.detail.enabled)
     }
-    const handleBlurSidebarChatTitlesStorageChange = (event: StorageEvent) => {
-      if (event.key !== SETTINGS_BLUR_SIDEBAR_CHAT_TITLES_ENABLED) return
-      setBlurSidebarChatTitles(
+    const handlePixelateSidebarChatTitlesStorageChange = (
+      event: StorageEvent,
+    ) => {
+      if (event.key !== SETTINGS_PIXELATE_SIDEBAR_CHAT_TITLES_ENABLED) return
+      setPixelateSidebarChatTitles(
         event.newValue === null ? true : event.newValue === 'true',
       )
     }
@@ -1198,10 +1202,13 @@ export function ChatInterface({
       handlePiiCheckChange as EventListener,
     )
     window.addEventListener(
-      BLUR_SIDEBAR_CHAT_TITLES_CHANGED_EVENT,
-      handleBlurSidebarChatTitlesChange as EventListener,
+      PIXELATE_SIDEBAR_CHAT_TITLES_CHANGED_EVENT,
+      handlePixelateSidebarChatTitlesChange as EventListener,
     )
-    window.addEventListener('storage', handleBlurSidebarChatTitlesStorageChange)
+    window.addEventListener(
+      'storage',
+      handlePixelateSidebarChatTitlesStorageChange,
+    )
 
     return () => {
       window.removeEventListener(
@@ -1209,12 +1216,12 @@ export function ChatInterface({
         handlePiiCheckChange as EventListener,
       )
       window.removeEventListener(
-        BLUR_SIDEBAR_CHAT_TITLES_CHANGED_EVENT,
-        handleBlurSidebarChatTitlesChange as EventListener,
+        PIXELATE_SIDEBAR_CHAT_TITLES_CHANGED_EVENT,
+        handlePixelateSidebarChatTitlesChange as EventListener,
       )
       window.removeEventListener(
         'storage',
-        handleBlurSidebarChatTitlesStorageChange,
+        handlePixelateSidebarChatTitlesStorageChange,
       )
     }
   }, [])
@@ -3075,7 +3082,7 @@ export function ChatInterface({
                   setIsOpen={setIsSidebarOpen}
                   project={activeProject}
                   isDarkMode={isDarkMode}
-                  blurSidebarChatTitles={blurSidebarChatTitles}
+                  pixelateSidebarChatTitles={pixelateSidebarChatTitles}
                   onExitProject={handleExitProject}
                   onExitProjectWhileDragging={handleExitProjectWhileDragging}
                   onNewChat={() => createNewChat(false, true)}
@@ -3119,7 +3126,7 @@ export function ChatInterface({
                   projectName={loadingProject?.name}
                   isLoading={true}
                   isDarkMode={isDarkMode}
-                  blurSidebarChatTitles={blurSidebarChatTitles}
+                  pixelateSidebarChatTitles={pixelateSidebarChatTitles}
                   onExitProject={handleExitProject}
                   onExitProjectWhileDragging={handleExitProjectWhileDragging}
                   onNewChat={() => {}}
@@ -3145,7 +3152,7 @@ export function ChatInterface({
                 chats={chats}
                 currentChat={currentChat}
                 isDarkMode={isDarkMode}
-                blurSidebarChatTitles={blurSidebarChatTitles}
+                pixelateSidebarChatTitles={pixelateSidebarChatTitles}
                 createNewChat={createNewChat}
                 handleChatSelect={handleChatSelect}
                 onOpenChatById={(chatId) => loadChatById(chatId, false)}

--- a/src/components/chat/chat-list-item.tsx
+++ b/src/components/chat/chat-list-item.tsx
@@ -17,6 +17,7 @@ import { useEffect, useId, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { CiFloppyDisk } from 'react-icons/ci'
 import { FaLock } from '../icons/lazy-icons'
+import { PixelatedText } from '../ui/pixelated-text'
 import { cn } from '../ui/utils'
 import { formatRelativeTime } from './chat-list-utils'
 import { TypingAnimation } from './typing-animation'
@@ -63,7 +64,7 @@ interface ChatListItemProps {
   isEditing: boolean
   editingTitle: string
   isDarkMode: boolean
-  blurSidebarChatTitles?: boolean
+  pixelateSidebarChatTitles?: boolean
   showEncryptionStatus?: boolean
   showSyncStatus?: boolean
   /**
@@ -149,7 +150,7 @@ export function ChatListItem({
   isEditing,
   editingTitle,
   isDarkMode,
-  blurSidebarChatTitles = true,
+  pixelateSidebarChatTitles = true,
   showEncryptionStatus = false,
   showSyncStatus = false,
   isStreaming = false,
@@ -190,8 +191,8 @@ export function ChatListItem({
   const messageCount = chat.messages?.length ?? chat.messageCount ?? 0
   const isNewChat = messageCount === 0 && !chat.decryptionFailed
   const hasRealTitle = !chat.isBlankChat && !chat.decryptionFailed
-  const shouldBlurTitle =
-    blurSidebarChatTitles && hasRealTitle && !isNewChat && !isSelected
+  const shouldPixelateTitle =
+    pixelateSidebarChatTitles && hasRealTitle && !isNewChat && !isSelected
 
   useEffect(() => {
     if (
@@ -380,13 +381,15 @@ export function ChatListItem({
                   aria-hidden="true"
                 />
               )}
-              <span
+              <PixelatedText
+                text={displayTitle}
+                active={shouldPixelateTitle}
+                renderKey={isDarkMode}
                 className={cn(
-                  'truncate font-aeonik-fono text-sm font-medium transition-[filter]',
+                  'truncate font-aeonik-fono text-sm font-medium',
                   chat.decryptionFailed
                     ? 'text-orange-500'
                     : 'text-content-primary',
-                  shouldBlurTitle && 'sidebar-chat-title-motion-blurred',
                 )}
               >
                 {chat.decryptionFailed ? (
@@ -400,7 +403,7 @@ export function ChatListItem({
                 ) : (
                   displayTitle
                 )}
-              </span>
+              </PixelatedText>
               {isStreaming ? (
                 <span
                   className="mx-2 flex w-[18px] flex-shrink-0 items-center justify-center"

--- a/src/components/chat/chat-list-item.tsx
+++ b/src/components/chat/chat-list-item.tsx
@@ -377,10 +377,13 @@ export function ChatListItem({
               )}
               <span
                 className={cn(
-                  'truncate font-aeonik-fono text-sm font-medium',
+                  'truncate font-aeonik-fono text-sm font-medium transition-[filter]',
                   chat.decryptionFailed
                     ? 'text-orange-500'
                     : 'text-content-primary',
+                  !chat.isBlankChat &&
+                    !chat.decryptionFailed &&
+                    'blur-sm group-focus-within:blur-none group-hover:blur-none',
                 )}
               >
                 {chat.decryptionFailed ? (

--- a/src/components/chat/chat-list-item.tsx
+++ b/src/components/chat/chat-list-item.tsx
@@ -383,6 +383,7 @@ export function ChatListItem({
                     : 'text-content-primary',
                   !chat.isBlankChat &&
                     !chat.decryptionFailed &&
+                    !isSelected &&
                     'blur-sm group-focus-within:blur-none group-hover:blur-none',
                 )}
               >

--- a/src/components/chat/chat-list-item.tsx
+++ b/src/components/chat/chat-list-item.tsx
@@ -21,6 +21,12 @@ import { cn } from '../ui/utils'
 import { formatRelativeTime } from './chat-list-utils'
 import { TypingAnimation } from './typing-animation'
 
+const TITLE_PIXEL = '■'
+
+function pixelateTitle(title: string): string {
+  return title.replace(/\S/g, TITLE_PIXEL)
+}
+
 export interface ChatItemData {
   id: string
   title: string
@@ -63,6 +69,7 @@ interface ChatListItemProps {
   isEditing: boolean
   editingTitle: string
   isDarkMode: boolean
+  pixelateSidebarChatTitles?: boolean
   showEncryptionStatus?: boolean
   showSyncStatus?: boolean
   /**
@@ -148,6 +155,7 @@ export function ChatListItem({
   isEditing,
   editingTitle,
   isDarkMode,
+  pixelateSidebarChatTitles = true,
   showEncryptionStatus = false,
   showSyncStatus = false,
   isStreaming = false,
@@ -187,6 +195,9 @@ export function ChatListItem({
 
   const messageCount = chat.messages?.length ?? chat.messageCount ?? 0
   const isNewChat = messageCount === 0 && !chat.decryptionFailed
+  const hasRealTitle = !chat.isBlankChat && !chat.decryptionFailed
+  const shouldPixelateTitle =
+    pixelateSidebarChatTitles && hasRealTitle && !isSelected
 
   useEffect(() => {
     if (
@@ -376,28 +387,30 @@ export function ChatListItem({
                 />
               )}
               <span
+                data-pixelated-title={
+                  shouldPixelateTitle ? pixelateTitle(displayTitle) : undefined
+                }
                 className={cn(
-                  'truncate font-aeonik-fono text-sm font-medium transition-[filter]',
+                  'truncate font-aeonik-fono text-sm font-medium',
                   chat.decryptionFailed
                     ? 'text-orange-500'
                     : 'text-content-primary',
-                  !chat.isBlankChat &&
-                    !chat.decryptionFailed &&
-                    !isSelected &&
-                    'blur-sm group-focus-within:blur-none group-hover:blur-none',
+                  shouldPixelateTitle && 'sidebar-chat-title-pixelated',
                 )}
               >
-                {chat.decryptionFailed ? (
-                  'Encrypted'
-                ) : isAnimating ? (
-                  <TypingAnimation
-                    fromText={animationFromTitle}
-                    toText={animationToTitle}
-                    onComplete={handleAnimationComplete}
-                  />
-                ) : (
-                  displayTitle
-                )}
+                <span className="sidebar-chat-title-text">
+                  {chat.decryptionFailed ? (
+                    'Encrypted'
+                  ) : isAnimating ? (
+                    <TypingAnimation
+                      fromText={animationFromTitle}
+                      toText={animationToTitle}
+                      onComplete={handleAnimationComplete}
+                    />
+                  ) : (
+                    displayTitle
+                  )}
+                </span>
               </span>
               {isStreaming ? (
                 <span
@@ -492,7 +505,7 @@ export function ChatListItem({
       {!isEditing && (
         <div className="flex flex-shrink-0 items-center gap-1.5">
           <div className="pointer-events-none hidden items-center opacity-0 transition-opacity md:flex md:group-focus-within:pointer-events-auto md:group-focus-within:opacity-100 md:group-hover:pointer-events-auto md:group-hover:opacity-100">
-            {!chat.decryptionFailed && !chat.isBlankChat && (
+            {hasRealTitle && (
               <button
                 type="button"
                 className={cn(

--- a/src/components/chat/chat-list-item.tsx
+++ b/src/components/chat/chat-list-item.tsx
@@ -195,6 +195,13 @@ export function ChatListItem({
     pixelateSidebarChatTitles && hasRealTitle && !isNewChat && !isSelected
 
   useEffect(() => {
+    if (shouldPixelateTitle) {
+      setDisplayTitle(chat.title)
+      setIsAnimating(false)
+      prevTitleRef.current = chat.title
+      return
+    }
+
     if (
       enableTitleAnimation &&
       prevTitleRef.current !== chat.title &&
@@ -208,7 +215,7 @@ export function ChatListItem({
       setDisplayTitle(chat.title)
       prevTitleRef.current = chat.title
     }
-  }, [chat.title, enableTitleAnimation])
+  }, [chat.title, enableTitleAnimation, shouldPixelateTitle])
 
   const handleAnimationComplete = () => {
     setDisplayTitle(chat.title)

--- a/src/components/chat/chat-list-item.tsx
+++ b/src/components/chat/chat-list-item.tsx
@@ -190,7 +190,8 @@ export function ChatListItem({
   const messageCount = chat.messages?.length ?? chat.messageCount ?? 0
   const isNewChat = messageCount === 0 && !chat.decryptionFailed
   const hasRealTitle = !chat.isBlankChat && !chat.decryptionFailed
-  const shouldBlurTitle = blurSidebarChatTitles && hasRealTitle && !isSelected
+  const shouldBlurTitle =
+    blurSidebarChatTitles && hasRealTitle && !isNewChat && !isSelected
 
   useEffect(() => {
     if (

--- a/src/components/chat/chat-list-item.tsx
+++ b/src/components/chat/chat-list-item.tsx
@@ -385,7 +385,7 @@ export function ChatListItem({
                   chat.decryptionFailed
                     ? 'text-orange-500'
                     : 'text-content-primary',
-                  shouldBlurTitle && 'sidebar-chat-title-blurred',
+                  shouldBlurTitle && 'sidebar-chat-title-motion-blurred',
                 )}
               >
                 {chat.decryptionFailed ? (

--- a/src/components/chat/chat-list-item.tsx
+++ b/src/components/chat/chat-list-item.tsx
@@ -64,7 +64,7 @@ interface ChatListItemProps {
   isEditing: boolean
   editingTitle: string
   isDarkMode: boolean
-  pixelateSidebarChatTitles?: boolean
+  pixelateSidebarChatTitles: boolean
   showEncryptionStatus?: boolean
   showSyncStatus?: boolean
   /**
@@ -150,7 +150,7 @@ export function ChatListItem({
   isEditing,
   editingTitle,
   isDarkMode,
-  pixelateSidebarChatTitles = true,
+  pixelateSidebarChatTitles,
   showEncryptionStatus = false,
   showSyncStatus = false,
   isStreaming = false,

--- a/src/components/chat/chat-list-item.tsx
+++ b/src/components/chat/chat-list-item.tsx
@@ -21,12 +21,6 @@ import { cn } from '../ui/utils'
 import { formatRelativeTime } from './chat-list-utils'
 import { TypingAnimation } from './typing-animation'
 
-const TITLE_PIXEL = '■'
-
-function pixelateTitle(title: string): string {
-  return title.replace(/\S/g, TITLE_PIXEL)
-}
-
 export interface ChatItemData {
   id: string
   title: string
@@ -69,7 +63,7 @@ interface ChatListItemProps {
   isEditing: boolean
   editingTitle: string
   isDarkMode: boolean
-  pixelateSidebarChatTitles?: boolean
+  blurSidebarChatTitles?: boolean
   showEncryptionStatus?: boolean
   showSyncStatus?: boolean
   /**
@@ -155,7 +149,7 @@ export function ChatListItem({
   isEditing,
   editingTitle,
   isDarkMode,
-  pixelateSidebarChatTitles = true,
+  blurSidebarChatTitles = true,
   showEncryptionStatus = false,
   showSyncStatus = false,
   isStreaming = false,
@@ -196,8 +190,7 @@ export function ChatListItem({
   const messageCount = chat.messages?.length ?? chat.messageCount ?? 0
   const isNewChat = messageCount === 0 && !chat.decryptionFailed
   const hasRealTitle = !chat.isBlankChat && !chat.decryptionFailed
-  const shouldPixelateTitle =
-    pixelateSidebarChatTitles && hasRealTitle && !isSelected
+  const shouldBlurTitle = blurSidebarChatTitles && hasRealTitle && !isSelected
 
   useEffect(() => {
     if (
@@ -387,30 +380,25 @@ export function ChatListItem({
                 />
               )}
               <span
-                data-pixelated-title={
-                  shouldPixelateTitle ? pixelateTitle(displayTitle) : undefined
-                }
                 className={cn(
-                  'truncate font-aeonik-fono text-sm font-medium',
+                  'truncate font-aeonik-fono text-sm font-medium transition-[filter]',
                   chat.decryptionFailed
                     ? 'text-orange-500'
                     : 'text-content-primary',
-                  shouldPixelateTitle && 'sidebar-chat-title-pixelated',
+                  shouldBlurTitle && 'sidebar-chat-title-blurred',
                 )}
               >
-                <span className="sidebar-chat-title-text">
-                  {chat.decryptionFailed ? (
-                    'Encrypted'
-                  ) : isAnimating ? (
-                    <TypingAnimation
-                      fromText={animationFromTitle}
-                      toText={animationToTitle}
-                      onComplete={handleAnimationComplete}
-                    />
-                  ) : (
-                    displayTitle
-                  )}
-                </span>
+                {chat.decryptionFailed ? (
+                  'Encrypted'
+                ) : isAnimating ? (
+                  <TypingAnimation
+                    fromText={animationFromTitle}
+                    toText={animationToTitle}
+                    onComplete={handleAnimationComplete}
+                  />
+                ) : (
+                  displayTitle
+                )}
               </span>
               {isStreaming ? (
                 <span

--- a/src/components/chat/chat-list.tsx
+++ b/src/components/chat/chat-list.tsx
@@ -13,6 +13,9 @@ import {
 } from './chat-list-item'
 import { DeleteConfirmation } from './delete-confirmation'
 
+const SIDEBAR_CHAT_TITLE_BLUR_FILTER_ID = 'sidebar-chat-title-horizontal-blur'
+const SIDEBAR_CHAT_TITLE_BLUR_STD_DEVIATION = '1.5 0.15'
+
 function Shimmer({ className }: { className?: string }) {
   return (
     <div
@@ -200,7 +203,28 @@ export function ChatList({
 
   return (
     <>
-      <div role="list" className="space-y-2 p-2">
+      <svg aria-hidden="true" className="absolute h-0 w-0" focusable="false">
+        <defs>
+          <filter
+            id={SIDEBAR_CHAT_TITLE_BLUR_FILTER_ID}
+            colorInterpolationFilters="sRGB"
+          >
+            <feGaussianBlur
+              in="SourceGraphic"
+              stdDeviation={SIDEBAR_CHAT_TITLE_BLUR_STD_DEVIATION}
+            />
+          </filter>
+        </defs>
+      </svg>
+      <div
+        role="list"
+        className="space-y-2 p-2"
+        style={
+          {
+            '--sidebar-chat-title-blur-filter': `url(#${SIDEBAR_CHAT_TITLE_BLUR_FILTER_ID})`,
+          } as React.CSSProperties
+        }
+      >
         {lastBlankIndex < 0 && loadingIndicator}
         {visibleChats.map((chat, index) => (
           <Fragment key={getChatKey(chat)}>

--- a/src/components/chat/chat-list.tsx
+++ b/src/components/chat/chat-list.tsx
@@ -27,7 +27,7 @@ interface ChatListProps {
   currentChatIsBlank?: boolean
   currentChatIsLocalOnly?: boolean
   isDarkMode: boolean
-  pixelateSidebarChatTitles?: boolean
+  pixelateSidebarChatTitles: boolean
   isLoading?: boolean
   showEncryptionStatus?: boolean
   showSyncStatus?: boolean
@@ -64,7 +64,7 @@ export function ChatList({
   currentChatIsBlank,
   currentChatIsLocalOnly,
   isDarkMode,
-  pixelateSidebarChatTitles = true,
+  pixelateSidebarChatTitles,
   isLoading = false,
   showEncryptionStatus = false,
   showSyncStatus = false,

--- a/src/components/chat/chat-list.tsx
+++ b/src/components/chat/chat-list.tsx
@@ -27,7 +27,7 @@ interface ChatListProps {
   currentChatIsBlank?: boolean
   currentChatIsLocalOnly?: boolean
   isDarkMode: boolean
-  pixelateSidebarChatTitles?: boolean
+  blurSidebarChatTitles?: boolean
   isLoading?: boolean
   showEncryptionStatus?: boolean
   showSyncStatus?: boolean
@@ -64,7 +64,7 @@ export function ChatList({
   currentChatIsBlank,
   currentChatIsLocalOnly,
   isDarkMode,
-  pixelateSidebarChatTitles = true,
+  blurSidebarChatTitles = true,
   isLoading = false,
   showEncryptionStatus = false,
   showSyncStatus = false,
@@ -211,7 +211,7 @@ export function ChatList({
                 isEditing={editingChatId === chat.id}
                 editingTitle={editingTitle}
                 isDarkMode={isDarkMode}
-                pixelateSidebarChatTitles={pixelateSidebarChatTitles}
+                blurSidebarChatTitles={blurSidebarChatTitles}
                 showEncryptionStatus={showEncryptionStatus}
                 showSyncStatus={showSyncStatus}
                 isStreaming={!chat.isBlankChat && streamingChats.has(chat.id)}

--- a/src/components/chat/chat-list.tsx
+++ b/src/components/chat/chat-list.tsx
@@ -200,7 +200,7 @@ export function ChatList({
 
   return (
     <>
-      <div role="list" className="space-y-2 p-2">
+      <div role="list" className="chat-title-privacy-region space-y-2 p-2">
         {lastBlankIndex < 0 && loadingIndicator}
         {visibleChats.map((chat, index) => (
           <Fragment key={getChatKey(chat)}>

--- a/src/components/chat/chat-list.tsx
+++ b/src/components/chat/chat-list.tsx
@@ -13,9 +13,6 @@ import {
 } from './chat-list-item'
 import { DeleteConfirmation } from './delete-confirmation'
 
-const SIDEBAR_CHAT_TITLE_BLUR_FILTER_ID = 'sidebar-chat-title-horizontal-blur'
-const SIDEBAR_CHAT_TITLE_BLUR_STD_DEVIATION = '2.25 0.2'
-
 function Shimmer({ className }: { className?: string }) {
   return (
     <div
@@ -30,7 +27,7 @@ interface ChatListProps {
   currentChatIsBlank?: boolean
   currentChatIsLocalOnly?: boolean
   isDarkMode: boolean
-  blurSidebarChatTitles?: boolean
+  pixelateSidebarChatTitles?: boolean
   isLoading?: boolean
   showEncryptionStatus?: boolean
   showSyncStatus?: boolean
@@ -67,7 +64,7 @@ export function ChatList({
   currentChatIsBlank,
   currentChatIsLocalOnly,
   isDarkMode,
-  blurSidebarChatTitles = true,
+  pixelateSidebarChatTitles = true,
   isLoading = false,
   showEncryptionStatus = false,
   showSyncStatus = false,
@@ -203,28 +200,7 @@ export function ChatList({
 
   return (
     <>
-      <svg aria-hidden="true" className="absolute h-0 w-0" focusable="false">
-        <defs>
-          <filter
-            id={SIDEBAR_CHAT_TITLE_BLUR_FILTER_ID}
-            colorInterpolationFilters="sRGB"
-          >
-            <feGaussianBlur
-              in="SourceGraphic"
-              stdDeviation={SIDEBAR_CHAT_TITLE_BLUR_STD_DEVIATION}
-            />
-          </filter>
-        </defs>
-      </svg>
-      <div
-        role="list"
-        className="space-y-2 p-2"
-        style={
-          {
-            '--sidebar-chat-title-blur-filter': `url(#${SIDEBAR_CHAT_TITLE_BLUR_FILTER_ID})`,
-          } as React.CSSProperties
-        }
-      >
+      <div role="list" className="space-y-2 p-2">
         {lastBlankIndex < 0 && loadingIndicator}
         {visibleChats.map((chat, index) => (
           <Fragment key={getChatKey(chat)}>
@@ -235,7 +211,7 @@ export function ChatList({
                 isEditing={editingChatId === chat.id}
                 editingTitle={editingTitle}
                 isDarkMode={isDarkMode}
-                blurSidebarChatTitles={blurSidebarChatTitles}
+                pixelateSidebarChatTitles={pixelateSidebarChatTitles}
                 showEncryptionStatus={showEncryptionStatus}
                 showSyncStatus={showSyncStatus}
                 isStreaming={!chat.isBlankChat && streamingChats.has(chat.id)}

--- a/src/components/chat/chat-list.tsx
+++ b/src/components/chat/chat-list.tsx
@@ -27,6 +27,7 @@ interface ChatListProps {
   currentChatIsBlank?: boolean
   currentChatIsLocalOnly?: boolean
   isDarkMode: boolean
+  pixelateSidebarChatTitles?: boolean
   isLoading?: boolean
   showEncryptionStatus?: boolean
   showSyncStatus?: boolean
@@ -63,6 +64,7 @@ export function ChatList({
   currentChatIsBlank,
   currentChatIsLocalOnly,
   isDarkMode,
+  pixelateSidebarChatTitles = true,
   isLoading = false,
   showEncryptionStatus = false,
   showSyncStatus = false,
@@ -209,6 +211,7 @@ export function ChatList({
                 isEditing={editingChatId === chat.id}
                 editingTitle={editingTitle}
                 isDarkMode={isDarkMode}
+                pixelateSidebarChatTitles={pixelateSidebarChatTitles}
                 showEncryptionStatus={showEncryptionStatus}
                 showSyncStatus={showSyncStatus}
                 isStreaming={!chat.isBlankChat && streamingChats.has(chat.id)}

--- a/src/components/chat/chat-list.tsx
+++ b/src/components/chat/chat-list.tsx
@@ -14,7 +14,7 @@ import {
 import { DeleteConfirmation } from './delete-confirmation'
 
 const SIDEBAR_CHAT_TITLE_BLUR_FILTER_ID = 'sidebar-chat-title-horizontal-blur'
-const SIDEBAR_CHAT_TITLE_BLUR_STD_DEVIATION = '1.5 0.15'
+const SIDEBAR_CHAT_TITLE_BLUR_STD_DEVIATION = '2.25 0.2'
 
 function Shimmer({ className }: { className?: string }) {
   return (

--- a/src/components/chat/chat-sidebar.tsx
+++ b/src/components/chat/chat-sidebar.tsx
@@ -960,7 +960,7 @@ export function ChatSidebar({
         aria-label="Chat history"
         inert={!isOpen}
         className={cn(
-          'fixed z-40 flex h-dvh flex-col overflow-hidden border-r',
+          'chat-title-privacy-region fixed z-40 flex h-dvh flex-col overflow-hidden border-r',
           // On mobile: slide in/out. On desktop: always positioned, just toggle width
           isMobile
             ? isOpen

--- a/src/components/chat/chat-sidebar.tsx
+++ b/src/components/chat/chat-sidebar.tsx
@@ -87,7 +87,7 @@ type ChatSidebarProps = {
   chats: Chat[]
   currentChat: Chat
   isDarkMode: boolean
-  blurSidebarChatTitles: boolean
+  pixelateSidebarChatTitles: boolean
   createNewChat: (isLocalOnly?: boolean, fromUserAction?: boolean) => void
   handleChatSelect: (chatId: string) => void
   /**
@@ -170,7 +170,7 @@ export function ChatSidebar({
   chats,
   currentChat,
   isDarkMode,
-  blurSidebarChatTitles,
+  pixelateSidebarChatTitles,
   createNewChat,
   handleChatSelect,
   onOpenChatById,
@@ -2042,7 +2042,7 @@ export function ChatSidebar({
                       currentChatIsBlank={currentChat?.isBlankChat}
                       currentChatIsLocalOnly={currentChat?.isLocalOnly}
                       isDarkMode={isDarkMode}
-                      blurSidebarChatTitles={blurSidebarChatTitles}
+                      pixelateSidebarChatTitles={pixelateSidebarChatTitles}
                       isLoading={
                         isSearchActive &&
                         chatSearch.isSearching &&

--- a/src/components/chat/chat-sidebar.tsx
+++ b/src/components/chat/chat-sidebar.tsx
@@ -960,7 +960,7 @@ export function ChatSidebar({
         aria-label="Chat history"
         inert={!isOpen}
         className={cn(
-          'chat-title-privacy-region fixed z-40 flex h-dvh flex-col overflow-hidden border-r',
+          'fixed z-40 flex h-dvh flex-col overflow-hidden border-r',
           // On mobile: slide in/out. On desktop: always positioned, just toggle width
           isMobile
             ? isOpen

--- a/src/components/chat/chat-sidebar.tsx
+++ b/src/components/chat/chat-sidebar.tsx
@@ -87,6 +87,7 @@ type ChatSidebarProps = {
   chats: Chat[]
   currentChat: Chat
   isDarkMode: boolean
+  pixelateSidebarChatTitles: boolean
   createNewChat: (isLocalOnly?: boolean, fromUserAction?: boolean) => void
   handleChatSelect: (chatId: string) => void
   /**
@@ -169,6 +170,7 @@ export function ChatSidebar({
   chats,
   currentChat,
   isDarkMode,
+  pixelateSidebarChatTitles,
   createNewChat,
   handleChatSelect,
   onOpenChatById,
@@ -2040,6 +2042,7 @@ export function ChatSidebar({
                       currentChatIsBlank={currentChat?.isBlankChat}
                       currentChatIsLocalOnly={currentChat?.isLocalOnly}
                       isDarkMode={isDarkMode}
+                      pixelateSidebarChatTitles={pixelateSidebarChatTitles}
                       isLoading={
                         isSearchActive &&
                         chatSearch.isSearching &&

--- a/src/components/chat/chat-sidebar.tsx
+++ b/src/components/chat/chat-sidebar.tsx
@@ -87,7 +87,7 @@ type ChatSidebarProps = {
   chats: Chat[]
   currentChat: Chat
   isDarkMode: boolean
-  pixelateSidebarChatTitles: boolean
+  blurSidebarChatTitles: boolean
   createNewChat: (isLocalOnly?: boolean, fromUserAction?: boolean) => void
   handleChatSelect: (chatId: string) => void
   /**
@@ -170,7 +170,7 @@ export function ChatSidebar({
   chats,
   currentChat,
   isDarkMode,
-  pixelateSidebarChatTitles,
+  blurSidebarChatTitles,
   createNewChat,
   handleChatSelect,
   onOpenChatById,
@@ -2042,7 +2042,7 @@ export function ChatSidebar({
                       currentChatIsBlank={currentChat?.isBlankChat}
                       currentChatIsLocalOnly={currentChat?.isLocalOnly}
                       isDarkMode={isDarkMode}
-                      pixelateSidebarChatTitles={pixelateSidebarChatTitles}
+                      blurSidebarChatTitles={blurSidebarChatTitles}
                       isLoading={
                         isSearchActive &&
                         chatSearch.isSearching &&

--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -3,11 +3,11 @@ import { cn } from '@/components/ui/utils'
 import { UserAvatar } from '@/components/user-avatar'
 import { API_BASE_URL } from '@/config'
 import {
+  SETTINGS_BLUR_SIDEBAR_CHAT_TITLES,
   SETTINGS_CHAT_FONT,
   SETTINGS_CLOUD_SYNC_EXPLICITLY_DISABLED,
   SETTINGS_GENUI_ENABLED,
   SETTINGS_PII_CHECK_ENABLED,
-  SETTINGS_PIXELATE_SIDEBAR_CHAT_TITLES,
   SETTINGS_WEB_SEARCH_AVAILABLE,
   USER_PREFS_ADDITIONAL_CONTEXT,
   USER_PREFS_CUSTOM_PROMPT_ENABLED,
@@ -434,7 +434,7 @@ export function SettingsModal({
   // Web Search PII check setting (defaults to on)
   const [piiCheckEnabled, setPiiCheckEnabled] = useState<boolean>(true)
 
-  const [pixelateSidebarChatTitles, setPixelateSidebarChatTitles] =
+  const [blurSidebarChatTitles, setBlurSidebarChatTitles] =
     useState<boolean>(true)
 
   const [webSearchAvailable, setWebSearchAvailable] = useState<boolean>(true)
@@ -644,13 +644,13 @@ export function SettingsModal({
     const savedPiiCheck = localStorage.getItem(SETTINGS_PII_CHECK_ENABLED)
     setPiiCheckEnabled(savedPiiCheck === null ? true : savedPiiCheck === 'true')
 
-    const savedPixelateSidebarChatTitles = localStorage.getItem(
-      SETTINGS_PIXELATE_SIDEBAR_CHAT_TITLES,
+    const savedBlurSidebarChatTitles = localStorage.getItem(
+      SETTINGS_BLUR_SIDEBAR_CHAT_TITLES,
     )
-    setPixelateSidebarChatTitles(
-      savedPixelateSidebarChatTitles === null
+    setBlurSidebarChatTitles(
+      savedBlurSidebarChatTitles === null
         ? true
-        : savedPixelateSidebarChatTitles === 'true',
+        : savedBlurSidebarChatTitles === 'true',
     )
 
     const savedWebSearchAvailable = localStorage.getItem(
@@ -714,7 +714,7 @@ export function SettingsModal({
       handleProfileSyncUpdate,
     )
     window.addEventListener(
-      'pixelateSidebarChatTitlesChanged',
+      'blurSidebarChatTitlesChanged',
       handleProfileSyncUpdate,
     )
     window.addEventListener('cloudSyncSettingChanged', handleCloudSyncUpdate)
@@ -735,7 +735,7 @@ export function SettingsModal({
         handleProfileSyncUpdate,
       )
       window.removeEventListener(
-        'pixelateSidebarChatTitlesChanged',
+        'blurSidebarChatTitlesChanged',
         handleProfileSyncUpdate,
       )
       window.removeEventListener(
@@ -2354,29 +2354,29 @@ ${encryptionKey.replace('key_', '')}
                       <div className="flex items-start justify-between">
                         <div className="mr-3 flex-1">
                           <div className="font-aeonik text-sm font-medium text-content-primary">
-                            Pixelate sidebar chat titles
+                            Blur sidebar chat titles
                           </div>
                           <div className="font-aeonik-fono text-xs text-content-muted">
-                            Pixelate inactive chat titles until you hover over
-                            them.
+                            Subtly blur inactive chat titles until you hover
+                            over them.
                           </div>
                         </div>
                         <label className="relative inline-flex cursor-pointer items-center">
                           <input
                             type="checkbox"
-                            aria-label="Pixelate sidebar chat titles"
-                            checked={pixelateSidebarChatTitles}
+                            aria-label="Blur sidebar chat titles"
+                            checked={blurSidebarChatTitles}
                             onChange={(e) => {
                               const newValue = e.target.checked
-                              setPixelateSidebarChatTitles(newValue)
+                              setBlurSidebarChatTitles(newValue)
                               if (isClient) {
                                 localStorage.setItem(
-                                  SETTINGS_PIXELATE_SIDEBAR_CHAT_TITLES,
+                                  SETTINGS_BLUR_SIDEBAR_CHAT_TITLES,
                                   newValue.toString(),
                                 )
                                 window.dispatchEvent(
                                   new CustomEvent(
-                                    'pixelateSidebarChatTitlesChanged',
+                                    'blurSidebarChatTitlesChanged',
                                     {
                                       detail: { enabled: newValue },
                                     },

--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -2,8 +2,9 @@ import { TextureGrid } from '@/components/texture-grid'
 import { cn } from '@/components/ui/utils'
 import { UserAvatar } from '@/components/user-avatar'
 import { API_BASE_URL } from '@/config'
+import { BLUR_SIDEBAR_CHAT_TITLES_CHANGED_EVENT } from '@/constants/settings-events'
 import {
-  SETTINGS_BLUR_SIDEBAR_CHAT_TITLES,
+  SETTINGS_BLUR_SIDEBAR_CHAT_TITLES_ENABLED,
   SETTINGS_CHAT_FONT,
   SETTINGS_CLOUD_SYNC_EXPLICITLY_DISABLED,
   SETTINGS_GENUI_ENABLED,
@@ -645,7 +646,7 @@ export function SettingsModal({
     setPiiCheckEnabled(savedPiiCheck === null ? true : savedPiiCheck === 'true')
 
     const savedBlurSidebarChatTitles = localStorage.getItem(
-      SETTINGS_BLUR_SIDEBAR_CHAT_TITLES,
+      SETTINGS_BLUR_SIDEBAR_CHAT_TITLES_ENABLED,
     )
     setBlurSidebarChatTitles(
       savedBlurSidebarChatTitles === null
@@ -696,6 +697,11 @@ export function SettingsModal({
     const handleProfileSyncUpdate = () => {
       loadSettingsFromStorage()
     }
+    const handleBlurSidebarChatTitlesUpdate = (
+      event: CustomEvent<{ enabled: boolean }>,
+    ) => {
+      setBlurSidebarChatTitles(event.detail.enabled)
+    }
 
     // Listen for cloud sync setting changes (e.g., from modal or other sources)
     const handleCloudSyncUpdate = () => {
@@ -714,8 +720,8 @@ export function SettingsModal({
       handleProfileSyncUpdate,
     )
     window.addEventListener(
-      'blurSidebarChatTitlesChanged',
-      handleProfileSyncUpdate,
+      BLUR_SIDEBAR_CHAT_TITLES_CHANGED_EVENT,
+      handleBlurSidebarChatTitlesUpdate as EventListener,
     )
     window.addEventListener('cloudSyncSettingChanged', handleCloudSyncUpdate)
 
@@ -735,8 +741,8 @@ export function SettingsModal({
         handleProfileSyncUpdate,
       )
       window.removeEventListener(
-        'blurSidebarChatTitlesChanged',
-        handleProfileSyncUpdate,
+        BLUR_SIDEBAR_CHAT_TITLES_CHANGED_EVENT,
+        handleBlurSidebarChatTitlesUpdate as EventListener,
       )
       window.removeEventListener(
         'cloudSyncSettingChanged',
@@ -2371,12 +2377,12 @@ ${encryptionKey.replace('key_', '')}
                               setBlurSidebarChatTitles(newValue)
                               if (isClient) {
                                 localStorage.setItem(
-                                  SETTINGS_BLUR_SIDEBAR_CHAT_TITLES,
+                                  SETTINGS_BLUR_SIDEBAR_CHAT_TITLES_ENABLED,
                                   newValue.toString(),
                                 )
                                 window.dispatchEvent(
                                   new CustomEvent(
-                                    'blurSidebarChatTitlesChanged',
+                                    BLUR_SIDEBAR_CHAT_TITLES_CHANGED_EVENT,
                                     {
                                       detail: { enabled: newValue },
                                     },

--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -7,6 +7,7 @@ import {
   SETTINGS_CLOUD_SYNC_EXPLICITLY_DISABLED,
   SETTINGS_GENUI_ENABLED,
   SETTINGS_PII_CHECK_ENABLED,
+  SETTINGS_PIXELATE_SIDEBAR_CHAT_TITLES,
   SETTINGS_WEB_SEARCH_AVAILABLE,
   USER_PREFS_ADDITIONAL_CONTEXT,
   USER_PREFS_CUSTOM_PROMPT_ENABLED,
@@ -433,6 +434,9 @@ export function SettingsModal({
   // Web Search PII check setting (defaults to on)
   const [piiCheckEnabled, setPiiCheckEnabled] = useState<boolean>(true)
 
+  const [pixelateSidebarChatTitles, setPixelateSidebarChatTitles] =
+    useState<boolean>(true)
+
   const [webSearchAvailable, setWebSearchAvailable] = useState<boolean>(true)
 
   // Generative UI setting (defaults to on)
@@ -640,6 +644,15 @@ export function SettingsModal({
     const savedPiiCheck = localStorage.getItem(SETTINGS_PII_CHECK_ENABLED)
     setPiiCheckEnabled(savedPiiCheck === null ? true : savedPiiCheck === 'true')
 
+    const savedPixelateSidebarChatTitles = localStorage.getItem(
+      SETTINGS_PIXELATE_SIDEBAR_CHAT_TITLES,
+    )
+    setPixelateSidebarChatTitles(
+      savedPixelateSidebarChatTitles === null
+        ? true
+        : savedPixelateSidebarChatTitles === 'true',
+    )
+
     const savedWebSearchAvailable = localStorage.getItem(
       SETTINGS_WEB_SEARCH_AVAILABLE,
     )
@@ -700,6 +713,10 @@ export function SettingsModal({
       'webSearchAvailableChanged',
       handleProfileSyncUpdate,
     )
+    window.addEventListener(
+      'pixelateSidebarChatTitlesChanged',
+      handleProfileSyncUpdate,
+    )
     window.addEventListener('cloudSyncSettingChanged', handleCloudSyncUpdate)
 
     return () => {
@@ -715,6 +732,10 @@ export function SettingsModal({
       )
       window.removeEventListener(
         'webSearchAvailableChanged',
+        handleProfileSyncUpdate,
+      )
+      window.removeEventListener(
+        'pixelateSidebarChatTitlesChanged',
         handleProfileSyncUpdate,
       )
       window.removeEventListener(
@@ -2322,6 +2343,51 @@ ${encryptionKey.replace('key_', '')}
                             </span>
                           </button>
                         ))}
+                      </div>
+                    </div>
+                    <div
+                      className={cn(
+                        'rounded-lg border border-border-subtle p-4',
+                        isDarkMode ? 'bg-surface-sidebar' : 'bg-white',
+                      )}
+                    >
+                      <div className="flex items-start justify-between">
+                        <div className="mr-3 flex-1">
+                          <div className="font-aeonik text-sm font-medium text-content-primary">
+                            Pixelate sidebar chat titles
+                          </div>
+                          <div className="font-aeonik-fono text-xs text-content-muted">
+                            Pixelate inactive chat titles until you hover over
+                            them.
+                          </div>
+                        </div>
+                        <label className="relative inline-flex cursor-pointer items-center">
+                          <input
+                            type="checkbox"
+                            aria-label="Pixelate sidebar chat titles"
+                            checked={pixelateSidebarChatTitles}
+                            onChange={(e) => {
+                              const newValue = e.target.checked
+                              setPixelateSidebarChatTitles(newValue)
+                              if (isClient) {
+                                localStorage.setItem(
+                                  SETTINGS_PIXELATE_SIDEBAR_CHAT_TITLES,
+                                  newValue.toString(),
+                                )
+                                window.dispatchEvent(
+                                  new CustomEvent(
+                                    'pixelateSidebarChatTitlesChanged',
+                                    {
+                                      detail: { enabled: newValue },
+                                    },
+                                  ),
+                                )
+                              }
+                            }}
+                            className="peer sr-only"
+                          />
+                          <div className="peer h-5 w-9 rounded-full border border-border-subtle bg-content-muted/40 after:absolute after:left-[2px] after:top-[2px] after:h-4 after:w-4 after:rounded-full after:bg-content-muted/70 after:shadow-sm after:transition-all after:content-[''] peer-checked:bg-brand-accent-light peer-checked:after:translate-x-full peer-checked:after:bg-white peer-focus:outline-none peer-focus-visible:ring-2 peer-focus-visible:ring-border-strong" />
+                        </label>
                       </div>
                     </div>
                   </div>

--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -2,13 +2,13 @@ import { TextureGrid } from '@/components/texture-grid'
 import { cn } from '@/components/ui/utils'
 import { UserAvatar } from '@/components/user-avatar'
 import { API_BASE_URL } from '@/config'
-import { BLUR_SIDEBAR_CHAT_TITLES_CHANGED_EVENT } from '@/constants/settings-events'
+import { PIXELATE_SIDEBAR_CHAT_TITLES_CHANGED_EVENT } from '@/constants/settings-events'
 import {
-  SETTINGS_BLUR_SIDEBAR_CHAT_TITLES_ENABLED,
   SETTINGS_CHAT_FONT,
   SETTINGS_CLOUD_SYNC_EXPLICITLY_DISABLED,
   SETTINGS_GENUI_ENABLED,
   SETTINGS_PII_CHECK_ENABLED,
+  SETTINGS_PIXELATE_SIDEBAR_CHAT_TITLES_ENABLED,
   SETTINGS_WEB_SEARCH_AVAILABLE,
   USER_PREFS_ADDITIONAL_CONTEXT,
   USER_PREFS_CUSTOM_PROMPT_ENABLED,
@@ -435,7 +435,7 @@ export function SettingsModal({
   // Web Search PII check setting (defaults to on)
   const [piiCheckEnabled, setPiiCheckEnabled] = useState<boolean>(true)
 
-  const [blurSidebarChatTitles, setBlurSidebarChatTitles] =
+  const [pixelateSidebarChatTitles, setPixelateSidebarChatTitles] =
     useState<boolean>(true)
 
   const [webSearchAvailable, setWebSearchAvailable] = useState<boolean>(true)
@@ -645,13 +645,13 @@ export function SettingsModal({
     const savedPiiCheck = localStorage.getItem(SETTINGS_PII_CHECK_ENABLED)
     setPiiCheckEnabled(savedPiiCheck === null ? true : savedPiiCheck === 'true')
 
-    const savedBlurSidebarChatTitles = localStorage.getItem(
-      SETTINGS_BLUR_SIDEBAR_CHAT_TITLES_ENABLED,
+    const savedPixelateSidebarChatTitles = localStorage.getItem(
+      SETTINGS_PIXELATE_SIDEBAR_CHAT_TITLES_ENABLED,
     )
-    setBlurSidebarChatTitles(
-      savedBlurSidebarChatTitles === null
+    setPixelateSidebarChatTitles(
+      savedPixelateSidebarChatTitles === null
         ? true
-        : savedBlurSidebarChatTitles === 'true',
+        : savedPixelateSidebarChatTitles === 'true',
     )
 
     const savedWebSearchAvailable = localStorage.getItem(
@@ -697,10 +697,10 @@ export function SettingsModal({
     const handleProfileSyncUpdate = () => {
       loadSettingsFromStorage()
     }
-    const handleBlurSidebarChatTitlesUpdate = (
+    const handlePixelateSidebarChatTitlesUpdate = (
       event: CustomEvent<{ enabled: boolean }>,
     ) => {
-      setBlurSidebarChatTitles(event.detail.enabled)
+      setPixelateSidebarChatTitles(event.detail.enabled)
     }
 
     // Listen for cloud sync setting changes (e.g., from modal or other sources)
@@ -720,8 +720,8 @@ export function SettingsModal({
       handleProfileSyncUpdate,
     )
     window.addEventListener(
-      BLUR_SIDEBAR_CHAT_TITLES_CHANGED_EVENT,
-      handleBlurSidebarChatTitlesUpdate as EventListener,
+      PIXELATE_SIDEBAR_CHAT_TITLES_CHANGED_EVENT,
+      handlePixelateSidebarChatTitlesUpdate as EventListener,
     )
     window.addEventListener('cloudSyncSettingChanged', handleCloudSyncUpdate)
 
@@ -741,8 +741,8 @@ export function SettingsModal({
         handleProfileSyncUpdate,
       )
       window.removeEventListener(
-        BLUR_SIDEBAR_CHAT_TITLES_CHANGED_EVENT,
-        handleBlurSidebarChatTitlesUpdate as EventListener,
+        PIXELATE_SIDEBAR_CHAT_TITLES_CHANGED_EVENT,
+        handlePixelateSidebarChatTitlesUpdate as EventListener,
       )
       window.removeEventListener(
         'cloudSyncSettingChanged',
@@ -2360,29 +2360,29 @@ ${encryptionKey.replace('key_', '')}
                       <div className="flex items-start justify-between">
                         <div className="mr-3 flex-1">
                           <div className="font-aeonik text-sm font-medium text-content-primary">
-                            Blur sidebar chat titles
+                            Pixelate sidebar chat titles
                           </div>
                           <div className="font-aeonik-fono text-xs text-content-muted">
-                            Apply a horizontal blur to inactive titles until you
-                            hover over them.
+                            Pixelate inactive chat titles until you hover over
+                            them.
                           </div>
                         </div>
                         <label className="relative inline-flex cursor-pointer items-center">
                           <input
                             type="checkbox"
-                            aria-label="Blur sidebar chat titles"
-                            checked={blurSidebarChatTitles}
+                            aria-label="Pixelate sidebar chat titles"
+                            checked={pixelateSidebarChatTitles}
                             onChange={(e) => {
                               const newValue = e.target.checked
-                              setBlurSidebarChatTitles(newValue)
+                              setPixelateSidebarChatTitles(newValue)
                               if (isClient) {
                                 localStorage.setItem(
-                                  SETTINGS_BLUR_SIDEBAR_CHAT_TITLES_ENABLED,
+                                  SETTINGS_PIXELATE_SIDEBAR_CHAT_TITLES_ENABLED,
                                   newValue.toString(),
                                 )
                                 window.dispatchEvent(
                                   new CustomEvent(
-                                    BLUR_SIDEBAR_CHAT_TITLES_CHANGED_EVENT,
+                                    PIXELATE_SIDEBAR_CHAT_TITLES_CHANGED_EVENT,
                                     {
                                       detail: { enabled: newValue },
                                     },

--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -2357,8 +2357,8 @@ ${encryptionKey.replace('key_', '')}
                             Blur sidebar chat titles
                           </div>
                           <div className="font-aeonik-fono text-xs text-content-muted">
-                            Subtly blur inactive chat titles until you hover
-                            over them.
+                            Apply a horizontal blur to inactive titles until you
+                            hover over them.
                           </div>
                         </div>
                         <label className="relative inline-flex cursor-pointer items-center">

--- a/src/components/project/project-sidebar.tsx
+++ b/src/components/project/project-sidebar.tsx
@@ -96,7 +96,7 @@ interface ProjectSidebarProps {
   projectName?: string
   isLoading?: boolean
   isDarkMode: boolean
-  blurSidebarChatTitles: boolean
+  pixelateSidebarChatTitles: boolean
   onExitProject: () => void
   onExitProjectWhileDragging?: () => void
   onNewChat: () => void
@@ -266,7 +266,7 @@ export function ProjectSidebar({
   projectName,
   isLoading,
   isDarkMode,
-  blurSidebarChatTitles,
+  pixelateSidebarChatTitles,
   onExitProject,
   onExitProjectWhileDragging,
   onNewChat,
@@ -1386,7 +1386,7 @@ export function ProjectSidebar({
               currentChatId={currentChatId}
               currentChatIsBlank={!currentChatId}
               isDarkMode={isDarkMode}
-              blurSidebarChatTitles={blurSidebarChatTitles}
+              pixelateSidebarChatTitles={pixelateSidebarChatTitles}
               isLoading={isLoading}
               enableTitleAnimation={true}
               animatedDeleteConfirmation={false}

--- a/src/components/project/project-sidebar.tsx
+++ b/src/components/project/project-sidebar.tsx
@@ -96,7 +96,7 @@ interface ProjectSidebarProps {
   projectName?: string
   isLoading?: boolean
   isDarkMode: boolean
-  pixelateSidebarChatTitles: boolean
+  blurSidebarChatTitles: boolean
   onExitProject: () => void
   onExitProjectWhileDragging?: () => void
   onNewChat: () => void
@@ -266,7 +266,7 @@ export function ProjectSidebar({
   projectName,
   isLoading,
   isDarkMode,
-  pixelateSidebarChatTitles,
+  blurSidebarChatTitles,
   onExitProject,
   onExitProjectWhileDragging,
   onNewChat,
@@ -1386,7 +1386,7 @@ export function ProjectSidebar({
               currentChatId={currentChatId}
               currentChatIsBlank={!currentChatId}
               isDarkMode={isDarkMode}
-              pixelateSidebarChatTitles={pixelateSidebarChatTitles}
+              blurSidebarChatTitles={blurSidebarChatTitles}
               isLoading={isLoading}
               enableTitleAnimation={true}
               animatedDeleteConfirmation={false}

--- a/src/components/project/project-sidebar.tsx
+++ b/src/components/project/project-sidebar.tsx
@@ -749,7 +749,7 @@ export function ProjectSidebar({
       <div
         inert={!isOpen}
         className={cn(
-          'fixed z-40 flex h-dvh w-[85vw] flex-col overflow-hidden border-r',
+          'chat-title-privacy-region fixed z-40 flex h-dvh w-[85vw] flex-col overflow-hidden border-r',
           isOpen ? 'translate-x-0' : '-translate-x-full',
           'border-border-subtle bg-surface-sidebar text-content-primary',
           'transition-all duration-200 ease-in-out',

--- a/src/components/project/project-sidebar.tsx
+++ b/src/components/project/project-sidebar.tsx
@@ -749,7 +749,7 @@ export function ProjectSidebar({
       <div
         inert={!isOpen}
         className={cn(
-          'chat-title-privacy-region fixed z-40 flex h-dvh w-[85vw] flex-col overflow-hidden border-r',
+          'fixed z-40 flex h-dvh w-[85vw] flex-col overflow-hidden border-r',
           isOpen ? 'translate-x-0' : '-translate-x-full',
           'border-border-subtle bg-surface-sidebar text-content-primary',
           'transition-all duration-200 ease-in-out',

--- a/src/components/project/project-sidebar.tsx
+++ b/src/components/project/project-sidebar.tsx
@@ -96,6 +96,7 @@ interface ProjectSidebarProps {
   projectName?: string
   isLoading?: boolean
   isDarkMode: boolean
+  pixelateSidebarChatTitles: boolean
   onExitProject: () => void
   onExitProjectWhileDragging?: () => void
   onNewChat: () => void
@@ -265,6 +266,7 @@ export function ProjectSidebar({
   projectName,
   isLoading,
   isDarkMode,
+  pixelateSidebarChatTitles,
   onExitProject,
   onExitProjectWhileDragging,
   onNewChat,
@@ -1384,6 +1386,7 @@ export function ProjectSidebar({
               currentChatId={currentChatId}
               currentChatIsBlank={!currentChatId}
               isDarkMode={isDarkMode}
+              pixelateSidebarChatTitles={pixelateSidebarChatTitles}
               isLoading={isLoading}
               enableTitleAnimation={true}
               animatedDeleteConfirmation={false}

--- a/src/components/ui/pixelated-text.tsx
+++ b/src/components/ui/pixelated-text.tsx
@@ -65,12 +65,6 @@ export function PixelatedText({
   useIsomorphicLayoutEffect(() => {
     setIsCanvasReady(false)
     if (!active) return
-    if (
-      typeof window.matchMedia === 'function' &&
-      !window.matchMedia(HOVER_CAPABLE_POINTER_QUERY).matches
-    ) {
-      return
-    }
 
     const container = containerRef.current
     const source = sourceRef.current
@@ -78,6 +72,11 @@ export function PixelatedText({
     if (!container || !source || !canvas) return
 
     let cancelled = false
+    let resizeObserver: ResizeObserver | null = null
+    const pointerQuery =
+      typeof window.matchMedia === 'function'
+        ? window.matchMedia(HOVER_CAPABLE_POINTER_QUERY)
+        : null
 
     const drawPixelatedText = () => {
       if (cancelled) return
@@ -118,18 +117,36 @@ export function PixelatedText({
       setIsCanvasReady(true)
     }
 
-    drawPixelatedText()
+    const stopRendering = () => {
+      resizeObserver?.disconnect()
+      resizeObserver = null
+      setIsCanvasReady(false)
+    }
 
-    const resizeObserver =
-      typeof ResizeObserver === 'undefined'
-        ? null
-        : new ResizeObserver(drawPixelatedText)
-    resizeObserver?.observe(container)
+    const startRendering = () => {
+      if (cancelled) return
+      if (pointerQuery && !pointerQuery.matches) return
 
-    void document.fonts?.ready.then(drawPixelatedText)
+      drawPixelatedText()
+      if (typeof ResizeObserver !== 'undefined' && !resizeObserver) {
+        resizeObserver = new ResizeObserver(drawPixelatedText)
+        resizeObserver.observe(container)
+      }
+    }
+
+    const handlePointerCapabilityChange = () => {
+      stopRendering()
+      startRendering()
+    }
+
+    pointerQuery?.addEventListener('change', handlePointerCapabilityChange)
+    startRendering()
+
+    void document.fonts?.ready.then(startRendering)
 
     return () => {
       cancelled = true
+      pointerQuery?.removeEventListener('change', handlePointerCapabilityChange)
       resizeObserver?.disconnect()
     }
   }, [active, renderKey, text])

--- a/src/components/ui/pixelated-text.tsx
+++ b/src/components/ui/pixelated-text.tsx
@@ -139,25 +139,14 @@ export function PixelatedText({
       startRendering()
     }
 
-    if (typeof pointerQuery?.addEventListener === 'function') {
-      pointerQuery.addEventListener('change', handlePointerCapabilityChange)
-    } else {
-      pointerQuery?.addListener(handlePointerCapabilityChange)
-    }
+    pointerQuery?.addEventListener('change', handlePointerCapabilityChange)
     startRendering()
 
     void document.fonts?.ready.then(startRendering)
 
     return () => {
       cancelled = true
-      if (typeof pointerQuery?.removeEventListener === 'function') {
-        pointerQuery.removeEventListener(
-          'change',
-          handlePointerCapabilityChange,
-        )
-      } else {
-        pointerQuery?.removeListener(handlePointerCapabilityChange)
-      }
+      pointerQuery?.removeEventListener('change', handlePointerCapabilityChange)
       resizeObserver?.disconnect()
     }
   }, [active, renderKey, text])

--- a/src/components/ui/pixelated-text.tsx
+++ b/src/components/ui/pixelated-text.tsx
@@ -9,7 +9,7 @@ import {
 } from 'react'
 import { cn } from './utils'
 
-const PIXEL_SIZE_CSS_PX = 3
+const PIXEL_SIZE_CSS_PX = 2.5
 const MIN_CANVAS_DIMENSION = 1
 const TEXT_ELLIPSIS = '...'
 const HOVER_CAPABLE_POINTER_QUERY = '(hover: hover) and (pointer: fine)'

--- a/src/components/ui/pixelated-text.tsx
+++ b/src/components/ui/pixelated-text.tsx
@@ -42,6 +42,22 @@ function fitTextToWidth(
   return `${characters.slice(0, lowerBound).join('')}${TEXT_ELLIPSIS}`
 }
 
+function getCenteredTextBaseline(
+  metrics: TextMetrics,
+  canvasHeight: number,
+): number {
+  const ascent =
+    metrics.fontBoundingBoxAscent ?? metrics.actualBoundingBoxAscent
+  const descent =
+    metrics.fontBoundingBoxDescent ?? metrics.actualBoundingBoxDescent
+
+  if (!Number.isFinite(ascent) || !Number.isFinite(descent)) {
+    return canvasHeight / 2
+  }
+
+  return (canvasHeight + ascent - descent) / 2
+}
+
 interface PixelatedTextProps {
   text: string
   active: boolean
@@ -110,10 +126,14 @@ export function PixelatedText({
         styles.fontFamily,
       ].join(' ')
       context.imageSmoothingEnabled = false
-      context.textBaseline = 'middle'
+      context.textBaseline = 'alphabetic'
 
       const fittedText = fitTextToWidth(context, text, canvas.width)
-      context.fillText(fittedText, 0, canvas.height / 2)
+      const baseline = getCenteredTextBaseline(
+        context.measureText(fittedText),
+        canvas.height,
+      )
+      context.fillText(fittedText, 0, baseline)
       setIsCanvasReady(true)
     }
 

--- a/src/components/ui/pixelated-text.tsx
+++ b/src/components/ui/pixelated-text.tsx
@@ -9,7 +9,7 @@ import {
 } from 'react'
 import { cn } from './utils'
 
-const PIXEL_SIZE_CSS_PX = 2
+const PIXEL_SIZE_CSS_PX = 3
 const MIN_CANVAS_DIMENSION = 1
 const TEXT_ELLIPSIS = '...'
 const HOVER_CAPABLE_POINTER_QUERY = '(hover: hover) and (pointer: fine)'

--- a/src/components/ui/pixelated-text.tsx
+++ b/src/components/ui/pixelated-text.tsx
@@ -9,7 +9,7 @@ import {
 } from 'react'
 import { cn } from './utils'
 
-const PIXEL_SIZE_CSS_PX = 2.5
+const PIXEL_SIZE_CSS_PX = 2.75
 const MIN_CANVAS_DIMENSION = 1
 const TEXT_ELLIPSIS = '...'
 const HOVER_CAPABLE_POINTER_QUERY = '(hover: hover) and (pointer: fine)'

--- a/src/components/ui/pixelated-text.tsx
+++ b/src/components/ui/pixelated-text.tsx
@@ -139,14 +139,25 @@ export function PixelatedText({
       startRendering()
     }
 
-    pointerQuery?.addEventListener('change', handlePointerCapabilityChange)
+    if (typeof pointerQuery?.addEventListener === 'function') {
+      pointerQuery.addEventListener('change', handlePointerCapabilityChange)
+    } else {
+      pointerQuery?.addListener(handlePointerCapabilityChange)
+    }
     startRendering()
 
     void document.fonts?.ready.then(startRendering)
 
     return () => {
       cancelled = true
-      pointerQuery?.removeEventListener('change', handlePointerCapabilityChange)
+      if (typeof pointerQuery?.removeEventListener === 'function') {
+        pointerQuery.removeEventListener(
+          'change',
+          handlePointerCapabilityChange,
+        )
+      } else {
+        pointerQuery?.removeListener(handlePointerCapabilityChange)
+      }
       resizeObserver?.disconnect()
     }
   }, [active, renderKey, text])

--- a/src/components/ui/pixelated-text.tsx
+++ b/src/components/ui/pixelated-text.tsx
@@ -1,0 +1,159 @@
+'use client'
+
+import {
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react'
+import { cn } from './utils'
+
+const PIXEL_SIZE_CSS_PX = 2
+const MIN_CANVAS_DIMENSION = 1
+const TEXT_ELLIPSIS = '...'
+const HOVER_CAPABLE_POINTER_QUERY = '(hover: hover) and (pointer: fine)'
+
+const useIsomorphicLayoutEffect =
+  typeof window === 'undefined' ? useEffect : useLayoutEffect
+
+function fitTextToWidth(
+  context: CanvasRenderingContext2D,
+  text: string,
+  maxWidth: number,
+): string {
+  if (context.measureText(text).width <= maxWidth) return text
+
+  const characters = Array.from(text)
+  let lowerBound = 0
+  let upperBound = characters.length
+
+  while (lowerBound < upperBound) {
+    const midpoint = Math.ceil((lowerBound + upperBound) / 2)
+    const candidate = `${characters.slice(0, midpoint).join('')}${TEXT_ELLIPSIS}`
+
+    if (context.measureText(candidate).width <= maxWidth) {
+      lowerBound = midpoint
+    } else {
+      upperBound = midpoint - 1
+    }
+  }
+
+  return `${characters.slice(0, lowerBound).join('')}${TEXT_ELLIPSIS}`
+}
+
+interface PixelatedTextProps {
+  text: string
+  active: boolean
+  children: ReactNode
+  className?: string
+  renderKey?: string | boolean
+}
+
+export function PixelatedText({
+  text,
+  active,
+  children,
+  className,
+  renderKey,
+}: PixelatedTextProps) {
+  const containerRef = useRef<HTMLSpanElement>(null)
+  const sourceRef = useRef<HTMLSpanElement>(null)
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const [isCanvasReady, setIsCanvasReady] = useState(false)
+
+  useIsomorphicLayoutEffect(() => {
+    setIsCanvasReady(false)
+    if (!active) return
+    if (
+      typeof window.matchMedia === 'function' &&
+      !window.matchMedia(HOVER_CAPABLE_POINTER_QUERY).matches
+    ) {
+      return
+    }
+
+    const container = containerRef.current
+    const source = sourceRef.current
+    const canvas = canvasRef.current
+    if (!container || !source || !canvas) return
+
+    let cancelled = false
+
+    const drawPixelatedText = () => {
+      if (cancelled) return
+
+      const bounds = container.getBoundingClientRect()
+      if (bounds.width <= 0 || bounds.height <= 0) return
+
+      canvas.width = Math.max(
+        MIN_CANVAS_DIMENSION,
+        Math.ceil(bounds.width / PIXEL_SIZE_CSS_PX),
+      )
+      canvas.height = Math.max(
+        MIN_CANVAS_DIMENSION,
+        Math.ceil(bounds.height / PIXEL_SIZE_CSS_PX),
+      )
+
+      const context = canvas.getContext('2d')
+      if (!context) return
+
+      const styles = window.getComputedStyle(source)
+      const fontSize = Number.parseFloat(styles.fontSize)
+      if (!Number.isFinite(fontSize)) return
+
+      context.clearRect(0, 0, canvas.width, canvas.height)
+      context.fillStyle = styles.color
+      context.font = [
+        styles.fontStyle,
+        styles.fontVariant,
+        styles.fontWeight,
+        `${fontSize / PIXEL_SIZE_CSS_PX}px`,
+        styles.fontFamily,
+      ].join(' ')
+      context.imageSmoothingEnabled = false
+      context.textBaseline = 'middle'
+
+      const fittedText = fitTextToWidth(context, text, canvas.width)
+      context.fillText(fittedText, 0, canvas.height / 2)
+      setIsCanvasReady(true)
+    }
+
+    drawPixelatedText()
+
+    const resizeObserver =
+      typeof ResizeObserver === 'undefined'
+        ? null
+        : new ResizeObserver(drawPixelatedText)
+    resizeObserver?.observe(container)
+
+    void document.fonts?.ready.then(drawPixelatedText)
+
+    return () => {
+      cancelled = true
+      resizeObserver?.disconnect()
+    }
+  }, [active, renderKey, text])
+
+  return (
+    <span
+      ref={containerRef}
+      data-pixelation-ready={isCanvasReady ? 'true' : undefined}
+      className={cn(
+        'relative block min-w-0',
+        active && 'pixelated-text',
+        className,
+      )}
+    >
+      <span ref={sourceRef} className="pixelated-text-source">
+        {children}
+      </span>
+      {active && (
+        <canvas
+          ref={canvasRef}
+          aria-hidden="true"
+          className="pixelated-text-canvas pointer-events-none absolute inset-0 h-full w-full"
+        />
+      )}
+    </span>
+  )
+}

--- a/src/constants/settings-events.ts
+++ b/src/constants/settings-events.ts
@@ -1,2 +1,2 @@
-export const BLUR_SIDEBAR_CHAT_TITLES_CHANGED_EVENT =
-  'blurSidebarChatTitlesChanged'
+export const PIXELATE_SIDEBAR_CHAT_TITLES_CHANGED_EVENT =
+  'pixelateSidebarChatTitlesChanged'

--- a/src/constants/settings-events.ts
+++ b/src/constants/settings-events.ts
@@ -1,0 +1,2 @@
+export const BLUR_SIDEBAR_CHAT_TITLES_CHANGED_EVENT =
+  'blurSidebarChatTitlesChanged'

--- a/src/constants/storage-keys.ts
+++ b/src/constants/storage-keys.ts
@@ -39,6 +39,8 @@ export const SETTINGS_WEB_SEARCH_AVAILABLE =
   'tinfoil-settings-web-search-available'
 export const SETTINGS_CODE_EXECUTION_ENABLED =
   'tinfoil-settings-code-execution-enabled'
+export const SETTINGS_PIXELATE_SIDEBAR_CHAT_TITLES =
+  'tinfoil-settings-pixelate-sidebar-chat-titles'
 export const SETTINGS_PII_CHECK_ENABLED = 'tinfoil-settings-pii-check-enabled'
 export const SETTINGS_GENUI_ENABLED = 'tinfoil-settings-genui-enabled'
 export const SETTINGS_THEME_MODE = 'tinfoil-settings-theme-mode'

--- a/src/constants/storage-keys.ts
+++ b/src/constants/storage-keys.ts
@@ -39,8 +39,8 @@ export const SETTINGS_WEB_SEARCH_AVAILABLE =
   'tinfoil-settings-web-search-available'
 export const SETTINGS_CODE_EXECUTION_ENABLED =
   'tinfoil-settings-code-execution-enabled'
-export const SETTINGS_BLUR_SIDEBAR_CHAT_TITLES =
-  'tinfoil-settings-blur-sidebar-chat-titles'
+export const SETTINGS_BLUR_SIDEBAR_CHAT_TITLES_ENABLED =
+  'tinfoil-settings-blur-sidebar-chat-titles-enabled'
 export const SETTINGS_PII_CHECK_ENABLED = 'tinfoil-settings-pii-check-enabled'
 export const SETTINGS_GENUI_ENABLED = 'tinfoil-settings-genui-enabled'
 export const SETTINGS_THEME_MODE = 'tinfoil-settings-theme-mode'

--- a/src/constants/storage-keys.ts
+++ b/src/constants/storage-keys.ts
@@ -39,8 +39,8 @@ export const SETTINGS_WEB_SEARCH_AVAILABLE =
   'tinfoil-settings-web-search-available'
 export const SETTINGS_CODE_EXECUTION_ENABLED =
   'tinfoil-settings-code-execution-enabled'
-export const SETTINGS_PIXELATE_SIDEBAR_CHAT_TITLES =
-  'tinfoil-settings-pixelate-sidebar-chat-titles'
+export const SETTINGS_BLUR_SIDEBAR_CHAT_TITLES =
+  'tinfoil-settings-blur-sidebar-chat-titles'
 export const SETTINGS_PII_CHECK_ENABLED = 'tinfoil-settings-pii-check-enabled'
 export const SETTINGS_GENUI_ENABLED = 'tinfoil-settings-genui-enabled'
 export const SETTINGS_THEME_MODE = 'tinfoil-settings-theme-mode'

--- a/src/constants/storage-keys.ts
+++ b/src/constants/storage-keys.ts
@@ -39,8 +39,8 @@ export const SETTINGS_WEB_SEARCH_AVAILABLE =
   'tinfoil-settings-web-search-available'
 export const SETTINGS_CODE_EXECUTION_ENABLED =
   'tinfoil-settings-code-execution-enabled'
-export const SETTINGS_BLUR_SIDEBAR_CHAT_TITLES_ENABLED =
-  'tinfoil-settings-blur-sidebar-chat-titles-enabled'
+export const SETTINGS_PIXELATE_SIDEBAR_CHAT_TITLES_ENABLED =
+  'tinfoil-settings-pixelate-sidebar-chat-titles-enabled'
 export const SETTINGS_PII_CHECK_ENABLED = 'tinfoil-settings-pii-check-enabled'
 export const SETTINGS_GENUI_ENABLED = 'tinfoil-settings-genui-enabled'
 export const SETTINGS_THEME_MODE = 'tinfoil-settings-theme-mode'

--- a/src/hooks/use-lossless-profile-sync.ts
+++ b/src/hooks/use-lossless-profile-sync.ts
@@ -343,7 +343,7 @@ export function useProfileSync() {
       'webSearchEnabledChanged',
       'webSearchAvailableChanged',
       'codeExecutionEnabledChanged',
-      'pixelateSidebarChatTitlesChanged',
+      'blurSidebarChatTitlesChanged',
       'piiCheckEnabledChanged',
       'genUIEnabledChanged',
       'chatFontChanged',

--- a/src/hooks/use-lossless-profile-sync.ts
+++ b/src/hooks/use-lossless-profile-sync.ts
@@ -343,6 +343,7 @@ export function useProfileSync() {
       'webSearchEnabledChanged',
       'webSearchAvailableChanged',
       'codeExecutionEnabledChanged',
+      'pixelateSidebarChatTitlesChanged',
       'piiCheckEnabledChanged',
       'genUIEnabledChanged',
       'chatFontChanged',

--- a/src/hooks/use-lossless-profile-sync.ts
+++ b/src/hooks/use-lossless-profile-sync.ts
@@ -1,5 +1,5 @@
 import { CLOUD_SYNC } from '@/config'
-import { BLUR_SIDEBAR_CHAT_TITLES_CHANGED_EVENT } from '@/constants/settings-events'
+import { PIXELATE_SIDEBAR_CHAT_TITLES_CHANGED_EVENT } from '@/constants/settings-events'
 import {
   SYNC_PROFILE_CHANGED_AT,
   SYNC_PROFILE_DIRTY,
@@ -344,7 +344,7 @@ export function useProfileSync() {
       'webSearchEnabledChanged',
       'webSearchAvailableChanged',
       'codeExecutionEnabledChanged',
-      BLUR_SIDEBAR_CHAT_TITLES_CHANGED_EVENT,
+      PIXELATE_SIDEBAR_CHAT_TITLES_CHANGED_EVENT,
       'piiCheckEnabledChanged',
       'genUIEnabledChanged',
       'chatFontChanged',

--- a/src/hooks/use-lossless-profile-sync.ts
+++ b/src/hooks/use-lossless-profile-sync.ts
@@ -1,4 +1,5 @@
 import { CLOUD_SYNC } from '@/config'
+import { BLUR_SIDEBAR_CHAT_TITLES_CHANGED_EVENT } from '@/constants/settings-events'
 import {
   SYNC_PROFILE_CHANGED_AT,
   SYNC_PROFILE_DIRTY,
@@ -343,7 +344,7 @@ export function useProfileSync() {
       'webSearchEnabledChanged',
       'webSearchAvailableChanged',
       'codeExecutionEnabledChanged',
-      'blurSidebarChatTitlesChanged',
+      BLUR_SIDEBAR_CHAT_TITLES_CHANGED_EVENT,
       'piiCheckEnabledChanged',
       'genUIEnabledChanged',
       'chatFontChanged',

--- a/src/services/cloud/profile-merge.ts
+++ b/src/services/cloud/profile-merge.ts
@@ -25,7 +25,7 @@ export const PROFILE_MERGE_FIELDS = [
   'webSearchEnabled',
   'webSearchAvailable',
   'codeExecutionEnabled',
-  'pixelateSidebarChatTitles',
+  'blurSidebarChatTitles',
   'piiCheckEnabled',
   'genUIEnabled',
   'chatFont',

--- a/src/services/cloud/profile-merge.ts
+++ b/src/services/cloud/profile-merge.ts
@@ -32,6 +32,11 @@ export const PROFILE_MERGE_FIELDS = [
   'projectUploadPreference',
 ] as const
 
+// Older clients omit this field, while the setting itself has no unset state.
+const PRESERVE_LOCAL_WHEN_REMOTE_OMITS = new Set<
+  (typeof PROFILE_MERGE_FIELDS)[number]
+>(['pixelateSidebarChatTitlesEnabled'])
+
 // A blob's field clocks are trustworthy only when they were maintained
 // at the row's current server version. If a clock-unaware client wrote
 // since, clockVersion lags the etag and we must not trust the clocks.
@@ -147,11 +152,13 @@ export function mergeProfilesThreeWay(args: {
     if (valuesEqual(localValue, baselineValue)) {
       if (Object.prototype.hasOwnProperty.call(remote, field)) {
         ;(merged as Record<string, unknown>)[field] = remoteValue
+        if (rc) mergedClocks[field] = rc
+        adoptedRemote ||= !valuesEqual(localValue, remoteValue)
+      } else if (PRESERVE_LOCAL_WHEN_REMOTE_OMITS.has(field)) {
+        if (lc) mergedClocks[field] = lc
       } else {
         delete (merged as Record<string, unknown>)[field]
       }
-      if (rc) mergedClocks[field] = rc
-      adoptedRemote ||= !valuesEqual(localValue, remoteValue)
     } else if (valuesEqual(localValue, remoteValue)) {
       const clock = laterClock(lc, rc)
       if (clock) mergedClocks[field] = clock

--- a/src/services/cloud/profile-merge.ts
+++ b/src/services/cloud/profile-merge.ts
@@ -25,6 +25,7 @@ export const PROFILE_MERGE_FIELDS = [
   'webSearchEnabled',
   'webSearchAvailable',
   'codeExecutionEnabled',
+  'pixelateSidebarChatTitles',
   'piiCheckEnabled',
   'genUIEnabled',
   'chatFont',

--- a/src/services/cloud/profile-merge.ts
+++ b/src/services/cloud/profile-merge.ts
@@ -25,7 +25,7 @@ export const PROFILE_MERGE_FIELDS = [
   'webSearchEnabled',
   'webSearchAvailable',
   'codeExecutionEnabled',
-  'blurSidebarChatTitlesEnabled',
+  'pixelateSidebarChatTitlesEnabled',
   'piiCheckEnabled',
   'genUIEnabled',
   'chatFont',

--- a/src/services/cloud/profile-merge.ts
+++ b/src/services/cloud/profile-merge.ts
@@ -25,7 +25,7 @@ export const PROFILE_MERGE_FIELDS = [
   'webSearchEnabled',
   'webSearchAvailable',
   'codeExecutionEnabled',
-  'blurSidebarChatTitles',
+  'blurSidebarChatTitlesEnabled',
   'piiCheckEnabled',
   'genUIEnabled',
   'chatFont',

--- a/src/services/cloud/profile-settings-serializer.ts
+++ b/src/services/cloud/profile-settings-serializer.ts
@@ -217,10 +217,10 @@ export function loadLocalSettings(): ProfileData {
   const pixelateSidebarChatTitlesEnabled = localStorage.getItem(
     SETTINGS_PIXELATE_SIDEBAR_CHAT_TITLES_ENABLED,
   )
-  settings.pixelateSidebarChatTitlesEnabled =
-    pixelateSidebarChatTitlesEnabled === null
-      ? true
-      : pixelateSidebarChatTitlesEnabled === 'true'
+  if (pixelateSidebarChatTitlesEnabled !== null) {
+    settings.pixelateSidebarChatTitlesEnabled =
+      pixelateSidebarChatTitlesEnabled === 'true'
+  }
 
   const piiCheckEnabled = localStorage.getItem(SETTINGS_PII_CHECK_ENABLED)
   if (piiCheckEnabled !== null) {

--- a/src/services/cloud/profile-settings-serializer.ts
+++ b/src/services/cloud/profile-settings-serializer.ts
@@ -1,10 +1,10 @@
-import { BLUR_SIDEBAR_CHAT_TITLES_CHANGED_EVENT } from '@/constants/settings-events'
+import { PIXELATE_SIDEBAR_CHAT_TITLES_CHANGED_EVENT } from '@/constants/settings-events'
 import {
-  SETTINGS_BLUR_SIDEBAR_CHAT_TITLES_ENABLED,
   SETTINGS_CHAT_FONT,
   SETTINGS_CODE_EXECUTION_ENABLED,
   SETTINGS_GENUI_ENABLED,
   SETTINGS_PII_CHECK_ENABLED,
+  SETTINGS_PIXELATE_SIDEBAR_CHAT_TITLES_ENABLED,
   SETTINGS_REASONING_EFFORT,
   SETTINGS_THEME,
   SETTINGS_THEME_MODE,
@@ -93,8 +93,8 @@ export function hasProfileChanged(
     profile1.webSearchEnabled !== profile2.webSearchEnabled ||
     profile1.webSearchAvailable !== profile2.webSearchAvailable ||
     profile1.codeExecutionEnabled !== profile2.codeExecutionEnabled ||
-    profile1.blurSidebarChatTitlesEnabled !==
-      profile2.blurSidebarChatTitlesEnabled ||
+    profile1.pixelateSidebarChatTitlesEnabled !==
+      profile2.pixelateSidebarChatTitlesEnabled ||
     profile1.piiCheckEnabled !== profile2.piiCheckEnabled ||
     profile1.genUIEnabled !== profile2.genUIEnabled ||
     profile1.chatFont !== profile2.chatFont ||
@@ -214,13 +214,13 @@ export function loadLocalSettings(): ProfileData {
     settings.codeExecutionEnabled = codeExecutionEnabled === 'true'
   }
 
-  const blurSidebarChatTitlesEnabled = localStorage.getItem(
-    SETTINGS_BLUR_SIDEBAR_CHAT_TITLES_ENABLED,
+  const pixelateSidebarChatTitlesEnabled = localStorage.getItem(
+    SETTINGS_PIXELATE_SIDEBAR_CHAT_TITLES_ENABLED,
   )
-  settings.blurSidebarChatTitlesEnabled =
-    blurSidebarChatTitlesEnabled === null
+  settings.pixelateSidebarChatTitlesEnabled =
+    pixelateSidebarChatTitlesEnabled === null
       ? true
-      : blurSidebarChatTitlesEnabled === 'true'
+      : pixelateSidebarChatTitlesEnabled === 'true'
 
   const piiCheckEnabled = localStorage.getItem(SETTINGS_PII_CHECK_ENABLED)
   if (piiCheckEnabled !== null) {
@@ -273,7 +273,7 @@ export function resetSettingsToLocalDefaults(): ProfileData {
     webSearchEnabled: true,
     webSearchAvailable: true,
     codeExecutionEnabled: false,
-    blurSidebarChatTitlesEnabled: true,
+    pixelateSidebarChatTitlesEnabled: true,
     piiCheckEnabled: true,
     genUIEnabled: true,
     chatFont: 'system',
@@ -471,14 +471,14 @@ export function applySettingsToLocal(settings: ProfileData): void {
     )
   }
 
-  if (settings.blurSidebarChatTitlesEnabled !== undefined) {
+  if (settings.pixelateSidebarChatTitlesEnabled !== undefined) {
     localStorage.setItem(
-      SETTINGS_BLUR_SIDEBAR_CHAT_TITLES_ENABLED,
-      String(settings.blurSidebarChatTitlesEnabled),
+      SETTINGS_PIXELATE_SIDEBAR_CHAT_TITLES_ENABLED,
+      String(settings.pixelateSidebarChatTitlesEnabled),
     )
     window.dispatchEvent(
-      new CustomEvent(BLUR_SIDEBAR_CHAT_TITLES_CHANGED_EVENT, {
-        detail: { enabled: settings.blurSidebarChatTitlesEnabled },
+      new CustomEvent(PIXELATE_SIDEBAR_CHAT_TITLES_CHANGED_EVENT, {
+        detail: { enabled: settings.pixelateSidebarChatTitlesEnabled },
       }),
     )
   }

--- a/src/services/cloud/profile-settings-serializer.ts
+++ b/src/services/cloud/profile-settings-serializer.ts
@@ -1,9 +1,9 @@
 import {
+  SETTINGS_BLUR_SIDEBAR_CHAT_TITLES,
   SETTINGS_CHAT_FONT,
   SETTINGS_CODE_EXECUTION_ENABLED,
   SETTINGS_GENUI_ENABLED,
   SETTINGS_PII_CHECK_ENABLED,
-  SETTINGS_PIXELATE_SIDEBAR_CHAT_TITLES,
   SETTINGS_REASONING_EFFORT,
   SETTINGS_THEME,
   SETTINGS_THEME_MODE,
@@ -92,7 +92,7 @@ export function hasProfileChanged(
     profile1.webSearchEnabled !== profile2.webSearchEnabled ||
     profile1.webSearchAvailable !== profile2.webSearchAvailable ||
     profile1.codeExecutionEnabled !== profile2.codeExecutionEnabled ||
-    profile1.pixelateSidebarChatTitles !== profile2.pixelateSidebarChatTitles ||
+    profile1.blurSidebarChatTitles !== profile2.blurSidebarChatTitles ||
     profile1.piiCheckEnabled !== profile2.piiCheckEnabled ||
     profile1.genUIEnabled !== profile2.genUIEnabled ||
     profile1.chatFont !== profile2.chatFont ||
@@ -212,13 +212,11 @@ export function loadLocalSettings(): ProfileData {
     settings.codeExecutionEnabled = codeExecutionEnabled === 'true'
   }
 
-  const pixelateSidebarChatTitles = localStorage.getItem(
-    SETTINGS_PIXELATE_SIDEBAR_CHAT_TITLES,
+  const blurSidebarChatTitles = localStorage.getItem(
+    SETTINGS_BLUR_SIDEBAR_CHAT_TITLES,
   )
-  settings.pixelateSidebarChatTitles =
-    pixelateSidebarChatTitles === null
-      ? true
-      : pixelateSidebarChatTitles === 'true'
+  settings.blurSidebarChatTitles =
+    blurSidebarChatTitles === null ? true : blurSidebarChatTitles === 'true'
 
   const piiCheckEnabled = localStorage.getItem(SETTINGS_PII_CHECK_ENABLED)
   if (piiCheckEnabled !== null) {
@@ -271,7 +269,7 @@ export function resetSettingsToLocalDefaults(): ProfileData {
     webSearchEnabled: true,
     webSearchAvailable: true,
     codeExecutionEnabled: false,
-    pixelateSidebarChatTitles: true,
+    blurSidebarChatTitles: true,
     piiCheckEnabled: true,
     genUIEnabled: true,
     chatFont: 'system',
@@ -469,14 +467,14 @@ export function applySettingsToLocal(settings: ProfileData): void {
     )
   }
 
-  if (settings.pixelateSidebarChatTitles !== undefined) {
+  if (settings.blurSidebarChatTitles !== undefined) {
     localStorage.setItem(
-      SETTINGS_PIXELATE_SIDEBAR_CHAT_TITLES,
-      String(settings.pixelateSidebarChatTitles),
+      SETTINGS_BLUR_SIDEBAR_CHAT_TITLES,
+      String(settings.blurSidebarChatTitles),
     )
     window.dispatchEvent(
-      new CustomEvent('pixelateSidebarChatTitlesChanged', {
-        detail: { enabled: settings.pixelateSidebarChatTitles },
+      new CustomEvent('blurSidebarChatTitlesChanged', {
+        detail: { enabled: settings.blurSidebarChatTitles },
       }),
     )
   }

--- a/src/services/cloud/profile-settings-serializer.ts
+++ b/src/services/cloud/profile-settings-serializer.ts
@@ -3,6 +3,7 @@ import {
   SETTINGS_CODE_EXECUTION_ENABLED,
   SETTINGS_GENUI_ENABLED,
   SETTINGS_PII_CHECK_ENABLED,
+  SETTINGS_PIXELATE_SIDEBAR_CHAT_TITLES,
   SETTINGS_REASONING_EFFORT,
   SETTINGS_THEME,
   SETTINGS_THEME_MODE,
@@ -91,6 +92,7 @@ export function hasProfileChanged(
     profile1.webSearchEnabled !== profile2.webSearchEnabled ||
     profile1.webSearchAvailable !== profile2.webSearchAvailable ||
     profile1.codeExecutionEnabled !== profile2.codeExecutionEnabled ||
+    profile1.pixelateSidebarChatTitles !== profile2.pixelateSidebarChatTitles ||
     profile1.piiCheckEnabled !== profile2.piiCheckEnabled ||
     profile1.genUIEnabled !== profile2.genUIEnabled ||
     profile1.chatFont !== profile2.chatFont ||
@@ -210,6 +212,14 @@ export function loadLocalSettings(): ProfileData {
     settings.codeExecutionEnabled = codeExecutionEnabled === 'true'
   }
 
+  const pixelateSidebarChatTitles = localStorage.getItem(
+    SETTINGS_PIXELATE_SIDEBAR_CHAT_TITLES,
+  )
+  settings.pixelateSidebarChatTitles =
+    pixelateSidebarChatTitles === null
+      ? true
+      : pixelateSidebarChatTitles === 'true'
+
   const piiCheckEnabled = localStorage.getItem(SETTINGS_PII_CHECK_ENABLED)
   if (piiCheckEnabled !== null) {
     settings.piiCheckEnabled = piiCheckEnabled === 'true'
@@ -261,6 +271,7 @@ export function resetSettingsToLocalDefaults(): ProfileData {
     webSearchEnabled: true,
     webSearchAvailable: true,
     codeExecutionEnabled: false,
+    pixelateSidebarChatTitles: true,
     piiCheckEnabled: true,
     genUIEnabled: true,
     chatFont: 'system',
@@ -454,6 +465,18 @@ export function applySettingsToLocal(settings: ProfileData): void {
     window.dispatchEvent(
       new CustomEvent('codeExecutionEnabledChanged', {
         detail: { enabled: settings.codeExecutionEnabled },
+      }),
+    )
+  }
+
+  if (settings.pixelateSidebarChatTitles !== undefined) {
+    localStorage.setItem(
+      SETTINGS_PIXELATE_SIDEBAR_CHAT_TITLES,
+      String(settings.pixelateSidebarChatTitles),
+    )
+    window.dispatchEvent(
+      new CustomEvent('pixelateSidebarChatTitlesChanged', {
+        detail: { enabled: settings.pixelateSidebarChatTitles },
       }),
     )
   }

--- a/src/services/cloud/profile-settings-serializer.ts
+++ b/src/services/cloud/profile-settings-serializer.ts
@@ -1,5 +1,6 @@
+import { BLUR_SIDEBAR_CHAT_TITLES_CHANGED_EVENT } from '@/constants/settings-events'
 import {
-  SETTINGS_BLUR_SIDEBAR_CHAT_TITLES,
+  SETTINGS_BLUR_SIDEBAR_CHAT_TITLES_ENABLED,
   SETTINGS_CHAT_FONT,
   SETTINGS_CODE_EXECUTION_ENABLED,
   SETTINGS_GENUI_ENABLED,
@@ -92,7 +93,8 @@ export function hasProfileChanged(
     profile1.webSearchEnabled !== profile2.webSearchEnabled ||
     profile1.webSearchAvailable !== profile2.webSearchAvailable ||
     profile1.codeExecutionEnabled !== profile2.codeExecutionEnabled ||
-    profile1.blurSidebarChatTitles !== profile2.blurSidebarChatTitles ||
+    profile1.blurSidebarChatTitlesEnabled !==
+      profile2.blurSidebarChatTitlesEnabled ||
     profile1.piiCheckEnabled !== profile2.piiCheckEnabled ||
     profile1.genUIEnabled !== profile2.genUIEnabled ||
     profile1.chatFont !== profile2.chatFont ||
@@ -212,11 +214,13 @@ export function loadLocalSettings(): ProfileData {
     settings.codeExecutionEnabled = codeExecutionEnabled === 'true'
   }
 
-  const blurSidebarChatTitles = localStorage.getItem(
-    SETTINGS_BLUR_SIDEBAR_CHAT_TITLES,
+  const blurSidebarChatTitlesEnabled = localStorage.getItem(
+    SETTINGS_BLUR_SIDEBAR_CHAT_TITLES_ENABLED,
   )
-  settings.blurSidebarChatTitles =
-    blurSidebarChatTitles === null ? true : blurSidebarChatTitles === 'true'
+  settings.blurSidebarChatTitlesEnabled =
+    blurSidebarChatTitlesEnabled === null
+      ? true
+      : blurSidebarChatTitlesEnabled === 'true'
 
   const piiCheckEnabled = localStorage.getItem(SETTINGS_PII_CHECK_ENABLED)
   if (piiCheckEnabled !== null) {
@@ -269,7 +273,7 @@ export function resetSettingsToLocalDefaults(): ProfileData {
     webSearchEnabled: true,
     webSearchAvailable: true,
     codeExecutionEnabled: false,
-    blurSidebarChatTitles: true,
+    blurSidebarChatTitlesEnabled: true,
     piiCheckEnabled: true,
     genUIEnabled: true,
     chatFont: 'system',
@@ -467,14 +471,14 @@ export function applySettingsToLocal(settings: ProfileData): void {
     )
   }
 
-  if (settings.blurSidebarChatTitles !== undefined) {
+  if (settings.blurSidebarChatTitlesEnabled !== undefined) {
     localStorage.setItem(
-      SETTINGS_BLUR_SIDEBAR_CHAT_TITLES,
-      String(settings.blurSidebarChatTitles),
+      SETTINGS_BLUR_SIDEBAR_CHAT_TITLES_ENABLED,
+      String(settings.blurSidebarChatTitlesEnabled),
     )
     window.dispatchEvent(
-      new CustomEvent('blurSidebarChatTitlesChanged', {
-        detail: { enabled: settings.blurSidebarChatTitles },
+      new CustomEvent(BLUR_SIDEBAR_CHAT_TITLES_CHANGED_EVENT, {
+        detail: { enabled: settings.blurSidebarChatTitlesEnabled },
       }),
     )
   }

--- a/src/services/cloud/profile-sync.ts
+++ b/src/services/cloud/profile-sync.ts
@@ -79,7 +79,7 @@ export interface ProfileData {
   webSearchEnabled?: boolean
   webSearchAvailable?: boolean
   codeExecutionEnabled?: boolean
-  blurSidebarChatTitles?: boolean
+  blurSidebarChatTitlesEnabled?: boolean
   piiCheckEnabled?: boolean
   genUIEnabled?: boolean
   chatFont?: 'system' | 'serif' | 'mono' | 'dyslexic'

--- a/src/services/cloud/profile-sync.ts
+++ b/src/services/cloud/profile-sync.ts
@@ -79,6 +79,7 @@ export interface ProfileData {
   webSearchEnabled?: boolean
   webSearchAvailable?: boolean
   codeExecutionEnabled?: boolean
+  pixelateSidebarChatTitles?: boolean
   piiCheckEnabled?: boolean
   genUIEnabled?: boolean
   chatFont?: 'system' | 'serif' | 'mono' | 'dyslexic'

--- a/src/services/cloud/profile-sync.ts
+++ b/src/services/cloud/profile-sync.ts
@@ -79,7 +79,7 @@ export interface ProfileData {
   webSearchEnabled?: boolean
   webSearchAvailable?: boolean
   codeExecutionEnabled?: boolean
-  pixelateSidebarChatTitles?: boolean
+  blurSidebarChatTitles?: boolean
   piiCheckEnabled?: boolean
   genUIEnabled?: boolean
   chatFont?: 'system' | 'serif' | 'mono' | 'dyslexic'

--- a/src/services/cloud/profile-sync.ts
+++ b/src/services/cloud/profile-sync.ts
@@ -79,7 +79,7 @@ export interface ProfileData {
   webSearchEnabled?: boolean
   webSearchAvailable?: boolean
   codeExecutionEnabled?: boolean
-  blurSidebarChatTitlesEnabled?: boolean
+  pixelateSidebarChatTitlesEnabled?: boolean
   piiCheckEnabled?: boolean
   genUIEnabled?: boolean
   chatFont?: 'system' | 'serif' | 'mono' | 'dyslexic'

--- a/src/services/cloud/schemas.ts
+++ b/src/services/cloud/schemas.ts
@@ -147,7 +147,7 @@ export const ProfileDataSchema = z
     webSearchEnabled: z.boolean().optional(),
     webSearchAvailable: z.boolean().optional(),
     codeExecutionEnabled: z.boolean().optional(),
-    pixelateSidebarChatTitles: z.boolean().optional(),
+    blurSidebarChatTitles: z.boolean().optional(),
     piiCheckEnabled: z.boolean().optional(),
     genUIEnabled: z.boolean().optional(),
     chatFont: z.enum(['system', 'serif', 'mono', 'dyslexic']).optional(),

--- a/src/services/cloud/schemas.ts
+++ b/src/services/cloud/schemas.ts
@@ -147,7 +147,7 @@ export const ProfileDataSchema = z
     webSearchEnabled: z.boolean().optional(),
     webSearchAvailable: z.boolean().optional(),
     codeExecutionEnabled: z.boolean().optional(),
-    blurSidebarChatTitlesEnabled: z.boolean().optional(),
+    pixelateSidebarChatTitlesEnabled: z.boolean().optional(),
     piiCheckEnabled: z.boolean().optional(),
     genUIEnabled: z.boolean().optional(),
     chatFont: z.enum(['system', 'serif', 'mono', 'dyslexic']).optional(),

--- a/src/services/cloud/schemas.ts
+++ b/src/services/cloud/schemas.ts
@@ -147,7 +147,7 @@ export const ProfileDataSchema = z
     webSearchEnabled: z.boolean().optional(),
     webSearchAvailable: z.boolean().optional(),
     codeExecutionEnabled: z.boolean().optional(),
-    blurSidebarChatTitles: z.boolean().optional(),
+    blurSidebarChatTitlesEnabled: z.boolean().optional(),
     piiCheckEnabled: z.boolean().optional(),
     genUIEnabled: z.boolean().optional(),
     chatFont: z.enum(['system', 'serif', 'mono', 'dyslexic']).optional(),

--- a/src/services/cloud/schemas.ts
+++ b/src/services/cloud/schemas.ts
@@ -147,6 +147,7 @@ export const ProfileDataSchema = z
     webSearchEnabled: z.boolean().optional(),
     webSearchAvailable: z.boolean().optional(),
     codeExecutionEnabled: z.boolean().optional(),
+    pixelateSidebarChatTitles: z.boolean().optional(),
     piiCheckEnabled: z.boolean().optional(),
     genUIEnabled: z.boolean().optional(),
     chatFont: z.enum(['system', 'serif', 'mono', 'dyslexic']).optional(),

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -162,14 +162,29 @@
 }
 
 @layer utilities {
+  .pixelated-text-canvas {
+    display: none;
+  }
+
   @media (hover: hover) and (pointer: fine) {
-    .sidebar-chat-title-motion-blurred {
-      filter: var(--sidebar-chat-title-blur-filter);
+    .pixelated-text[data-pixelation-ready='true'] .pixelated-text-source {
+      opacity: 0;
     }
 
-    .group:hover .sidebar-chat-title-motion-blurred,
-    .group:focus-within .sidebar-chat-title-motion-blurred {
-      filter: none;
+    .pixelated-text[data-pixelation-ready='true'] .pixelated-text-canvas {
+      display: block;
+      image-rendering: pixelated;
+      opacity: 1;
+    }
+
+    .group:hover .pixelated-text .pixelated-text-source,
+    .group:focus-within .pixelated-text .pixelated-text-source {
+      opacity: 1;
+    }
+
+    .group:hover .pixelated-text .pixelated-text-canvas,
+    .group:focus-within .pixelated-text .pixelated-text-canvas {
+      opacity: 0;
     }
   }
 }

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -90,6 +90,7 @@
     --chart-4: 210 34% 18%;
     --chart-5: 221 39.3% 11%;
     --radius: 0.375rem;
+    --sidebar-chat-title-blur: 1.5px;
   }
 
   [data-theme='dark'],
@@ -163,32 +164,13 @@
 
 @layer utilities {
   @media (hover: hover) and (pointer: fine) {
-    .sidebar-chat-title-pixelated {
-      position: relative;
+    .sidebar-chat-title-blurred {
+      filter: blur(var(--sidebar-chat-title-blur));
     }
 
-    .sidebar-chat-title-pixelated .sidebar-chat-title-text {
-      opacity: 0;
-    }
-
-    .sidebar-chat-title-pixelated::after {
-      position: absolute;
-      inset: 0;
-      overflow: hidden;
-      color: inherit;
-      content: attr(data-pixelated-title);
-      text-overflow: ellipsis;
-      white-space: nowrap;
-    }
-
-    .group:hover .sidebar-chat-title-pixelated .sidebar-chat-title-text,
-    .group:focus-within .sidebar-chat-title-pixelated .sidebar-chat-title-text {
-      opacity: 1;
-    }
-
-    .group:hover .sidebar-chat-title-pixelated::after,
-    .group:focus-within .sidebar-chat-title-pixelated::after {
-      content: none;
+    .group:hover .sidebar-chat-title-blurred,
+    .group:focus-within .sidebar-chat-title-blurred {
+      filter: blur(0);
     }
   }
 }

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -90,7 +90,6 @@
     --chart-4: 210 34% 18%;
     --chart-5: 221 39.3% 11%;
     --radius: 0.375rem;
-    --sidebar-chat-title-blur: 1.5px;
   }
 
   [data-theme='dark'],
@@ -164,13 +163,13 @@
 
 @layer utilities {
   @media (hover: hover) and (pointer: fine) {
-    .sidebar-chat-title-blurred {
-      filter: blur(var(--sidebar-chat-title-blur));
+    .sidebar-chat-title-motion-blurred {
+      filter: var(--sidebar-chat-title-blur-filter);
     }
 
-    .group:hover .sidebar-chat-title-blurred,
-    .group:focus-within .sidebar-chat-title-blurred {
-      filter: blur(0);
+    .group:hover .sidebar-chat-title-motion-blurred,
+    .group:focus-within .sidebar-chat-title-motion-blurred {
+      filter: none;
     }
   }
 }

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -161,6 +161,38 @@
   }
 }
 
+@layer utilities {
+  @media (hover: hover) and (pointer: fine) {
+    .sidebar-chat-title-pixelated {
+      position: relative;
+    }
+
+    .sidebar-chat-title-pixelated .sidebar-chat-title-text {
+      opacity: 0;
+    }
+
+    .sidebar-chat-title-pixelated::after {
+      position: absolute;
+      inset: 0;
+      overflow: hidden;
+      color: inherit;
+      content: attr(data-pixelated-title);
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .group:hover .sidebar-chat-title-pixelated .sidebar-chat-title-text,
+    .group:focus-within .sidebar-chat-title-pixelated .sidebar-chat-title-text {
+      opacity: 1;
+    }
+
+    .group:hover .sidebar-chat-title-pixelated::after,
+    .group:focus-within .sidebar-chat-title-pixelated::after {
+      content: none;
+    }
+  }
+}
+
 @layer base {
   * {
     @apply border-border;

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -177,13 +177,17 @@
       opacity: 1;
     }
 
-    .group:hover .pixelated-text .pixelated-text-source,
-    .group:focus-within .pixelated-text .pixelated-text-source {
+    .chat-title-privacy-region:hover .pixelated-text .pixelated-text-source,
+    .chat-title-privacy-region:focus-within
+      .pixelated-text
+      .pixelated-text-source {
       opacity: 1;
     }
 
-    .group:hover .pixelated-text .pixelated-text-canvas,
-    .group:focus-within .pixelated-text .pixelated-text-canvas {
+    .chat-title-privacy-region:hover .pixelated-text .pixelated-text-canvas,
+    .chat-title-privacy-region:focus-within
+      .pixelated-text
+      .pixelated-text-canvas {
       opacity: 0;
     }
   }

--- a/tests/components/chat/chat-list-item.test.tsx
+++ b/tests/components/chat/chat-list-item.test.tsx
@@ -5,7 +5,7 @@ import {
 import { fireEvent, render, screen } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 
-const chat: ChatItemData = {
+const savedChat: ChatItemData = {
   id: 'chat-123',
   title: 'Trip planning',
   messageCount: 2,
@@ -14,18 +14,25 @@ const chat: ChatItemData = {
 function renderChatListItem({
   href,
   onSelect = vi.fn(),
+  chat = savedChat,
+  isSelected = false,
+  pixelateSidebarChatTitles,
 }: {
   href?: string
   onSelect?: () => void
+  chat?: ChatItemData
+  isSelected?: boolean
+  pixelateSidebarChatTitles?: boolean
 } = {}) {
   render(
     <ChatListItem
       chat={chat}
       href={href}
-      isSelected={false}
+      isSelected={isSelected}
       isEditing={false}
       editingTitle=""
       isDarkMode={false}
+      pixelateSidebarChatTitles={pixelateSidebarChatTitles}
       onSelect={onSelect}
       onStartEdit={vi.fn()}
       onTitleChange={vi.fn()}
@@ -62,5 +69,50 @@ describe('ChatListItem navigation semantics', () => {
     fireEvent.click(screen.getByRole('button', { name: /Trip planning/ }))
     expect(onSelect).toHaveBeenCalledOnce()
     expect(screen.queryByRole('link')).not.toBeInTheDocument()
+  })
+})
+
+describe('ChatListItem title privacy', () => {
+  it('pixelates inactive saved chat titles by default', () => {
+    renderChatListItem()
+
+    expect(screen.getByText('Trip planning').parentElement).toHaveClass(
+      'sidebar-chat-title-pixelated',
+    )
+    expect(screen.getByText('Trip planning').parentElement).toHaveAttribute(
+      'data-pixelated-title',
+      '■■■■ ■■■■■■■■',
+    )
+  })
+
+  it('keeps the active chat title clear', () => {
+    renderChatListItem({ isSelected: true })
+
+    expect(screen.getByText('Trip planning').parentElement).not.toHaveClass(
+      'sidebar-chat-title-pixelated',
+    )
+  })
+
+  it('keeps the new chat title clear', () => {
+    renderChatListItem({
+      chat: {
+        id: 'blank-chat',
+        title: 'New Chat',
+        isBlankChat: true,
+        messageCount: 0,
+      },
+    })
+
+    expect(screen.getByText('New Chat').parentElement).not.toHaveClass(
+      'sidebar-chat-title-pixelated',
+    )
+  })
+
+  it('keeps saved chat titles clear when pixelation is disabled', () => {
+    renderChatListItem({ pixelateSidebarChatTitles: false })
+
+    expect(screen.getByText('Trip planning').parentElement).not.toHaveClass(
+      'sidebar-chat-title-pixelated',
+    )
   })
 })

--- a/tests/components/chat/chat-list-item.test.tsx
+++ b/tests/components/chat/chat-list-item.test.tsx
@@ -16,7 +16,7 @@ function renderChatListItem({
   onSelect = vi.fn(),
   chat = savedChat,
   isSelected = false,
-  pixelateSidebarChatTitles,
+  pixelateSidebarChatTitles = true,
   enableTitleAnimation = false,
 }: {
   href?: string

--- a/tests/components/chat/chat-list-item.test.tsx
+++ b/tests/components/chat/chat-list-item.test.tsx
@@ -17,36 +17,44 @@ function renderChatListItem({
   chat = savedChat,
   isSelected = false,
   pixelateSidebarChatTitles,
+  enableTitleAnimation = false,
 }: {
   href?: string
   onSelect?: () => void
   chat?: ChatItemData
   isSelected?: boolean
   pixelateSidebarChatTitles?: boolean
+  enableTitleAnimation?: boolean
 } = {}) {
-  render(
+  const renderItem = (item: ChatItemData) => (
     <ChatListItem
-      chat={chat}
+      chat={item}
       href={href}
       isSelected={isSelected}
       isEditing={false}
       editingTitle=""
       isDarkMode={false}
       pixelateSidebarChatTitles={pixelateSidebarChatTitles}
+      enableTitleAnimation={enableTitleAnimation}
       onSelect={onSelect}
       onStartEdit={vi.fn()}
       onTitleChange={vi.fn()}
       onSaveTitle={vi.fn()}
       onCancelEdit={vi.fn()}
       onRequestDelete={vi.fn()}
-    />,
+    />
   )
-  return onSelect
+  const view = render(renderItem(chat))
+  return {
+    onSelect,
+    rerenderChat: (updatedChat: ChatItemData) =>
+      view.rerender(renderItem(updatedChat)),
+  }
 }
 
 describe('ChatListItem navigation semantics', () => {
   it('renders persistent chats as links and handles ordinary clicks in place', () => {
-    const onSelect = renderChatListItem({ href: '/chat/chat-123' })
+    const { onSelect } = renderChatListItem({ href: '/chat/chat-123' })
     const link = screen.getByRole('link', { name: /Trip planning/ })
 
     expect(link).toHaveAttribute('href', '/chat/chat-123')
@@ -55,7 +63,7 @@ describe('ChatListItem navigation semantics', () => {
   })
 
   it('preserves modified- and middle-click link behavior', () => {
-    const onSelect = renderChatListItem({ href: '/chat/chat-123' })
+    const { onSelect } = renderChatListItem({ href: '/chat/chat-123' })
     const link = screen.getByRole('link')
 
     fireEvent.click(link, { ctrlKey: true })
@@ -64,7 +72,7 @@ describe('ChatListItem navigation semantics', () => {
   })
 
   it('renders chats without destinations as buttons', () => {
-    const onSelect = renderChatListItem()
+    const { onSelect } = renderChatListItem()
 
     fireEvent.click(screen.getByRole('button', { name: /Trip planning/ }))
     expect(onSelect).toHaveBeenCalledOnce()
@@ -122,6 +130,17 @@ describe('ChatListItem title privacy', () => {
     renderChatListItem({ pixelateSidebarChatTitles: false })
 
     expect(screen.getByText('Trip planning').parentElement).not.toHaveClass(
+      'pixelated-text',
+    )
+  })
+
+  it('updates pixelated titles without hiding a stale animation', () => {
+    const { rerenderChat } = renderChatListItem({ enableTitleAnimation: true })
+
+    rerenderChat({ ...savedChat, title: 'Updated trip' })
+
+    expect(screen.queryByText('Trip planning')).not.toBeInTheDocument()
+    expect(screen.getByText('Updated trip').parentElement).toHaveClass(
       'pixelated-text',
     )
   })

--- a/tests/components/chat/chat-list-item.test.tsx
+++ b/tests/components/chat/chat-list-item.test.tsx
@@ -16,13 +16,13 @@ function renderChatListItem({
   onSelect = vi.fn(),
   chat = savedChat,
   isSelected = false,
-  blurSidebarChatTitles,
+  pixelateSidebarChatTitles,
 }: {
   href?: string
   onSelect?: () => void
   chat?: ChatItemData
   isSelected?: boolean
-  blurSidebarChatTitles?: boolean
+  pixelateSidebarChatTitles?: boolean
 } = {}) {
   render(
     <ChatListItem
@@ -32,7 +32,7 @@ function renderChatListItem({
       isEditing={false}
       editingTitle=""
       isDarkMode={false}
-      blurSidebarChatTitles={blurSidebarChatTitles}
+      pixelateSidebarChatTitles={pixelateSidebarChatTitles}
       onSelect={onSelect}
       onStartEdit={vi.fn()}
       onTitleChange={vi.fn()}
@@ -73,19 +73,19 @@ describe('ChatListItem navigation semantics', () => {
 })
 
 describe('ChatListItem title privacy', () => {
-  it('blurs inactive saved chat titles by default', () => {
+  it('pixelates inactive saved chat titles by default', () => {
     renderChatListItem()
 
-    expect(screen.getByText('Trip planning')).toHaveClass(
-      'sidebar-chat-title-motion-blurred',
+    expect(screen.getByText('Trip planning').parentElement).toHaveClass(
+      'pixelated-text',
     )
   })
 
   it('keeps the active chat title clear', () => {
     renderChatListItem({ isSelected: true })
 
-    expect(screen.getByText('Trip planning')).not.toHaveClass(
-      'sidebar-chat-title-motion-blurred',
+    expect(screen.getByText('Trip planning').parentElement).not.toHaveClass(
+      'pixelated-text',
     )
   })
 
@@ -99,8 +99,8 @@ describe('ChatListItem title privacy', () => {
       },
     })
 
-    expect(screen.getByText('New Chat')).not.toHaveClass(
-      'sidebar-chat-title-motion-blurred',
+    expect(screen.getByText('New Chat').parentElement).not.toHaveClass(
+      'pixelated-text',
     )
   })
 
@@ -113,16 +113,16 @@ describe('ChatListItem title privacy', () => {
       },
     })
 
-    expect(screen.getByText('Empty saved chat')).not.toHaveClass(
-      'sidebar-chat-title-motion-blurred',
+    expect(screen.getByText('Empty saved chat').parentElement).not.toHaveClass(
+      'pixelated-text',
     )
   })
 
-  it('keeps saved chat titles clear when blurring is disabled', () => {
-    renderChatListItem({ blurSidebarChatTitles: false })
+  it('keeps saved chat titles clear when pixelation is disabled', () => {
+    renderChatListItem({ pixelateSidebarChatTitles: false })
 
-    expect(screen.getByText('Trip planning')).not.toHaveClass(
-      'sidebar-chat-title-motion-blurred',
+    expect(screen.getByText('Trip planning').parentElement).not.toHaveClass(
+      'pixelated-text',
     )
   })
 })

--- a/tests/components/chat/chat-list-item.test.tsx
+++ b/tests/components/chat/chat-list-item.test.tsx
@@ -104,6 +104,20 @@ describe('ChatListItem title privacy', () => {
     )
   })
 
+  it('keeps saved chats without messages clear', () => {
+    renderChatListItem({
+      chat: {
+        id: 'empty-saved-chat',
+        title: 'Empty saved chat',
+        messageCount: 0,
+      },
+    })
+
+    expect(screen.getByText('Empty saved chat')).not.toHaveClass(
+      'sidebar-chat-title-motion-blurred',
+    )
+  })
+
   it('keeps saved chat titles clear when blurring is disabled', () => {
     renderChatListItem({ blurSidebarChatTitles: false })
 

--- a/tests/components/chat/chat-list-item.test.tsx
+++ b/tests/components/chat/chat-list-item.test.tsx
@@ -16,13 +16,13 @@ function renderChatListItem({
   onSelect = vi.fn(),
   chat = savedChat,
   isSelected = false,
-  pixelateSidebarChatTitles,
+  blurSidebarChatTitles,
 }: {
   href?: string
   onSelect?: () => void
   chat?: ChatItemData
   isSelected?: boolean
-  pixelateSidebarChatTitles?: boolean
+  blurSidebarChatTitles?: boolean
 } = {}) {
   render(
     <ChatListItem
@@ -32,7 +32,7 @@ function renderChatListItem({
       isEditing={false}
       editingTitle=""
       isDarkMode={false}
-      pixelateSidebarChatTitles={pixelateSidebarChatTitles}
+      blurSidebarChatTitles={blurSidebarChatTitles}
       onSelect={onSelect}
       onStartEdit={vi.fn()}
       onTitleChange={vi.fn()}
@@ -73,23 +73,19 @@ describe('ChatListItem navigation semantics', () => {
 })
 
 describe('ChatListItem title privacy', () => {
-  it('pixelates inactive saved chat titles by default', () => {
+  it('blurs inactive saved chat titles by default', () => {
     renderChatListItem()
 
-    expect(screen.getByText('Trip planning').parentElement).toHaveClass(
-      'sidebar-chat-title-pixelated',
-    )
-    expect(screen.getByText('Trip planning').parentElement).toHaveAttribute(
-      'data-pixelated-title',
-      '■■■■ ■■■■■■■■',
+    expect(screen.getByText('Trip planning')).toHaveClass(
+      'sidebar-chat-title-blurred',
     )
   })
 
   it('keeps the active chat title clear', () => {
     renderChatListItem({ isSelected: true })
 
-    expect(screen.getByText('Trip planning').parentElement).not.toHaveClass(
-      'sidebar-chat-title-pixelated',
+    expect(screen.getByText('Trip planning')).not.toHaveClass(
+      'sidebar-chat-title-blurred',
     )
   })
 
@@ -103,16 +99,16 @@ describe('ChatListItem title privacy', () => {
       },
     })
 
-    expect(screen.getByText('New Chat').parentElement).not.toHaveClass(
-      'sidebar-chat-title-pixelated',
+    expect(screen.getByText('New Chat')).not.toHaveClass(
+      'sidebar-chat-title-blurred',
     )
   })
 
-  it('keeps saved chat titles clear when pixelation is disabled', () => {
-    renderChatListItem({ pixelateSidebarChatTitles: false })
+  it('keeps saved chat titles clear when blurring is disabled', () => {
+    renderChatListItem({ blurSidebarChatTitles: false })
 
-    expect(screen.getByText('Trip planning').parentElement).not.toHaveClass(
-      'sidebar-chat-title-pixelated',
+    expect(screen.getByText('Trip planning')).not.toHaveClass(
+      'sidebar-chat-title-blurred',
     )
   })
 })

--- a/tests/components/chat/chat-list-item.test.tsx
+++ b/tests/components/chat/chat-list-item.test.tsx
@@ -77,7 +77,7 @@ describe('ChatListItem title privacy', () => {
     renderChatListItem()
 
     expect(screen.getByText('Trip planning')).toHaveClass(
-      'sidebar-chat-title-blurred',
+      'sidebar-chat-title-motion-blurred',
     )
   })
 
@@ -85,7 +85,7 @@ describe('ChatListItem title privacy', () => {
     renderChatListItem({ isSelected: true })
 
     expect(screen.getByText('Trip planning')).not.toHaveClass(
-      'sidebar-chat-title-blurred',
+      'sidebar-chat-title-motion-blurred',
     )
   })
 
@@ -100,7 +100,7 @@ describe('ChatListItem title privacy', () => {
     })
 
     expect(screen.getByText('New Chat')).not.toHaveClass(
-      'sidebar-chat-title-blurred',
+      'sidebar-chat-title-motion-blurred',
     )
   })
 
@@ -108,7 +108,7 @@ describe('ChatListItem title privacy', () => {
     renderChatListItem({ blurSidebarChatTitles: false })
 
     expect(screen.getByText('Trip planning')).not.toHaveClass(
-      'sidebar-chat-title-blurred',
+      'sidebar-chat-title-motion-blurred',
     )
   })
 })

--- a/tests/components/ui/pixelated-text.test.tsx
+++ b/tests/components/ui/pixelated-text.test.tsx
@@ -5,8 +5,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 const CANVAS_TEXT_WIDTH_PER_CHARACTER = 4
 const SOURCE_WIDTH = 100
 const SOURCE_HEIGHT = 20
-const EXPECTED_CANVAS_WIDTH = 34
-const EXPECTED_CANVAS_HEIGHT = 7
+const EXPECTED_CANVAS_WIDTH = 40
+const EXPECTED_CANVAS_HEIGHT = 8
 
 describe('PixelatedText', () => {
   const fillText = vi.fn()
@@ -67,7 +67,7 @@ describe('PixelatedText', () => {
     expect(canvas).toHaveProperty('width', EXPECTED_CANVAS_WIDTH)
     expect(canvas).toHaveProperty('height', EXPECTED_CANVAS_HEIGHT)
     expect(fillText).toHaveBeenCalledWith(
-      'Priva...',
+      'Private...',
       0,
       EXPECTED_CANVAS_HEIGHT / 2,
     )

--- a/tests/components/ui/pixelated-text.test.tsx
+++ b/tests/components/ui/pixelated-text.test.tsx
@@ -1,5 +1,5 @@
 import { PixelatedText } from '@/components/ui/pixelated-text'
-import { render, screen } from '@testing-library/react'
+import { act, render, screen } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const CANVAS_TEXT_WIDTH_PER_CHARACTER = 4
@@ -85,10 +85,20 @@ describe('PixelatedText', () => {
     expect(source.parentElement?.querySelector('canvas')).toBeNull()
   })
 
-  it('skips canvas rendering on touch-only devices', () => {
+  it('renders when a touch-only device gains a hover-capable pointer', () => {
+    let handleChange: (() => void) | undefined
+    const pointerQuery = {
+      matches: false,
+      addEventListener: vi.fn(
+        (_event: string, listener: EventListenerOrEventListenerObject) => {
+          handleChange = listener as () => void
+        },
+      ),
+      removeEventListener: vi.fn(),
+    }
     vi.stubGlobal(
       'matchMedia',
-      vi.fn(() => ({ matches: false })),
+      vi.fn(() => pointerQuery),
     )
 
     render(
@@ -101,5 +111,14 @@ describe('PixelatedText', () => {
       'data-pixelation-ready',
     )
     expect(fillText).not.toHaveBeenCalled()
+
+    pointerQuery.matches = true
+    act(() => handleChange?.())
+
+    expect(screen.getByText('Touch title').parentElement).toHaveAttribute(
+      'data-pixelation-ready',
+      'true',
+    )
+    expect(fillText).toHaveBeenCalled()
   })
 })

--- a/tests/components/ui/pixelated-text.test.tsx
+++ b/tests/components/ui/pixelated-text.test.tsx
@@ -1,0 +1,99 @@
+import { PixelatedText } from '@/components/ui/pixelated-text'
+import { render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const CANVAS_TEXT_WIDTH_PER_CHARACTER = 4
+const SOURCE_WIDTH = 100
+const SOURCE_HEIGHT = 20
+
+describe('PixelatedText', () => {
+  const fillText = vi.fn()
+  const context = {
+    clearRect: vi.fn(),
+    fillStyle: '',
+    fillText,
+    font: '',
+    imageSmoothingEnabled: true,
+    measureText: vi.fn((text: string) => ({
+      width: text.length * CANVAS_TEXT_WIDTH_PER_CHARACTER,
+    })),
+    textBaseline: 'alphabetic',
+  } as unknown as CanvasRenderingContext2D
+
+  beforeEach(() => {
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+      bottom: SOURCE_HEIGHT,
+      height: SOURCE_HEIGHT,
+      left: 0,
+      right: SOURCE_WIDTH,
+      top: 0,
+      width: SOURCE_WIDTH,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    })
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(context)
+    vi.spyOn(window, 'getComputedStyle').mockReturnValue({
+      color: 'rgb(17, 24, 39)',
+      fontFamily: 'Aeonik Fono',
+      fontSize: '14px',
+      fontStyle: 'normal',
+      fontVariant: 'normal',
+      fontWeight: '500',
+    } as CSSStyleDeclaration)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+    fillText.mockClear()
+  })
+
+  it('draws text onto a low-resolution canvas', () => {
+    render(
+      <PixelatedText text="Private title" active={true}>
+        Private title
+      </PixelatedText>,
+    )
+
+    const source = screen.getByText('Private title')
+    const container = source.parentElement
+    const canvas = container?.querySelector('canvas')
+
+    expect(container).toHaveAttribute('data-pixelation-ready', 'true')
+    expect(canvas).toHaveAttribute('aria-hidden', 'true')
+    expect(canvas).toHaveProperty('width', SOURCE_WIDTH / 2)
+    expect(canvas).toHaveProperty('height', SOURCE_HEIGHT / 2)
+    expect(fillText).toHaveBeenCalledWith('Private t...', 0, SOURCE_HEIGHT / 4)
+  })
+
+  it('renders only accessible source text when inactive', () => {
+    render(
+      <PixelatedText text="Current chat" active={false}>
+        Current chat
+      </PixelatedText>,
+    )
+
+    const source = screen.getByText('Current chat')
+    expect(source.parentElement).not.toHaveAttribute('data-pixelation-ready')
+    expect(source.parentElement?.querySelector('canvas')).toBeNull()
+  })
+
+  it('skips canvas rendering on touch-only devices', () => {
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn(() => ({ matches: false })),
+    )
+
+    render(
+      <PixelatedText text="Touch title" active={true}>
+        Touch title
+      </PixelatedText>,
+    )
+
+    expect(screen.getByText('Touch title').parentElement).not.toHaveAttribute(
+      'data-pixelation-ready',
+    )
+    expect(fillText).not.toHaveBeenCalled()
+  })
+})

--- a/tests/components/ui/pixelated-text.test.tsx
+++ b/tests/components/ui/pixelated-text.test.tsx
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 const CANVAS_TEXT_WIDTH_PER_CHARACTER = 4
 const SOURCE_WIDTH = 100
 const SOURCE_HEIGHT = 20
-const EXPECTED_CANVAS_WIDTH = 40
+const EXPECTED_CANVAS_WIDTH = 37
 const EXPECTED_CANVAS_HEIGHT = 8
 const FONT_ASCENT = 4
 const FONT_DESCENT = 1
@@ -73,7 +73,7 @@ describe('PixelatedText', () => {
     expect(canvas).toHaveProperty('width', EXPECTED_CANVAS_WIDTH)
     expect(canvas).toHaveProperty('height', EXPECTED_CANVAS_HEIGHT)
     expect(fillText).toHaveBeenCalledWith(
-      'Private...',
+      'Privat...',
       0,
       EXPECTED_TEXT_BASELINE,
     )

--- a/tests/components/ui/pixelated-text.test.tsx
+++ b/tests/components/ui/pixelated-text.test.tsx
@@ -7,6 +7,10 @@ const SOURCE_WIDTH = 100
 const SOURCE_HEIGHT = 20
 const EXPECTED_CANVAS_WIDTH = 40
 const EXPECTED_CANVAS_HEIGHT = 8
+const FONT_ASCENT = 4
+const FONT_DESCENT = 1
+const EXPECTED_TEXT_BASELINE =
+  (EXPECTED_CANVAS_HEIGHT + FONT_ASCENT - FONT_DESCENT) / 2
 
 describe('PixelatedText', () => {
   const fillText = vi.fn()
@@ -17,6 +21,8 @@ describe('PixelatedText', () => {
     font: '',
     imageSmoothingEnabled: true,
     measureText: vi.fn((text: string) => ({
+      fontBoundingBoxAscent: FONT_ASCENT,
+      fontBoundingBoxDescent: FONT_DESCENT,
       width: text.length * CANVAS_TEXT_WIDTH_PER_CHARACTER,
     })),
     textBaseline: 'alphabetic',
@@ -69,7 +75,7 @@ describe('PixelatedText', () => {
     expect(fillText).toHaveBeenCalledWith(
       'Private...',
       0,
-      EXPECTED_CANVAS_HEIGHT / 2,
+      EXPECTED_TEXT_BASELINE,
     )
   })
 

--- a/tests/components/ui/pixelated-text.test.tsx
+++ b/tests/components/ui/pixelated-text.test.tsx
@@ -5,6 +5,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 const CANVAS_TEXT_WIDTH_PER_CHARACTER = 4
 const SOURCE_WIDTH = 100
 const SOURCE_HEIGHT = 20
+const EXPECTED_CANVAS_WIDTH = 34
+const EXPECTED_CANVAS_HEIGHT = 7
 
 describe('PixelatedText', () => {
   const fillText = vi.fn()
@@ -62,9 +64,13 @@ describe('PixelatedText', () => {
 
     expect(container).toHaveAttribute('data-pixelation-ready', 'true')
     expect(canvas).toHaveAttribute('aria-hidden', 'true')
-    expect(canvas).toHaveProperty('width', SOURCE_WIDTH / 2)
-    expect(canvas).toHaveProperty('height', SOURCE_HEIGHT / 2)
-    expect(fillText).toHaveBeenCalledWith('Private t...', 0, SOURCE_HEIGHT / 4)
+    expect(canvas).toHaveProperty('width', EXPECTED_CANVAS_WIDTH)
+    expect(canvas).toHaveProperty('height', EXPECTED_CANVAS_HEIGHT)
+    expect(fillText).toHaveBeenCalledWith(
+      'Priva...',
+      0,
+      EXPECTED_CANVAS_HEIGHT / 2,
+    )
   })
 
   it('renders only accessible source text when inactive', () => {

--- a/tests/components/ui/pixelated-text.test.tsx
+++ b/tests/components/ui/pixelated-text.test.tsx
@@ -121,4 +121,35 @@ describe('PixelatedText', () => {
     )
     expect(fillText).toHaveBeenCalled()
   })
+
+  it('supports legacy media query listeners', () => {
+    let handleChange: (() => void) | undefined
+    const pointerQuery = {
+      matches: false,
+      addListener: vi.fn((listener: () => void) => {
+        handleChange = listener
+      }),
+      removeListener: vi.fn(),
+    }
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn(() => pointerQuery),
+    )
+
+    const view = render(
+      <PixelatedText text="Legacy browser title" active={true}>
+        Legacy browser title
+      </PixelatedText>,
+    )
+
+    pointerQuery.matches = true
+    act(() => handleChange?.())
+
+    expect(
+      screen.getByText('Legacy browser title').parentElement,
+    ).toHaveAttribute('data-pixelation-ready', 'true')
+
+    view.unmount()
+    expect(pointerQuery.removeListener).toHaveBeenCalledWith(handleChange)
+  })
 })

--- a/tests/components/ui/pixelated-text.test.tsx
+++ b/tests/components/ui/pixelated-text.test.tsx
@@ -121,35 +121,4 @@ describe('PixelatedText', () => {
     )
     expect(fillText).toHaveBeenCalled()
   })
-
-  it('supports legacy media query listeners', () => {
-    let handleChange: (() => void) | undefined
-    const pointerQuery = {
-      matches: false,
-      addListener: vi.fn((listener: () => void) => {
-        handleChange = listener
-      }),
-      removeListener: vi.fn(),
-    }
-    vi.stubGlobal(
-      'matchMedia',
-      vi.fn(() => pointerQuery),
-    )
-
-    const view = render(
-      <PixelatedText text="Legacy browser title" active={true}>
-        Legacy browser title
-      </PixelatedText>,
-    )
-
-    pointerQuery.matches = true
-    act(() => handleChange?.())
-
-    expect(
-      screen.getByText('Legacy browser title').parentElement,
-    ).toHaveAttribute('data-pixelation-ready', 'true')
-
-    view.unmount()
-    expect(pointerQuery.removeListener).toHaveBeenCalledWith(handleChange)
-  })
 })

--- a/tests/services/cloud/profile-merge.test.ts
+++ b/tests/services/cloud/profile-merge.test.ts
@@ -193,15 +193,22 @@ describe('changedProfileFields', () => {
       traits: ['x'],
       thinkingEnabled: true,
       webSearchAvailable: true,
+      pixelateSidebarChatTitles: true,
     }
     const local: ProfileData = {
       nickname: 'b',
       traits: ['x', 'y'],
       thinkingEnabled: true,
       webSearchAvailable: false,
+      pixelateSidebarChatTitles: false,
     }
     const fields = changedProfileFields(local, baseline)
-    expect(fields.sort()).toEqual(['nickname', 'traits', 'webSearchAvailable'])
+    expect(fields.sort()).toEqual([
+      'nickname',
+      'pixelateSidebarChatTitles',
+      'traits',
+      'webSearchAvailable',
+    ])
   })
 })
 

--- a/tests/services/cloud/profile-merge.test.ts
+++ b/tests/services/cloud/profile-merge.test.ts
@@ -193,19 +193,19 @@ describe('changedProfileFields', () => {
       traits: ['x'],
       thinkingEnabled: true,
       webSearchAvailable: true,
-      pixelateSidebarChatTitles: true,
+      blurSidebarChatTitles: true,
     }
     const local: ProfileData = {
       nickname: 'b',
       traits: ['x', 'y'],
       thinkingEnabled: true,
       webSearchAvailable: false,
-      pixelateSidebarChatTitles: false,
+      blurSidebarChatTitles: false,
     }
     const fields = changedProfileFields(local, baseline)
     expect(fields.sort()).toEqual([
+      'blurSidebarChatTitles',
       'nickname',
-      'pixelateSidebarChatTitles',
       'traits',
       'webSearchAvailable',
     ])

--- a/tests/services/cloud/profile-merge.test.ts
+++ b/tests/services/cloud/profile-merge.test.ts
@@ -273,6 +273,17 @@ describe('mergeProfilesThreeWay', () => {
     expect(result.conflicts).toEqual([])
   })
 
+  it('preserves pixelation preferences omitted by older profiles', () => {
+    const result = mergeProfilesThreeWay({
+      baseline: { pixelateSidebarChatTitlesEnabled: false },
+      local: { pixelateSidebarChatTitlesEnabled: false },
+      remote: { version: 2 },
+    })
+
+    expect(result.merged.pixelateSidebarChatTitlesEnabled).toBe(false)
+    expect(result.conflicts).toEqual([])
+  })
+
   it('retains local data and reports an ambiguous conflict', () => {
     const result = mergeProfilesThreeWay({
       baseline: { nickname: 'Ada' },

--- a/tests/services/cloud/profile-merge.test.ts
+++ b/tests/services/cloud/profile-merge.test.ts
@@ -193,19 +193,19 @@ describe('changedProfileFields', () => {
       traits: ['x'],
       thinkingEnabled: true,
       webSearchAvailable: true,
-      blurSidebarChatTitlesEnabled: true,
+      pixelateSidebarChatTitlesEnabled: true,
     }
     const local: ProfileData = {
       nickname: 'b',
       traits: ['x', 'y'],
       thinkingEnabled: true,
       webSearchAvailable: false,
-      blurSidebarChatTitlesEnabled: false,
+      pixelateSidebarChatTitlesEnabled: false,
     }
     const fields = changedProfileFields(local, baseline)
     expect(fields.sort()).toEqual([
-      'blurSidebarChatTitlesEnabled',
       'nickname',
+      'pixelateSidebarChatTitlesEnabled',
       'traits',
       'webSearchAvailable',
     ])

--- a/tests/services/cloud/profile-merge.test.ts
+++ b/tests/services/cloud/profile-merge.test.ts
@@ -193,18 +193,18 @@ describe('changedProfileFields', () => {
       traits: ['x'],
       thinkingEnabled: true,
       webSearchAvailable: true,
-      blurSidebarChatTitles: true,
+      blurSidebarChatTitlesEnabled: true,
     }
     const local: ProfileData = {
       nickname: 'b',
       traits: ['x', 'y'],
       thinkingEnabled: true,
       webSearchAvailable: false,
-      blurSidebarChatTitles: false,
+      blurSidebarChatTitlesEnabled: false,
     }
     const fields = changedProfileFields(local, baseline)
     expect(fields.sort()).toEqual([
-      'blurSidebarChatTitles',
+      'blurSidebarChatTitlesEnabled',
       'nickname',
       'traits',
       'webSearchAvailable',

--- a/tests/services/cloud/profile-settings-serializer.test.ts
+++ b/tests/services/cloud/profile-settings-serializer.test.ts
@@ -2,6 +2,7 @@ import {
   SETTINGS_CHAT_FONT,
   SETTINGS_CODE_EXECUTION_ENABLED,
   SETTINGS_PII_CHECK_ENABLED,
+  SETTINGS_PIXELATE_SIDEBAR_CHAT_TITLES,
   SETTINGS_REASONING_EFFORT,
   SETTINGS_SELECTED_MODEL,
   SETTINGS_THINKING_ENABLED,
@@ -104,6 +105,7 @@ describe('profile-settings-serializer', () => {
     localStorage.setItem(SETTINGS_WEB_SEARCH_ENABLED, 'false')
     localStorage.setItem(SETTINGS_WEB_SEARCH_AVAILABLE, 'false')
     localStorage.setItem(SETTINGS_CODE_EXECUTION_ENABLED, 'true')
+    localStorage.setItem(SETTINGS_PIXELATE_SIDEBAR_CHAT_TITLES, 'false')
     localStorage.setItem(SETTINGS_PII_CHECK_ENABLED, 'false')
     localStorage.setItem(SETTINGS_CHAT_FONT, 'mono')
     localStorage.setItem(USER_PREFS_PROJECT_UPLOAD, 'project')
@@ -118,6 +120,7 @@ describe('profile-settings-serializer', () => {
       webSearchEnabled: false,
       webSearchAvailable: false,
       codeExecutionEnabled: true,
+      pixelateSidebarChatTitles: false,
       piiCheckEnabled: false,
       chatFont: 'mono',
       projectUploadPreference: 'project',
@@ -171,6 +174,7 @@ describe('profile-settings-serializer', () => {
       webSearchEnabled: true,
       webSearchAvailable: false,
       codeExecutionEnabled: false,
+      pixelateSidebarChatTitles: true,
       piiCheckEnabled: true,
       chatFont: 'serif',
       projectUploadPreference: 'chat',
@@ -188,6 +192,9 @@ describe('profile-settings-serializer', () => {
     expect(localStorage.getItem(SETTINGS_WEB_SEARCH_ENABLED)).toBe('true')
     expect(localStorage.getItem(SETTINGS_WEB_SEARCH_AVAILABLE)).toBe('false')
     expect(localStorage.getItem(SETTINGS_CODE_EXECUTION_ENABLED)).toBe('false')
+    expect(localStorage.getItem(SETTINGS_PIXELATE_SIDEBAR_CHAT_TITLES)).toBe(
+      'true',
+    )
     expect(localStorage.getItem(SETTINGS_PII_CHECK_ENABLED)).toBe('true')
     expect(localStorage.getItem(SETTINGS_CHAT_FONT)).toBe('serif')
     expect(localStorage.getItem(USER_PREFS_PROJECT_UPLOAD)).toBe('chat')
@@ -195,5 +202,9 @@ describe('profile-settings-serializer', () => {
 
   it('defaults web search availability to on', () => {
     expect(loadLocalSettings().webSearchAvailable).toBe(true)
+  })
+
+  it('defaults sidebar chat title pixelation to on', () => {
+    expect(loadLocalSettings().pixelateSidebarChatTitles).toBe(true)
   })
 })

--- a/tests/services/cloud/profile-settings-serializer.test.ts
+++ b/tests/services/cloud/profile-settings-serializer.test.ts
@@ -204,7 +204,7 @@ describe('profile-settings-serializer', () => {
     expect(loadLocalSettings().webSearchAvailable).toBe(true)
   })
 
-  it('defaults sidebar chat title pixelation to on', () => {
-    expect(loadLocalSettings().pixelateSidebarChatTitlesEnabled).toBe(true)
+  it('omits sidebar chat title pixelation when it has not been set', () => {
+    expect(loadLocalSettings().pixelateSidebarChatTitlesEnabled).toBeUndefined()
   })
 })

--- a/tests/services/cloud/profile-settings-serializer.test.ts
+++ b/tests/services/cloud/profile-settings-serializer.test.ts
@@ -1,5 +1,5 @@
 import {
-  SETTINGS_BLUR_SIDEBAR_CHAT_TITLES,
+  SETTINGS_BLUR_SIDEBAR_CHAT_TITLES_ENABLED,
   SETTINGS_CHAT_FONT,
   SETTINGS_CODE_EXECUTION_ENABLED,
   SETTINGS_PII_CHECK_ENABLED,
@@ -105,7 +105,7 @@ describe('profile-settings-serializer', () => {
     localStorage.setItem(SETTINGS_WEB_SEARCH_ENABLED, 'false')
     localStorage.setItem(SETTINGS_WEB_SEARCH_AVAILABLE, 'false')
     localStorage.setItem(SETTINGS_CODE_EXECUTION_ENABLED, 'true')
-    localStorage.setItem(SETTINGS_BLUR_SIDEBAR_CHAT_TITLES, 'false')
+    localStorage.setItem(SETTINGS_BLUR_SIDEBAR_CHAT_TITLES_ENABLED, 'false')
     localStorage.setItem(SETTINGS_PII_CHECK_ENABLED, 'false')
     localStorage.setItem(SETTINGS_CHAT_FONT, 'mono')
     localStorage.setItem(USER_PREFS_PROJECT_UPLOAD, 'project')
@@ -120,7 +120,7 @@ describe('profile-settings-serializer', () => {
       webSearchEnabled: false,
       webSearchAvailable: false,
       codeExecutionEnabled: true,
-      blurSidebarChatTitles: false,
+      blurSidebarChatTitlesEnabled: false,
       piiCheckEnabled: false,
       chatFont: 'mono',
       projectUploadPreference: 'project',
@@ -174,7 +174,7 @@ describe('profile-settings-serializer', () => {
       webSearchEnabled: true,
       webSearchAvailable: false,
       codeExecutionEnabled: false,
-      blurSidebarChatTitles: true,
+      blurSidebarChatTitlesEnabled: true,
       piiCheckEnabled: true,
       chatFont: 'serif',
       projectUploadPreference: 'chat',
@@ -192,7 +192,9 @@ describe('profile-settings-serializer', () => {
     expect(localStorage.getItem(SETTINGS_WEB_SEARCH_ENABLED)).toBe('true')
     expect(localStorage.getItem(SETTINGS_WEB_SEARCH_AVAILABLE)).toBe('false')
     expect(localStorage.getItem(SETTINGS_CODE_EXECUTION_ENABLED)).toBe('false')
-    expect(localStorage.getItem(SETTINGS_BLUR_SIDEBAR_CHAT_TITLES)).toBe('true')
+    expect(
+      localStorage.getItem(SETTINGS_BLUR_SIDEBAR_CHAT_TITLES_ENABLED),
+    ).toBe('true')
     expect(localStorage.getItem(SETTINGS_PII_CHECK_ENABLED)).toBe('true')
     expect(localStorage.getItem(SETTINGS_CHAT_FONT)).toBe('serif')
     expect(localStorage.getItem(USER_PREFS_PROJECT_UPLOAD)).toBe('chat')
@@ -203,6 +205,6 @@ describe('profile-settings-serializer', () => {
   })
 
   it('defaults sidebar chat title blurring to on', () => {
-    expect(loadLocalSettings().blurSidebarChatTitles).toBe(true)
+    expect(loadLocalSettings().blurSidebarChatTitlesEnabled).toBe(true)
   })
 })

--- a/tests/services/cloud/profile-settings-serializer.test.ts
+++ b/tests/services/cloud/profile-settings-serializer.test.ts
@@ -1,8 +1,8 @@
 import {
+  SETTINGS_BLUR_SIDEBAR_CHAT_TITLES,
   SETTINGS_CHAT_FONT,
   SETTINGS_CODE_EXECUTION_ENABLED,
   SETTINGS_PII_CHECK_ENABLED,
-  SETTINGS_PIXELATE_SIDEBAR_CHAT_TITLES,
   SETTINGS_REASONING_EFFORT,
   SETTINGS_SELECTED_MODEL,
   SETTINGS_THINKING_ENABLED,
@@ -105,7 +105,7 @@ describe('profile-settings-serializer', () => {
     localStorage.setItem(SETTINGS_WEB_SEARCH_ENABLED, 'false')
     localStorage.setItem(SETTINGS_WEB_SEARCH_AVAILABLE, 'false')
     localStorage.setItem(SETTINGS_CODE_EXECUTION_ENABLED, 'true')
-    localStorage.setItem(SETTINGS_PIXELATE_SIDEBAR_CHAT_TITLES, 'false')
+    localStorage.setItem(SETTINGS_BLUR_SIDEBAR_CHAT_TITLES, 'false')
     localStorage.setItem(SETTINGS_PII_CHECK_ENABLED, 'false')
     localStorage.setItem(SETTINGS_CHAT_FONT, 'mono')
     localStorage.setItem(USER_PREFS_PROJECT_UPLOAD, 'project')
@@ -120,7 +120,7 @@ describe('profile-settings-serializer', () => {
       webSearchEnabled: false,
       webSearchAvailable: false,
       codeExecutionEnabled: true,
-      pixelateSidebarChatTitles: false,
+      blurSidebarChatTitles: false,
       piiCheckEnabled: false,
       chatFont: 'mono',
       projectUploadPreference: 'project',
@@ -174,7 +174,7 @@ describe('profile-settings-serializer', () => {
       webSearchEnabled: true,
       webSearchAvailable: false,
       codeExecutionEnabled: false,
-      pixelateSidebarChatTitles: true,
+      blurSidebarChatTitles: true,
       piiCheckEnabled: true,
       chatFont: 'serif',
       projectUploadPreference: 'chat',
@@ -192,9 +192,7 @@ describe('profile-settings-serializer', () => {
     expect(localStorage.getItem(SETTINGS_WEB_SEARCH_ENABLED)).toBe('true')
     expect(localStorage.getItem(SETTINGS_WEB_SEARCH_AVAILABLE)).toBe('false')
     expect(localStorage.getItem(SETTINGS_CODE_EXECUTION_ENABLED)).toBe('false')
-    expect(localStorage.getItem(SETTINGS_PIXELATE_SIDEBAR_CHAT_TITLES)).toBe(
-      'true',
-    )
+    expect(localStorage.getItem(SETTINGS_BLUR_SIDEBAR_CHAT_TITLES)).toBe('true')
     expect(localStorage.getItem(SETTINGS_PII_CHECK_ENABLED)).toBe('true')
     expect(localStorage.getItem(SETTINGS_CHAT_FONT)).toBe('serif')
     expect(localStorage.getItem(USER_PREFS_PROJECT_UPLOAD)).toBe('chat')
@@ -204,7 +202,7 @@ describe('profile-settings-serializer', () => {
     expect(loadLocalSettings().webSearchAvailable).toBe(true)
   })
 
-  it('defaults sidebar chat title pixelation to on', () => {
-    expect(loadLocalSettings().pixelateSidebarChatTitles).toBe(true)
+  it('defaults sidebar chat title blurring to on', () => {
+    expect(loadLocalSettings().blurSidebarChatTitles).toBe(true)
   })
 })

--- a/tests/services/cloud/profile-settings-serializer.test.ts
+++ b/tests/services/cloud/profile-settings-serializer.test.ts
@@ -1,8 +1,8 @@
 import {
-  SETTINGS_BLUR_SIDEBAR_CHAT_TITLES_ENABLED,
   SETTINGS_CHAT_FONT,
   SETTINGS_CODE_EXECUTION_ENABLED,
   SETTINGS_PII_CHECK_ENABLED,
+  SETTINGS_PIXELATE_SIDEBAR_CHAT_TITLES_ENABLED,
   SETTINGS_REASONING_EFFORT,
   SETTINGS_SELECTED_MODEL,
   SETTINGS_THINKING_ENABLED,
@@ -105,7 +105,7 @@ describe('profile-settings-serializer', () => {
     localStorage.setItem(SETTINGS_WEB_SEARCH_ENABLED, 'false')
     localStorage.setItem(SETTINGS_WEB_SEARCH_AVAILABLE, 'false')
     localStorage.setItem(SETTINGS_CODE_EXECUTION_ENABLED, 'true')
-    localStorage.setItem(SETTINGS_BLUR_SIDEBAR_CHAT_TITLES_ENABLED, 'false')
+    localStorage.setItem(SETTINGS_PIXELATE_SIDEBAR_CHAT_TITLES_ENABLED, 'false')
     localStorage.setItem(SETTINGS_PII_CHECK_ENABLED, 'false')
     localStorage.setItem(SETTINGS_CHAT_FONT, 'mono')
     localStorage.setItem(USER_PREFS_PROJECT_UPLOAD, 'project')
@@ -120,7 +120,7 @@ describe('profile-settings-serializer', () => {
       webSearchEnabled: false,
       webSearchAvailable: false,
       codeExecutionEnabled: true,
-      blurSidebarChatTitlesEnabled: false,
+      pixelateSidebarChatTitlesEnabled: false,
       piiCheckEnabled: false,
       chatFont: 'mono',
       projectUploadPreference: 'project',
@@ -174,7 +174,7 @@ describe('profile-settings-serializer', () => {
       webSearchEnabled: true,
       webSearchAvailable: false,
       codeExecutionEnabled: false,
-      blurSidebarChatTitlesEnabled: true,
+      pixelateSidebarChatTitlesEnabled: true,
       piiCheckEnabled: true,
       chatFont: 'serif',
       projectUploadPreference: 'chat',
@@ -193,7 +193,7 @@ describe('profile-settings-serializer', () => {
     expect(localStorage.getItem(SETTINGS_WEB_SEARCH_AVAILABLE)).toBe('false')
     expect(localStorage.getItem(SETTINGS_CODE_EXECUTION_ENABLED)).toBe('false')
     expect(
-      localStorage.getItem(SETTINGS_BLUR_SIDEBAR_CHAT_TITLES_ENABLED),
+      localStorage.getItem(SETTINGS_PIXELATE_SIDEBAR_CHAT_TITLES_ENABLED),
     ).toBe('true')
     expect(localStorage.getItem(SETTINGS_PII_CHECK_ENABLED)).toBe('true')
     expect(localStorage.getItem(SETTINGS_CHAT_FONT)).toBe('serif')
@@ -204,7 +204,7 @@ describe('profile-settings-serializer', () => {
     expect(loadLocalSettings().webSearchAvailable).toBe(true)
   })
 
-  it('defaults sidebar chat title blurring to on', () => {
-    expect(loadLocalSettings().blurSidebarChatTitlesEnabled).toBe(true)
+  it('defaults sidebar chat title pixelation to on', () => {
+    expect(loadLocalSettings().pixelateSidebarChatTitlesEnabled).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary
- render inactive sidebar chat titles to low-resolution canvases for genuine pixelation
- reveal accessible source text on hover or keyboard focus while leaving touch-only devices, active chats, and new chats clear
- add a default-on, profile-synced pixelation setting across chat and project sidebars

## Testing
- `npm run test:unit -- --run` (115 files, 1374 tests passed)
- `npm run test:unit -- --run tests/components/ui/pixelated-text.test.tsx tests/components/chat/chat-list-item.test.tsx tests/services/cloud/profile-settings-serializer.test.ts tests/services/cloud/profile-merge.test.ts`
- `npx tsc --noEmit`
- ESLint and Prettier checks on modified files