### PR TITLE
Refresh application icons with tinfoil-icons 2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@radix-ui/react-tooltip": "^1.2.0",
         "@tailwindcss/typography": "^0.5.16",
         "@tinfoilsh/passkey-kit": "^0.1.0",
-        "@tinfoilsh/tinfoil-icons": "^2.1.0",
+        "@tinfoilsh/tinfoil-icons": "^2.2.0",
         "autoprefixer": "^10.4.21",
         "boring-avatars": "^2.0.4",
         "class-variance-authority": "^0.7.1",
@@ -3396,9 +3396,9 @@
       }
     },
     "node_modules/@tinfoilsh/tinfoil-icons": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@tinfoilsh/tinfoil-icons/-/tinfoil-icons-2.1.0.tgz",
-      "integrity": "sha512-jWak5QJmqPNlhQjnZbuzrPVHC8vyKeZfGH4+xp++pEfEAAVBYO7RopBPjX0VeUXJ2wFhH9lvJpRYwabG+/5kHQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@tinfoilsh/tinfoil-icons/-/tinfoil-icons-2.2.0.tgz",
+      "integrity": "sha512-5hNWUcNznX8gf9ttKQ7FAvDUdRff12oMvUeATUGLk21J+zBWfpD/hvwePdY12zGYaoZPGVDK9A7h7+kFKqmoSQ==",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@radix-ui/react-tooltip": "^1.2.0",
         "@tailwindcss/typography": "^0.5.16",
         "@tinfoilsh/passkey-kit": "^0.1.0",
-        "@tinfoilsh/tinfoil-icons": "^2.0.4",
+        "@tinfoilsh/tinfoil-icons": "^2.1.0",
         "autoprefixer": "^10.4.21",
         "boring-avatars": "^2.0.4",
         "class-variance-authority": "^0.7.1",
@@ -3396,9 +3396,9 @@
       }
     },
     "node_modules/@tinfoilsh/tinfoil-icons": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@tinfoilsh/tinfoil-icons/-/tinfoil-icons-2.0.4.tgz",
-      "integrity": "sha512-h706EjKvSIwUIwq0HqbbpCQoehwOyHUkPLiA4f5ZUm79VYMKZDKmq2wSN8/oS9Zb2ttE1nN49OxmpsBI3tOthw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@tinfoilsh/tinfoil-icons/-/tinfoil-icons-2.1.0.tgz",
+      "integrity": "sha512-jWak5QJmqPNlhQjnZbuzrPVHC8vyKeZfGH4+xp++pEfEAAVBYO7RopBPjX0VeUXJ2wFhH9lvJpRYwabG+/5kHQ==",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@radix-ui/react-tooltip": "^1.2.0",
     "@tailwindcss/typography": "^0.5.16",
     "@tinfoilsh/passkey-kit": "^0.1.0",
-    "@tinfoilsh/tinfoil-icons": "^2.0.4",
+    "@tinfoilsh/tinfoil-icons": "^2.1.0",
     "autoprefixer": "^10.4.21",
     "boring-avatars": "^2.0.4",
     "class-variance-authority": "^0.7.1",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@radix-ui/react-tooltip": "^1.2.0",
     "@tailwindcss/typography": "^0.5.16",
     "@tinfoilsh/passkey-kit": "^0.1.0",
-    "@tinfoilsh/tinfoil-icons": "^2.1.0",
+    "@tinfoilsh/tinfoil-icons": "^2.2.0",
     "autoprefixer": "^10.4.21",
     "boring-avatars": "^2.0.4",
     "class-variance-authority": "^0.7.1",

--- a/src/components/chat/DataFlowDiagram.tsx
+++ b/src/components/chat/DataFlowDiagram.tsx
@@ -1,6 +1,10 @@
-import { TfLockLocked, TfServer1 } from '@tinfoilsh/tinfoil-icons'
+import {
+  TfKey,
+  TfLockLocked,
+  TfServer1,
+  TfShieldCheck,
+} from '@tinfoilsh/tinfoil-icons'
 import { memo, useLayoutEffect, useRef, useState } from 'react'
-import { HiOutlineKey, HiShieldCheck } from 'react-icons/hi2'
 
 const ARROW_COLOR = 'hsl(var(--content-muted) / 0.7)'
 
@@ -141,7 +145,7 @@ export const DataFlowDiagram = memo(function DataFlowDiagram() {
           style={{ left: 'calc(50% - 30px)', transform: 'translateX(-50%)' }}
         >
           <div className="flex items-center gap-1.5 whitespace-nowrap rounded border border-brand-accent-light/40 bg-brand-accent-light/10 px-3 py-1.5 text-base font-medium text-brand-accent-dark dark:border-brand-accent-light/30 dark:bg-brand-accent-light/10 dark:text-brand-accent-light">
-            <HiShieldCheck className="h-4 w-4" />
+            <TfShieldCheck className="h-4 w-4" aria-hidden="true" />
             <span>Attestation Proof</span>
           </div>
         </div>
@@ -196,7 +200,10 @@ export const DataFlowDiagram = memo(function DataFlowDiagram() {
           style={{ left: 0, top: 190, width: 195 }}
         >
           <div className="flex items-center gap-2 whitespace-nowrap">
-            <HiOutlineKey className="h-4 w-4 shrink-0 text-content-muted" />
+            <TfKey
+              className="h-4 w-4 shrink-0 !text-content-muted"
+              aria-hidden="true"
+            />
             <span className="text-base font-medium text-content-primary">
               Tinfoil Chat App
             </span>

--- a/src/components/chat/DataFlowDiagram.tsx
+++ b/src/components/chat/DataFlowDiagram.tsx
@@ -1,6 +1,5 @@
+import { TfLockLocked, TfServer1 } from '@tinfoilsh/tinfoil-icons'
 import { memo, useLayoutEffect, useRef, useState } from 'react'
-import { BiSolidLock } from 'react-icons/bi'
-import { HiOutlineServer } from 'react-icons/hi'
 import { HiOutlineKey, HiShieldCheck } from 'react-icons/hi2'
 
 const ARROW_COLOR = 'hsl(var(--content-muted) / 0.7)'
@@ -158,7 +157,7 @@ export const DataFlowDiagram = memo(function DataFlowDiagram() {
           }}
         >
           <div className="flex items-center gap-2 whitespace-nowrap">
-            <HiOutlineServer className="h-4 w-4 shrink-0 text-content-muted" />
+            <TfServer1 className="h-4 w-4 shrink-0 !text-content-muted" />
             <span className="text-base font-medium text-content-primary">
               Tinfoil Server
             </span>
@@ -181,7 +180,7 @@ export const DataFlowDiagram = memo(function DataFlowDiagram() {
           }}
         >
           <div className="flex items-center gap-2 whitespace-nowrap">
-            <BiSolidLock className="h-3.5 w-3.5 shrink-0 text-brand-accent-dark dark:text-brand-accent-light" />
+            <TfLockLocked className="h-3.5 w-3.5 shrink-0 !text-brand-accent-dark dark:!text-brand-accent-light" />
             <span className="text-base font-medium text-content-primary">
               Secure Enclave
             </span>

--- a/src/components/chat/WelcomeScreen.tsx
+++ b/src/components/chat/WelcomeScreen.tsx
@@ -3,9 +3,9 @@ import { Modal, ModalTitle } from '@/components/ui/modal'
 import { findSelectableModel, type BaseModel } from '@/config/models'
 import { USER_PREFS_NICKNAME } from '@/constants/storage-keys'
 import { useUser } from '@clerk/nextjs'
+import { TfLockLocked } from '@tinfoilsh/tinfoil-icons'
 import { motion } from 'framer-motion'
 import React, { memo, useEffect, useRef, useState } from 'react'
-import { BiSolidLock } from 'react-icons/bi'
 import { ChatInput } from './chat-input'
 import { PromptPresetSuggestions } from './components/prompt-preset-suggestions'
 import { CONSTANTS } from './constants'
@@ -349,8 +349,8 @@ export const WelcomeScreen = memo(function WelcomeScreen({
               onClick={() => setIsPrivacyOpen(true)}
               className="group flex w-full items-center justify-center gap-1.5 py-1.5 text-sm text-content-secondary transition-colors hover:text-content-primary sm:gap-2 sm:text-base md:justify-start"
             >
-              <BiSolidLock
-                className="h-4 w-4 text-brand-accent-dark dark:text-brand-accent-light"
+              <TfLockLocked
+                className="h-4 w-4 !text-brand-accent-dark dark:!text-brand-accent-light"
                 aria-hidden="true"
               />
               <span className="shrink-0 whitespace-nowrap">

--- a/src/components/chat/ask-sidebar.tsx
+++ b/src/components/chat/ask-sidebar.tsx
@@ -89,7 +89,7 @@ export function AskSidebar({
         {/* Header */}
         <div className="flex flex-shrink-0 items-center justify-between border-b border-border-subtle px-4 py-3">
           <div className="flex items-center gap-2 text-content-primary">
-            <TfChat2 className="h-5 w-5" />
+            <TfChat2 className="h-5 w-5" aria-hidden="true" />
             <span className="text-sm font-medium">Ask</span>
           </div>
           <button

--- a/src/components/chat/ask-sidebar.tsx
+++ b/src/components/chat/ask-sidebar.tsx
@@ -1,8 +1,8 @@
 import { cn } from '@/components/ui/utils'
 import { findSelectableModel, type BaseModel } from '@/config/models'
 import { XMarkIcon } from '@heroicons/react/24/outline'
+import { TfChat2 } from '@tinfoilsh/tinfoil-icons'
 import { memo, useRef } from 'react'
-import { PiChatCircleText } from 'react-icons/pi'
 import { LoadingDots } from '../loading-dots'
 import { CONSTANTS } from './constants'
 import type { SidebarChatState } from './hooks/use-sidebar-chat'
@@ -89,7 +89,7 @@ export function AskSidebar({
         {/* Header */}
         <div className="flex flex-shrink-0 items-center justify-between border-b border-border-subtle px-4 py-3">
           <div className="flex items-center gap-2 text-content-primary">
-            <PiChatCircleText className="h-5 w-5" />
+            <TfChat2 className="h-5 w-5" />
             <span className="text-sm font-medium">Ask</span>
           </div>
           <button

--- a/src/components/chat/chat-input.tsx
+++ b/src/components/chat/chat-input.tsx
@@ -1328,7 +1328,7 @@ export function ChatInput({
                 >
                   {isRecording ? (
                     <StopIcon
-                      className="h-6 w-6 md:h-5 md:w-5"
+                      className="h-6 w-6 md:h-4 md:w-4"
                       aria-hidden="true"
                     />
                   ) : isTranscribing ? (
@@ -1338,7 +1338,7 @@ export function ChatInput({
                     />
                   ) : (
                     <TfMicrophone
-                      className="h-6 w-6 md:h-5 md:w-5"
+                      className="h-6 w-6 md:h-4 md:w-4"
                       aria-hidden="true"
                     />
                   )}

--- a/src/components/chat/chat-input.tsx
+++ b/src/components/chat/chat-input.tsx
@@ -10,7 +10,13 @@ import {
   StopIcon,
   XMarkIcon,
 } from '@heroicons/react/24/outline'
-import { TfAttachment, TfFolder, TfMicrophone } from '@tinfoilsh/tinfoil-icons'
+import {
+  TfAttachment,
+  TfFolder,
+  TfGlobe,
+  TfMicrophone,
+  TfTerminal,
+} from '@tinfoilsh/tinfoil-icons'
 import type { FormEvent, RefObject } from 'react'
 import {
   useCallback,
@@ -19,14 +25,7 @@ import {
   useRef,
   useState,
 } from 'react'
-import {
-  PiGlobe,
-  PiGlobeX,
-  PiPlusLight,
-  PiQuotes,
-  PiSpinner,
-  PiTerminalWindow,
-} from 'react-icons/pi'
+import { PiGlobeX, PiPlusLight, PiQuotes, PiSpinner } from 'react-icons/pi'
 import {
   ContextUsageIndicator,
   type ContextUsage,
@@ -1258,7 +1257,10 @@ export function ChatInput({
                           className="flex w-full items-center gap-3 px-3 py-2 text-left text-sm text-content-primary hover:bg-surface-chat-background"
                         >
                           {webSearchEnabled ? (
-                            <PiGlobe className="h-5 w-5 text-content-secondary" />
+                            <TfGlobe
+                              className="h-5 w-5 !text-content-secondary"
+                              aria-hidden="true"
+                            />
                           ) : (
                             <PiGlobeX className="h-5 w-5 text-content-secondary" />
                           )}
@@ -1279,7 +1281,10 @@ export function ChatInput({
                           }}
                           className="flex w-full items-center gap-3 px-3 py-2 text-left text-sm text-content-primary hover:bg-surface-chat-background"
                         >
-                          <PiTerminalWindow className="h-5 w-5 text-content-secondary" />
+                          <TfTerminal
+                            className="h-5 w-5 !text-content-secondary"
+                            aria-hidden="true"
+                          />
                           <span className="flex-1">Code execution</span>
                           {codeExecutionEnabled && (
                             <MenuCheckmark className="h-4 w-4 text-brand-accent-light" />

--- a/src/components/chat/chat-input.tsx
+++ b/src/components/chat/chat-input.tsx
@@ -1262,7 +1262,10 @@ export function ChatInput({
                               aria-hidden="true"
                             />
                           ) : (
-                            <PiGlobeX className="h-5 w-5 text-content-secondary" />
+                            <PiGlobeX
+                              className="h-5 w-5 text-content-secondary"
+                              aria-hidden="true"
+                            />
                           )}
                           <span className="flex-1">Web search</span>
                           {webSearchEnabled && (

--- a/src/components/chat/chat-input.tsx
+++ b/src/components/chat/chat-input.tsx
@@ -5,11 +5,7 @@ import { getProjectColor } from '@/constants/project-colors'
 import { useToast } from '@/hooks/use-toast'
 import { getTinfoilClient } from '@/services/inference/tinfoil-client'
 import { logError } from '@/utils/error-handling'
-import {
-  Squares2X2Icon,
-  StopIcon,
-  XMarkIcon,
-} from '@heroicons/react/24/outline'
+import { StopIcon, XMarkIcon } from '@heroicons/react/24/outline'
 import {
   TfAttachment,
   TfFolder,
@@ -19,6 +15,7 @@ import {
   TfPlus,
   TfQuote,
   TfTerminal,
+  TfTools,
 } from '@tinfoilsh/tinfoil-icons'
 import type { FormEvent, RefObject } from 'react'
 import {
@@ -1241,7 +1238,7 @@ export function ChatInput({
                           }}
                           className="flex w-full items-center gap-3 px-3 py-2 text-left text-sm text-content-primary hover:bg-surface-chat-background"
                         >
-                          <Squares2X2Icon className="h-5 w-5 text-content-secondary" />
+                          <TfTools className="h-5 w-5 text-content-secondary" />
                           Change system prompt
                         </button>
                       )}

--- a/src/components/chat/chat-input.tsx
+++ b/src/components/chat/chat-input.tsx
@@ -6,12 +6,11 @@ import { useToast } from '@/hooks/use-toast'
 import { getTinfoilClient } from '@/services/inference/tinfoil-client'
 import { logError } from '@/utils/error-handling'
 import {
-  FolderIcon,
-  MicrophoneIcon,
   Squares2X2Icon,
   StopIcon,
   XMarkIcon,
 } from '@heroicons/react/24/outline'
+import { TfAttachment, TfFolder, TfMicrophone } from '@tinfoilsh/tinfoil-icons'
 import type { FormEvent, RefObject } from 'react'
 import {
   useCallback,
@@ -23,7 +22,6 @@ import {
 import {
   PiGlobe,
   PiGlobeX,
-  PiPaperclipLight,
   PiPlusLight,
   PiQuotes,
   PiSpinner,
@@ -745,7 +743,7 @@ export function ChatInput({
                     )}
                     style={colorStyle}
                   >
-                    <FolderIcon className="h-3 w-3" />
+                    <TfFolder className="h-3 w-3" aria-hidden="true" />
                     <span className="text-xs font-medium">
                       {activeProject.name}
                     </span>
@@ -1225,7 +1223,10 @@ export function ChatInput({
                         }}
                         className="flex w-full items-center gap-3 px-3 py-2 text-left text-sm text-content-primary hover:bg-surface-chat-background"
                       >
-                        <PiPaperclipLight className="h-5 w-5 text-content-secondary" />
+                        <TfAttachment
+                          className="h-5 w-5 !text-content-secondary"
+                          aria-hidden="true"
+                        />
                         Add files or photos
                       </button>
                       {onOpenPromptLibrary && (
@@ -1331,7 +1332,7 @@ export function ChatInput({
                       aria-hidden="true"
                     />
                   ) : (
-                    <MicrophoneIcon
+                    <TfMicrophone
                       className="h-6 w-6 md:h-5 md:w-5"
                       aria-hidden="true"
                     />

--- a/src/components/chat/chat-input.tsx
+++ b/src/components/chat/chat-input.tsx
@@ -14,7 +14,10 @@ import {
   TfAttachment,
   TfFolder,
   TfGlobe,
+  TfGlobeX,
   TfMicrophone,
+  TfPlus,
+  TfQuote,
   TfTerminal,
 } from '@tinfoilsh/tinfoil-icons'
 import type { FormEvent, RefObject } from 'react'
@@ -25,7 +28,7 @@ import {
   useRef,
   useState,
 } from 'react'
-import { PiGlobeX, PiPlusLight, PiQuotes, PiSpinner } from 'react-icons/pi'
+import { PiSpinner } from 'react-icons/pi'
 import {
   ContextUsageIndicator,
   type ContextUsage,
@@ -796,7 +799,7 @@ export function ChatInput({
 
           {quote && (
             <div className="mb-3 mt-1 flex items-start gap-2 rounded-2xl border border-border-subtle bg-surface-chat-background px-3 py-2">
-              <PiQuotes className="mt-0.5 h-4 w-4 flex-shrink-0 text-content-secondary" />
+              <TfQuote className="mt-0.5 h-4 w-4 flex-shrink-0 text-content-secondary" />
               <p className="line-clamp-3 flex-1 whitespace-pre-wrap text-sm text-content-secondary">
                 {quote.length > QUOTE_PREVIEW_MAX_LENGTH
                   ? `${quote.slice(0, QUOTE_PREVIEW_MAX_LENGTH).trimEnd()}…`
@@ -1198,7 +1201,7 @@ export function ChatInput({
                   aria-haspopup="menu"
                   className="flex h-7 w-7 items-center justify-center rounded-lg text-content-secondary transition-colors hover:bg-surface-chat-background hover:text-content-primary"
                 >
-                  <PiPlusLight className="h-5 w-5" />
+                  <TfPlus className="h-5 w-5" />
                 </button>
                 {isInputMenuOpen && (
                   <>
@@ -1262,7 +1265,7 @@ export function ChatInput({
                               aria-hidden="true"
                             />
                           ) : (
-                            <PiGlobeX
+                            <TfGlobeX
                               className="h-5 w-5 text-content-secondary"
                               aria-hidden="true"
                             />

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -3400,7 +3400,10 @@ export function ChatInterface({
         <div className="max-w-md text-center">
           <div className="mb-6 flex justify-center">
             <div className="rounded-full bg-surface-chat p-4">
-              <TfTinSad className="h-8 w-8 !text-content-secondary" />
+              <TfTinSad
+                className="h-8 w-8 !text-content-secondary"
+                aria-hidden="true"
+              />
             </div>
           </div>
           <h2 className="mb-3 text-xl font-semibold text-content-primary">
@@ -3434,7 +3437,10 @@ export function ChatInterface({
       <div className="flex h-screen items-center justify-center bg-surface-chat-background px-4 font-aeonik">
         <div className="max-w-md text-center">
           <div className="mb-6 flex justify-center">
-            <TfTinSad className="h-24 w-24 !text-content-secondary" />
+            <TfTinSad
+              className="h-24 w-24 !text-content-secondary"
+              aria-hidden="true"
+            />
           </div>
           <h2 className="mb-3 text-xl font-semibold text-content-primary">
             Something went wrong

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -38,17 +38,11 @@ import {
 } from '@/services/inference/tinfoil-client'
 import { generateTitle, getTitleContent } from '@/services/inference/title'
 import { useAuth, useUser } from '@clerk/nextjs'
-import {
-  ArrowDownIcon,
-  ChatBubbleLeftRightIcon,
-} from '@heroicons/react/24/outline'
+import { ArrowDownIcon } from '@heroicons/react/24/outline'
 import { AnimatePresence, motion } from 'framer-motion'
 import Link from 'next/link'
-import { BiSolidLock, BiSolidLockOpen } from 'react-icons/bi'
 import { GoSidebarCollapse } from 'react-icons/go'
-import { IoShareOutline } from 'react-icons/io5'
-import { PiFilePlusLight, PiNotePencilLight, PiSpinner } from 'react-icons/pi'
-import { SlGhost } from 'react-icons/sl'
+import { PiFilePlusLight, PiSpinner } from 'react-icons/pi'
 import { getMessageImages } from './attachment-helpers'
 
 import {
@@ -105,7 +99,15 @@ import {
   getContextTokenBudget,
   getHistoryTokenBudget,
 } from '@/utils/token-estimation'
-import { TfTinSad } from '@tinfoilsh/tinfoil-icons'
+import {
+  TfChat2,
+  TfGhost,
+  TfLockLocked,
+  TfLockOpened,
+  TfShare,
+  TfTinSad,
+  TfWriting2,
+} from '@tinfoilsh/tinfoil-icons'
 import dynamic from 'next/dynamic'
 import Head from 'next/head'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
@@ -3336,7 +3338,10 @@ export function ChatInterface({
         <div className="max-w-md text-center">
           <div className="mb-6 flex justify-center">
             <div className="rounded-full bg-surface-chat p-4">
-              <ChatBubbleLeftRightIcon className="h-8 w-8 text-content-secondary" />
+              <TfChat2
+                className="h-8 w-8 !text-content-secondary"
+                aria-hidden="true"
+              />
             </div>
           </div>
           <h2 className="mb-3 text-xl font-semibold text-content-primary">
@@ -3363,7 +3368,10 @@ export function ChatInterface({
         <div className="max-w-md text-center">
           <div className="mb-6 flex justify-center">
             <div className="rounded-full bg-surface-chat p-4">
-              <ChatBubbleLeftRightIcon className="h-8 w-8 text-content-secondary" />
+              <TfChat2
+                className="h-8 w-8 !text-content-secondary"
+                aria-hidden="true"
+              />
             </div>
           </div>
           <h2 className="mb-3 text-xl font-semibold text-content-primary">
@@ -3409,7 +3417,7 @@ export function ChatInterface({
         <div className="max-w-md text-center">
           <div className="mb-6 flex justify-center">
             <div className="rounded-full bg-surface-chat p-4">
-              <TfTinSad className="h-8 w-8 text-content-secondary" />
+              <TfTinSad className="h-8 w-8 !text-content-secondary" />
             </div>
           </div>
           <h2 className="mb-3 text-xl font-semibold text-content-primary">
@@ -3443,7 +3451,7 @@ export function ChatInterface({
       <div className="flex h-screen items-center justify-center bg-surface-chat-background px-4 font-aeonik">
         <div className="max-w-md text-center">
           <div className="mb-6 flex justify-center">
-            <TfTinSad className="h-24 w-24 text-content-secondary" />
+            <TfTinSad className="h-24 w-24 !text-content-secondary" />
           </div>
           <h2 className="mb-3 text-xl font-semibold text-content-primary">
             Something went wrong
@@ -3565,7 +3573,7 @@ export function ChatInterface({
             })(),
           }}
         >
-          <SlGhost className="h-3.5 w-3.5 shrink-0" />
+          <TfGhost className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
           <span>Temporary chat</span>
         </div>
       )}
@@ -3611,7 +3619,7 @@ export function ChatInterface({
                 className="flex items-center justify-center rounded-lg border border-border-subtle bg-surface-chat-background p-2.5 text-content-secondary transition-all duration-200 hover:bg-surface-chat hover:text-content-primary"
                 aria-label="New chat"
               >
-                <PiNotePencilLight className="h-4 w-4" />
+                <TfWriting2 className="h-4 w-4" aria-hidden="true" />
               </Link>
             )}
 
@@ -3638,7 +3646,7 @@ export function ChatInterface({
                         : 'border-border-subtle bg-surface-chat-background text-content-secondary hover:bg-surface-chat hover:text-content-primary',
                     )}
                   >
-                    <SlGhost className="h-4 w-4" />
+                    <TfGhost className="h-4 w-4" aria-hidden="true" />
                   </button>
                   <span className="pointer-events-none absolute -bottom-8 left-1/2 -translate-x-1/2 whitespace-nowrap rounded border border-border-subtle bg-surface-chat-background px-2 py-1 text-xs text-content-primary opacity-0 shadow-sm transition-opacity group-hover:opacity-100">
                     {label}
@@ -3657,7 +3665,7 @@ export function ChatInterface({
                 className="flex items-center justify-center gap-1.5 rounded-lg border border-border-subtle bg-surface-chat-background p-2.5 text-content-secondary transition-all duration-200 hover:bg-surface-chat hover:text-content-primary md:px-3 md:py-2"
                 aria-label="Share"
               >
-                <IoShareOutline className="h-4 w-4" />
+                <TfShare className="h-4 w-4" aria-hidden="true" />
                 <span className="hidden text-sm md:inline">Share</span>
               </button>
             )}
@@ -3687,14 +3695,20 @@ export function ChatInterface({
                 </>
               ) : verificationStatus === 'verified' ? (
                 <>
-                  <BiSolidLock className="h-4 w-4 text-brand-accent-dark dark:text-brand-accent-light" />
+                  <TfLockLocked
+                    className="h-4 w-4 !text-brand-accent-dark dark:!text-brand-accent-light"
+                    aria-hidden="true"
+                  />
                   <span className="text-sm leading-none text-brand-accent-dark dark:text-brand-accent-light">
                     Verified
                   </span>
                 </>
               ) : (
                 <>
-                  <BiSolidLockOpen className="h-4 w-4 text-red-500" />
+                  <TfLockOpened
+                    className="h-4 w-4 !text-red-500"
+                    aria-hidden="true"
+                  />
                   <span className="text-sm leading-none text-red-500">
                     Error
                   </span>

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -104,6 +104,7 @@ import {
   TfGhost,
   TfLockLocked,
   TfLockOpened,
+  TfPerson,
   TfShare,
   TfTinSad,
   TfWriting2,
@@ -3259,19 +3260,10 @@ export function ChatInterface({
         <div className="max-w-md text-center">
           <div className="mb-6 flex justify-center">
             <div className="rounded-full bg-surface-chat p-4">
-              <svg
-                className="h-8 w-8 text-content-secondary"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-                strokeWidth={1.5}
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  d="M15.75 6a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0zM4.501 20.118a7.5 7.5 0 0114.998 0A17.933 17.933 0 0112 21.75c-2.676 0-5.216-.584-7.499-1.632z"
-                />
-              </svg>
+              <TfPerson
+                className="h-8 w-8 !text-content-secondary"
+                aria-hidden="true"
+              />
             </div>
           </div>
           <h2 className="mb-3 text-xl font-semibold text-content-primary">
@@ -3298,19 +3290,10 @@ export function ChatInterface({
         <div className="max-w-md text-center">
           <div className="mb-6 flex justify-center">
             <div className="rounded-full bg-surface-chat p-4">
-              <svg
-                className="h-8 w-8 text-orange-500"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-                strokeWidth={1.5}
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  d="M16.5 10.5V6.75a4.5 4.5 0 10-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 002.25-2.25v-6.75a2.25 2.25 0 00-2.25-2.25H6.75a2.25 2.25 0 00-2.25 2.25v6.75a2.25 2.25 0 002.25 2.25z"
-                />
-              </svg>
+              <TfLockLocked
+                className="h-8 w-8 !text-orange-500"
+                aria-hidden="true"
+              />
             </div>
           </div>
           <h2 className="mb-3 text-xl font-semibold text-content-primary">

--- a/src/components/chat/chat-list-item.tsx
+++ b/src/components/chat/chat-list-item.tsx
@@ -5,19 +5,23 @@ import { canRequestChatPin } from '@/services/storage/pinned-chats'
 import { isPlainPrimaryClick } from '@/utils/navigation'
 import {
   CheckIcon,
-  CloudArrowUpIcon,
   CloudIcon,
   EllipsisVerticalIcon,
-  ExclamationTriangleIcon,
   XMarkIcon,
 } from '@heroicons/react/24/outline'
-import { TfFolder, TfTrash, TfWriting } from '@tinfoilsh/tinfoil-icons'
+import {
+  TfCloudSync,
+  TfFolder,
+  TfLockLocked,
+  TfTrash,
+  TfWarning,
+  TfWriting,
+} from '@tinfoilsh/tinfoil-icons'
 import Link from 'next/link'
 import { useEffect, useId, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { CiFloppyDisk } from 'react-icons/ci'
 import { PiPushPin, PiPushPinFill } from 'react-icons/pi'
-import { FaLock } from '../icons/lazy-icons'
 import { RedactedText } from '../ui/redacted-text'
 import { cn } from '../ui/utils'
 import { formatRelativeTime } from './chat-list-utils'
@@ -434,8 +438,8 @@ export function ChatListItem({
           <>
             <span className="flex items-center gap-1.5">
               {showEncryptionStatus && chat.decryptionFailed && (
-                <FaLock
-                  className="h-3.5 w-3.5 flex-shrink-0 text-orange-500"
+                <TfLockLocked
+                  className="h-3.5 w-3.5 flex-shrink-0 !text-orange-500"
                   title="Encrypted chat"
                   aria-hidden="true"
                 />
@@ -526,10 +530,7 @@ export function ChatListItem({
                         className="flex items-center text-orange-500"
                         title="This chat couldn't be synced"
                       >
-                        <ExclamationTriangleIcon
-                          className="h-3 w-3"
-                          aria-hidden="true"
-                        />
+                        <TfWarning className="h-3 w-3" aria-hidden="true" />
                         <span className="sr-only">
                           This chat couldn&apos;t be synced
                         </span>
@@ -541,10 +542,7 @@ export function ChatListItem({
                         className="flex items-center text-blue-500"
                         title="Syncing with cloud"
                       >
-                        <CloudArrowUpIcon
-                          className="h-3 w-3"
-                          aria-hidden="true"
-                        />
+                        <TfCloudSync className="h-3 w-3" aria-hidden="true" />
                         <span className="sr-only">Syncing with cloud</span>
                       </span>
                     ) : null}

--- a/src/components/chat/chat-list-item.tsx
+++ b/src/components/chat/chat-list-item.tsx
@@ -11,6 +11,7 @@ import {
 } from '@heroicons/react/24/outline'
 import {
   TfCloudSync,
+  TfFloppyDisk,
   TfFolder,
   TfLockLocked,
   TfTrash,
@@ -20,7 +21,6 @@ import {
 import Link from 'next/link'
 import { useEffect, useId, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
-import { CiFloppyDisk } from 'react-icons/ci'
 import { PiPushPin, PiPushPinFill } from 'react-icons/pi'
 import { RedactedText } from '../ui/redacted-text'
 import { cn } from '../ui/utils'
@@ -522,7 +522,7 @@ export function ChatListItem({
                             ·
                           </span>
                         )}
-                        <CiFloppyDisk className="h-3 w-3" aria-hidden="true" />
+                        <TfFloppyDisk className="h-3 w-3" aria-hidden="true" />
                         Only saved locally
                       </span>
                     ) : !chat.isBlankChat && syncFailed ? (
@@ -851,7 +851,7 @@ export function ChatListItem({
                                 onConvertToLocal()
                               }}
                             >
-                              <CiFloppyDisk
+                              <TfFloppyDisk
                                 className="h-4 w-4"
                                 aria-hidden="true"
                               />

--- a/src/components/chat/chat-list-item.tsx
+++ b/src/components/chat/chat-list-item.tsx
@@ -9,11 +9,9 @@ import {
   CloudIcon,
   EllipsisVerticalIcon,
   ExclamationTriangleIcon,
-  FolderIcon,
-  PencilSquareIcon,
-  TrashIcon,
   XMarkIcon,
 } from '@heroicons/react/24/outline'
+import { TfFolder, TfTrash, TfWriting } from '@tinfoilsh/tinfoil-icons'
 import Link from 'next/link'
 import { useEffect, useId, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
@@ -606,7 +604,7 @@ export function ChatListItem({
                 aria-label="Rename chat"
                 title="Rename"
               >
-                <PencilSquareIcon className="h-4 w-4" aria-hidden="true" />
+                <TfWriting className="h-4 w-4" aria-hidden="true" />
               </button>
             )}
             {!chat.isBlankChat && (
@@ -622,7 +620,7 @@ export function ChatListItem({
                 aria-label="Delete chat"
                 title="Delete"
               >
-                <TrashIcon className="h-4 w-4" aria-hidden="true" />
+                <TfTrash className="h-4 w-4" aria-hidden="true" />
               </button>
             )}
           </div>
@@ -701,10 +699,7 @@ export function ChatListItem({
                               onStartEdit()
                             }}
                           >
-                            <PencilSquareIcon
-                              className="h-4 w-4"
-                              aria-hidden="true"
-                            />
+                            <TfWriting className="h-4 w-4" aria-hidden="true" />
                             Rename
                           </button>
                         )}
@@ -764,7 +759,7 @@ export function ChatListItem({
                               }}
                             >
                               <span className="flex items-center gap-3">
-                                <FolderIcon
+                                <TfFolder
                                   className="h-4 w-4"
                                   aria-hidden="true"
                                 />
@@ -805,10 +800,7 @@ export function ChatListItem({
                               onRemoveFromProject()
                             }}
                           >
-                            <FolderIcon
-                              className="h-4 w-4"
-                              aria-hidden="true"
-                            />
+                            <TfFolder className="h-4 w-4" aria-hidden="true" />
                             Move out of project
                           </button>
                         )}
@@ -884,7 +876,7 @@ export function ChatListItem({
                             onRequestDelete()
                           }}
                         >
-                          <TrashIcon className="h-4 w-4" aria-hidden="true" />
+                          <TfTrash className="h-4 w-4" aria-hidden="true" />
                           Delete
                         </button>
                       </>
@@ -943,8 +935,8 @@ export function ChatListItem({
                                 onMoveToProject?.(project.id)
                               }}
                             >
-                              <FolderIcon
-                                className="h-4 w-4 text-content-muted"
+                              <TfFolder
+                                className="h-4 w-4 !text-content-muted"
                                 aria-hidden="true"
                               />
                               <span className="truncate">{project.name}</span>

--- a/src/components/chat/chat-sidebar.tsx
+++ b/src/components/chat/chat-sidebar.tsx
@@ -36,6 +36,7 @@ import {
 } from '@heroicons/react/24/outline'
 import {
   TfChat2,
+  TfFloppyDisk,
   TfFolder,
   TfLockLocked,
   TfMicrophone,
@@ -46,7 +47,6 @@ import {
   TfWriting2,
 } from '@tinfoilsh/tinfoil-icons'
 import { AnimatePresence, motion } from 'framer-motion'
-import { CiFloppyDisk } from 'react-icons/ci'
 import { GoSidebarCollapse, GoSidebarExpand } from 'react-icons/go'
 import { PiPushPin, PiSpinner } from 'react-icons/pi'
 import { ChatList, type ChatItemData } from './chat-list'
@@ -2113,7 +2113,7 @@ export function ChatSidebar({
                               : 'text-content-muted hover:text-content-secondary',
                         )}
                       >
-                        <CiFloppyDisk className="h-3.5 w-3.5" />
+                        <TfFloppyDisk className="h-3.5 w-3.5" />
                         Local
                       </button>
                     </div>

--- a/src/components/chat/chat-sidebar.tsx
+++ b/src/components/chat/chat-sidebar.tsx
@@ -30,27 +30,24 @@ import {
   ChevronDownIcon,
   ChevronRightIcon,
   CloudIcon,
-  Cog6ToothIcon,
   ExclamationTriangleIcon,
-  FolderIcon,
   FolderPlusIcon,
   MagnifyingGlassIcon,
-  TrashIcon,
   XMarkIcon,
 } from '@heroicons/react/24/outline'
+import {
+  TfChat2,
+  TfFolder,
+  TfMicrophone,
+  TfSetting,
+  TfTrash,
+  TfWriting2,
+} from '@tinfoilsh/tinfoil-icons'
 import { AnimatePresence, motion } from 'framer-motion'
 import { CiFloppyDisk } from 'react-icons/ci'
 import { FaLock } from 'react-icons/fa6'
 import { GoSidebarCollapse, GoSidebarExpand } from 'react-icons/go'
-import { IoChatbubblesOutline } from 'react-icons/io5'
-import {
-  PiFolder,
-  PiMicrophone,
-  PiNotePencilLight,
-  PiPushPin,
-  PiSparkle,
-  PiSpinner,
-} from 'react-icons/pi'
+import { PiPushPin, PiSparkle, PiSpinner } from 'react-icons/pi'
 import { ChatList, type ChatItemData } from './chat-list'
 import { formatRelativeTime } from './chat-list-utils'
 import { CONSTANTS } from './constants'
@@ -949,7 +946,7 @@ export function ChatSidebar({
                   )}
                   aria-label="New chat"
                 >
-                  <PiNotePencilLight className="h-5 w-5" />
+                  <TfWriting2 className="h-5 w-5" aria-hidden="true" />
                 </Link>
                 <span className="pointer-events-none absolute left-full top-1/2 z-50 ml-2 -translate-y-1/2 whitespace-nowrap rounded border border-border-subtle bg-surface-chat-background px-2 py-1 text-xs text-content-primary opacity-0 shadow-sm transition-opacity group-hover:opacity-100">
                   New chat{' '}
@@ -1008,7 +1005,7 @@ export function ChatSidebar({
                     )}
                     aria-label="Projects"
                   >
-                    <FolderIcon className="h-5 w-5" />
+                    <TfFolder className="h-5 w-5" aria-hidden="true" />
                   </button>
                   <span className="pointer-events-none absolute left-full top-1/2 z-50 ml-2 -translate-y-1/2 whitespace-nowrap rounded border border-border-subtle bg-surface-chat-background px-2 py-1 text-xs text-content-primary opacity-0 shadow-sm transition-opacity group-hover:opacity-100">
                     Projects
@@ -1030,7 +1027,7 @@ export function ChatSidebar({
                   )}
                   aria-label="Chats"
                 >
-                  <IoChatbubblesOutline className="h-5 w-5" />
+                  <TfChat2 className="h-5 w-5" aria-hidden="true" />
                 </button>
                 <span className="pointer-events-none absolute left-full top-1/2 z-50 ml-2 -translate-y-1/2 whitespace-nowrap rounded border border-border-subtle bg-surface-chat-background px-2 py-1 text-xs text-content-primary opacity-0 shadow-sm transition-opacity group-hover:opacity-100">
                   Chats <span className="text-content-muted">{modKey}.</span>
@@ -1047,7 +1044,7 @@ export function ChatSidebar({
                   )}
                   aria-label="Settings"
                 >
-                  <Cog6ToothIcon className="h-5 w-5" />
+                  <TfSetting className="h-5 w-5" aria-hidden="true" />
                   {syncNeedsAttention && (
                     <span
                       className="absolute right-1.5 top-1.5 h-2 w-2 rounded-full bg-orange-500"
@@ -1116,7 +1113,7 @@ export function ChatSidebar({
                 aria-label="Settings"
                 className="relative rounded p-1.5 text-content-muted transition-all duration-200 hover:text-content-secondary"
               >
-                <Cog6ToothIcon className="h-5 w-5" aria-hidden="true" />
+                <TfSetting className="h-5 w-5" aria-hidden="true" />
                 {syncNeedsAttention && (
                   <span
                     className="absolute right-0.5 top-0.5 h-2 w-2 rounded-full bg-orange-500"
@@ -1171,7 +1168,10 @@ export function ChatSidebar({
                 </h4>
                 <div className="space-y-2.5">
                   <div className="flex items-center gap-3 text-xs text-content-secondary">
-                    <PiMicrophone className="h-4 w-4 flex-shrink-0 text-content-muted" />
+                    <TfMicrophone
+                      className="h-4 w-4 flex-shrink-0 !text-content-muted"
+                      aria-hidden="true"
+                    />
                     <span>Speech-to-text voice input</span>
                   </div>
 
@@ -1181,7 +1181,10 @@ export function ChatSidebar({
                   </div>
 
                   <div className="flex items-center gap-3 text-xs text-content-secondary">
-                    <PiFolder className="h-4 w-4 flex-shrink-0 text-content-muted" />
+                    <TfFolder
+                      className="h-4 w-4 flex-shrink-0 !text-content-muted"
+                      aria-hidden="true"
+                    />
                     <span>Create projects to chat with files</span>
                   </div>
                 </div>
@@ -1330,7 +1333,7 @@ export function ChatSidebar({
               )}
             >
               <span className="flex items-center gap-2">
-                <PiNotePencilLight className="h-4 w-4" />
+                <TfWriting2 className="h-4 w-4" aria-hidden="true" />
                 <span className="font-aeonik font-medium">New chat</span>
               </span>
               <span className="text-xs text-content-muted">
@@ -1497,7 +1500,7 @@ export function ChatSidebar({
                 )}
               >
                 <span className="flex items-center gap-2">
-                  <FolderIcon className="h-4 w-4" />
+                  <TfFolder className="h-4 w-4" aria-hidden="true" />
                   <span className="font-aeonik font-medium">
                     {isProjectMode && activeProjectName
                       ? activeProjectName
@@ -1605,11 +1608,11 @@ export function ChatSidebar({
                                     {project.decryptionFailed ? (
                                       <FaLock className="mt-0.5 h-4 w-4 shrink-0 self-start text-orange-500" />
                                     ) : (
-                                      <FolderIcon
+                                      <TfFolder
                                         className={cn(
                                           'mt-0.5 h-4 w-4 shrink-0 self-start',
                                           !getProjectColor(project.color) &&
-                                            'text-content-muted',
+                                            '!text-content-muted',
                                         )}
                                         style={
                                           getProjectColor(project.color)
@@ -1685,7 +1688,10 @@ export function ChatSidebar({
                                         {deletingProjectId === project.id ? (
                                           <PiSpinner className="h-4 w-4 animate-spin" />
                                         ) : (
-                                          <TrashIcon className="h-4 w-4" />
+                                          <TfTrash
+                                            className="h-4 w-4"
+                                            aria-hidden="true"
+                                          />
                                         )}
                                       </button>
                                     )}
@@ -1922,7 +1928,7 @@ export function ChatSidebar({
                 className="flex w-full items-center justify-between px-4 py-3 text-left"
               >
                 <span className="flex items-center gap-2">
-                  <IoChatbubblesOutline className="h-4 w-4" />
+                  <TfChat2 className="h-4 w-4" aria-hidden="true" />
                   <span className="truncate font-aeonik font-medium">
                     Chats
                   </span>

--- a/src/components/chat/chat-sidebar.tsx
+++ b/src/components/chat/chat-sidebar.tsx
@@ -30,7 +30,6 @@ import {
   ChevronDownIcon,
   ChevronRightIcon,
   CloudIcon,
-  FolderPlusIcon,
   MagnifyingGlassIcon,
   XMarkIcon,
 } from '@heroicons/react/24/outline'
@@ -38,6 +37,7 @@ import {
   TfChat2,
   TfFloppyDisk,
   TfFolder,
+  TfFolderPlus,
   TfLockLocked,
   TfMicrophone,
   TfSetting,
@@ -1588,7 +1588,7 @@ export function ChatSidebar({
                               {isCreatingProject ? (
                                 <div className="h-4 w-4 animate-spin rounded-full border-2 border-content-muted border-t-transparent" />
                               ) : (
-                                <FolderPlusIcon className="h-4 w-4 shrink-0" />
+                                <TfFolderPlus className="h-4 w-4 shrink-0" />
                               )}
                               <span className="truncate">
                                 {isCreatingProject

--- a/src/components/chat/chat-sidebar.tsx
+++ b/src/components/chat/chat-sidebar.tsx
@@ -30,7 +30,6 @@ import {
   ChevronDownIcon,
   ChevronRightIcon,
   CloudIcon,
-  ExclamationTriangleIcon,
   FolderPlusIcon,
   MagnifyingGlassIcon,
   XMarkIcon,
@@ -38,16 +37,18 @@ import {
 import {
   TfChat2,
   TfFolder,
+  TfLockLocked,
   TfMicrophone,
   TfSetting,
+  TfSparkle,
   TfTrash,
+  TfWarning,
   TfWriting2,
 } from '@tinfoilsh/tinfoil-icons'
 import { AnimatePresence, motion } from 'framer-motion'
 import { CiFloppyDisk } from 'react-icons/ci'
-import { FaLock } from 'react-icons/fa6'
 import { GoSidebarCollapse, GoSidebarExpand } from 'react-icons/go'
-import { PiPushPin, PiSparkle, PiSpinner } from 'react-icons/pi'
+import { PiPushPin, PiSpinner } from 'react-icons/pi'
 import { ChatList, type ChatItemData } from './chat-list'
 import { formatRelativeTime } from './chat-list-utils'
 import { CONSTANTS } from './constants'
@@ -1176,7 +1177,10 @@ export function ChatSidebar({
                   </div>
 
                   <div className="flex items-center gap-3 text-xs text-content-secondary">
-                    <PiSparkle className="h-4 w-4 flex-shrink-0 text-content-muted" />
+                    <TfSparkle
+                      className="h-4 w-4 flex-shrink-0 !text-content-muted"
+                      aria-hidden="true"
+                    />
                     <span>No daily request limits</span>
                   </div>
 
@@ -1264,7 +1268,10 @@ export function ChatSidebar({
             <div className="relative z-10 flex-none px-2 pt-2">
               <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 p-3">
                 <div className="flex items-start gap-2">
-                  <ExclamationTriangleIcon className="mt-0.5 h-4 w-4 flex-shrink-0 text-amber-500" />
+                  <TfWarning
+                    className="mt-0.5 h-4 w-4 flex-shrink-0 !text-amber-500"
+                    aria-hidden="true"
+                  />
                   <div className="flex-1">
                     <p className="font-aeonik text-xs font-semibold text-content-primary">
                       {backupWarningNeedsRecovery
@@ -1606,7 +1613,10 @@ export function ChatSidebar({
                                 const projectContent = (
                                   <>
                                     {project.decryptionFailed ? (
-                                      <FaLock className="mt-0.5 h-4 w-4 shrink-0 self-start text-orange-500" />
+                                      <TfLockLocked
+                                        className="mt-0.5 h-4 w-4 shrink-0 self-start !text-orange-500"
+                                        aria-hidden="true"
+                                      />
                                     ) : (
                                       <TfFolder
                                         className={cn(

--- a/src/components/chat/cloud-sync-health-card.tsx
+++ b/src/components/chat/cloud-sync-health-card.tsx
@@ -8,8 +8,8 @@ import type {
 import {
   CheckCircleIcon,
   ExclamationCircleIcon,
-  ExclamationTriangleIcon,
 } from '@heroicons/react/24/outline'
+import { TfWarning } from '@tinfoilsh/tinfoil-icons'
 import { cn } from '../ui/utils'
 import { formatRelativeTime } from './chat-list-utils'
 
@@ -133,8 +133,8 @@ export function CloudSyncHealthCard({
               aria-hidden="true"
             />
           ) : status.tone === 'warning' ? (
-            <ExclamationTriangleIcon
-              className="mt-0.5 h-4 w-4 shrink-0 text-amber-500"
+            <TfWarning
+              className="mt-0.5 h-4 w-4 shrink-0 !text-amber-500"
               aria-hidden="true"
             />
           ) : (

--- a/src/components/chat/cloud-sync-health-card.tsx
+++ b/src/components/chat/cloud-sync-health-card.tsx
@@ -5,11 +5,8 @@ import type {
   SyncActionReason,
   SyncHealthSnapshot,
 } from '@/services/cloud/sync-health'
-import {
-  CheckCircleIcon,
-  ExclamationCircleIcon,
-} from '@heroicons/react/24/outline'
-import { TfWarning } from '@tinfoilsh/tinfoil-icons'
+import { ExclamationCircleIcon } from '@heroicons/react/24/outline'
+import { TfBoxCheckmark, TfWarning } from '@tinfoilsh/tinfoil-icons'
 import { cn } from '../ui/utils'
 import { formatRelativeTime } from './chat-list-utils'
 
@@ -128,7 +125,7 @@ export function CloudSyncHealthCard({
       <div className="flex items-start justify-between gap-3">
         <div className="flex min-w-0 items-start gap-2">
           {status.tone === 'ok' ? (
-            <CheckCircleIcon
+            <TfBoxCheckmark
               className="mt-0.5 h-4 w-4 shrink-0 text-brand-accent-dark dark:text-brand-accent-light"
               aria-hidden="true"
             />

--- a/src/components/chat/components/mac-file-icon.tsx
+++ b/src/components/chat/components/mac-file-icon.tsx
@@ -1,5 +1,5 @@
+import { TfDocument } from '@tinfoilsh/tinfoil-icons'
 import {
-  BsFile,
   BsFiletypeCss,
   BsFiletypeCsv,
   BsFiletypeDoc,
@@ -105,7 +105,7 @@ export function MacFileIcon({
       case 'mov':
         return <BsFiletypeMov size={size} className={iconClass} />
       default:
-        return <BsFile size={size} className={iconClass} />
+        return <TfDocument width={size} size={size} className={iconClass} />
     }
   }
 

--- a/src/components/chat/components/prompt-preset-suggestions.tsx
+++ b/src/components/chat/components/prompt-preset-suggestions.tsx
@@ -1,5 +1,5 @@
 import { cn } from '@/components/ui/utils'
-import { Squares2X2Icon } from '@heroicons/react/24/outline'
+import { TfTools } from '@tinfoilsh/tinfoil-icons'
 import { usePromptLibrary } from '../hooks/use-prompt-library'
 import { BUILT_IN_PROMPT_PRESETS } from '../prompts/built-in-presets'
 import type { PromptPreset } from '../prompts/types'
@@ -60,7 +60,7 @@ export function PromptPresetSuggestions({
           'border-border-subtle bg-surface-chat-background text-content-secondary hover:bg-surface-chat hover:text-content-primary',
         )}
       >
-        <Squares2X2Icon className="h-3.5 w-3.5" aria-hidden="true" />
+        <TfTools className="h-3.5 w-3.5" aria-hidden="true" />
         <span>More</span>
       </button>
     </>
@@ -74,7 +74,7 @@ export function PromptPresetSuggestions({
           onClick={onOpenLibrary}
           className="flex h-10 items-center justify-center gap-1.5 rounded-lg border border-border-subtle bg-surface-chat-background px-4 text-sm text-content-secondary transition-colors hover:bg-surface-chat hover:text-content-primary"
         >
-          <Squares2X2Icon className="h-3.5 w-3.5" aria-hidden="true" />
+          <TfTools className="h-3.5 w-3.5" aria-hidden="true" />
           <span>Prompts</span>
         </button>
       </div>

--- a/src/components/chat/genui/GenUIToolCallRenderer.tsx
+++ b/src/components/chat/genui/GenUIToolCallRenderer.tsx
@@ -10,7 +10,8 @@
  * via `GenUIInputAreaRenderer`.
  */
 import { logError } from '@/utils/error-handling'
-import { RefreshCw, Sparkles } from 'lucide-react'
+import { TfRefresh1 } from '@tinfoilsh/tinfoil-icons'
+import { Sparkles } from 'lucide-react'
 import React, { memo, useEffect, useState } from 'react'
 import { PiSpinner } from 'react-icons/pi'
 import { tryParsePartialJson } from './partial-json'
@@ -405,7 +406,7 @@ function ParseFailureCard({
             disabled={isRetrying}
             className="inline-flex w-full flex-shrink-0 items-center justify-center gap-1.5 rounded-md border border-brand-accent-dark bg-brand-accent-dark px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-brand-accent-dark/90 disabled:cursor-default disabled:opacity-60 md:w-auto"
           >
-            <RefreshCw
+            <TfRefresh1
               className={`h-3.5 w-3.5 ${isRetrying ? 'animate-spin' : ''}`}
             />
             {isRetrying ? 'Fixing widget...' : 'Retry widget'}

--- a/src/components/chat/genui/GenUIToolCallRenderer.tsx
+++ b/src/components/chat/genui/GenUIToolCallRenderer.tsx
@@ -407,6 +407,7 @@ function ParseFailureCard({
           >
             <TfRefresh1
               className={`h-3.5 w-3.5 ${isRetrying ? 'animate-spin' : ''}`}
+              aria-hidden="true"
             />
             {isRetrying ? 'Fixing widget...' : 'Retry widget'}
           </button>

--- a/src/components/chat/genui/GenUIToolCallRenderer.tsx
+++ b/src/components/chat/genui/GenUIToolCallRenderer.tsx
@@ -10,8 +10,7 @@
  * via `GenUIInputAreaRenderer`.
  */
 import { logError } from '@/utils/error-handling'
-import { TfRefresh1 } from '@tinfoilsh/tinfoil-icons'
-import { Sparkles } from 'lucide-react'
+import { TfRefresh1, TfStars } from '@tinfoilsh/tinfoil-icons'
 import React, { memo, useEffect, useState } from 'react'
 import { PiSpinner } from 'react-icons/pi'
 import { tryParsePartialJson } from './partial-json'
@@ -134,8 +133,8 @@ export const GenUIToolCallRenderer = memo(function GenUIToolCallRenderer({
               key={tc.id}
               className="my-4 flex items-start gap-2.5 rounded-lg border border-orange-500/30 bg-orange-500/10 px-3 py-2.5 text-sm"
             >
-              <Sparkles
-                className="mt-0.5 h-4 w-4 flex-shrink-0 text-orange-500"
+              <TfStars
+                className="mt-0.5 h-4 w-4 flex-shrink-0 !text-orange-500"
                 aria-hidden
               />
               <div className="flex flex-col">

--- a/src/components/chat/genui/widgets/ArtifactPreview.tsx
+++ b/src/components/chat/genui/widgets/ArtifactPreview.tsx
@@ -20,7 +20,8 @@ import {
 } from '@/components/ui/card'
 import { cn } from '@/components/ui/utils'
 import { sanitizeUrl } from '@braintree/sanitize-url'
-import { Code2, Download, ExternalLink, Eye, FileText } from 'lucide-react'
+import { TfCode2 } from '@tinfoilsh/tinfoil-icons'
+import { Download, ExternalLink, Eye, FileText } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import ReactMarkdown from 'react-markdown'
 import { z } from 'zod'
@@ -364,7 +365,7 @@ export function ArtifactPreviewPanel({
           >
             {mode === 'preview' ? (
               <>
-                <Code2 className="h-3.5 w-3.5" />
+                <TfCode2 className="h-3.5 w-3.5" />
                 <span>Source</span>
               </>
             ) : (

--- a/src/components/chat/genui/widgets/MapView.tsx
+++ b/src/components/chat/genui/widgets/MapView.tsx
@@ -2,8 +2,9 @@ import { Card } from '@/components/ui/card'
 import { getMapKitToken } from '@/services/mapkit-token'
 import { logError } from '@/utils/error-handling'
 import { load as loadMapKitJs, type MapKit } from '@apple/mapkit-loader'
+import { TfCopy } from '@tinfoilsh/tinfoil-icons'
 import type { LucideIcon } from 'lucide-react'
-import { Copy, ExternalLink, MapPin, Navigation } from 'lucide-react'
+import { ExternalLink, MapPin, Navigation } from 'lucide-react'
 import { memo, useEffect, useMemo, useRef, useState } from 'react'
 import type { Location, Props } from './Map'
 
@@ -551,7 +552,7 @@ export default function MapWidget(props: Props & { isDarkMode?: boolean }) {
               onClick={copyAddress}
               className="inline-flex items-center gap-1.5 rounded-md border border-border-subtle bg-surface-chat-background px-3 py-1.5 text-xs text-content-primary transition-colors hover:border-content-primary/40"
             >
-              <Copy className="h-3.5 w-3.5" />
+              <TfCopy className="h-3.5 w-3.5" />
               {copied ? 'Copied' : 'Copy address'}
             </button>
           )}

--- a/src/components/chat/genui/widgets/MessageCompose.tsx
+++ b/src/components/chat/genui/widgets/MessageCompose.tsx
@@ -1,5 +1,6 @@
 import { Card } from '@/components/ui/card'
-import { Copy, Send } from 'lucide-react'
+import { TfCopy } from '@tinfoilsh/tinfoil-icons'
+import { Send } from 'lucide-react'
 import { useCallback, useState } from 'react'
 import { z } from 'zod'
 import { defineGenUIWidget } from '../types'
@@ -134,7 +135,7 @@ function EmailComposeCard({ to, title, variants }: Props) {
             className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs text-content-muted transition-colors hover:bg-surface-card hover:text-content-primary"
             aria-label="Copy body"
           >
-            <Copy className="h-3.5 w-3.5" />
+            <TfCopy className="h-3.5 w-3.5" />
             {copied ? 'Copied' : 'Copy'}
           </button>
           <a
@@ -229,7 +230,7 @@ function MessageOnlyCard({ title, variants }: Props) {
             onClick={copyBody}
             className="inline-flex items-center gap-1.5 rounded-lg border border-border-subtle bg-surface-chat-background px-3 py-1.5 text-sm text-content-primary transition-colors hover:border-content-primary/40"
           >
-            <Copy className="h-4 w-4" />
+            <TfCopy className="h-4 w-4" />
             {copied ? 'Copied' : 'Copy'}
           </button>
         </div>

--- a/src/components/chat/genui/widgets/RecipeCard.tsx
+++ b/src/components/chat/genui/widgets/RecipeCard.tsx
@@ -1,7 +1,8 @@
 import { ImageWithSkeleton } from '@/components/preview/image-with-skeleton'
 import { Card } from '@/components/ui/card'
 import { sanitizeUrl } from '@braintree/sanitize-url'
-import { Check, Clock, Flame, Printer, RotateCcw, Users } from 'lucide-react'
+import { TfRefresh1 } from '@tinfoilsh/tinfoil-icons'
+import { Check, Clock, Flame, Printer, Users } from 'lucide-react'
 import { useState, type Dispatch, type SetStateAction } from 'react'
 import { z } from 'zod'
 import { defineGenUIWidget } from '../types'
@@ -272,7 +273,7 @@ function Recipe({
                 className="inline-flex items-center gap-1 rounded-md border border-border-subtle bg-surface-chat-background px-2.5 py-1 text-xs text-content-muted transition-colors hover:bg-surface-card hover:text-content-primary"
                 aria-label="Reset checklist"
               >
-                <RotateCcw className="h-3.5 w-3.5" />
+                <TfRefresh1 className="h-3.5 w-3.5" />
                 Reset
               </button>
             )}

--- a/src/components/chat/hooks/use-prompt-library.ts
+++ b/src/components/chat/hooks/use-prompt-library.ts
@@ -3,8 +3,8 @@ import {
   USER_PREFS_FAVORITE_PROMPT_PRESETS,
 } from '@/constants/storage-keys'
 import { logError } from '@/utils/error-handling'
+import { TfWriting } from '@tinfoilsh/tinfoil-icons'
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import { PiNotePencil } from 'react-icons/pi'
 import { BUILT_IN_PROMPT_PRESETS } from '../prompts/built-in-presets'
 import type { PromptPreset, UserPromptPreset } from '../prompts/types'
 
@@ -16,7 +16,7 @@ const PROMPT_LIBRARY_CHANGED_EVENT = 'promptLibraryChanged'
 
 export const MAX_FAVORITE_PRESETS = 3
 
-const DEFAULT_USER_PRESET_ICON = PiNotePencil
+const DEFAULT_USER_PRESET_ICON = TfWriting
 
 type UsePromptLibraryReturn = {
   builtInPresets: PromptPreset[]

--- a/src/components/chat/message-queue.tsx
+++ b/src/components/chat/message-queue.tsx
@@ -1,6 +1,6 @@
 import { FiArrowUp } from '@/components/icons/lazy-icons'
 import { cn } from '@/components/ui/utils'
-import { TrashIcon } from '@heroicons/react/24/outline'
+import { TfTrash } from '@tinfoilsh/tinfoil-icons'
 import { HiOutlineQueueList } from 'react-icons/hi2'
 import type { Attachment, QueuedMessage } from './types'
 
@@ -93,7 +93,7 @@ export function MessageQueue({ queue, onRemove, onSend }: MessageQueueProps) {
               aria-label="Remove queued message"
               className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full text-content-secondary transition-colors hover:bg-surface-chat-background hover:text-content-primary"
             >
-              <TrashIcon className="h-3.5 w-3.5" />
+              <TfTrash className="h-3.5 w-3.5" aria-hidden="true" />
             </button>
           </div>
         )

--- a/src/components/chat/mfa-settings-card.tsx
+++ b/src/components/chat/mfa-settings-card.tsx
@@ -3,13 +3,9 @@ import { getClerkErrorMessage } from '@/utils/clerk-errors'
 import { logError, logWarning } from '@/utils/error-handling'
 import { useReverification, useUser } from '@clerk/nextjs'
 import { isReverificationCancelledError } from '@clerk/nextjs/errors'
-import {
-  ArrowDownTrayIcon,
-  CheckCircleIcon,
-  ShieldCheckIcon,
-} from '@heroicons/react/24/outline'
+import { ArrowDownTrayIcon, CheckCircleIcon } from '@heroicons/react/24/outline'
 import * as DialogPrimitive from '@radix-ui/react-dialog'
-import { TfCopy } from '@tinfoilsh/tinfoil-icons'
+import { TfCopy, TfShieldCheck } from '@tinfoilsh/tinfoil-icons'
 import { memo, useCallback, useRef, useState, type FormEvent } from 'react'
 import { PiSpinner } from 'react-icons/pi'
 import QRCode from 'react-qr-code'
@@ -215,7 +211,10 @@ export function MfaSettingsCard({ isDarkMode }: MfaSettingsCardProps) {
         )}
       >
         <div className="flex items-start gap-3">
-          <ShieldCheckIcon className="mt-0.5 h-5 w-5 shrink-0 text-content-muted" />
+          <TfShieldCheck
+            className="mt-0.5 h-5 w-5 shrink-0 !text-content-muted"
+            aria-hidden="true"
+          />
           <div className="min-w-0 flex-1">
             <div className="flex items-center justify-between gap-3">
               <div>

--- a/src/components/chat/mfa-settings-card.tsx
+++ b/src/components/chat/mfa-settings-card.tsx
@@ -6,10 +6,10 @@ import { isReverificationCancelledError } from '@clerk/nextjs/errors'
 import {
   ArrowDownTrayIcon,
   CheckCircleIcon,
-  ClipboardDocumentIcon,
   ShieldCheckIcon,
 } from '@heroicons/react/24/outline'
 import * as DialogPrimitive from '@radix-ui/react-dialog'
+import { TfCopy } from '@tinfoilsh/tinfoil-icons'
 import { memo, useCallback, useRef, useState, type FormEvent } from 'react'
 import { PiSpinner } from 'react-icons/pi'
 import QRCode from 'react-qr-code'
@@ -309,7 +309,7 @@ export function MfaSettingsCard({ isDarkMode }: MfaSettingsCardProps) {
                     {copiedTarget === 'setup-key' ? (
                       <CheckCircleIcon className="h-4 w-4 text-brand-accent-dark dark:text-brand-accent-light" />
                     ) : (
-                      <ClipboardDocumentIcon className="h-4 w-4" />
+                      <TfCopy className="h-4 w-4" aria-hidden="true" />
                     )}
                   </button>
                 </div>
@@ -432,7 +432,7 @@ export function MfaSettingsCard({ isDarkMode }: MfaSettingsCardProps) {
                     }
                     className="flex items-center gap-2 text-xs font-medium text-content-secondary transition-colors hover:text-content-primary"
                   >
-                    <ClipboardDocumentIcon className="h-4 w-4" />
+                    <TfCopy className="h-4 w-4" aria-hidden="true" />
                     {copiedTarget === 'backup-codes' ? 'Copied' : 'Copy'} all
                     codes
                   </button>

--- a/src/components/chat/prompt-library-modal.tsx
+++ b/src/components/chat/prompt-library-modal.tsx
@@ -4,14 +4,13 @@ import {
   ArrowLeftIcon,
   CheckIcon,
   PlusIcon,
-  SparklesIcon,
   Squares2X2Icon,
   StarIcon,
   XMarkIcon,
 } from '@heroicons/react/24/outline'
 import { StarIcon as StarIconSolid } from '@heroicons/react/24/solid'
 import * as DialogPrimitive from '@radix-ui/react-dialog'
-import { TfTrash, TfWriting } from '@tinfoilsh/tinfoil-icons'
+import { TfStars, TfTrash, TfWriting } from '@tinfoilsh/tinfoil-icons'
 import { useEffect, useId, useMemo, useRef, useState } from 'react'
 import { ConfirmDialog } from './components/confirm-dialog'
 import { CONSTANTS } from './constants'
@@ -531,7 +530,7 @@ function PresetDetail({
                   onClick={onUseThis}
                   className="flex w-full items-center justify-center gap-1.5 whitespace-nowrap rounded-lg bg-brand-accent-dark px-3 py-2 text-sm font-semibold text-white transition-colors hover:bg-brand-accent-dark/90"
                 >
-                  <SparklesIcon className="h-4 w-4" />
+                  <TfStars className="h-4 w-4" aria-hidden="true" />
                   Use for this chat
                 </button>
               )}
@@ -556,7 +555,7 @@ function PresetDetail({
               onClick={onUseThis}
               className="flex w-full items-center justify-center gap-1.5 whitespace-nowrap rounded-lg bg-brand-accent-dark px-3 py-2 text-sm font-semibold text-white transition-colors hover:bg-brand-accent-dark/90 md:w-auto"
             >
-              <SparklesIcon className="h-4 w-4" />
+              <TfStars className="h-4 w-4" aria-hidden="true" />
               Use for this chat
             </button>
           )}

--- a/src/components/chat/prompt-library-modal.tsx
+++ b/src/components/chat/prompt-library-modal.tsx
@@ -3,16 +3,15 @@ import { acquireInteractionLock } from '@/utils/interaction-lock'
 import {
   ArrowLeftIcon,
   CheckIcon,
-  PencilSquareIcon,
   PlusIcon,
   SparklesIcon,
   Squares2X2Icon,
   StarIcon,
-  TrashIcon,
   XMarkIcon,
 } from '@heroicons/react/24/outline'
 import { StarIcon as StarIconSolid } from '@heroicons/react/24/solid'
 import * as DialogPrimitive from '@radix-ui/react-dialog'
+import { TfTrash, TfWriting } from '@tinfoilsh/tinfoil-icons'
 import { useEffect, useId, useMemo, useRef, useState } from 'react'
 import { ConfirmDialog } from './components/confirm-dialog'
 import { CONSTANTS } from './constants'
@@ -597,7 +596,7 @@ function PresetDetail({
             onClick={onEdit}
             className="flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium text-content-secondary transition-colors hover:bg-surface-chat hover:text-content-primary"
           >
-            <PencilSquareIcon className="h-3.5 w-3.5" />
+            <TfWriting className="h-3.5 w-3.5" aria-hidden="true" />
             Edit
           </button>
         )}
@@ -615,7 +614,7 @@ function PresetDetail({
             onClick={onDelete}
             className="flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium text-red-500 transition-colors hover:bg-red-500/10"
           >
-            <TrashIcon className="h-3.5 w-3.5" />
+            <TfTrash className="h-3.5 w-3.5" aria-hidden="true" />
             Delete
           </button>
         )}

--- a/src/components/chat/prompt-library-modal.tsx
+++ b/src/components/chat/prompt-library-modal.tsx
@@ -4,13 +4,12 @@ import {
   ArrowLeftIcon,
   CheckIcon,
   PlusIcon,
-  Squares2X2Icon,
   StarIcon,
   XMarkIcon,
 } from '@heroicons/react/24/outline'
 import { StarIcon as StarIconSolid } from '@heroicons/react/24/solid'
 import * as DialogPrimitive from '@radix-ui/react-dialog'
-import { TfStars, TfTrash, TfWriting } from '@tinfoilsh/tinfoil-icons'
+import { TfStars, TfTools, TfTrash, TfWriting } from '@tinfoilsh/tinfoil-icons'
 import { useEffect, useId, useMemo, useRef, useState } from 'react'
 import { ConfirmDialog } from './components/confirm-dialog'
 import { CONSTANTS } from './constants'
@@ -295,8 +294,8 @@ export function PromptLibraryModal({
                       <ArrowLeftIcon className="h-5 w-5" aria-hidden="true" />
                     </button>
                   )}
-                  <Squares2X2Icon
-                    className="hidden h-5 w-5 text-content-secondary md:block"
+                  <TfTools
+                    className="hidden h-5 w-5 !text-content-secondary md:block"
                     aria-hidden="true"
                   />
                   <DialogPrimitive.Title className="truncate text-base font-semibold text-content-primary md:text-lg">

--- a/src/components/chat/prompts/built-in-presets.ts
+++ b/src/components/chat/prompts/built-in-presets.ts
@@ -1,12 +1,12 @@
 import {
-  PiCode,
-  PiLightbulb,
-  PiLightning,
-  PiMaskHappy,
-  PiPencilLine,
-  PiStudent,
-  PiTranslate,
-} from 'react-icons/pi'
+  TfCode2,
+  TfLightning,
+  TfMask,
+  TfScholar,
+  TfTranslation,
+  TfWriting2,
+} from '@tinfoilsh/tinfoil-icons'
+import { PiLightbulb } from 'react-icons/pi'
 import type { PromptPreset } from './types'
 
 const wrap = (body: string) => `<system>\n${body.trim()}\n</system>`
@@ -16,7 +16,7 @@ export const BUILT_IN_PROMPT_PRESETS: PromptPreset[] = [
     id: 'builtin:tutor',
     name: 'Tutor',
     description: 'Patient teacher who explains step by step',
-    Icon: PiStudent,
+    Icon: TfScholar,
     isBuiltIn: true,
     systemPrompt: wrap(`
 You are a patient tutor. Open by gauging the learner's current level with one
@@ -45,7 +45,7 @@ Respond in {LANGUAGE}. The user's timezone is {TIMEZONE}.
     name: 'Code Reviewer',
     description:
       'Thorough reviewer who finds bugs, security issues, and design smells',
-    Icon: PiCode,
+    Icon: TfCode2,
     isBuiltIn: true,
     systemPrompt: wrap(`
 You review code carefully. For each snippet the user shares, work through it
@@ -78,7 +78,7 @@ Respond in {LANGUAGE}. The user's timezone is {TIMEZONE}.
     id: 'builtin:writing-coach',
     name: 'Writing Coach',
     description: 'Editor who sharpens prose without flattening your voice',
-    Icon: PiPencilLine,
+    Icon: TfWriting2,
     isBuiltIn: true,
     systemPrompt: wrap(`
 You sharpen writing without erasing the writer's voice. Work as an analyzer
@@ -144,7 +144,7 @@ Respond in {LANGUAGE}. The user's timezone is {TIMEZONE}.
     name: 'Translator',
     description:
       'Faithful translator that preserves tone, register, and formatting',
-    Icon: PiTranslate,
+    Icon: TfTranslation,
     isBuiltIn: true,
     systemPrompt: wrap(`
 You translate accurately and faithfully. Detect the source language. If the
@@ -178,7 +178,7 @@ Respond in {LANGUAGE}. The user's timezone is {TIMEZONE}.
     id: 'builtin:roleplay',
     name: 'Role-play',
     description: 'Collaborative storyteller with in-character dialogue',
-    Icon: PiMaskHappy,
+    Icon: TfMask,
     isBuiltIn: true,
     systemPrompt: wrap(`
 <role>
@@ -249,7 +249,7 @@ Respond in {LANGUAGE}. The user's timezone is {TIMEZONE}.
     id: 'builtin:concise',
     name: 'Concise Assistant',
     description: 'No-fluff answers with the minimum needed context',
-    Icon: PiLightning,
+    Icon: TfLightning,
     isBuiltIn: true,
     systemPrompt: wrap(`
 Answer in the fewest words that fully address the question. Treat brevity as

--- a/src/components/chat/prompts/built-in-presets.ts
+++ b/src/components/chat/prompts/built-in-presets.ts
@@ -1,12 +1,12 @@
 import {
   TfCode2,
+  TfLightbulb,
   TfLightning,
   TfMask,
   TfScholar,
   TfTranslation,
   TfWriting2,
 } from '@tinfoilsh/tinfoil-icons'
-import { PiLightbulb } from 'react-icons/pi'
 import type { PromptPreset } from './types'
 
 const wrap = (body: string) => `<system>\n${body.trim()}\n</system>`
@@ -110,7 +110,7 @@ Respond in {LANGUAGE}. The user's timezone is {TIMEZONE}.
     name: 'Brainstorming Partner',
     description:
       'Divergence engine that resists settling on the obvious answer',
-    Icon: PiLightbulb,
+    Icon: TfLightbulb,
     isBuiltIn: true,
     systemPrompt: wrap(`
 You are a divergence engine. When the user shares a problem, your job is to

--- a/src/components/chat/quote-selection-popover.tsx
+++ b/src/components/chat/quote-selection-popover.tsx
@@ -67,6 +67,25 @@ export function QuoteSelectionPopover({
       return
     }
 
+    const getMessageElement = (node: Node) => {
+      const element =
+        node.nodeType === Node.ELEMENT_NODE
+          ? (node as Element)
+          : node.parentElement
+      return (
+        element?.closest(
+          '[data-message-role="user"], [data-message-role="assistant"]',
+        ) ?? null
+      )
+    }
+    const startMessage = getMessageElement(range.startContainer)
+    const endMessage = getMessageElement(range.endContainer)
+
+    if (!startMessage || startMessage !== endMessage) {
+      hidePopover()
+      return
+    }
+
     const text = selection.toString().trim()
     if (text.length < MIN_SELECTION_LENGTH) {
       hidePopover()

--- a/src/components/chat/quote-selection-popover.tsx
+++ b/src/components/chat/quote-selection-popover.tsx
@@ -181,7 +181,7 @@ export function QuoteSelectionPopover({
         onClick={handleQuoteClick}
         className="flex items-center gap-1.5 rounded-full px-3 py-1.5 text-sm font-medium text-content-primary transition-colors hover:bg-surface-chat-background"
       >
-        <PiQuotes className="h-4 w-4" />
+        <PiQuotes className="h-4 w-4" aria-hidden="true" />
         <span>Quote</span>
       </button>
       {onAsk && (
@@ -190,7 +190,7 @@ export function QuoteSelectionPopover({
           onClick={handleAskClick}
           className="flex items-center gap-1.5 rounded-full px-3 py-1.5 text-sm font-medium text-content-primary transition-colors hover:bg-surface-chat-background"
         >
-          <TfChat2 className="h-4 w-4" />
+          <TfChat2 className="h-4 w-4" aria-hidden="true" />
           <span>Ask</span>
         </button>
       )}

--- a/src/components/chat/quote-selection-popover.tsx
+++ b/src/components/chat/quote-selection-popover.tsx
@@ -1,5 +1,6 @@
+import { TfChat2 } from '@tinfoilsh/tinfoil-icons'
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { PiChatCircleText, PiQuotes } from 'react-icons/pi'
+import { PiQuotes } from 'react-icons/pi'
 
 type PopoverPosition = {
   top: number
@@ -170,7 +171,7 @@ export function QuoteSelectionPopover({
           onClick={handleAskClick}
           className="flex items-center gap-1.5 rounded-full px-3 py-1.5 text-sm font-medium text-content-primary transition-colors hover:bg-surface-chat-background"
         >
-          <PiChatCircleText className="h-4 w-4" />
+          <TfChat2 className="h-4 w-4" />
           <span>Ask</span>
         </button>
       )}

--- a/src/components/chat/quote-selection-popover.tsx
+++ b/src/components/chat/quote-selection-popover.tsx
@@ -1,6 +1,5 @@
-import { TfChat2 } from '@tinfoilsh/tinfoil-icons'
+import { TfChat2, TfQuote } from '@tinfoilsh/tinfoil-icons'
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { PiQuotes } from 'react-icons/pi'
 
 type PopoverPosition = {
   top: number
@@ -181,7 +180,7 @@ export function QuoteSelectionPopover({
         onClick={handleQuoteClick}
         className="flex items-center gap-1.5 rounded-full px-3 py-1.5 text-sm font-medium text-content-primary transition-colors hover:bg-surface-chat-background"
       >
-        <PiQuotes className="h-4 w-4" aria-hidden="true" />
+        <TfQuote className="h-4 w-4" aria-hidden="true" />
         <span>Quote</span>
       </button>
       {onAsk && (

--- a/src/components/chat/renderers/components/DocumentList.tsx
+++ b/src/components/chat/renderers/components/DocumentList.tsx
@@ -1,8 +1,8 @@
 import { XMarkIcon } from '@heroicons/react/24/outline'
+import { TfDocument } from '@tinfoilsh/tinfoil-icons'
 import { memo, useEffect, useState } from 'react'
 import { createPortal } from 'react-dom'
 import {
-  BsFile,
   BsFiletypeCss,
   BsFiletypeCsv,
   BsFiletypeDoc,
@@ -112,7 +112,7 @@ function getFileIcon(filename: string, size: number = 20) {
     case 'mov':
       return <BsFiletypeMov size={size} className={iconClass} />
     default:
-      return <BsFile size={size} className={iconClass} />
+      return <TfDocument width={size} size={size} className={iconClass} />
   }
 }
 

--- a/src/components/chat/renderers/components/MessageActions.tsx
+++ b/src/components/chat/renderers/components/MessageActions.tsx
@@ -1,9 +1,9 @@
 import { CONSTANTS } from '@/components/chat/constants'
 import { logWarning } from '@/utils/error-handling'
 import { convertLatexForCopy } from '@/utils/latex-processing'
+import { TfCopy } from '@tinfoilsh/tinfoil-icons'
 import { memo, useEffect, useRef, useState } from 'react'
 import { BsCheckLg } from 'react-icons/bs'
-import { RxCopy } from 'react-icons/rx'
 
 interface MessageActionsProps {
   content: string
@@ -74,7 +74,7 @@ export const MessageActions = memo(function MessageActions({
             <span aria-live="polite">Copied!</span>
           </>
         ) : (
-          <RxCopy className="h-3.5 w-3.5" />
+          <TfCopy className="h-3.5 w-3.5" />
         )}
       </button>
       {!isCopied && (

--- a/src/components/chat/renderers/default/DefaultMessageRenderer.tsx
+++ b/src/components/chat/renderers/default/DefaultMessageRenderer.tsx
@@ -3,17 +3,15 @@ import { renderGenUIResolved } from '@/components/chat/genui/render'
 import { cn } from '@/components/ui/utils'
 import { REQUEST_UPGRADE_EVENT } from '@/constants/chat-events'
 import {
-  ArrowPathIcon,
   ArrowUturnLeftIcon,
   ChevronDownIcon,
   InformationCircleIcon,
   LockClosedIcon,
-  PencilSquareIcon,
 } from '@heroicons/react/24/outline'
+import { TfCopy, TfRefresh1, TfWriting } from '@tinfoilsh/tinfoil-icons'
 import React, { memo, useState, type JSX } from 'react'
 import { BsCheckLg } from 'react-icons/bs'
 import { GoClockFill } from 'react-icons/go'
-import { RxCopy } from 'react-icons/rx'
 import { hasMessageAttachments } from '../../attachment-helpers'
 import { hasVisibleAssistantMessage } from '../../hooks/streaming/interrupted-message'
 import { CodeExecProcess } from '../components/CodeExecProcess'
@@ -655,7 +653,7 @@ const DefaultMessageComponent = ({
                       aria-label="Regenerate response"
                       className="rounded-lg p-2 text-content-secondary transition-colors hover:bg-surface-chat-background hover:text-content-primary"
                     >
-                      <ArrowPathIcon className="h-4 w-4" aria-hidden="true" />
+                      <TfRefresh1 className="h-4 w-4" aria-hidden="true" />
                     </button>
                     <span className="pointer-events-none absolute -bottom-8 left-1/2 -translate-x-1/2 whitespace-nowrap rounded border border-border-subtle bg-surface-chat-background px-2 py-1 text-xs text-content-primary opacity-0 shadow-sm transition-opacity group-hover/regen:opacity-100">
                       Regenerate
@@ -670,10 +668,7 @@ const DefaultMessageComponent = ({
                       aria-label="Edit message"
                       className="rounded-lg p-2 text-content-secondary transition-colors hover:bg-surface-chat-background hover:text-content-primary"
                     >
-                      <PencilSquareIcon
-                        className="h-4 w-4"
-                        aria-hidden="true"
-                      />
+                      <TfWriting className="h-4 w-4" aria-hidden="true" />
                     </button>
                     <span className="pointer-events-none absolute -bottom-8 left-1/2 -translate-x-1/2 whitespace-nowrap rounded border border-border-subtle bg-surface-chat-background px-2 py-1 text-xs text-content-primary opacity-0 shadow-sm transition-opacity group-hover/edit:opacity-100">
                       Edit
@@ -696,7 +691,7 @@ const DefaultMessageComponent = ({
                         <span>Copied!</span>
                       </>
                     ) : (
-                      <RxCopy className="h-4 w-4" aria-hidden="true" />
+                      <TfCopy className="h-4 w-4" aria-hidden="true" />
                     )}
                   </button>
                   {!copiedUser && (
@@ -738,10 +733,7 @@ const DefaultMessageComponent = ({
                       aria-label="Regenerate response"
                       className="flex items-center gap-1.5 rounded px-2 py-2 text-xs font-medium text-content-secondary transition-all hover:bg-surface-chat-background hover:text-content-primary"
                     >
-                      <ArrowPathIcon
-                        className="h-3.5 w-3.5"
-                        aria-hidden="true"
-                      />
+                      <TfRefresh1 className="h-3.5 w-3.5" aria-hidden="true" />
                     </button>
                     <span className="pointer-events-none absolute -bottom-8 left-1/2 -translate-x-1/2 whitespace-nowrap rounded border border-border-subtle bg-surface-chat-background px-2 py-1 text-xs text-content-primary opacity-0 shadow-sm transition-opacity group-hover/regen:opacity-100">
                       Regenerate

--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -74,7 +74,6 @@ import {
   EyeIcon,
   EyeSlashIcon,
   PlusIcon,
-  Squares2X2Icon,
   UserIcon,
   XMarkIcon,
 } from '@heroicons/react/24/outline'
@@ -89,6 +88,7 @@ import {
   TfPerson,
   TfShieldCheck,
   TfSunLightMode,
+  TfTools,
   TfTrash,
   TfWriting,
 } from '@tinfoilsh/tinfoil-icons'
@@ -2164,7 +2164,7 @@ ${encryptionKey.replace('key_', '')}
     {
       id: 'prompts' as const,
       label: 'Prompts',
-      icon: Squares2X2Icon,
+      icon: TfTools,
     },
     ...(isSignedIn
       ? [

--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -84,8 +84,10 @@ import {
   TfChat2,
   TfCloudSync,
   TfComputer,
+  TfLightbulb,
   TfMoon,
   TfPerson,
+  TfShieldCheck,
   TfSunLightMode,
   TfTrash,
   TfWriting,
@@ -96,9 +98,8 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { AiOutlineExport } from 'react-icons/ai'
 import { BsQrCode } from 'react-icons/bs'
 import { GoPasskeyFill } from 'react-icons/go'
-import { IoShieldCheckmark } from 'react-icons/io5'
 import { PiSignIn, PiSpinner } from 'react-icons/pi'
-import { RiLightbulbFill, RiShieldKeyholeFill } from 'react-icons/ri'
+import { RiShieldKeyholeFill } from 'react-icons/ri'
 import QRCode from 'react-qr-code'
 import { CloudSyncHealthCard } from './cloud-sync-health-card'
 import { ConfirmDialog } from './components/confirm-dialog'
@@ -3328,7 +3329,10 @@ ${encryptionKey.replace('key_', '')}
                       className="flex w-full items-center justify-between p-4"
                     >
                       <div className="flex items-center gap-2">
-                        <RiLightbulbFill className="h-4 w-4 text-content-muted" />
+                        <TfLightbulb
+                          className="h-4 w-4 !text-content-muted"
+                          aria-hidden="true"
+                        />
                         <h3 className="font-aeonik text-sm font-medium text-content-secondary">
                           How It Works
                         </h3>
@@ -3646,7 +3650,10 @@ ${encryptionKey.replace('key_', '')}
                               </div>
                             </div>
                             <div className="ml-6 mt-2 flex items-center gap-1.5">
-                              <IoShieldCheckmark className="h-3.5 w-3.5 text-brand-accent-light" />
+                              <TfShieldCheck
+                                className="h-3.5 w-3.5 !text-brand-accent-light"
+                                aria-hidden="true"
+                              />
                               <span className="text-xs font-medium text-brand-accent-light">
                                 Passkey active
                               </span>

--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -209,7 +209,7 @@ function StepNumber({ step }: { step: keyof typeof STEP_ICONS }) {
   return (
     <>
       <Icon
-        className="h-3 w-3 shrink-0 !text-content-secondary"
+        className="mt-1 h-3 w-3 shrink-0 !text-content-secondary"
         aria-hidden="true"
       />
       <span className="sr-only">Step {step}:</span>

--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -74,7 +74,6 @@ import {
   EyeIcon,
   EyeSlashIcon,
   PlusIcon,
-  UserIcon,
   XMarkIcon,
 } from '@heroicons/react/24/outline'
 import {
@@ -2159,7 +2158,7 @@ ${encryptionKey.replace('key_', '')}
     {
       id: 'personalization' as const,
       label: 'Personalization',
-      icon: UserIcon,
+      icon: TfPerson,
     },
     {
       id: 'prompts' as const,

--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -83,6 +83,7 @@ import {
   TfCloudSync,
   TfComputer,
   TfDownload,
+  TfKey,
   TfLightbulb,
   TfMoon,
   TfNumber1,
@@ -102,7 +103,6 @@ import Link from 'next/link'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { BsQrCode } from 'react-icons/bs'
 import { PiSignIn, PiSpinner } from 'react-icons/pi'
-import { RiShieldKeyholeFill } from 'react-icons/ri'
 import QRCode from 'react-qr-code'
 import { CloudSyncHealthCard } from './cloud-sync-health-card'
 import { ConfirmDialog } from './components/confirm-dialog'
@@ -209,7 +209,7 @@ function StepNumber({ step }: { step: keyof typeof STEP_ICONS }) {
   return (
     <>
       <Icon
-        className="h-6 w-6 shrink-0 !text-content-secondary"
+        className="h-3 w-3 shrink-0 !text-content-secondary"
         aria-hidden="true"
       />
       <span className="sr-only">Step {step}:</span>
@@ -3452,7 +3452,7 @@ ${encryptionKey.replace('key_', '')}
                     >
                       <div className="flex w-full items-center justify-between p-4">
                         <div className="flex items-center gap-2">
-                          <RiShieldKeyholeFill className="h-4 w-4 text-content-muted" />
+                          <TfKey className="h-4 w-4 text-content-muted" />
                           <h3 className="font-aeonik text-sm font-medium text-content-secondary">
                             Your Personal Encryption Key
                           </h3>

--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -69,30 +69,33 @@ import {
   ArrowPathIcon,
   ArrowTopRightOnSquareIcon,
   ArrowUpTrayIcon,
-  ChatBubbleLeftRightIcon,
   CheckCircleIcon,
   ChevronDownIcon,
-  ComputerDesktopIcon,
-  CreditCardIcon,
   EyeIcon,
   EyeSlashIcon,
-  MoonIcon,
-  PencilSquareIcon,
   PlusIcon,
   Squares2X2Icon,
-  SunIcon,
-  TrashIcon,
   UserCircleIcon,
   UserIcon,
   XMarkIcon,
 } from '@heroicons/react/24/outline'
+import {
+  TfAdjustmentToggle,
+  TfCard,
+  TfChat2,
+  TfCloudSync,
+  TfComputer,
+  TfMoon,
+  TfSunLightMode,
+  TfTrash,
+  TfWriting,
+} from '@tinfoilsh/tinfoil-icons'
 import { AnimatePresence, motion } from 'framer-motion'
 import Link from 'next/link'
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { AiOutlineCloudSync, AiOutlineExport } from 'react-icons/ai'
+import { AiOutlineExport } from 'react-icons/ai'
 import { BsQrCode } from 'react-icons/bs'
 import { GoPasskeyFill } from 'react-icons/go'
-import { HiOutlineAdjustmentsVertical } from 'react-icons/hi2'
 import { IoShieldCheckmark } from 'react-icons/io5'
 import { PiSignIn, PiSpinner } from 'react-icons/pi'
 import { RiLightbulbFill, RiShieldKeyholeFill } from 'react-icons/ri'
@@ -2145,12 +2148,12 @@ ${encryptionKey.replace('key_', '')}
     {
       id: 'general' as const,
       label: 'General',
-      icon: HiOutlineAdjustmentsVertical,
+      icon: TfAdjustmentToggle,
     },
     {
       id: 'chat' as const,
       label: 'Chat Settings',
-      icon: ChatBubbleLeftRightIcon,
+      icon: TfChat2,
     },
     {
       id: 'personalization' as const,
@@ -2167,7 +2170,7 @@ ${encryptionKey.replace('key_', '')}
           {
             id: 'cloud-sync' as const,
             label: 'Cloud Sync',
-            icon: AiOutlineCloudSync,
+            icon: TfCloudSync,
           },
         ]
       : []),
@@ -2247,7 +2250,7 @@ ${encryptionKey.replace('key_', '')}
                 {item.id === 'account' && isSignedIn ? (
                   <UserAvatar size={16} />
                 ) : (
-                  <item.icon className="h-4 w-4" />
+                  <item.icon className="h-4 w-4" aria-hidden="true" />
                 )}
                 {item.label}
                 {item.id === 'cloud-sync' && syncNeedsAttention && (
@@ -2297,7 +2300,7 @@ ${encryptionKey.replace('key_', '')}
                 {item.id === 'account' && isSignedIn ? (
                   <UserAvatar size={20} />
                 ) : (
-                  <item.icon className="h-5 w-5" />
+                  <item.icon className="h-5 w-5" aria-hidden="true" />
                 )}
                 {item.label}
                 {item.id === 'cloud-sync' && syncNeedsAttention && (
@@ -2362,17 +2365,17 @@ ${encryptionKey.replace('key_', '')}
                           {
                             id: 'light' as const,
                             label: 'Light',
-                            icon: SunIcon,
+                            icon: TfSunLightMode,
                           },
                           {
                             id: 'dark' as const,
                             label: 'Dark',
-                            icon: MoonIcon,
+                            icon: TfMoon,
                           },
                           {
                             id: 'system' as const,
                             label: 'System',
-                            icon: ComputerDesktopIcon,
+                            icon: TfComputer,
                           },
                         ].map((theme) => (
                           <button
@@ -2385,7 +2388,10 @@ ${encryptionKey.replace('key_', '')}
                                 : 'border-border-subtle hover:border-border-strong',
                             )}
                           >
-                            <theme.icon className="h-5 w-5 text-content-primary" />
+                            <theme.icon
+                              className="h-5 w-5 !text-content-primary"
+                              aria-hidden="true"
+                            />
                             <span className="text-xs text-content-secondary">
                               {theme.label}
                             </span>
@@ -4528,7 +4534,10 @@ ${encryptionKey.replace('key_', '')}
                           >
                             <div className="text-left">
                               <div className="flex items-center gap-3">
-                                <CreditCardIcon className="h-5 w-5 text-content-muted" />
+                                <TfCard
+                                  className="h-5 w-5 !text-content-muted"
+                                  aria-hidden="true"
+                                />
                                 <div className="font-aeonik text-sm font-medium text-content-primary">
                                   Manage Billing
                                 </div>
@@ -4738,7 +4747,7 @@ function PresetRow({
             aria-label={`Edit ${preset.name}`}
             className="rounded-md p-1.5 text-content-secondary transition-colors hover:bg-surface-chat hover:text-content-primary"
           >
-            <PencilSquareIcon className="h-4 w-4" />
+            <TfWriting className="h-4 w-4" aria-hidden="true" />
           </button>
         )}
         <button
@@ -4756,7 +4765,7 @@ function PresetRow({
             aria-label={`Delete ${preset.name}`}
             className="rounded-md p-1.5 text-red-500 transition-colors hover:bg-red-500/10"
           >
-            <TrashIcon className="h-4 w-4" />
+            <TfTrash className="h-4 w-4" aria-hidden="true" />
           </button>
         )}
       </div>

--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -75,7 +75,6 @@ import {
   EyeSlashIcon,
   PlusIcon,
   Squares2X2Icon,
-  UserCircleIcon,
   UserIcon,
   XMarkIcon,
 } from '@heroicons/react/24/outline'
@@ -86,6 +85,7 @@ import {
   TfCloudSync,
   TfComputer,
   TfMoon,
+  TfPerson,
   TfSunLightMode,
   TfTrash,
   TfWriting,
@@ -2144,7 +2144,7 @@ ${encryptionKey.replace('key_', '')}
   if (!isOpen) return null
 
   const navItems = [
-    { id: 'account' as const, label: 'Account', icon: UserCircleIcon },
+    { id: 'account' as const, label: 'Account', icon: TfPerson },
     {
       id: 'general' as const,
       label: 'General',
@@ -4584,7 +4584,10 @@ ${encryptionKey.replace('key_', '')}
                         >
                           <div className="text-left">
                             <div className="flex items-center gap-3">
-                              <UserCircleIcon className="h-5 w-5 text-content-muted" />
+                              <TfPerson
+                                className="h-5 w-5 !text-content-muted"
+                                aria-hidden="true"
+                              />
                               <div className="font-aeonik text-sm font-medium text-content-primary">
                                 Dashboard
                               </div>
@@ -4608,7 +4611,10 @@ ${encryptionKey.replace('key_', '')}
                           isDarkMode ? 'bg-surface-sidebar' : 'bg-white',
                         )}
                       >
-                        <UserCircleIcon className="mx-auto h-12 w-12 text-content-muted" />
+                        <TfPerson
+                          className="mx-auto h-12 w-12 !text-content-muted"
+                          aria-hidden="true"
+                        />
                         <h3 className="mt-3 font-aeonik text-base font-medium text-content-primary">
                           Sign in to your account
                         </h3>

--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -84,6 +84,10 @@ import {
   TfComputer,
   TfLightbulb,
   TfMoon,
+  TfNumber1,
+  TfNumber2,
+  TfNumber3,
+  TfNumber4,
   TfPerson,
   TfShieldCheck,
   TfSunLightMode,
@@ -192,10 +196,26 @@ const ScrambleText = ({
   )
 }
 
-const STEP_CIRCLE_CLASSES = cn(
-  'flex h-6 w-6 shrink-0 items-center justify-center rounded-full font-aeonik-fono text-xs font-medium leading-none',
-  'bg-content-muted/20 text-content-secondary',
-)
+const STEP_ICONS = {
+  1: TfNumber1,
+  2: TfNumber2,
+  3: TfNumber3,
+  4: TfNumber4,
+} as const
+
+function StepNumber({ step }: { step: keyof typeof STEP_ICONS }) {
+  const Icon = STEP_ICONS[step]
+
+  return (
+    <>
+      <Icon
+        className="h-6 w-6 shrink-0 !text-content-secondary"
+        aria-hidden="true"
+      />
+      <span className="sr-only">Step {step}:</span>
+    </>
+  )
+}
 
 export type SettingsTab =
   'general' | 'chat' | 'personalization' | 'prompts' | 'cloud-sync' | 'account'
@@ -3346,7 +3366,7 @@ ${encryptionKey.replace('key_', '')}
                     {isHowItWorksOpen && (
                       <div className="space-y-3 border-t border-border-subtle p-4">
                         <div className="flex items-start gap-3">
-                          <div className={STEP_CIRCLE_CLASSES}>1</div>
+                          <StepNumber step={1} />
                           <div className="font-aeonik-fono text-sm text-content-muted">
                             Your chats are encrypted with a key that only you
                             possess and stored encrypted in the cloud. Nobody
@@ -3354,14 +3374,14 @@ ${encryptionKey.replace('key_', '')}
                           </div>
                         </div>
                         <div className="flex items-start gap-3">
-                          <div className={STEP_CIRCLE_CLASSES}>2</div>
+                          <StepNumber step={2} />
                           <div className="font-aeonik-fono text-sm text-content-muted">
                             Only you have the encryption key. Tinfoil cannot
                             read your messages.
                           </div>
                         </div>
                         <div className="flex items-start gap-3">
-                          <div className={STEP_CIRCLE_CLASSES}>3</div>
+                          <StepNumber step={3} />
                           <div className="font-aeonik-fono text-sm text-content-muted">
                             Use a passkey to seamlessly sync your chats across
                             devices, or manually enter your encryption key.
@@ -3989,16 +4009,7 @@ ${encryptionKey.replace('key_', '')}
                       )}
                     >
                       <div className="flex items-start gap-3">
-                        <div
-                          className={cn(
-                            'flex h-6 w-6 shrink-0 items-center justify-center rounded-full font-aeonik-fono text-xs font-medium leading-none',
-                            isDarkMode
-                              ? 'bg-content-muted/20 text-content-secondary'
-                              : 'bg-content-muted/20 text-content-secondary',
-                          )}
-                        >
-                          1
-                        </div>
+                        <StepNumber step={1} />
                         <div className="font-aeonik-fono text-sm text-content-muted">
                           Open{' '}
                           <a
@@ -4017,32 +4028,14 @@ ${encryptionKey.replace('key_', '')}
                         </div>
                       </div>
                       <div className="flex items-start gap-3">
-                        <div
-                          className={cn(
-                            'flex h-6 w-6 shrink-0 items-center justify-center rounded-full font-aeonik-fono text-xs font-medium leading-none',
-                            isDarkMode
-                              ? 'bg-content-muted/20 text-content-secondary'
-                              : 'bg-content-muted/20 text-content-secondary',
-                          )}
-                        >
-                          2
-                        </div>
+                        <StepNumber step={2} />
                         <div className="font-aeonik-fono text-sm text-content-muted">
                           Click on &quot;Export data&quot; and confirm the
                           export.
                         </div>
                       </div>
                       <div className="flex items-start gap-3">
-                        <div
-                          className={cn(
-                            'flex h-6 w-6 shrink-0 items-center justify-center rounded-full font-aeonik-fono text-xs font-medium leading-none',
-                            isDarkMode
-                              ? 'bg-content-muted/20 text-content-secondary'
-                              : 'bg-content-muted/20 text-content-secondary',
-                          )}
-                        >
-                          3
-                        </div>
+                        <StepNumber step={3} />
                         <div className="font-aeonik-fono text-sm text-content-muted">
                           {shouldImportOffDevice()
                             ? 'Download the ZIP file you receive by email.'
@@ -4050,16 +4043,7 @@ ${encryptionKey.replace('key_', '')}
                         </div>
                       </div>
                       <div className="flex items-start gap-3">
-                        <div
-                          className={cn(
-                            'flex h-6 w-6 shrink-0 items-center justify-center rounded-full font-aeonik-fono text-xs font-medium leading-none',
-                            isDarkMode
-                              ? 'bg-content-muted/20 text-content-secondary'
-                              : 'bg-content-muted/20 text-content-secondary',
-                          )}
-                        >
-                          4
-                        </div>
+                        <StepNumber step={4} />
                         <div className="font-aeonik-fono text-sm text-content-muted">
                           {shouldImportOffDevice() ? (
                             <>
@@ -4121,16 +4105,7 @@ ${encryptionKey.replace('key_', '')}
                       )}
                     >
                       <div className="flex items-start gap-3">
-                        <div
-                          className={cn(
-                            'flex h-6 w-6 shrink-0 items-center justify-center rounded-full font-aeonik-fono text-xs font-medium leading-none',
-                            isDarkMode
-                              ? 'bg-content-muted/20 text-content-secondary'
-                              : 'bg-content-muted/20 text-content-secondary',
-                          )}
-                        >
-                          1
-                        </div>
+                        <StepNumber step={1} />
                         <div className="font-aeonik-fono text-sm text-content-muted">
                           Open{' '}
                           <a
@@ -4149,32 +4124,14 @@ ${encryptionKey.replace('key_', '')}
                         </div>
                       </div>
                       <div className="flex items-start gap-3">
-                        <div
-                          className={cn(
-                            'flex h-6 w-6 shrink-0 items-center justify-center rounded-full font-aeonik-fono text-xs font-medium leading-none',
-                            isDarkMode
-                              ? 'bg-content-muted/20 text-content-secondary'
-                              : 'bg-content-muted/20 text-content-secondary',
-                          )}
-                        >
-                          2
-                        </div>
+                        <StepNumber step={2} />
                         <div className="font-aeonik-fono text-sm text-content-muted">
                           Click on &quot;Export data&quot; and confirm the
                           export.
                         </div>
                       </div>
                       <div className="flex items-start gap-3">
-                        <div
-                          className={cn(
-                            'flex h-6 w-6 shrink-0 items-center justify-center rounded-full font-aeonik-fono text-xs font-medium leading-none',
-                            isDarkMode
-                              ? 'bg-content-muted/20 text-content-secondary'
-                              : 'bg-content-muted/20 text-content-secondary',
-                          )}
-                        >
-                          3
-                        </div>
+                        <StepNumber step={3} />
                         <div className="font-aeonik-fono text-sm text-content-muted">
                           {shouldImportOffDevice()
                             ? 'Download the ZIP file you receive by email.'
@@ -4182,16 +4139,7 @@ ${encryptionKey.replace('key_', '')}
                         </div>
                       </div>
                       <div className="flex items-start gap-3">
-                        <div
-                          className={cn(
-                            'flex h-6 w-6 shrink-0 items-center justify-center rounded-full font-aeonik-fono text-xs font-medium leading-none',
-                            isDarkMode
-                              ? 'bg-content-muted/20 text-content-secondary'
-                              : 'bg-content-muted/20 text-content-secondary',
-                          )}
-                        >
-                          4
-                        </div>
+                        <StepNumber step={4} />
                         <div className="font-aeonik-fono text-sm text-content-muted">
                           {shouldImportOffDevice() ? (
                             <>

--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -82,6 +82,7 @@ import {
   TfChat2,
   TfCloudSync,
   TfComputer,
+  TfDownload,
   TfLightbulb,
   TfMoon,
   TfNumber1,
@@ -89,6 +90,7 @@ import {
   TfNumber3,
   TfNumber4,
   TfPerson,
+  TfPersonKey,
   TfShieldCheck,
   TfSunLightMode,
   TfTools,
@@ -98,9 +100,7 @@ import {
 import { AnimatePresence, motion } from 'framer-motion'
 import Link from 'next/link'
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { AiOutlineExport } from 'react-icons/ai'
 import { BsQrCode } from 'react-icons/bs'
-import { GoPasskeyFill } from 'react-icons/go'
 import { PiSignIn, PiSpinner } from 'react-icons/pi'
 import { RiShieldKeyholeFill } from 'react-icons/ri'
 import QRCode from 'react-qr-code'
@@ -294,7 +294,7 @@ function PasskeyBundleInventory({
             >
               <div className="min-w-0">
                 <div className="flex items-center gap-2">
-                  <GoPasskeyFill className="h-4 w-4 shrink-0 text-content-secondary" />
+                  <TfPersonKey className="h-4 w-4 shrink-0 text-content-secondary" />
                   <span className="truncate text-sm font-medium text-content-primary">
                     {isCurrentPlatform ? 'This platform' : 'Other platform'}
                   </span>
@@ -3657,7 +3657,7 @@ ${encryptionKey.replace('key_', '')}
                             )}
                           >
                             <div className="flex items-start gap-2">
-                              <GoPasskeyFill className="mt-0.5 h-4 w-4 shrink-0 text-brand-accent-light" />
+                              <TfPersonKey className="mt-0.5 h-4 w-4 shrink-0 text-brand-accent-light" />
                               <div>
                                 <span className="text-sm font-medium text-content-primary">
                                   Sync and backup using Passkeys
@@ -3776,7 +3776,7 @@ ${encryptionKey.replace('key_', '')}
                               )}
                             >
                               <div className="flex gap-2">
-                                <GoPasskeyFill className="mt-[3px] h-4 w-4 shrink-0 text-content-secondary" />
+                                <TfPersonKey className="mt-[3px] h-4 w-4 shrink-0 text-content-secondary" />
                                 <div>
                                   <span className="text-sm font-medium leading-tight text-content-primary">
                                     {isSettingUpPasskey
@@ -3830,7 +3830,7 @@ ${encryptionKey.replace('key_', '')}
                               )}
                             >
                               <div className="flex gap-2">
-                                <GoPasskeyFill className="mt-[3px] h-4 w-4 shrink-0 text-content-secondary" />
+                                <TfPersonKey className="mt-[3px] h-4 w-4 shrink-0 text-content-secondary" />
                                 <div>
                                   <span className="text-sm font-medium leading-tight text-content-primary">
                                     {isSettingUpPasskey
@@ -4303,7 +4303,7 @@ ${encryptionKey.replace('key_', '')}
                         exportType === 'chats' ? (
                           <ArrowPathIcon className="h-4 w-4 animate-spin" />
                         ) : (
-                          <AiOutlineExport className="h-4 w-4" />
+                          <TfDownload className="h-4 w-4" />
                         )}
                         {isPreparingExport && exportType === 'chats'
                           ? 'Please wait while we prepare the export...'
@@ -4354,7 +4354,7 @@ ${encryptionKey.replace('key_', '')}
                           ) : projectsLoading ? (
                             <ArrowPathIcon className="h-4 w-4 animate-spin" />
                           ) : (
-                            <AiOutlineExport className="h-4 w-4" />
+                            <TfDownload className="h-4 w-4" />
                           )}
                           {isExporting && exportType === 'projects'
                             ? 'Exporting...'

--- a/src/components/chat/share-modal.tsx
+++ b/src/components/chat/share-modal.tsx
@@ -5,13 +5,12 @@ import { shareSeal as enclaveShareSeal } from '@/services/sync-enclave/sync-api'
 import type { ShareableChatData } from '@/utils/compression'
 import {
   CheckIcon,
-  DocumentDuplicateIcon,
   GlobeAltIcon,
   LinkIcon,
-  LockClosedIcon,
   XMarkIcon,
 } from '@heroicons/react/24/outline'
 import * as DialogPrimitive from '@radix-ui/react-dialog'
+import { TfCopy, TfLockLocked } from '@tinfoilsh/tinfoil-icons'
 import { useEffect, useRef, useState } from 'react'
 import { Card, CardContent } from '../ui/card'
 import {
@@ -366,7 +365,10 @@ export function ShareModal({
                         {isShareEnabled ? (
                           <GlobeAltIcon className="h-5 w-5" />
                         ) : (
-                          <LockClosedIcon className="h-5 w-5" />
+                          <TfLockLocked
+                            className="h-5 w-5"
+                            aria-hidden="true"
+                          />
                         )}
                       </div>
                       <div className="flex-1 space-y-4">
@@ -446,7 +448,10 @@ export function ShareModal({
                                 </>
                               ) : (
                                 <>
-                                  <DocumentDuplicateIcon className="h-4 w-4" />
+                                  <TfCopy
+                                    className="h-4 w-4"
+                                    aria-hidden="true"
+                                  />
                                   Copy
                                 </>
                               )}
@@ -477,7 +482,7 @@ export function ShareModal({
                         </>
                       ) : (
                         <>
-                          <DocumentDuplicateIcon className="h-3 w-3" />
+                          <TfCopy className="h-3 w-3" aria-hidden="true" />
                           Copy to Clipboard
                         </>
                       )}

--- a/src/components/chat/share-modal.tsx
+++ b/src/components/chat/share-modal.tsx
@@ -391,7 +391,10 @@ export function ShareModal({
                               aria-label="Make this conversation shareable with anyone who has the link"
                               className="peer h-5 w-5 cursor-pointer appearance-none rounded border border-border-subtle bg-surface-chat transition-all checked:border-brand-accent-dark checked:bg-brand-accent-dark"
                             />
-                            <CheckIcon className="pointer-events-none absolute left-1/2 top-1/2 h-3.5 w-3.5 -translate-x-1/2 -translate-y-1/2 text-white opacity-0 peer-checked:opacity-100" />
+                            <CheckIcon
+                              className="pointer-events-none absolute left-1/2 top-1/2 h-3.5 w-3.5 -translate-x-1/2 -translate-y-1/2 text-white opacity-0 peer-checked:opacity-100"
+                              aria-hidden="true"
+                            />
                           </div>
                           <span className="text-sm font-medium text-content-primary">
                             Make this conversation shareable with anyone who has
@@ -413,7 +416,10 @@ export function ShareModal({
                                 </>
                               ) : (
                                 <>
-                                  <LinkIcon className="h-4 w-4" />
+                                  <LinkIcon
+                                    className="h-4 w-4"
+                                    aria-hidden="true"
+                                  />
                                   Create share link
                                 </>
                               )}
@@ -438,7 +444,10 @@ export function ShareModal({
                             >
                               {isLinkCopied ? (
                                 <>
-                                  <CheckIcon className="h-4 w-4" />
+                                  <CheckIcon
+                                    className="h-4 w-4"
+                                    aria-hidden="true"
+                                  />
                                   Copied!
                                 </>
                               ) : (

--- a/src/components/chat/share-modal.tsx
+++ b/src/components/chat/share-modal.tsx
@@ -3,14 +3,9 @@ import { useToast } from '@/hooks/use-toast'
 import { uploadSharedChat } from '@/services/share-api'
 import { shareSeal as enclaveShareSeal } from '@/services/sync-enclave/sync-api'
 import type { ShareableChatData } from '@/utils/compression'
-import {
-  CheckIcon,
-  GlobeAltIcon,
-  LinkIcon,
-  XMarkIcon,
-} from '@heroicons/react/24/outline'
+import { CheckIcon, LinkIcon, XMarkIcon } from '@heroicons/react/24/outline'
 import * as DialogPrimitive from '@radix-ui/react-dialog'
-import { TfCopy, TfLockLocked } from '@tinfoilsh/tinfoil-icons'
+import { TfCopy, TfGlobe, TfLockLocked } from '@tinfoilsh/tinfoil-icons'
 import { useEffect, useRef, useState } from 'react'
 import { Card, CardContent } from '../ui/card'
 import {
@@ -363,7 +358,7 @@ export function ShareModal({
                     <div className="flex items-start gap-4 p-4">
                       <div className="mt-1 rounded-full bg-surface-chat p-2 text-content-secondary">
                         {isShareEnabled ? (
-                          <GlobeAltIcon className="h-5 w-5" />
+                          <TfGlobe className="h-5 w-5" aria-hidden="true" />
                         ) : (
                           <TfLockLocked
                             className="h-5 w-5"

--- a/src/components/chat/stream-error-banner.tsx
+++ b/src/components/chat/stream-error-banner.tsx
@@ -2,11 +2,8 @@
 
 import type { StreamErrorInfo } from '@/components/chat/hooks/use-chat-streams'
 import { cn } from '@/components/ui/utils'
-import {
-  ArrowPathIcon,
-  ChevronDownIcon,
-  XMarkIcon,
-} from '@heroicons/react/24/outline'
+import { ChevronDownIcon, XMarkIcon } from '@heroicons/react/24/outline'
+import { TfRefresh1 } from '@tinfoilsh/tinfoil-icons'
 import { useState, useSyncExternalStore } from 'react'
 
 interface StreamErrorBannerProps {
@@ -227,7 +224,7 @@ export function StreamErrorBanner({
                   'cursor-default opacity-50 hover:bg-transparent',
               )}
             >
-              <ArrowPathIcon className="h-3.5 w-3.5" aria-hidden="true" />
+              <TfRefresh1 className="h-3.5 w-3.5" aria-hidden="true" />
               {retryDisabled ? 'Offline' : retryLabel}
             </button>
           )}

--- a/src/components/code-block.tsx
+++ b/src/components/code-block.tsx
@@ -1,5 +1,6 @@
 import { toast } from '@/hooks/use-toast'
 import { downloadMarkdownAsPdf } from '@/utils/markdown-pdf-export'
+import { TfCode, TfCopy } from '@tinfoilsh/tinfoil-icons'
 import DOMPurify from 'isomorphic-dompurify'
 import { memo, useEffect, useId, useMemo, useRef, useState } from 'react'
 import { BsFiletypeMd, BsFiletypePdf } from 'react-icons/bs'
@@ -13,20 +14,7 @@ import remarkGfm from 'remark-gfm'
 import { CONSTANTS } from './chat/constants'
 
 const CodeIcon = () => (
-  <svg
-    className="h-4 w-4"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    aria-hidden="true"
-    focusable="false"
-  >
-    <polyline points="16 18 22 12 16 6" />
-    <polyline points="8 6 2 12 8 18" />
-  </svg>
+  <TfCode className="h-4 w-4" aria-hidden="true" focusable="false" />
 )
 
 const EyeIcon = () => (
@@ -1076,20 +1064,10 @@ export const CodeBlock = memo(function CodeBlock({
                 />
               </svg>
             ) : (
-              <svg
-                className="h-5 w-5 text-content-muted"
-                fill="none"
-                strokeWidth="1.5"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
+              <TfCopy
+                className="h-5 w-5 !text-content-muted"
                 aria-hidden="true"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  d="M15.666 3.888A2.25 2.25 0 0013.5 2.25h-3c-1.03 0-1.9.693-2.166 1.638m7.332 0c.055.194.084.4.084.612v0a.75.75 0 01-.75.75H9a.75.75 0 01-.75-.75v0c0-.212.03-.418.084-.612m7.332 0c.646.049 1.288.11 1.927.184 1.1.128 1.907 1.077 1.907 2.185V19.5a2.25 2.25 0 01-2.25 2.25H6.75A2.25 2.25 0 014.5 19.5V6.257c0-1.108.806-2.057 1.907-2.185a48.208 48.208 0 011.927-.184"
-                />
-              </svg>
+              />
             )}
           </button>
           <span className="pointer-events-none absolute -top-8 right-0 hidden whitespace-nowrap rounded border border-border-subtle bg-surface-chat-background px-2 py-1 text-xs text-content-primary shadow-sm group-hover/copy:block">

--- a/src/components/code-block.tsx
+++ b/src/components/code-block.tsx
@@ -1046,7 +1046,7 @@ export const CodeBlock = memo(function CodeBlock({
           <button
             onClick={copyToClipboard}
             aria-label={copied ? 'Copied' : 'Copy code'}
-            className="rounded-lg bg-surface-input p-2 hover:bg-surface-input/80"
+            className="rounded-lg bg-surface-input p-2 text-content-muted hover:bg-surface-input/80"
           >
             {copied ? (
               <svg
@@ -1064,10 +1064,7 @@ export const CodeBlock = memo(function CodeBlock({
                 />
               </svg>
             ) : (
-              <TfCopy
-                className="h-5 w-5 !text-content-muted"
-                aria-hidden="true"
-              />
+              <TfCopy className="h-5 w-5" aria-hidden="true" />
             )}
           </button>
           <span className="pointer-events-none absolute -top-8 right-0 hidden whitespace-nowrap rounded border border-border-subtle bg-surface-chat-background px-2 py-1 text-xs text-content-primary shadow-sm group-hover/copy:block">

--- a/src/components/copy-button.tsx
+++ b/src/components/copy-button.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@/components/ui/button'
+import { TfCopy } from '@tinfoilsh/tinfoil-icons'
 import { Check } from 'lucide-react'
 import { useState } from 'react'
-import { RxCopy } from 'react-icons/rx'
 import { CONSTANTS } from './chat/constants'
 
 function CopyButton({ text }: { text: string }) {
@@ -20,7 +20,7 @@ function CopyButton({ text }: { text: string }) {
       className="h-6 w-6"
       onClick={handleCopy}
     >
-      {copied ? <Check className="h-4 w-4" /> : <RxCopy className="h-4 w-4" />}
+      {copied ? <Check className="h-4 w-4" /> : <TfCopy className="h-4 w-4" />}
     </Button>
   )
 }

--- a/src/components/icons/lazy-icons.tsx
+++ b/src/components/icons/lazy-icons.tsx
@@ -6,12 +6,6 @@ const AiOutlineLoading3QuartersLazy = lazy(() =>
     default: m.AiOutlineLoading3Quarters,
   })),
 )
-const FaLockLazy = lazy(() =>
-  import('react-icons/fa').then((m) => ({ default: m.FaLock })),
-)
-const FaKeyLazy = lazy(() =>
-  import('react-icons/fa').then((m) => ({ default: m.FaKey })),
-)
 const MdOutlineCloudOffLazy = lazy(() =>
   import('react-icons/md').then((m) => ({ default: m.MdOutlineCloudOff })),
 )
@@ -72,12 +66,6 @@ function IconWrapper({ Icon, ...props }: { Icon: any } & IconBaseProps) {
 
 export const AiOutlineLoading3Quarters = (props: IconBaseProps) => (
   <IconWrapper Icon={AiOutlineLoading3QuartersLazy} {...props} />
-)
-export const FaLock = (props: IconBaseProps) => (
-  <IconWrapper Icon={FaLockLazy} {...props} />
-)
-export const FaKey = (props: IconBaseProps) => (
-  <IconWrapper Icon={FaKeyLazy} {...props} />
 )
 export const MdOutlineCloudOff = (props: IconBaseProps) => (
   <IconWrapper Icon={MdOutlineCloudOffLazy} {...props} />

--- a/src/components/icons/lazy-icons.tsx
+++ b/src/components/icons/lazy-icons.tsx
@@ -1,9 +1,6 @@
 import { lazy, Suspense } from 'react'
 import type { IconBaseProps } from 'react-icons'
 
-const AiOutlineCloudSyncLazy = lazy(() =>
-  import('react-icons/ai').then((m) => ({ default: m.AiOutlineCloudSync })),
-)
 const AiOutlineLoading3QuartersLazy = lazy(() =>
   import('react-icons/ai').then((m) => ({
     default: m.AiOutlineLoading3Quarters,
@@ -73,9 +70,6 @@ function IconWrapper({ Icon, ...props }: { Icon: any } & IconBaseProps) {
   )
 }
 
-export const AiOutlineCloudSync = (props: IconBaseProps) => (
-  <IconWrapper Icon={AiOutlineCloudSyncLazy} {...props} />
-)
 export const AiOutlineLoading3Quarters = (props: IconBaseProps) => (
   <IconWrapper Icon={AiOutlineLoading3QuartersLazy} {...props} />
 )

--- a/src/components/modals/add-to-project-context-modal.tsx
+++ b/src/components/modals/add-to-project-context-modal.tsx
@@ -1,5 +1,5 @@
 import { cn } from '@/components/ui/utils'
-import { FolderIcon } from '@heroicons/react/24/outline'
+import { TfFolder } from '@tinfoilsh/tinfoil-icons'
 import { useEffect, useState } from 'react'
 
 interface AddToProjectContextModalProps {
@@ -64,7 +64,10 @@ export function AddToProjectContextModal({
       >
         <div className="mb-3 flex items-center justify-center sm:mb-4">
           <div className="rounded-full bg-brand-accent-dark/10 p-2 dark:bg-brand-accent-light/10 sm:p-3">
-            <FolderIcon className="h-6 w-6 text-brand-accent-dark dark:text-brand-accent-light sm:h-8 sm:w-8" />
+            <TfFolder
+              className="h-6 w-6 !text-brand-accent-dark dark:!text-brand-accent-light sm:h-8 sm:w-8"
+              aria-hidden="true"
+            />
           </div>
         </div>
 

--- a/src/components/modals/cloud-sync-setup-modal.tsx
+++ b/src/components/modals/cloud-sync-setup-modal.tsx
@@ -19,10 +19,10 @@ import {
   ArrowDownTrayIcon,
   ArrowUpTrayIcon,
   CheckIcon,
-  DocumentDuplicateIcon,
 } from '@heroicons/react/24/outline'
 import {
   TfCloud,
+  TfCopy,
   TfFingerprint,
   TfKey,
   TfLock,
@@ -648,7 +648,7 @@ ${generatedKey.replace('key_', '')}
                 </>
               ) : (
                 <>
-                  <DocumentDuplicateIcon className="h-4 w-4" />
+                  <TfCopy className="h-4 w-4" aria-hidden="true" />
                   Copy
                 </>
               )}

--- a/src/components/modals/first-login-key-modal.tsx
+++ b/src/components/modals/first-login-key-modal.tsx
@@ -1,10 +1,6 @@
 import { Modal, ModalTitle } from '@/components/ui/modal'
-import {
-  ArrowUpTrayIcon,
-  KeyIcon,
-  SparklesIcon,
-  XMarkIcon,
-} from '@heroicons/react/24/outline'
+import { ArrowUpTrayIcon, XMarkIcon } from '@heroicons/react/24/outline'
+import { TfKey, TfStars } from '@tinfoilsh/tinfoil-icons'
 import { useCallback, useRef, useState } from 'react'
 
 interface FirstLoginKeyModalProps {
@@ -129,7 +125,10 @@ export function FirstLoginKeyModal({
         <>
           <ModalTitle className="flex items-center justify-between">
             <div className="flex items-center gap-2">
-              <KeyIcon className="h-6 w-6 text-content-primary" />
+              <TfKey
+                className="h-6 w-6 !text-content-primary"
+                aria-hidden="true"
+              />
               <span>Welcome to Tinfoil Chat</span>
             </div>
           </ModalTitle>
@@ -163,7 +162,10 @@ export function FirstLoginKeyModal({
                 className="w-full rounded-lg border border-brand-accent-dark/40 bg-brand-accent-dark p-4 text-left text-white shadow-md transition-colors hover:bg-brand-accent-dark/90"
               >
                 <div className="flex items-start gap-3">
-                  <SparklesIcon className="mt-0.5 h-5 w-5 text-white" />
+                  <TfStars
+                    className="mt-0.5 h-5 w-5 !text-white"
+                    aria-hidden="true"
+                  />
                   <div>
                     <h4 className="font-medium text-white">
                       Create New Encryption Key

--- a/src/components/project/project-header.tsx
+++ b/src/components/project/project-header.tsx
@@ -1,11 +1,8 @@
 'use client'
 
 import { cn } from '@/components/ui/utils'
-import {
-  ArrowLeftIcon,
-  Cog6ToothIcon,
-  FolderIcon,
-} from '@heroicons/react/24/outline'
+import { ArrowLeftIcon } from '@heroicons/react/24/outline'
+import { TfFolder, TfSetting } from '@tinfoilsh/tinfoil-icons'
 import { useProject } from './project-context'
 
 interface ProjectHeaderProps {
@@ -48,11 +45,14 @@ export function ProjectHeader({
         <div className="h-5 w-px bg-border-subtle" />
 
         <div className="flex items-center gap-2">
-          <FolderIcon
+          <TfFolder
             className={cn(
               'h-5 w-5',
-              isDarkMode ? 'text-brand-accent-light' : 'text-brand-accent-dark',
+              isDarkMode
+                ? '!text-brand-accent-light'
+                : '!text-brand-accent-dark',
             )}
+            aria-hidden="true"
           />
           <span
             className={cn(
@@ -75,7 +75,7 @@ export function ProjectHeader({
         )}
         title="Project settings"
       >
-        <Cog6ToothIcon className="h-5 w-5" />
+        <TfSetting className="h-5 w-5" aria-hidden="true" />
       </button>
     </div>
   )

--- a/src/components/project/project-selector-modal.tsx
+++ b/src/components/project/project-selector-modal.tsx
@@ -3,11 +3,8 @@
 import { cn } from '@/components/ui/utils'
 import { useProjects } from '@/hooks/use-projects'
 import type { Project } from '@/types/project'
-import {
-  FolderIcon,
-  FolderPlusIcon,
-  XMarkIcon,
-} from '@heroicons/react/24/outline'
+import { FolderPlusIcon, XMarkIcon } from '@heroicons/react/24/outline'
+import { TfFolder } from '@tinfoilsh/tinfoil-icons'
 import { AnimatePresence, motion } from 'framer-motion'
 import { useCallback, useState } from 'react'
 import { useProject } from './project-context'
@@ -160,7 +157,10 @@ export function ProjectSelectorModal({
                       </div>
                     ) : projects.length === 0 ? (
                       <div className="py-8 text-center">
-                        <FolderIcon className="mx-auto mb-2 h-10 w-10 text-content-muted" />
+                        <TfFolder
+                          className="mx-auto mb-2 h-10 w-10 !text-content-muted"
+                          aria-hidden="true"
+                        />
                         <p className="font-aeonik-fono text-sm text-content-muted">
                           No projects yet
                         </p>
@@ -183,13 +183,14 @@ export function ProjectSelectorModal({
                               loadingAction && 'cursor-not-allowed opacity-50',
                             )}
                           >
-                            <FolderIcon
+                            <TfFolder
                               className={cn(
                                 'mt-0.5 h-5 w-5 flex-shrink-0',
                                 isDarkMode
-                                  ? 'text-brand-accent-light'
-                                  : 'text-brand-accent-dark',
+                                  ? '!text-brand-accent-light'
+                                  : '!text-brand-accent-dark',
                               )}
+                              aria-hidden="true"
                             />
                             <div className="min-w-0 flex-1">
                               <div className="truncate font-aeonik font-medium text-content-primary">

--- a/src/components/project/project-selector-modal.tsx
+++ b/src/components/project/project-selector-modal.tsx
@@ -3,8 +3,8 @@
 import { cn } from '@/components/ui/utils'
 import { useProjects } from '@/hooks/use-projects'
 import type { Project } from '@/types/project'
-import { FolderPlusIcon, XMarkIcon } from '@heroicons/react/24/outline'
-import { TfFolder } from '@tinfoilsh/tinfoil-icons'
+import { XMarkIcon } from '@heroicons/react/24/outline'
+import { TfFolder, TfFolderPlus } from '@tinfoilsh/tinfoil-icons'
 import { AnimatePresence, motion } from 'framer-motion'
 import { useCallback, useState } from 'react'
 import { useProject } from './project-context'
@@ -141,7 +141,7 @@ export function ProjectSelectorModal({
                           : 'hover:bg-surface-sidebar',
                       )}
                     >
-                      <FolderPlusIcon className="h-6 w-6" />
+                      <TfFolderPlus className="h-6 w-6" />
                       <span className="font-aeonik font-medium">
                         New Project
                       </span>

--- a/src/components/project/project-sidebar.tsx
+++ b/src/components/project/project-sidebar.tsx
@@ -40,7 +40,6 @@ import {
   CheckIcon,
   ChevronDownIcon,
   ChevronUpIcon,
-  DocumentIcon,
   DocumentPlusIcon,
   NoSymbolIcon,
 } from '@heroicons/react/24/outline'
@@ -1386,7 +1385,7 @@ export function ProjectSidebar({
               )}
             >
               <span className="flex items-center gap-2">
-                <DocumentIcon className="h-4 w-4" />
+                <TfDocument className="h-4 w-4" />
                 <span className="font-aeonik font-medium">
                   Documents {isLoading ? '' : `(${projectDocuments.length})`}
                 </span>

--- a/src/components/project/project-sidebar.tsx
+++ b/src/components/project/project-sidebar.tsx
@@ -45,6 +45,7 @@ import {
   NoSymbolIcon,
 } from '@heroicons/react/24/outline'
 import {
+  TfDocument,
   TfFolder,
   TfSetting,
   TfTrash,
@@ -54,7 +55,6 @@ import {
 import { AnimatePresence, motion } from 'framer-motion'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import {
-  BsFile,
   BsFiletypeCss,
   BsFiletypeCsv,
   BsFiletypeDoc,
@@ -211,7 +211,7 @@ function getFileIcon(filename: string, className: string) {
     case 'mov':
       return <BsFiletypeMov className={className} />
     default:
-      return <BsFile className={className} />
+      return <TfDocument className={className} />
   }
 }
 

--- a/src/components/project/project-sidebar.tsx
+++ b/src/components/project/project-sidebar.tsx
@@ -40,14 +40,17 @@ import {
   CheckIcon,
   ChevronDownIcon,
   ChevronUpIcon,
-  Cog6ToothIcon,
   DocumentIcon,
   DocumentPlusIcon,
-  FolderIcon,
   NoSymbolIcon,
-  PencilSquareIcon,
-  TrashIcon,
 } from '@heroicons/react/24/outline'
+import {
+  TfFolder,
+  TfSetting,
+  TfTrash,
+  TfWriting,
+  TfWriting2,
+} from '@tinfoilsh/tinfoil-icons'
 import { AnimatePresence, motion } from 'framer-motion'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import {
@@ -78,7 +81,7 @@ import {
   BsFiletypeXml,
 } from 'react-icons/bs'
 import { GoSidebarCollapse, GoSidebarExpand } from 'react-icons/go'
-import { PiNotePencilLight, PiPushPin } from 'react-icons/pi'
+import { PiPushPin } from 'react-icons/pi'
 import { CONSTANTS } from '../chat/constants'
 import { useProject } from './project-context'
 
@@ -273,7 +276,7 @@ function DangerZoneAction({
           : 'border-red-300 bg-red-50 text-red-700 hover:bg-red-100',
       )}
     >
-      <TrashIcon className="h-3.5 w-3.5" aria-hidden="true" />
+      <TfTrash className="h-3.5 w-3.5" aria-hidden="true" />
       {triggerLabel}
     </button>
   )
@@ -790,7 +793,10 @@ export function ProjectSidebar({
                 className="group/logo relative rounded p-2"
                 aria-label="Expand sidebar"
               >
-                <FolderIcon className="h-6 w-6 text-content-secondary transition-opacity group-hover/logo:opacity-0" />
+                <TfFolder
+                  className="h-6 w-6 !text-content-secondary transition-opacity group-hover/logo:opacity-0"
+                  aria-hidden="true"
+                />
                 <GoSidebarCollapse className="absolute inset-0 m-auto h-5 w-5 text-content-secondary opacity-0 transition-opacity group-hover/logo:opacity-100" />
               </button>
             </div>
@@ -812,7 +818,7 @@ export function ProjectSidebar({
                   )}
                   aria-label="New chat"
                 >
-                  <PiNotePencilLight className="h-5 w-5" />
+                  <TfWriting2 className="h-5 w-5" aria-hidden="true" />
                 </Link>
                 <span className="pointer-events-none absolute left-full top-1/2 z-50 ml-2 -translate-y-1/2 whitespace-nowrap rounded border border-border-subtle bg-surface-chat-background px-2 py-1 text-xs text-content-primary opacity-0 shadow-sm transition-opacity group-hover:opacity-100">
                   New chat{' '}
@@ -903,7 +909,7 @@ export function ProjectSidebar({
                 aria-label="Settings"
                 className="rounded p-1.5 text-content-muted transition-all duration-200 hover:text-content-secondary"
               >
-                <Cog6ToothIcon className="h-5 w-5" />
+                <TfSetting className="h-5 w-5" aria-hidden="true" />
               </button>
               <span className="pointer-events-none absolute left-1/2 top-full z-50 mt-1 -translate-x-1/2 whitespace-nowrap rounded border border-border-subtle bg-surface-chat-background px-2 py-1 text-xs text-content-primary opacity-0 shadow-sm transition-opacity group-hover:opacity-100">
                 Settings
@@ -1038,7 +1044,10 @@ export function ProjectSidebar({
                           displayProjectName
                         )}
                       </span>
-                      <PencilSquareIcon className="h-4 w-4 shrink-0 text-content-muted opacity-0 transition-opacity group-hover:opacity-100" />
+                      <TfWriting
+                        className="h-4 w-4 shrink-0 !text-content-muted opacity-0 transition-opacity group-hover:opacity-100"
+                        aria-hidden="true"
+                      />
                     </button>
                   </h2>
                   <p className="mt-0.5 font-aeonik-fono text-xs text-content-muted">
@@ -1070,7 +1079,7 @@ export function ProjectSidebar({
               )}
             >
               <span className="flex items-center gap-2">
-                <PiNotePencilLight className="h-4 w-4" />
+                <TfWriting2 className="h-4 w-4" aria-hidden="true" />
                 <span className="font-aeonik font-medium">New chat</span>
               </span>
               <span className="text-xs text-content-muted">
@@ -1174,7 +1183,7 @@ export function ProjectSidebar({
               )}
             >
               <span className="flex items-center gap-2">
-                <Cog6ToothIcon className="h-4 w-4" />
+                <TfSetting className="h-4 w-4" aria-hidden="true" />
                 <span className="font-aeonik font-medium">
                   Project Settings
                 </span>
@@ -1534,7 +1543,7 @@ export function ProjectSidebar({
                                   'cursor-not-allowed opacity-50',
                               )}
                             >
-                              <TrashIcon className="h-3 w-3" />
+                              <TfTrash className="h-3 w-3" aria-hidden="true" />
                             </button>
                           </div>
                         ))}


### PR DESCRIPTION
## Summary
- update `@tinfoilsh/tinfoil-icons` from 2.0.4 to 2.1.0
- replace matching third-party and inline UI icons with the expanded Tinfoil icon set
- preserve intended colors and decorative icon accessibility while removing an obsolete lazy icon

## Testing
- `npx tsc --noEmit`
- `npx eslint $(git diff --name-only --diff-filter=ACMR -- '*.ts' '*.tsx')`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrades `@tinfoilsh/tinfoil-icons` to 2.2.0 and replaces remaining Heroicons/Lucide/`react-icons` for consistent theming and better accessibility. Quote selection actions now appear only when the selection stays within one message (previously could show across messages).

- Standardizes icons across chat, sidebars, modals, settings, projects, GenUI widgets, code blocks, and share flows using branded components (e.g., `TfCopy`, `TfRefresh1`, `TfTools`, `TfWriting`/`TfWriting2`, `TfDocument`, `TfCloudSync`, `TfGlobe`/`TfGlobeX`, `TfShieldCheck`, `TfNumber{1..4}`).
- Improves accessibility and color intent: marks decorative icons `aria-hidden`, applies explicit color utilities, aligns account/personalization and numbered step icons, and slightly reduces chat input icon sizes.
- Removes obsolete lazy `react-icons` wrappers in `icons/lazy-icons.tsx`.

**Migration**
- Replace any remaining `AiOutlineCloudSync`, `FaLock`, or `FaKey` imports with `TfCloudSync`, `TfLockLocked`, or `TfKey`.

<sup>Written for commit d5c0a3519929376a1b71bd8ab18cf4b52038700a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/460?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

