### PR TITLE
Fix misc UX bugs reported by users

### DIFF
--- a/src/components/chat/chat-input.tsx
+++ b/src/components/chat/chat-input.tsx
@@ -614,69 +614,6 @@ export function ChatInput({
   return (
     <div className="flex flex-col gap-2">
       <div className="relative">
-        {/* Project tab - manila folder style, absolutely positioned */}
-        {isProjectMode &&
-          activeProject &&
-          (() => {
-            const projectColor = getProjectColor(activeProject.color)
-            const colorStyle = projectColor
-              ? {
-                  borderColor: projectColor.hex,
-                  backgroundColor: projectColor.hex,
-                }
-              : undefined
-            return (
-              <div className="pointer-events-none absolute right-8 top-px z-10 hidden -translate-y-full md:block">
-                <div
-                  className={cn(
-                    'pointer-events-auto inline-flex items-center gap-1.5 rounded-t-site-tab border border-b-0 px-2.5 py-1',
-                    projectColor
-                      ? 'text-gray-900'
-                      : 'border-border-subtle bg-surface-chat text-content-secondary',
-                  )}
-                  style={colorStyle}
-                >
-                  <FolderIcon className="h-3 w-3" />
-                  <span className="text-xs font-medium">
-                    {activeProject.name}
-                  </span>
-                </div>
-              </div>
-            )
-          })()}
-        {/* Prompt preset tab - shows the active prompt for this chat */}
-        {activePromptPreset &&
-          (() => {
-            const ActivePresetIcon = activePromptPreset.Icon
-            return (
-              <div className="pointer-events-none absolute left-8 top-px z-10 -translate-y-full">
-                <div className="pointer-events-auto inline-flex items-center gap-1 rounded-t-3xl border border-b-0 border-border-subtle bg-surface-chat px-2.5 py-1 text-content-secondary">
-                  <button
-                    type="button"
-                    onClick={onOpenPromptLibrary}
-                    disabled={!onOpenPromptLibrary}
-                    className="flex items-center gap-1.5 transition-colors hover:text-content-primary"
-                    aria-label={`Change prompt (currently ${activePromptPreset.name})`}
-                  >
-                    <ActivePresetIcon className="h-3 w-3" />
-                    <span className="text-xs font-medium">
-                      {activePromptPreset.name}
-                    </span>
-                  </button>
-                  {onClearPromptPreset && (
-                    <button
-                      type="button"
-                      onClick={onClearPromptPreset}
-                      aria-label="Stop using this prompt"
-                      className="ml-0.5 rounded-full p-0.5 transition-colors hover:text-content-primary"
-                    >
-                      <XMarkIcon className="h-3 w-3" />
-                    </button>
-                  )}
-                </div>
-              </div>
-            )
-          })()}
         {mobileHeader}
         {(isProjectMode && activeProject) || loadingProject ? (
           <ProjectModeBanner
@@ -687,12 +624,80 @@ export function ChatInput({
         ) : null}
         <div
           className={cn(
-            'rounded-3xl border bg-white px-3 py-3 shadow-md transition-colors dark:bg-surface-chat md:rounded-4xl md:px-6 md:py-4',
+            // relative anchors the folder-style tabs below to the card
+            // itself. Anchoring them to the outer container breaks on
+            // mobile, where in-flow elements (the Prompts button, project
+            // banner) sit above the card and push the container's top edge
+            // away from the card top the tabs are meant to attach to.
+            'relative rounded-3xl border bg-white px-3 py-3 shadow-md transition-colors dark:bg-surface-chat md:rounded-4xl md:px-6 md:py-4',
             isTemporaryMode
               ? 'border-dashed border-content-muted'
               : 'border-border-subtle',
           )}
         >
+          {/* Project tab - manila folder style, absolutely positioned */}
+          {isProjectMode &&
+            activeProject &&
+            (() => {
+              const projectColor = getProjectColor(activeProject.color)
+              const colorStyle = projectColor
+                ? {
+                    borderColor: projectColor.hex,
+                    backgroundColor: projectColor.hex,
+                  }
+                : undefined
+              return (
+                <div className="pointer-events-none absolute right-8 top-px z-10 hidden -translate-y-full md:block">
+                  <div
+                    className={cn(
+                      'pointer-events-auto inline-flex items-center gap-1.5 rounded-t-site-tab border border-b-0 px-2.5 py-1',
+                      projectColor
+                        ? 'text-gray-900'
+                        : 'border-border-subtle bg-surface-chat text-content-secondary',
+                    )}
+                    style={colorStyle}
+                  >
+                    <FolderIcon className="h-3 w-3" />
+                    <span className="text-xs font-medium">
+                      {activeProject.name}
+                    </span>
+                  </div>
+                </div>
+              )
+            })()}
+          {/* Prompt preset tab - shows the active prompt for this chat */}
+          {activePromptPreset &&
+            (() => {
+              const ActivePresetIcon = activePromptPreset.Icon
+              return (
+                <div className="pointer-events-none absolute left-8 top-px z-10 -translate-y-full">
+                  <div className="pointer-events-auto inline-flex items-center gap-1 rounded-t-3xl border border-b-0 border-border-subtle bg-surface-chat px-2.5 py-1 text-content-secondary">
+                    <button
+                      type="button"
+                      onClick={onOpenPromptLibrary}
+                      disabled={!onOpenPromptLibrary}
+                      className="flex items-center gap-1.5 transition-colors hover:text-content-primary"
+                      aria-label={`Change prompt (currently ${activePromptPreset.name})`}
+                    >
+                      <ActivePresetIcon className="h-3 w-3" />
+                      <span className="text-xs font-medium">
+                        {activePromptPreset.name}
+                      </span>
+                    </button>
+                    {onClearPromptPreset && (
+                      <button
+                        type="button"
+                        onClick={onClearPromptPreset}
+                        aria-label="Stop using this prompt"
+                        className="ml-0.5 rounded-full p-0.5 transition-colors hover:text-content-primary"
+                      >
+                        <XMarkIcon className="h-3 w-3" />
+                      </button>
+                    )}
+                  </div>
+                </div>
+              )
+            })()}
           {/* No accept filter: unknown extensions are sniffed for text
               content and rejected gracefully after selection instead of
               being blocked by the picker. */}

--- a/src/components/chat/chat-input.tsx
+++ b/src/components/chat/chat-input.tsx
@@ -8,6 +8,7 @@ import { logError } from '@/utils/error-handling'
 import {
   FolderIcon,
   MicrophoneIcon,
+  Squares2X2Icon,
   StopIcon,
   XMarkIcon,
 } from '@heroicons/react/24/outline'
@@ -21,7 +22,6 @@ import {
 } from 'react'
 import {
   PiGlobe,
-  PiGlobeX,
   PiPaperclipLight,
   PiPlusLight,
   PiQuotes,
@@ -37,6 +37,18 @@ import { CONSTANTS } from './constants'
 import type { PromptPreset } from './prompts/types'
 import type { ProcessedDocument } from './renderers/types'
 import type { LoadingState } from './types'
+
+function MenuCheckmark({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 20 20" fill="currentColor">
+      <path
+        fillRule="evenodd"
+        d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+        clipRule="evenodd"
+      />
+    </svg>
+  )
+}
 
 // Tracks every mounted textarea per shared external ref so an unmounting
 // instance can hand the shared ref over to a surviving instance.
@@ -270,8 +282,8 @@ export function ChatInput({
   const audioChunksRef = useRef<Blob[]>([])
   const recordingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
-  // --- Mobile attachment menu state ---
-  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false)
+  // --- Input options menu state (the "+" button) ---
+  const [isInputMenuOpen, setIsInputMenuOpen] = useState(false)
 
   // Random placeholder - use first one initially to avoid SSR hydration mismatch,
   // then randomize after mount
@@ -1101,89 +1113,96 @@ export function ChatInput({
               {audioStatus}
             </span>
             <div className="flex items-center gap-1">
-              {/* Mobile: + button with dropdown menu */}
-              <div className="relative md:hidden">
+              {/* Unified + button opening the input options menu */}
+              <div className="relative">
                 <button
+                  id="input-options-button"
                   type="button"
-                  onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
-                  aria-label="Attachment options"
-                  aria-expanded={isMobileMenuOpen}
+                  onClick={() => setIsInputMenuOpen(!isInputMenuOpen)}
+                  aria-label="Input options"
+                  aria-expanded={isInputMenuOpen}
+                  aria-haspopup="menu"
                   className="flex h-7 w-7 items-center justify-center rounded-lg text-content-secondary transition-colors hover:bg-surface-chat-background hover:text-content-primary"
                 >
                   <PiPlusLight className="h-5 w-5" />
                 </button>
-                {isMobileMenuOpen && (
+                {isInputMenuOpen && (
                   <>
                     <div
                       className="fixed inset-0 z-10"
-                      onClick={() => setIsMobileMenuOpen(false)}
+                      onClick={() => setIsInputMenuOpen(false)}
                     />
-                    <div className="absolute bottom-full left-0 z-20 mb-2 min-w-[180px] rounded-xl border border-border-subtle bg-surface-chat py-1.5 shadow-lg">
+                    <div
+                      role="menu"
+                      className="absolute bottom-full left-0 z-20 mb-2 min-w-[220px] rounded-xl border border-border-subtle bg-surface-chat py-1.5 shadow-lg"
+                    >
                       <button
                         type="button"
+                        role="menuitem"
                         onClick={() => {
                           triggerFileInput()
-                          setIsMobileMenuOpen(false)
+                          setIsInputMenuOpen(false)
                         }}
                         className="flex w-full items-center gap-3 px-3 py-2 text-left text-sm text-content-primary hover:bg-surface-chat-background"
                       >
                         <PiPaperclipLight className="h-5 w-5 text-content-secondary" />
                         Add files or photos
                       </button>
+                      {onOpenPromptLibrary && (
+                        <button
+                          type="button"
+                          role="menuitem"
+                          onClick={() => {
+                            onOpenPromptLibrary()
+                            setIsInputMenuOpen(false)
+                          }}
+                          className="flex w-full items-center gap-3 px-3 py-2 text-left text-sm text-content-primary hover:bg-surface-chat-background"
+                        >
+                          <Squares2X2Icon className="h-5 w-5 text-content-secondary" />
+                          Change system prompt
+                        </button>
+                      )}
+                      {(onWebSearchToggle || onCodeExecutionToggle) && (
+                        <div className="my-1.5 border-t border-border-subtle" />
+                      )}
                       {onWebSearchToggle && (
                         <button
                           type="button"
+                          role="menuitemcheckbox"
+                          aria-checked={webSearchEnabled}
                           onClick={() => {
                             onWebSearchToggle()
-                            setIsMobileMenuOpen(false)
+                            setIsInputMenuOpen(false)
                           }}
                           className="flex w-full items-center gap-3 px-3 py-2 text-left text-sm text-content-primary hover:bg-surface-chat-background"
                         >
                           <PiGlobe className="h-5 w-5 text-content-secondary" />
                           <span className="flex-1">Web search</span>
                           {webSearchEnabled && (
-                            <svg
-                              className="h-4 w-4 text-brand-accent-light"
-                              viewBox="0 0 20 20"
-                              fill="currentColor"
-                            >
-                              <path
-                                fillRule="evenodd"
-                                d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-                                clipRule="evenodd"
-                              />
-                            </svg>
+                            <MenuCheckmark className="h-4 w-4 text-brand-accent-light" />
                           )}
                         </button>
                       )}
                       {onCodeExecutionToggle && (
                         <button
                           type="button"
+                          role="menuitemcheckbox"
+                          aria-checked={codeExecutionEnabled}
                           onClick={() => {
                             onCodeExecutionToggle()
-                            setIsMobileMenuOpen(false)
+                            setIsInputMenuOpen(false)
                           }}
                           className="flex w-full items-center gap-3 px-3 py-2 text-left text-sm text-content-primary hover:bg-surface-chat-background"
                         >
                           <PiTerminalWindow className="h-5 w-5 text-content-secondary" />
                           <span className="flex-1">Code execution</span>
                           {codeExecutionEnabled && (
-                            <svg
-                              className="h-4 w-4 text-brand-accent-light"
-                              viewBox="0 0 20 20"
-                              fill="currentColor"
-                            >
-                              <path
-                                fillRule="evenodd"
-                                d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-                                clipRule="evenodd"
-                              />
-                            </svg>
+                            <MenuCheckmark className="h-4 w-4 text-brand-accent-light" />
                           )}
                         </button>
                       )}
                       {contextUsage && (
-                        <div className="flex w-full items-center gap-3 px-3 py-2 text-left text-sm text-content-primary">
+                        <div className="flex w-full items-center gap-3 px-3 py-2 text-left text-sm text-content-primary md:hidden">
                           <span className="flex-1">Context</span>
                           <ContextUsageIndicator usage={contextUsage} />
                         </div>
@@ -1192,92 +1211,46 @@ export function ChatInput({
                   </>
                 )}
               </div>
-
-              {/* Desktop: Original buttons */}
-              <div className="group relative hidden md:block">
+              {/* Web search stays visible outside the menu while enabled so
+                  its active state is glanceable and one-click to turn off. */}
+              {onWebSearchToggle && webSearchEnabled && (
                 <button
-                  id="upload-button"
+                  id="web-search-button"
                   type="button"
-                  onClick={triggerFileInput}
-                  aria-label="Upload document"
-                  className="flex h-7 w-7 items-center justify-center rounded-lg text-content-secondary transition-colors hover:bg-surface-chat-background hover:text-content-primary"
+                  onClick={onWebSearchToggle}
+                  aria-label="Web search"
+                  aria-pressed
+                  className={cn(
+                    'flex h-7 items-center justify-center gap-1.5 rounded-lg px-2 transition-colors',
+                    isDarkMode
+                      ? 'bg-brand-accent-light/20 text-brand-accent-light'
+                      : 'bg-brand-accent-dark/20 text-brand-accent-dark',
+                  )}
                 >
-                  <PiPaperclipLight className="h-5 w-5" />
+                  <PiGlobe className="h-5 w-5" />
+                  <span className="hidden translate-y-px text-xs font-medium leading-none md:inline">
+                    Search
+                  </span>
                 </button>
-                <span className="pointer-events-none absolute -top-8 left-1/2 -translate-x-1/2 whitespace-nowrap rounded border border-border-subtle bg-surface-chat-background px-2 py-1 text-xs text-content-primary opacity-0 shadow-sm transition-opacity group-hover:opacity-100">
-                  Upload document
-                </span>
-              </div>
-              {onWebSearchToggle && (
-                <div className="group relative hidden md:block">
-                  <button
-                    id="web-search-button"
-                    type="button"
-                    onClick={onWebSearchToggle}
-                    aria-label="Web search"
-                    aria-pressed={webSearchEnabled}
-                    className={cn(
-                      'flex h-7 items-center justify-center gap-1.5 rounded-lg transition-colors',
-                      webSearchEnabled
-                        ? cn(
-                            'px-2',
-                            isDarkMode
-                              ? 'bg-brand-accent-light/20 text-brand-accent-light'
-                              : 'bg-brand-accent-dark/20 text-brand-accent-dark',
-                          )
-                        : 'w-7 text-content-secondary hover:bg-surface-chat-background hover:text-content-primary',
-                    )}
-                  >
-                    {webSearchEnabled ? (
-                      <PiGlobe className="h-5 w-5" />
-                    ) : (
-                      <PiGlobeX className="h-5 w-5" />
-                    )}
-                    {webSearchEnabled && (
-                      <span className="translate-y-px text-xs font-medium leading-none">
-                        Search
-                      </span>
-                    )}
-                  </button>
-                  {!webSearchEnabled && (
-                    <span className="pointer-events-none absolute -top-8 left-1/2 -translate-x-1/2 whitespace-nowrap rounded border border-border-subtle bg-surface-chat-background px-2 py-1 text-xs text-content-primary opacity-0 shadow-sm transition-opacity group-hover:opacity-100">
-                      Web search
-                    </span>
-                  )}
-                </div>
               )}
-              {onCodeExecutionToggle && (
-                <div className="group relative hidden md:block">
-                  <button
-                    type="button"
-                    onClick={onCodeExecutionToggle}
-                    aria-label="Code execution"
-                    aria-pressed={codeExecutionEnabled}
-                    className={cn(
-                      'flex h-7 items-center justify-center gap-1.5 rounded-lg transition-colors',
-                      codeExecutionEnabled
-                        ? cn(
-                            'px-2',
-                            isDarkMode
-                              ? 'bg-brand-accent-light/20 text-brand-accent-light'
-                              : 'bg-brand-accent-dark/20 text-brand-accent-dark',
-                          )
-                        : 'w-7 text-content-secondary hover:bg-surface-chat-background hover:text-content-primary',
-                    )}
-                  >
-                    <PiTerminalWindow className="h-5 w-5" />
-                    {codeExecutionEnabled && (
-                      <span className="translate-y-px text-xs font-medium leading-none">
-                        Code
-                      </span>
-                    )}
-                  </button>
-                  {!codeExecutionEnabled && (
-                    <span className="pointer-events-none absolute -top-8 left-1/2 -translate-x-1/2 whitespace-nowrap rounded border border-border-subtle bg-surface-chat-background px-2 py-1 text-xs text-content-primary opacity-0 shadow-sm transition-opacity group-hover:opacity-100">
-                      Code execution
-                    </span>
+              {onCodeExecutionToggle && codeExecutionEnabled && (
+                <button
+                  type="button"
+                  onClick={onCodeExecutionToggle}
+                  aria-label="Code execution"
+                  aria-pressed
+                  className={cn(
+                    'flex h-7 items-center justify-center gap-1.5 rounded-lg px-2 transition-colors',
+                    isDarkMode
+                      ? 'bg-brand-accent-light/20 text-brand-accent-light'
+                      : 'bg-brand-accent-dark/20 text-brand-accent-dark',
                   )}
-                </div>
+                >
+                  <PiTerminalWindow className="h-5 w-5" />
+                  <span className="hidden translate-y-px text-xs font-medium leading-none md:inline">
+                    Code
+                  </span>
+                </button>
               )}
             </div>
 

--- a/src/components/chat/chat-input.tsx
+++ b/src/components/chat/chat-input.tsx
@@ -22,6 +22,7 @@ import {
 } from 'react'
 import {
   PiGlobe,
+  PiGlobeX,
   PiPaperclipLight,
   PiPlusLight,
   PiQuotes,
@@ -1176,7 +1177,11 @@ export function ChatInput({
                           }}
                           className="flex w-full items-center gap-3 px-3 py-2 text-left text-sm text-content-primary hover:bg-surface-chat-background"
                         >
-                          <PiGlobe className="h-5 w-5 text-content-secondary" />
+                          {webSearchEnabled ? (
+                            <PiGlobe className="h-5 w-5 text-content-secondary" />
+                          ) : (
+                            <PiGlobeX className="h-5 w-5 text-content-secondary" />
+                          )}
                           <span className="flex-1">Web search</span>
                           {webSearchEnabled && (
                             <MenuCheckmark className="h-4 w-4 text-brand-accent-light" />
@@ -1211,47 +1216,6 @@ export function ChatInput({
                   </>
                 )}
               </div>
-              {/* Web search stays visible outside the menu while enabled so
-                  its active state is glanceable and one-click to turn off. */}
-              {onWebSearchToggle && webSearchEnabled && (
-                <button
-                  id="web-search-button"
-                  type="button"
-                  onClick={onWebSearchToggle}
-                  aria-label="Web search"
-                  aria-pressed
-                  className={cn(
-                    'flex h-7 items-center justify-center gap-1.5 rounded-lg px-2 transition-colors',
-                    isDarkMode
-                      ? 'bg-brand-accent-light/20 text-brand-accent-light'
-                      : 'bg-brand-accent-dark/20 text-brand-accent-dark',
-                  )}
-                >
-                  <PiGlobe className="h-5 w-5" />
-                  <span className="hidden translate-y-px text-xs font-medium leading-none md:inline">
-                    Search
-                  </span>
-                </button>
-              )}
-              {onCodeExecutionToggle && codeExecutionEnabled && (
-                <button
-                  type="button"
-                  onClick={onCodeExecutionToggle}
-                  aria-label="Code execution"
-                  aria-pressed
-                  className={cn(
-                    'flex h-7 items-center justify-center gap-1.5 rounded-lg px-2 transition-colors',
-                    isDarkMode
-                      ? 'bg-brand-accent-light/20 text-brand-accent-light'
-                      : 'bg-brand-accent-dark/20 text-brand-accent-dark',
-                  )}
-                >
-                  <PiTerminalWindow className="h-5 w-5" />
-                  <span className="hidden translate-y-px text-xs font-medium leading-none md:inline">
-                    Code
-                  </span>
-                </button>
-              )}
             </div>
 
             <div className="flex items-center gap-2">

--- a/src/components/chat/chat-input.tsx
+++ b/src/components/chat/chat-input.tsx
@@ -285,6 +285,58 @@ export function ChatInput({
 
   // --- Input options menu state (the "+" button) ---
   const [isInputMenuOpen, setIsInputMenuOpen] = useState(false)
+  const inputMenuRef = useRef<HTMLDivElement>(null)
+  const inputMenuTriggerRef = useRef<HTMLButtonElement>(null)
+
+  const getInputMenuItems = (): HTMLElement[] =>
+    Array.from(
+      inputMenuRef.current?.querySelectorAll<HTMLElement>(
+        '[role="menuitem"], [role="menuitemcheckbox"]',
+      ) ?? [],
+    )
+
+  // ARIA menu keyboard contract: focus moves into the menu on open,
+  // Escape dismisses and restores focus to the trigger, and arrow keys
+  // move between items (wrapping). Tab closes rather than tabbing through.
+  useEffect(() => {
+    if (isInputMenuOpen) {
+      getInputMenuItems()[0]?.focus()
+    }
+  }, [isInputMenuOpen])
+
+  const closeInputMenu = (restoreFocus: boolean) => {
+    setIsInputMenuOpen(false)
+    if (restoreFocus) {
+      inputMenuTriggerRef.current?.focus()
+    }
+  }
+
+  const handleInputMenuKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      e.preventDefault()
+      e.stopPropagation()
+      closeInputMenu(true)
+      return
+    }
+    if (e.key === 'Tab') {
+      closeInputMenu(false)
+      return
+    }
+    if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+      e.preventDefault()
+      const items = getInputMenuItems()
+      if (items.length === 0) return
+      const currentIndex = items.indexOf(document.activeElement as HTMLElement)
+      const delta = e.key === 'ArrowDown' ? 1 : -1
+      const nextIndex =
+        currentIndex === -1
+          ? delta === 1
+            ? 0
+            : items.length - 1
+          : (currentIndex + delta + items.length) % items.length
+      items[nextIndex]?.focus()
+    }
+  }
 
   // Random placeholder - use first one initially to avoid SSR hydration mismatch,
   // then randomize after mount
@@ -1118,6 +1170,7 @@ export function ChatInput({
               <div className="relative">
                 <button
                   id="input-options-button"
+                  ref={inputMenuTriggerRef}
                   type="button"
                   onClick={() => setIsInputMenuOpen(!isInputMenuOpen)}
                   aria-label="Input options"
@@ -1134,7 +1187,10 @@ export function ChatInput({
                       onClick={() => setIsInputMenuOpen(false)}
                     />
                     <div
+                      ref={inputMenuRef}
                       role="menu"
+                      aria-label="Input options"
+                      onKeyDown={handleInputMenuKeyDown}
                       className="absolute bottom-full left-0 z-20 mb-2 min-w-[220px] rounded-xl border border-border-subtle bg-surface-chat py-1.5 shadow-lg"
                     >
                       <button

--- a/src/components/chat/chat-input.tsx
+++ b/src/components/chat/chat-input.tsx
@@ -1184,7 +1184,7 @@ export function ChatInput({
                   <>
                     <div
                       className="fixed inset-0 z-10"
-                      onClick={() => setIsInputMenuOpen(false)}
+                      onClick={() => closeInputMenu(false)}
                     />
                     <div
                       ref={inputMenuRef}
@@ -1198,7 +1198,7 @@ export function ChatInput({
                         role="menuitem"
                         onClick={() => {
                           triggerFileInput()
-                          setIsInputMenuOpen(false)
+                          closeInputMenu(true)
                         }}
                         className="flex w-full items-center gap-3 px-3 py-2 text-left text-sm text-content-primary hover:bg-surface-chat-background"
                       >
@@ -1211,7 +1211,7 @@ export function ChatInput({
                           role="menuitem"
                           onClick={() => {
                             onOpenPromptLibrary()
-                            setIsInputMenuOpen(false)
+                            closeInputMenu(true)
                           }}
                           className="flex w-full items-center gap-3 px-3 py-2 text-left text-sm text-content-primary hover:bg-surface-chat-background"
                         >
@@ -1229,7 +1229,7 @@ export function ChatInput({
                           aria-checked={webSearchEnabled}
                           onClick={() => {
                             onWebSearchToggle()
-                            setIsInputMenuOpen(false)
+                            closeInputMenu(true)
                           }}
                           className="flex w-full items-center gap-3 px-3 py-2 text-left text-sm text-content-primary hover:bg-surface-chat-background"
                         >
@@ -1251,7 +1251,7 @@ export function ChatInput({
                           aria-checked={codeExecutionEnabled}
                           onClick={() => {
                             onCodeExecutionToggle()
-                            setIsInputMenuOpen(false)
+                            closeInputMenu(true)
                           }}
                           className="flex w-full items-center gap-3 px-3 py-2 text-left text-sm text-content-primary hover:bg-surface-chat-background"
                         >

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -825,8 +825,16 @@ export function ChatInterface({
         presetId: presetId ?? undefined,
       }
       setCurrentChat(updatedChat)
+      // Blank chats share an empty id (one per storage mode), so also match
+      // the mode to avoid rewriting the other blank entry.
       setChats((prev) =>
-        prev.map((c) => (c.id === currentChat.id ? updatedChat : c)),
+        prev.map((c) =>
+          c.id === currentChat.id &&
+          (!currentChat.isBlankChat ||
+            c.isLocalOnly === currentChat.isLocalOnly)
+            ? updatedChat
+            : c,
+        ),
       )
       const storeHistory = isSignedIn || !isCloudSyncEnabled()
       if (!updatedChat.isTemporary && storeHistory) {

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -764,6 +764,7 @@ export function ChatInterface({
     editMessage,
     regenerateMessage,
     resolveInputToolCall,
+    retryToolCall,
     initialChatDecryptionFailed,
     clearInitialChatDecryptionFailed,
     localChatNotFound,
@@ -3461,6 +3462,7 @@ export function ChatInterface({
                     handleLabelClick={handleLabelClick}
                     onEditMessage={editMessage}
                     onRegenerateMessage={regenerateMessage}
+                    onRetryToolCall={retryToolCall}
                     showScrollButton={showScrollButton}
                     webSearchEnabled={effectiveWebSearchEnabled}
                     onWebSearchToggle={

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -3569,7 +3569,10 @@ export function ChatInterface({
                         onOpenPromptLibrary={handleOpenPromptLibrary}
                         onClearPromptPreset={() => handleSetActivePreset(null)}
                         mobileHeader={
-                          !currentChat?.messages?.length ? (
+                          // With a preset active, the preset tab attached to
+                          // the input card already opens the library; the
+                          // mobile Prompts button would collide with it.
+                          !currentChat?.messages?.length && !activePreset ? (
                             <div className="mb-3 md:hidden">
                               <PromptPresetSuggestions
                                 activePreset={activePreset}

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -3534,7 +3534,7 @@ export function ChatInterface({
                       )}
                       {streamError && (
                         <StreamErrorBanner
-                          message={streamError}
+                          error={streamError}
                           onDismiss={dismissStreamError}
                           onRetry={retryLastMessage}
                           isDarkMode={isDarkMode}

--- a/src/components/chat/chat-list-item.tsx
+++ b/src/components/chat/chat-list-item.tsx
@@ -289,7 +289,12 @@ export function ChatListItem({
     // The mousedown that initiates a drag focuses the row's link, and since
     // the drag suppresses the click, focus would stay parked inside the
     // privacy region and keep pixelated titles revealed after the drop.
-    if (document.activeElement instanceof HTMLElement) {
+    // Scoped to this row so dragging never steals focus from unrelated
+    // controls (e.g. a rename input on another row or the search field).
+    if (
+      document.activeElement instanceof HTMLElement &&
+      e.currentTarget.contains(document.activeElement)
+    ) {
       document.activeElement.blur()
     }
     setIsDragging(true)

--- a/src/components/chat/chat-list-item.tsx
+++ b/src/components/chat/chat-list-item.tsx
@@ -286,6 +286,12 @@ export function ChatListItem({
       e.preventDefault()
       return
     }
+    // The mousedown that initiates a drag focuses the row's link, and since
+    // the drag suppresses the click, focus would stay parked inside the
+    // privacy region and keep pixelated titles revealed after the drop.
+    if (document.activeElement instanceof HTMLElement) {
+      document.activeElement.blur()
+    }
     setIsDragging(true)
     e.dataTransfer.effectAllowed = 'move'
     e.dataTransfer.setData('text/plain', chat.id)

--- a/src/components/chat/chat-messages.tsx
+++ b/src/components/chat/chat-messages.tsx
@@ -50,6 +50,10 @@ type ChatMessagesProps = {
   ) => void
   onEditMessage?: (messageIndex: number, newContent: string) => void
   onRegenerateMessage?: (messageIndex: number) => void
+  onRetryToolCall?: (
+    messageIndex: number,
+    toolCallId: string,
+  ) => Promise<boolean>
   showScrollButton?: boolean
   webSearchEnabled?: boolean
   onWebSearchToggle?: () => void
@@ -77,6 +81,7 @@ const ChatMessage = memo(
     hideActions = false,
     onEditMessage,
     onRegenerateMessage,
+    onRetryToolCall,
   }: {
     message: Message
     messageIndex: number
@@ -87,6 +92,10 @@ const ChatMessage = memo(
     hideActions?: boolean
     onEditMessage?: (messageIndex: number, newContent: string) => void
     onRegenerateMessage?: (messageIndex: number) => void
+    onRetryToolCall?: (
+      messageIndex: number,
+      toolCallId: string,
+    ) => Promise<boolean>
   }) {
     const normalized = ensureTimeline(message)
     const renderer = getRendererRegistry().getMessageRenderer(normalized, model)
@@ -103,6 +112,7 @@ const ChatMessage = memo(
         hideActions={hideActions}
         onEditMessage={onEditMessage}
         onRegenerateMessage={onRegenerateMessage}
+        onRetryToolCall={onRetryToolCall}
       />
     )
   },
@@ -119,7 +129,8 @@ const ChatMessage = memo(
       prevProps.isStreaming === nextProps.isStreaming &&
       prevProps.hideActions === nextProps.hideActions &&
       prevProps.onEditMessage === nextProps.onEditMessage &&
-      prevProps.onRegenerateMessage === nextProps.onRegenerateMessage
+      prevProps.onRegenerateMessage === nextProps.onRegenerateMessage &&
+      prevProps.onRetryToolCall === nextProps.onRetryToolCall
     )
   },
 )
@@ -251,6 +262,7 @@ export function ChatMessages({
   handleLabelClick,
   onEditMessage,
   onRegenerateMessage,
+  onRetryToolCall,
   showScrollButton,
   webSearchEnabled,
   onWebSearchToggle,
@@ -495,6 +507,9 @@ export function ChatMessages({
                       onRegenerateMessage={
                         recoveryDraft ? undefined : onRegenerateMessage
                       }
+                      onRetryToolCall={
+                        recoveryDraft ? undefined : onRetryToolCall
+                      }
                     />
                     {showRecoveryStatusAfter(message) && <RecoveryMessage />}
                     {renderRecoveryAfter(message, i)}
@@ -530,6 +545,7 @@ export function ChatMessages({
                 onRegenerateMessage={
                   recoveryDraft ? undefined : onRegenerateMessage
                 }
+                onRetryToolCall={recoveryDraft ? undefined : onRetryToolCall}
               />
               {showRecoveryStatusAfter(message) && <RecoveryMessage />}
               {renderRecoveryAfter(message, archivedMessages.length + i)}

--- a/src/components/chat/chat-sidebar.tsx
+++ b/src/components/chat/chat-sidebar.tsx
@@ -243,8 +243,6 @@ export function ChatSidebar({
     return true
   })
   const sidebarScrollRef = useRef<HTMLDivElement>(null)
-  const chatsSectionRef = useRef<HTMLDivElement>(null)
-  const lastSidebarScrollTopRef = useRef(0)
   const loadMoreSentinelRef = useRef<HTMLDivElement>(null)
   const [isIOS, setIsIOS] = useState(false)
   const [nativeAppDismissed, setNativeAppDismissed] = useState(false)
@@ -602,39 +600,26 @@ export function ChatSidebar({
   // The Projects header renders (and pins) only for premium users.
   const hasPinnedProjectsHeader = Boolean(isSignedIn && isPremium)
 
-  // Auto-collapse the projects list once the user scrolls down into the
-  // chat list: when the Chats header reaches its pinned position, the
-  // projects are out of view anyway, and collapsing them snaps the scroll
-  // back to the top of the chats instead of leaving a long dead scroll.
-  useEffect(() => {
-    const scroller = sidebarScrollRef.current
-    if (!scroller || !isProjectsExpanded) return
-
-    lastSidebarScrollTopRef.current = scroller.scrollTop
-
-    const handleScroll = () => {
-      const scrollTop = scroller.scrollTop
-      const isScrollingDown = scrollTop > lastSidebarScrollTopRef.current
-      lastSidebarScrollTopRef.current = scrollTop
-      if (!isScrollingDown) return
-
-      const chatsSection = chatsSectionRef.current
-      if (!chatsSection) return
-
-      const pinOffset = hasPinnedProjectsHeader
-        ? CONSTANTS.SIDEBAR_PINNED_HEADER_OFFSET_PX
-        : 0
-      const chatsTop =
-        chatsSection.getBoundingClientRect().top -
-        scroller.getBoundingClientRect().top
-      if (chatsTop <= pinOffset + CONSTANTS.SIDEBAR_PINNED_HEADER_EPSILON_PX) {
-        setIsProjectsExpanded(false)
-      }
+  // Projects and Chats behave as an accordion: expanding one collapses the
+  // other. This keeps the newly opened section at the top of the scroll
+  // area (expanding a section while scrolled deep into the other would
+  // otherwise appear to do nothing, since the new content renders at its
+  // flow position far above the viewport) and resets the scroll so the
+  // opened section's content is immediately visible.
+  const expandProjectsSection = useCallback(() => {
+    setIsProjectsExpanded(true)
+    setIsChatHistoryExpanded(false)
+    sidebarScrollRef.current?.scrollTo({ top: 0 })
+    if (projects.length === 0) {
+      refreshProjects()
     }
+  }, [projects.length, refreshProjects])
 
-    scroller.addEventListener('scroll', handleScroll, { passive: true })
-    return () => scroller.removeEventListener('scroll', handleScroll)
-  }, [isProjectsExpanded, hasPinnedProjectsHeader])
+  const expandChatsSection = useCallback(() => {
+    setIsChatHistoryExpanded(true)
+    setIsProjectsExpanded(false)
+    sidebarScrollRef.current?.scrollTo({ top: 0 })
+  }, [])
 
   // Auto-load more chats when scrolling to bottom
   useEffect(() => {
@@ -1243,10 +1228,10 @@ export function ChatSidebar({
                 type="button"
                 aria-expanded={isProjectsExpanded}
                 onClick={() => {
-                  const newExpanded = !isProjectsExpanded
-                  setIsProjectsExpanded(newExpanded)
-                  if (newExpanded && projects.length === 0) {
-                    refreshProjects()
+                  if (isProjectsExpanded) {
+                    setIsProjectsExpanded(false)
+                  } else {
+                    expandProjectsSection()
                   }
                 }}
                 onDragOver={(e) => {
@@ -1267,10 +1252,7 @@ export function ChatSidebar({
                     e.preventDefault()
                     setIsDropTargetProjectsHeader(true)
                     if (!isProjectsExpanded) {
-                      setIsProjectsExpanded(true)
-                      if (projects.length === 0) {
-                        refreshProjects()
-                      }
+                      expandProjectsSection()
                     }
                   }
                 }}
@@ -1662,7 +1644,6 @@ export function ChatSidebar({
               in the scroll container; the header pins below the Projects
               header while the chat list scrolls. */}
           <div
-            ref={chatsSectionRef}
             className={cn(
               'relative z-10 flex-none border-t border-border-subtle',
               !isChatHistoryExpanded && 'border-b',
@@ -1686,7 +1667,9 @@ export function ChatSidebar({
                 if (chatId) {
                   e.preventDefault()
                   setDropTargetChatHistory(true)
-                  setIsChatHistoryExpanded(true)
+                  if (!isChatHistoryExpanded) {
+                    expandChatsSection()
+                  }
                 }
               }}
               onDragLeave={() => {
@@ -1718,7 +1701,13 @@ export function ChatSidebar({
               <button
                 type="button"
                 aria-expanded={isChatHistoryExpanded}
-                onClick={() => setIsChatHistoryExpanded(!isChatHistoryExpanded)}
+                onClick={() => {
+                  if (isChatHistoryExpanded) {
+                    setIsChatHistoryExpanded(false)
+                  } else {
+                    expandChatsSection()
+                  }
+                }}
                 className="flex w-full items-center justify-between px-4 py-3 text-left"
               >
                 <span className="flex items-center gap-2">

--- a/src/components/chat/chat-sidebar.tsx
+++ b/src/components/chat/chat-sidebar.tsx
@@ -113,7 +113,7 @@ type ChatSidebarProps = {
    */
   backupWarningNeedsRecovery?: boolean
   onDismissBackupWarning?: () => void
-  onChatsUpdated?: () => void
+  onChatsUpdated?: () => void | Promise<void>
   /** Triggers a deep (all-pages) cloud sync from the sidebar "Sync" button. */
   onManualSync?: () => Promise<void>
   /** True while a cloud sync is in progress; drives the Sync button spinner. */
@@ -576,17 +576,29 @@ export function ChatSidebar({
     cleanupAndInitialize()
   }, [isSignedIn, user?.id, onChatsUpdated, initPagination])
 
-  // Load more chats from backend (delegated to CloudSync via hook)
-  const loadMoreChats = useCallback(async () => {
+  // Load more chats from backend (delegated to CloudSync via hook).
+  // Returns the number of chats the page added, or null on failure, so the
+  // auto-top-up path can latch itself off when a request stops making
+  // progress instead of looping.
+  const loadMoreChats = useCallback(async (): Promise<number | null> => {
     try {
-      if (isLoadingMore || !isSignedIn) return
+      if (isLoadingMore || !isSignedIn) return null
       const result = await loadMorePage()
       const savedCount = result?.saved ?? 0
       justLoadedMoreRef.current = savedCount > 0
       if (savedCount > 0) {
         setPendingChatsRender(true)
-        onChatsUpdated?.()
+        try {
+          // Await the reload so the render-pending flag is cleared even
+          // when the page's chats were all already present locally (the
+          // count-increase effect never fires in that case, and a stuck
+          // flag would permanently gate future pagination).
+          await onChatsUpdated?.()
+        } finally {
+          setPendingChatsRender(false)
+        }
       }
+      return savedCount
     } catch (error) {
       justLoadedMoreRef.current = false
       setPendingChatsRender(false)
@@ -594,6 +606,7 @@ export function ChatSidebar({
         component: 'ChatSidebar',
         action: 'loadMoreChats',
       })
+      return null
     }
   }, [isLoadingMore, isSignedIn, loadMorePage, onChatsUpdated])
 
@@ -714,6 +727,13 @@ export function ChatSidebar({
   const chatSearch = useChatSearch(chatSearchTerm, searchEnabled)
   const isSearchActive = searchEnabled && chatSearchTerm.trim().length > 0
 
+  // Latch that disables the automatic under-filled-viewport top-up after a
+  // page request fails or adds nothing new. Without it, an error (retried
+  // instantly by the effect re-run) or a run of zero-new-chat pages would
+  // loop through requests with no user interaction. A real scroll gesture
+  // re-arms it, making the next attempt deliberate.
+  const autoTopUpDisabledRef = useRef(false)
+
   // Auto-load more chats when the user scrolls near the bottom of the
   // sidebar. Deliberately scroll-event driven rather than an
   // IntersectionObserver: recreating an observer (this effect re-runs every
@@ -725,7 +745,7 @@ export function ChatSidebar({
     const scroller = sidebarScrollRef.current
     if (!scroller) return
 
-    const maybeLoadMore = () => {
+    const maybeLoadMore = (fromUserScroll: boolean) => {
       if (
         !shouldShowLoadMore ||
         isLoadingMore ||
@@ -736,25 +756,35 @@ export function ChatSidebar({
       ) {
         return
       }
+      if (fromUserScroll) {
+        autoTopUpDisabledRef.current = false
+      } else if (autoTopUpDisabledRef.current) {
+        return
+      }
       const distanceFromBottom =
         scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight
       if (
         distanceFromBottom <= CONSTANTS.SIDEBAR_AUTOLOAD_BOTTOM_THRESHOLD_PX
       ) {
-        loadMoreChats()
+        void loadMoreChats().then((savedCount) => {
+          if (savedCount === null || savedCount === 0) {
+            autoTopUpDisabledRef.current = true
+          }
+        })
       }
     }
 
     // Under-filled viewport: without a scrollbar the scroll listener can
     // never fire, so top up one page at a time (each render round-trips
     // through pendingChatsRender before the next check) until the list
-    // overflows or the last page is reached.
+    // overflows, the last page is reached, or the latch trips.
     if (scroller.scrollHeight <= scroller.clientHeight) {
-      maybeLoadMore()
+      maybeLoadMore(false)
     }
 
-    scroller.addEventListener('scroll', maybeLoadMore, { passive: true })
-    return () => scroller.removeEventListener('scroll', maybeLoadMore)
+    const onScroll = () => maybeLoadMore(true)
+    scroller.addEventListener('scroll', onScroll, { passive: true })
+    return () => scroller.removeEventListener('scroll', onScroll)
   }, [
     shouldShowLoadMore,
     isLoadingMore,

--- a/src/components/chat/chat-sidebar.tsx
+++ b/src/components/chat/chat-sidebar.tsx
@@ -244,6 +244,13 @@ export function ChatSidebar({
   })
   const sidebarScrollRef = useRef<HTMLDivElement>(null)
   const loadMoreSentinelRef = useRef<HTMLDivElement>(null)
+  // Hides the sidebar scrollbar while a section expand/collapse animates;
+  // the scroll height changes every frame and the scrollbar would flicker.
+  const [hideScrollbarDuringAnimation, setHideScrollbarDuringAnimation] =
+    useState(false)
+  const scrollbarHideTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  )
   const [isIOS, setIsIOS] = useState(false)
   const [nativeAppDismissed, setNativeAppDismissed] = useState(false)
   const {
@@ -600,6 +607,26 @@ export function ChatSidebar({
   // The Projects header renders (and pins) only for premium users.
   const hasPinnedProjectsHeader = Boolean(isSignedIn && isPremium)
 
+  const hideScrollbarWhileSectionsAnimate = useCallback(() => {
+    setHideScrollbarDuringAnimation(true)
+    if (scrollbarHideTimeoutRef.current !== null) {
+      clearTimeout(scrollbarHideTimeoutRef.current)
+    }
+    scrollbarHideTimeoutRef.current = setTimeout(() => {
+      scrollbarHideTimeoutRef.current = null
+      setHideScrollbarDuringAnimation(false)
+    }, CONSTANTS.SIDEBAR_SECTION_SCROLLBAR_HIDE_MS)
+  }, [])
+
+  useEffect(
+    () => () => {
+      if (scrollbarHideTimeoutRef.current !== null) {
+        clearTimeout(scrollbarHideTimeoutRef.current)
+      }
+    },
+    [],
+  )
+
   // Projects and Chats behave as an accordion: expanding one collapses the
   // other. This keeps the newly opened section at the top of the scroll
   // area (expanding a section while scrolled deep into the other would
@@ -607,19 +634,21 @@ export function ChatSidebar({
   // flow position far above the viewport) and resets the scroll so the
   // opened section's content is immediately visible.
   const expandProjectsSection = useCallback(() => {
+    hideScrollbarWhileSectionsAnimate()
     setIsProjectsExpanded(true)
     setIsChatHistoryExpanded(false)
     sidebarScrollRef.current?.scrollTo({ top: 0 })
     if (projects.length === 0) {
       refreshProjects()
     }
-  }, [projects.length, refreshProjects])
+  }, [projects.length, refreshProjects, hideScrollbarWhileSectionsAnimate])
 
   const expandChatsSection = useCallback(() => {
+    hideScrollbarWhileSectionsAnimate()
     setIsChatHistoryExpanded(true)
     setIsProjectsExpanded(false)
     sidebarScrollRef.current?.scrollTo({ top: 0 })
-  }, [])
+  }, [hideScrollbarWhileSectionsAnimate])
 
   // Auto-load more chats when scrolling to bottom
   useEffect(() => {
@@ -1043,7 +1072,10 @@ export function ChatSidebar({
             banner) stay pinned below. */}
         <div
           ref={sidebarScrollRef}
-          className="relative flex min-h-0 flex-1 flex-col overflow-y-auto"
+          className={cn(
+            'relative flex min-h-0 flex-1 flex-col overflow-y-auto',
+            hideScrollbarDuringAnimation && 'scrollbar-hide',
+          )}
         >
           {/* Message for non-premium users (signed in or not) */}
           {!isPremium && (
@@ -1229,6 +1261,7 @@ export function ChatSidebar({
                 aria-expanded={isProjectsExpanded}
                 onClick={() => {
                   if (isProjectsExpanded) {
+                    hideScrollbarWhileSectionsAnimate()
                     setIsProjectsExpanded(false)
                   } else {
                     expandProjectsSection()
@@ -1299,7 +1332,10 @@ export function ChatSidebar({
                     initial={{ height: 0, opacity: 0 }}
                     animate={{ height: 'auto', opacity: 1 }}
                     exit={{ height: 0, opacity: 0 }}
-                    transition={{ duration: 0.2, ease: 'easeInOut' }}
+                    transition={{
+                      duration: CONSTANTS.SIDEBAR_SECTION_ANIMATION_S,
+                      ease: 'easeInOut',
+                    }}
                     className="overflow-hidden"
                   >
                     <div
@@ -1703,6 +1739,7 @@ export function ChatSidebar({
                 aria-expanded={isChatHistoryExpanded}
                 onClick={() => {
                   if (isChatHistoryExpanded) {
+                    hideScrollbarWhileSectionsAnimate()
                     setIsChatHistoryExpanded(false)
                   } else {
                     expandChatsSection()
@@ -1750,7 +1787,10 @@ export function ChatSidebar({
                   initial={{ height: 0, opacity: 0 }}
                   animate={{ height: 'auto', opacity: 1 }}
                   exit={{ height: 0, opacity: 0 }}
-                  transition={{ duration: 0.2, ease: 'easeInOut' }}
+                  transition={{
+                    duration: CONSTANTS.SIDEBAR_SECTION_ANIMATION_S,
+                    ease: 'easeInOut',
+                  }}
                   className={cn('overflow-hidden', expandedPanelClass)}
                 >
                   {/* Tabs for Cloud/Local chats - show when signed in, cloud sync enabled, and local-only mode enabled */}
@@ -1984,7 +2024,10 @@ export function ChatSidebar({
                   initial={{ height: 0, opacity: 0 }}
                   animate={{ height: 'auto', opacity: 1 }}
                   exit={{ height: 0, opacity: 0 }}
-                  transition={{ duration: 0.2, ease: 'easeInOut' }}
+                  transition={{
+                    duration: CONSTANTS.SIDEBAR_SECTION_ANIMATION_S,
+                    ease: 'easeInOut',
+                  }}
                   className={cn('overflow-hidden', expandedPanelClass)}
                 >
                   <div

--- a/src/components/chat/chat-sidebar.tsx
+++ b/src/components/chat/chat-sidebar.tsx
@@ -243,6 +243,8 @@ export function ChatSidebar({
     return true
   })
   const sidebarScrollRef = useRef<HTMLDivElement>(null)
+  const chatsSectionRef = useRef<HTMLDivElement>(null)
+  const lastSidebarScrollTopRef = useRef(0)
   const loadMoreSentinelRef = useRef<HTMLDivElement>(null)
   const [isIOS, setIsIOS] = useState(false)
   const [nativeAppDismissed, setNativeAppDismissed] = useState(false)
@@ -596,6 +598,43 @@ export function ChatSidebar({
       )
     }
   }, [isClient])
+
+  // The Projects header renders (and pins) only for premium users.
+  const hasPinnedProjectsHeader = Boolean(isSignedIn && isPremium)
+
+  // Auto-collapse the projects list once the user scrolls down into the
+  // chat list: when the Chats header reaches its pinned position, the
+  // projects are out of view anyway, and collapsing them snaps the scroll
+  // back to the top of the chats instead of leaving a long dead scroll.
+  useEffect(() => {
+    const scroller = sidebarScrollRef.current
+    if (!scroller || !isProjectsExpanded) return
+
+    lastSidebarScrollTopRef.current = scroller.scrollTop
+
+    const handleScroll = () => {
+      const scrollTop = scroller.scrollTop
+      const isScrollingDown = scrollTop > lastSidebarScrollTopRef.current
+      lastSidebarScrollTopRef.current = scrollTop
+      if (!isScrollingDown) return
+
+      const chatsSection = chatsSectionRef.current
+      if (!chatsSection) return
+
+      const pinOffset = hasPinnedProjectsHeader
+        ? CONSTANTS.SIDEBAR_PINNED_HEADER_OFFSET_PX
+        : 0
+      const chatsTop =
+        chatsSection.getBoundingClientRect().top -
+        scroller.getBoundingClientRect().top
+      if (chatsTop <= pinOffset + CONSTANTS.SIDEBAR_PINNED_HEADER_EPSILON_PX) {
+        setIsProjectsExpanded(false)
+      }
+    }
+
+    scroller.addEventListener('scroll', handleScroll, { passive: true })
+    return () => scroller.removeEventListener('scroll', handleScroll)
+  }, [isProjectsExpanded, hasPinnedProjectsHeader])
 
   // Auto-load more chats when scrolling to bottom
   useEffect(() => {
@@ -1194,9 +1233,12 @@ export function ChatSidebar({
             </Link>
           </div>
 
-          {/* Projects dropdown - show for premium users */}
+          {/* Projects dropdown - show for premium users. The header and
+              list are direct children of the scroll container (no section
+              wrapper) so the sticky header pins to the scroll area itself
+              and stays visible for the rest of the scroll. */}
           {isSignedIn && isPremium && (
-            <div className="relative z-10 flex-none border-t border-border-subtle">
+            <>
               <button
                 type="button"
                 aria-expanded={isProjectsExpanded}
@@ -1239,7 +1281,7 @@ export function ChatSidebar({
                   setIsDropTargetProjectsHeader(false)
                 }}
                 className={cn(
-                  'sticky top-0 z-20 flex w-full cursor-pointer items-center justify-between bg-surface-sidebar px-4 py-3 text-sm transition-colors',
+                  'sticky top-0 z-30 flex w-full cursor-pointer items-center justify-between border-t border-border-subtle bg-surface-sidebar px-4 py-3 text-sm transition-colors',
                   isDropTargetProjectsHeader
                     ? isDarkMode
                       ? 'border border-white/30 bg-white/10'
@@ -1613,11 +1655,14 @@ export function ChatSidebar({
                   </motion.div>
                 )}
               </AnimatePresence>
-            </div>
+            </>
           )}
 
-          {/* Chats Header */}
+          {/* Chats section. Like Projects, header and content sit directly
+              in the scroll container; the header pins below the Projects
+              header while the chat list scrolls. */}
           <div
+            ref={chatsSectionRef}
             className={cn(
               'relative z-10 flex-none border-t border-border-subtle',
               !isChatHistoryExpanded && 'border-b',
@@ -1656,13 +1701,19 @@ export function ChatSidebar({
                 clearDragState()
               }}
               className={cn(
-                'sticky top-0 z-20 flex w-full items-center bg-surface-sidebar text-sm transition-colors',
+                'sticky z-20 flex w-full items-center bg-surface-sidebar text-sm transition-colors',
                 isDropTargetChatHistory
                   ? isDarkMode
                     ? 'border border-white/30 bg-white/10'
                     : 'border border-gray-400 bg-gray-200/30'
                   : 'text-content-secondary',
               )}
+              style={{
+                // Stack below the pinned Projects header when present.
+                top: hasPinnedProjectsHeader
+                  ? `${CONSTANTS.SIDEBAR_PINNED_HEADER_OFFSET_PX}px`
+                  : 0,
+              }}
             >
               <button
                 type="button"

--- a/src/components/chat/chat-sidebar.tsx
+++ b/src/components/chat/chat-sidebar.tsx
@@ -609,8 +609,19 @@ export function ChatSidebar({
     }
   }, [isClient])
 
-  // The Projects header renders (and pins) only for premium users.
+  // Drives both the Projects section's visibility and the Chats header's
+  // sticky offset so the two can never drift apart.
   const hasPinnedProjectsHeader = Boolean(isSignedIn && isPremium)
+
+  // Heal stale accordion state: a stored Projects=true flag (e.g. from a
+  // premium session) would otherwise leave a signed-out/non-premium user
+  // with no Projects section AND a collapsed chat list — an empty sidebar.
+  useEffect(() => {
+    if (!hasPinnedProjectsHeader && isProjectsExpanded) {
+      setIsProjectsExpanded(false)
+      setIsChatHistoryExpanded(true)
+    }
+  }, [hasPinnedProjectsHeader, isProjectsExpanded])
 
   const hideScrollbarWhileSectionsAnimate = useCallback(() => {
     setHideScrollbarDuringAnimation(true)
@@ -1276,7 +1287,7 @@ export function ChatSidebar({
               list are direct children of the scroll container (no section
               wrapper) so the sticky header pins to the scroll area itself
               and stays visible for the rest of the scroll. */}
-          {isSignedIn && isPremium && (
+          {hasPinnedProjectsHeader && (
             <>
               <button
                 type="button"

--- a/src/components/chat/chat-sidebar.tsx
+++ b/src/components/chat/chat-sidebar.tsx
@@ -249,7 +249,6 @@ export function ChatSidebar({
     return true
   })
   const sidebarScrollRef = useRef<HTMLDivElement>(null)
-  const loadMoreSentinelRef = useRef<HTMLDivElement>(null)
   // Hides the sidebar scrollbar while a section expand/collapse animates;
   // the scroll height changes every frame and the scrollbar would flicker.
   const [hideScrollbarDuringAnimation, setHideScrollbarDuringAnimation] =
@@ -656,40 +655,6 @@ export function ChatSidebar({
     sidebarScrollRef.current?.scrollTo({ top: 0 })
   }, [hideScrollbarWhileSectionsAnimate])
 
-  // Auto-load more chats when scrolling to bottom
-  useEffect(() => {
-    const sentinel = loadMoreSentinelRef.current
-    if (!sentinel) return
-
-    const observer = new IntersectionObserver(
-      (entries) => {
-        const entry = entries[0]
-        if (
-          entry.isIntersecting &&
-          shouldShowLoadMore &&
-          !isLoadingMore &&
-          isSignedIn
-        ) {
-          loadMoreChats()
-        }
-      },
-      {
-        root: sidebarScrollRef.current,
-        rootMargin: '100px',
-        threshold: 0,
-      },
-    )
-
-    observer.observe(sentinel)
-    return () => observer.disconnect()
-  }, [
-    shouldShowLoadMore,
-    isLoadingMore,
-    isSignedIn,
-    loadMoreChats,
-    isChatHistoryExpanded,
-  ])
-
   const sortedChats = useMemo(() => {
     // The incoming `chats` array is already sorted by `sortChats`
     // (blank-first, then most-recently-updated). We only filter
@@ -737,6 +702,57 @@ export function ChatSidebar({
     !(localOnlyModeEnabled && activeTab === 'local')
   const chatSearch = useChatSearch(chatSearchTerm, searchEnabled)
   const isSearchActive = searchEnabled && chatSearchTerm.trim().length > 0
+
+  // Auto-load more chats when the user scrolls near the bottom of the
+  // sidebar. Deliberately scroll-event driven rather than an
+  // IntersectionObserver: recreating an observer (this effect re-runs every
+  // time isLoadingMore flips after a page) re-fires its initial callback,
+  // and with the sentinel sitting inside the unified scroller that cascaded
+  // into fetching every remaining page. Scroll events only fire on real
+  // user scrolling, so each near-bottom scroll loads at most one page.
+  useEffect(() => {
+    const scroller = sidebarScrollRef.current
+    if (!scroller) return
+
+    const maybeLoadMore = () => {
+      if (
+        !shouldShowLoadMore ||
+        isLoadingMore ||
+        pendingChatsRender ||
+        !isSignedIn ||
+        !isChatHistoryExpanded ||
+        isSearchActive
+      ) {
+        return
+      }
+      const distanceFromBottom =
+        scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight
+      if (
+        distanceFromBottom <= CONSTANTS.SIDEBAR_AUTOLOAD_BOTTOM_THRESHOLD_PX
+      ) {
+        loadMoreChats()
+      }
+    }
+
+    // Under-filled viewport: without a scrollbar the scroll listener can
+    // never fire, so top up one page at a time (each render round-trips
+    // through pendingChatsRender before the next check) until the list
+    // overflows or the last page is reached.
+    if (scroller.scrollHeight <= scroller.clientHeight) {
+      maybeLoadMore()
+    }
+
+    scroller.addEventListener('scroll', maybeLoadMore, { passive: true })
+    return () => scroller.removeEventListener('scroll', maybeLoadMore)
+  }, [
+    shouldShowLoadMore,
+    isLoadingMore,
+    pendingChatsRender,
+    isSignedIn,
+    loadMoreChats,
+    isChatHistoryExpanded,
+    isSearchActive,
+  ])
 
   const searchResultChats = useMemo((): ChatItemData[] => {
     if (!isSearchActive) return []
@@ -2246,8 +2262,6 @@ export function ChatSidebar({
                         loadMoreButton={
                           isSearchActive ? undefined : (
                             <>
-                              {/* Sentinel element for intersection observer */}
-                              <div ref={loadMoreSentinelRef} className="h-1" />
                               {/* Shimmer placeholder while loading or waiting for chats to render */}
                               {(isLoadingMore || pendingChatsRender) && (
                                 <div className="space-y-1 px-2">

--- a/src/components/chat/chat-sidebar.tsx
+++ b/src/components/chat/chat-sidebar.tsx
@@ -242,8 +242,7 @@ export function ChatSidebar({
     }
     return true
   })
-  const [isChatListScrolled, setIsChatListScrolled] = useState(false)
-  const chatListRef = useRef<HTMLDivElement>(null)
+  const sidebarScrollRef = useRef<HTMLDivElement>(null)
   const loadMoreSentinelRef = useRef<HTMLDivElement>(null)
   const [isIOS, setIsIOS] = useState(false)
   const [nativeAppDismissed, setNativeAppDismissed] = useState(false)
@@ -598,19 +597,6 @@ export function ChatSidebar({
     }
   }, [isClient])
 
-  useEffect(() => {
-    const chatList = chatListRef.current
-    if (!chatList) return
-
-    const handleScroll = () => {
-      setIsChatListScrolled(chatList.scrollTop > 0)
-    }
-
-    handleScroll()
-    chatList.addEventListener('scroll', handleScroll)
-    return () => chatList.removeEventListener('scroll', handleScroll)
-  }, [isChatHistoryExpanded])
-
   // Auto-load more chats when scrolling to bottom
   useEffect(() => {
     const sentinel = loadMoreSentinelRef.current
@@ -629,7 +615,7 @@ export function ChatSidebar({
         }
       },
       {
-        root: chatListRef.current,
+        root: sidebarScrollRef.current,
         rootMargin: '100px',
         threshold: 0,
       },
@@ -1027,8 +1013,14 @@ export function ChatSidebar({
           </div>
         </div>
 
-        {/* Main sidebar content */}
-        <div className="relative flex h-full flex-col overflow-hidden">
+        {/* Main sidebar content - one scroll area covering the upsell box,
+            New Chat button, Projects, and Chats so long project or chat
+            lists never squeeze each other out of view. The footer (and iOS
+            banner) stay pinned below. */}
+        <div
+          ref={sidebarScrollRef}
+          className="relative flex min-h-0 flex-1 flex-col overflow-y-auto"
+        >
           {/* Message for non-premium users (signed in or not) */}
           {!isPremium && (
             <div
@@ -1247,7 +1239,7 @@ export function ChatSidebar({
                   setIsDropTargetProjectsHeader(false)
                 }}
                 className={cn(
-                  'flex w-full cursor-pointer items-center justify-between bg-surface-sidebar px-4 py-3 text-sm transition-colors',
+                  'sticky top-0 z-20 flex w-full cursor-pointer items-center justify-between bg-surface-sidebar px-4 py-3 text-sm transition-colors',
                   isDropTargetProjectsHeader
                     ? isDarkMode
                       ? 'border border-white/30 bg-white/10'
@@ -1287,10 +1279,7 @@ export function ChatSidebar({
                     className="overflow-hidden"
                   >
                     <div
-                      className={cn(
-                        'min-h-0 flex-1 space-y-1 overflow-y-auto px-2 py-2',
-                        expandedPanelClass,
-                      )}
+                      className={cn('space-y-1 px-2 py-2', expandedPanelClass)}
                     >
                       {/* Cloud sync disabled message */}
                       {!cloudSyncEnabled ? (
@@ -1667,7 +1656,7 @@ export function ChatSidebar({
                 clearDragState()
               }}
               className={cn(
-                'relative flex w-full items-center bg-surface-sidebar text-sm transition-colors',
+                'sticky top-0 z-20 flex w-full items-center bg-surface-sidebar text-sm transition-colors',
                 isDropTargetChatHistory
                   ? isDarkMode
                     ? 'border border-white/30 bg-white/10'
@@ -1947,331 +1936,328 @@ export function ChatSidebar({
                 </motion.div>
               )}
             </AnimatePresence>
-          </div>
 
-          {/* Scrollable Chat List */}
-          <AnimatePresence initial={false}>
-            {isChatHistoryExpanded && (
-              <motion.div
-                initial={{ height: 0, opacity: 0 }}
-                animate={{ height: 'auto', opacity: 1 }}
-                exit={{ height: 0, opacity: 0 }}
-                transition={{ duration: 0.2, ease: 'easeInOut' }}
-                className={cn('flex-1 overflow-hidden', expandedPanelClass)}
-              >
-                <div
-                  id="chat-storage-panel"
-                  role="tabpanel"
-                  aria-labelledby={
-                    activeTab === 'cloud' ? 'chat-cloud-tab' : 'chat-local-tab'
-                  }
-                  ref={chatListRef}
-                  onDragOver={(e) => {
-                    if (
-                      e.dataTransfer.types.includes('application/x-chat-id')
-                    ) {
-                      e.preventDefault()
-                      e.dataTransfer.dropEffect = 'move'
-                      setIsDropTargetChatList(true)
-                    }
-                  }}
-                  onDragEnter={(e) => {
-                    if (
-                      e.dataTransfer.types.includes('application/x-chat-id')
-                    ) {
-                      e.preventDefault()
-                      setIsDropTargetChatList(true)
-                    }
-                  }}
-                  onDragLeave={(e) => {
-                    // Only clear if leaving the container entirely
-                    if (!e.currentTarget.contains(e.relatedTarget as Node)) {
-                      setIsDropTargetChatList(false)
-                    }
-                  }}
-                  onDrop={async (e) => {
-                    e.preventDefault()
-                    const chatId = e.dataTransfer.getData(
-                      'application/x-chat-id',
-                    )
-                    if (chatId) {
-                      const chat = chats.find((c) => c.id === chatId)
-                      if (draggingChatFromProjectId) {
-                        // Dragging from project - remove from project
-                        if (activeTab === 'local' && onConvertChatToLocal) {
-                          await onConvertChatToLocal(chatId)
-                        } else if (onRemoveChatFromProject) {
-                          await onRemoveChatFromProject(chatId)
-                        }
-                      } else if (
-                        chat?.isLocalOnly &&
-                        activeTab === 'cloud' &&
-                        onConvertChatToCloud
-                      ) {
-                        // Local chat dropped on cloud tab area - convert to cloud
-                        await onConvertChatToCloud(chatId)
-                      } else if (
-                        !chat?.isLocalOnly &&
-                        activeTab === 'local' &&
-                        onConvertChatToLocal
-                      ) {
-                        // Cloud chat dropped on local tab area - convert to local
-                        await onConvertChatToLocal(chatId)
-                      }
-                    }
-                    setIsDropTargetChatList(false)
-                    clearDragState()
-                  }}
-                  className={cn(
-                    'relative z-10 h-full overflow-y-auto',
-                    isChatListScrolled && 'border-t border-border-subtle',
-                    isDropTargetChatList &&
-                      (isDarkMode
-                        ? 'border border-white/30 bg-white/10'
-                        : 'border border-gray-400 bg-gray-200/30'),
-                  )}
+            {/* Chat List - flows within the unified sidebar scroll area */}
+            <AnimatePresence initial={false}>
+              {isChatHistoryExpanded && (
+                <motion.div
+                  initial={{ height: 0, opacity: 0 }}
+                  animate={{ height: 'auto', opacity: 1 }}
+                  exit={{ height: 0, opacity: 0 }}
+                  transition={{ duration: 0.2, ease: 'easeInOut' }}
+                  className={cn('overflow-hidden', expandedPanelClass)}
                 >
-                  {isClient && (
-                    <ChatList
-                      chats={
-                        isSearchActive
-                          ? searchResultChats
-                          : (sortedChats as ChatItemData[])
+                  <div
+                    id="chat-storage-panel"
+                    role="tabpanel"
+                    aria-labelledby={
+                      activeTab === 'cloud'
+                        ? 'chat-cloud-tab'
+                        : 'chat-local-tab'
+                    }
+                    onDragOver={(e) => {
+                      if (
+                        e.dataTransfer.types.includes('application/x-chat-id')
+                      ) {
+                        e.preventDefault()
+                        e.dataTransfer.dropEffect = 'move'
+                        setIsDropTargetChatList(true)
                       }
-                      currentChatId={currentChat?.id}
-                      currentChatIsBlank={currentChat?.isBlankChat}
-                      currentChatIsLocalOnly={currentChat?.isLocalOnly}
-                      isDarkMode={isDarkMode}
-                      pixelateSidebarChatTitles={pixelateSidebarChatTitles}
-                      isLoading={
-                        isSearchActive &&
-                        chatSearch.isSearching &&
-                        searchResultChats.length === 0
+                    }}
+                    onDragEnter={(e) => {
+                      if (
+                        e.dataTransfer.types.includes('application/x-chat-id')
+                      ) {
+                        e.preventDefault()
+                        setIsDropTargetChatList(true)
                       }
-                      showEncryptionStatus={true}
-                      showSyncStatus={true}
-                      enableTitleAnimation={true}
-                      isDraggable={
-                        !isSearchActive &&
-                        isSignedIn &&
-                        cloudSyncEnabled &&
-                        (!!onMoveChatToProject ||
-                          !!onConvertChatToCloud ||
-                          !!onConvertChatToLocal)
+                    }}
+                    onDragLeave={(e) => {
+                      // Only clear if leaving the container entirely
+                      if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+                        setIsDropTargetChatList(false)
                       }
-                      showMoveToProject={
-                        !isSearchActive &&
-                        isSignedIn &&
-                        isPremium &&
-                        cloudSyncEnabled &&
-                        !!onMoveChatToProject
+                    }}
+                    onDrop={async (e) => {
+                      e.preventDefault()
+                      const chatId = e.dataTransfer.getData(
+                        'application/x-chat-id',
+                      )
+                      if (chatId) {
+                        const chat = chats.find((c) => c.id === chatId)
+                        if (draggingChatFromProjectId) {
+                          // Dragging from project - remove from project
+                          if (activeTab === 'local' && onConvertChatToLocal) {
+                            await onConvertChatToLocal(chatId)
+                          } else if (onRemoveChatFromProject) {
+                            await onRemoveChatFromProject(chatId)
+                          }
+                        } else if (
+                          chat?.isLocalOnly &&
+                          activeTab === 'cloud' &&
+                          onConvertChatToCloud
+                        ) {
+                          // Local chat dropped on cloud tab area - convert to cloud
+                          await onConvertChatToCloud(chatId)
+                        } else if (
+                          !chat?.isLocalOnly &&
+                          activeTab === 'local' &&
+                          onConvertChatToLocal
+                        ) {
+                          // Cloud chat dropped on local tab area - convert to local
+                          await onConvertChatToLocal(chatId)
+                        }
                       }
-                      getChatHref={(chat) =>
-                        chat.isBlankChat
-                          ? getNewChatPath({
-                              isLocalOnly: chat.isLocalOnly,
-                            })
-                          : getChatPath(chat.id, {
-                              isLocalOnly: chat.isLocalOnly,
-                            })
-                      }
-                      onSelectChat={
-                        isSearchActive
-                          ? handleSearchResultSelect
-                          : handleChatSelect
-                      }
-                      onAfterSelect={undefined}
-                      onUpdateTitle={updateChatTitle}
-                      onDeleteChat={deleteChat}
-                      onEncryptionKeyClick={onEncryptionKeyClick}
-                      onDragStart={(chatId) => setDraggingChat(chatId, null)}
-                      onDragEnd={() => {
-                        clearDragState()
-                      }}
-                      projects={projects.map((p) => ({
-                        id: p.id,
-                        name: p.name,
-                      }))}
-                      onMoveToProject={
-                        onMoveChatToProject
-                          ? async (chatId, projectId) => {
-                              // Convert local chat to cloud first if needed
-                              const chat = chats.find((c) => c.id === chatId)
-                              if (chat?.isLocalOnly && onConvertChatToCloud) {
-                                await onConvertChatToCloud(chatId)
+                      setIsDropTargetChatList(false)
+                      clearDragState()
+                    }}
+                    className={cn(
+                      'relative z-10',
+                      isDropTargetChatList &&
+                        (isDarkMode
+                          ? 'border border-white/30 bg-white/10'
+                          : 'border border-gray-400 bg-gray-200/30'),
+                    )}
+                  >
+                    {isClient && (
+                      <ChatList
+                        chats={
+                          isSearchActive
+                            ? searchResultChats
+                            : (sortedChats as ChatItemData[])
+                        }
+                        currentChatId={currentChat?.id}
+                        currentChatIsBlank={currentChat?.isBlankChat}
+                        currentChatIsLocalOnly={currentChat?.isLocalOnly}
+                        isDarkMode={isDarkMode}
+                        pixelateSidebarChatTitles={pixelateSidebarChatTitles}
+                        isLoading={
+                          isSearchActive &&
+                          chatSearch.isSearching &&
+                          searchResultChats.length === 0
+                        }
+                        showEncryptionStatus={true}
+                        showSyncStatus={true}
+                        enableTitleAnimation={true}
+                        isDraggable={
+                          !isSearchActive &&
+                          isSignedIn &&
+                          cloudSyncEnabled &&
+                          (!!onMoveChatToProject ||
+                            !!onConvertChatToCloud ||
+                            !!onConvertChatToLocal)
+                        }
+                        showMoveToProject={
+                          !isSearchActive &&
+                          isSignedIn &&
+                          isPremium &&
+                          cloudSyncEnabled &&
+                          !!onMoveChatToProject
+                        }
+                        getChatHref={(chat) =>
+                          chat.isBlankChat
+                            ? getNewChatPath({
+                                isLocalOnly: chat.isLocalOnly,
+                              })
+                            : getChatPath(chat.id, {
+                                isLocalOnly: chat.isLocalOnly,
+                              })
+                        }
+                        onSelectChat={
+                          isSearchActive
+                            ? handleSearchResultSelect
+                            : handleChatSelect
+                        }
+                        onAfterSelect={undefined}
+                        onUpdateTitle={updateChatTitle}
+                        onDeleteChat={deleteChat}
+                        onEncryptionKeyClick={onEncryptionKeyClick}
+                        onDragStart={(chatId) => setDraggingChat(chatId, null)}
+                        onDragEnd={() => {
+                          clearDragState()
+                        }}
+                        projects={projects.map((p) => ({
+                          id: p.id,
+                          name: p.name,
+                        }))}
+                        onMoveToProject={
+                          onMoveChatToProject
+                            ? async (chatId, projectId) => {
+                                // Convert local chat to cloud first if needed
+                                const chat = chats.find((c) => c.id === chatId)
+                                if (chat?.isLocalOnly && onConvertChatToCloud) {
+                                  await onConvertChatToCloud(chatId)
+                                }
+                                await onMoveChatToProject(chatId, projectId)
                               }
-                              await onMoveChatToProject(chatId, projectId)
-                            }
-                          : undefined
-                      }
-                      loadingIndicator={
-                        isSearchActive && chatSearch.isIndexing ? (
-                          <div className="flex items-center gap-2 px-4 py-2 text-content-secondary">
-                            <PiSpinner className="h-4 w-4 animate-spin" />
-                            <span className="text-sm">
-                              Building search index...
-                            </span>
-                          </div>
-                        ) : chatDecryptionProgress?.isDecrypting ? (
-                          <div className="flex items-center gap-2 px-4 py-2 text-content-secondary">
-                            <PiSpinner className="h-4 w-4 animate-spin" />
-                            <span className="text-sm">
-                              Loading chats
-                              {chatDecryptionProgress.total > 0
-                                ? ` (${chatDecryptionProgress.current}/${chatDecryptionProgress.total})`
-                                : '...'}
-                            </span>
-                          </div>
-                        ) : undefined
-                      }
-                      onConvertToCloud={onConvertChatToCloud}
-                      onConvertToLocal={onConvertChatToLocal}
-                      emptyState={
-                        isSearchActive ? (
-                          <div className="rounded-lg border border-border-subtle bg-surface-sidebar p-4 text-center">
-                            <p className="text-sm text-content-muted">
-                              No matching chats
-                            </p>
-                            {chatSearch.isIndexing && (
-                              <p className="mt-1 text-balance text-xs text-content-muted">
-                                The search index is still being built; results
-                                will fill in shortly
+                            : undefined
+                        }
+                        loadingIndicator={
+                          isSearchActive && chatSearch.isIndexing ? (
+                            <div className="flex items-center gap-2 px-4 py-2 text-content-secondary">
+                              <PiSpinner className="h-4 w-4 animate-spin" />
+                              <span className="text-sm">
+                                Building search index...
+                              </span>
+                            </div>
+                          ) : chatDecryptionProgress?.isDecrypting ? (
+                            <div className="flex items-center gap-2 px-4 py-2 text-content-secondary">
+                              <PiSpinner className="h-4 w-4 animate-spin" />
+                              <span className="text-sm">
+                                Loading chats
+                                {chatDecryptionProgress.total > 0
+                                  ? ` (${chatDecryptionProgress.current}/${chatDecryptionProgress.total})`
+                                  : '...'}
+                              </span>
+                            </div>
+                          ) : undefined
+                        }
+                        onConvertToCloud={onConvertChatToCloud}
+                        onConvertToLocal={onConvertChatToLocal}
+                        emptyState={
+                          isSearchActive ? (
+                            <div className="rounded-lg border border-border-subtle bg-surface-sidebar p-4 text-center">
+                              <p className="text-sm text-content-muted">
+                                No matching chats
                               </p>
-                            )}
-                          </div>
-                        ) : activeTab === 'local' ? (
-                          <div className="rounded-lg border border-border-subtle bg-surface-sidebar p-4 text-center">
-                            <p className="text-sm text-content-muted">
-                              No local chats yet
-                            </p>
-                            <p className="mt-1 text-xs text-content-muted">
-                              Disable cloud sync in settings to create
-                              local-only chats
-                            </p>
-                          </div>
-                        ) : undefined
-                      }
-                      loadMoreButton={
-                        isSearchActive ? undefined : (
-                          <>
-                            {/* Sentinel element for intersection observer */}
-                            <div ref={loadMoreSentinelRef} className="h-1" />
-                            {/* Shimmer placeholder while loading or waiting for chats to render */}
-                            {(isLoadingMore || pendingChatsRender) && (
-                              <div className="space-y-1 px-2">
-                                {[...Array(3)].map((_, i) => (
-                                  <div
-                                    key={i}
-                                    className="animate-pulse rounded-lg px-3 py-2"
-                                  >
+                              {chatSearch.isIndexing && (
+                                <p className="mt-1 text-balance text-xs text-content-muted">
+                                  The search index is still being built; results
+                                  will fill in shortly
+                                </p>
+                              )}
+                            </div>
+                          ) : activeTab === 'local' ? (
+                            <div className="rounded-lg border border-border-subtle bg-surface-sidebar p-4 text-center">
+                              <p className="text-sm text-content-muted">
+                                No local chats yet
+                              </p>
+                              <p className="mt-1 text-xs text-content-muted">
+                                Disable cloud sync in settings to create
+                                local-only chats
+                              </p>
+                            </div>
+                          ) : undefined
+                        }
+                        loadMoreButton={
+                          isSearchActive ? undefined : (
+                            <>
+                              {/* Sentinel element for intersection observer */}
+                              <div ref={loadMoreSentinelRef} className="h-1" />
+                              {/* Shimmer placeholder while loading or waiting for chats to render */}
+                              {(isLoadingMore || pendingChatsRender) && (
+                                <div className="space-y-1 px-2">
+                                  {[...Array(3)].map((_, i) => (
                                     <div
-                                      className={cn(
-                                        'mb-1.5 h-3.5 w-3/4 rounded',
-                                        isDarkMode
-                                          ? 'bg-gray-700'
-                                          : 'bg-gray-200',
-                                      )}
-                                    />
-                                    <div
-                                      className={cn(
-                                        'h-3 w-1/3 rounded',
-                                        isDarkMode
-                                          ? 'bg-gray-700'
-                                          : 'bg-gray-200',
-                                      )}
-                                    />
-                                  </div>
-                                ))}
-                              </div>
-                            )}
-                            {isSignedIn &&
-                              !shouldShowLoadMore &&
-                              !hasMoreRemote &&
-                              hasAttemptedLoadMore && (
-                                <div className="px-3 py-2 text-center text-xs text-content-muted">
-                                  No more chats
+                                      key={i}
+                                      className="animate-pulse rounded-lg px-3 py-2"
+                                    >
+                                      <div
+                                        className={cn(
+                                          'mb-1.5 h-3.5 w-3/4 rounded',
+                                          isDarkMode
+                                            ? 'bg-gray-700'
+                                            : 'bg-gray-200',
+                                        )}
+                                      />
+                                      <div
+                                        className={cn(
+                                          'h-3 w-1/3 rounded',
+                                          isDarkMode
+                                            ? 'bg-gray-700'
+                                            : 'bg-gray-200',
+                                        )}
+                                      />
+                                    </div>
+                                  ))}
                                 </div>
                               )}
-                          </>
-                        )
-                      }
-                    />
-                  )}
-                </div>
-              </motion.div>
-            )}
-          </AnimatePresence>
-
-          {/* App Store button for iOS users */}
-          {isClient && isIOS && !nativeAppDismissed && (
-            <div className="relative z-10 flex-none border-t border-border-subtle p-3">
-              <button
-                type="button"
-                onClick={() => {
-                  setNativeAppDismissed(true)
-                  try {
-                    localStorage.setItem(
-                      USER_PREFS_NATIVE_APP_DISMISSED,
-                      'true',
-                    )
-                  } catch {}
-                }}
-                aria-label="Dismiss"
-                className="absolute right-0 top-0 flex h-11 w-11 items-center justify-center text-content-muted transition-colors hover:text-content-primary"
-              >
-                <XMarkIcon className="h-4 w-4" />
-              </button>
-              <div className="text-center">
-                <p
-                  className={`mb-2 text-sm font-medium ${'text-content-secondary'}`}
-                >
-                  Get the native app
-                </p>
-                <a
-                  href="https://apps.apple.com/app/tinfoil/id6745201750"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="block w-full"
-                >
-                  <img
-                    src={
-                      isDarkMode ? '/appstore-dark.svg' : '/appstore-light.svg'
-                    }
-                    alt="Download on the App Store"
-                    className="mx-auto h-10 w-auto transition-opacity hover:opacity-80"
-                  />
-                </a>
-              </div>
-            </div>
-          )}
-
-          {/* Terms and privacy policy */}
-          <div className="relative z-10 mt-auto flex h-[56px] flex-none items-center justify-center border-t border-border-subtle bg-surface-sidebar p-3">
-            <p className="text-balance text-center text-xs leading-relaxed text-content-secondary">
-              By using this service, you agree to Tinfoil&apos;s{' '}
-              <Link
-                href="https://tinfoil.sh/terms"
-                className={
-                  isDarkMode
-                    ? 'text-white underline hover:text-content-secondary'
-                    : 'text-brand-accent-dark underline hover:text-brand-accent-dark/80'
-                }
-              >
-                Terms of Service
-              </Link>{' '}
-              and{' '}
-              <Link
-                href="https://tinfoil.sh/privacy"
-                className={
-                  isDarkMode
-                    ? 'text-white underline hover:text-content-secondary'
-                    : 'text-brand-accent-dark underline hover:text-brand-accent-dark/80'
-                }
-              >
-                Privacy Policy
-              </Link>
-            </p>
+                              {isSignedIn &&
+                                !shouldShowLoadMore &&
+                                !hasMoreRemote &&
+                                hasAttemptedLoadMore && (
+                                  <div className="px-3 py-2 text-center text-xs text-content-muted">
+                                    No more chats
+                                  </div>
+                                )}
+                            </>
+                          )
+                        }
+                      />
+                    )}
+                  </div>
+                </motion.div>
+              )}
+            </AnimatePresence>
           </div>
+        </div>
+
+        {/* App Store button for iOS users - pinned below the scroll area */}
+        {isClient && isIOS && !nativeAppDismissed && (
+          <div className="relative z-10 flex-none border-t border-border-subtle p-3">
+            <button
+              type="button"
+              onClick={() => {
+                setNativeAppDismissed(true)
+                try {
+                  localStorage.setItem(USER_PREFS_NATIVE_APP_DISMISSED, 'true')
+                } catch {}
+              }}
+              aria-label="Dismiss"
+              className="absolute right-0 top-0 flex h-11 w-11 items-center justify-center text-content-muted transition-colors hover:text-content-primary"
+            >
+              <XMarkIcon className="h-4 w-4" />
+            </button>
+            <div className="text-center">
+              <p
+                className={`mb-2 text-sm font-medium ${'text-content-secondary'}`}
+              >
+                Get the native app
+              </p>
+              <a
+                href="https://apps.apple.com/app/tinfoil/id6745201750"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="block w-full"
+              >
+                <img
+                  src={
+                    isDarkMode ? '/appstore-dark.svg' : '/appstore-light.svg'
+                  }
+                  alt="Download on the App Store"
+                  className="mx-auto h-10 w-auto transition-opacity hover:opacity-80"
+                />
+              </a>
+            </div>
+          </div>
+        )}
+
+        {/* Terms and privacy policy */}
+        <div className="relative z-10 mt-auto flex h-[56px] flex-none items-center justify-center border-t border-border-subtle bg-surface-sidebar p-3">
+          <p className="text-balance text-center text-xs leading-relaxed text-content-secondary">
+            By using this service, you agree to Tinfoil&apos;s{' '}
+            <Link
+              href="https://tinfoil.sh/terms"
+              className={
+                isDarkMode
+                  ? 'text-white underline hover:text-content-secondary'
+                  : 'text-brand-accent-dark underline hover:text-brand-accent-dark/80'
+              }
+            >
+              Terms of Service
+            </Link>{' '}
+            and{' '}
+            <Link
+              href="https://tinfoil.sh/privacy"
+              className={
+                isDarkMode
+                  ? 'text-white underline hover:text-content-secondary'
+                  : 'text-brand-accent-dark underline hover:text-brand-accent-dark/80'
+              }
+            >
+              Privacy Policy
+            </Link>
+          </p>
         </div>
       </nav>
 

--- a/src/components/chat/chat-sidebar.tsx
+++ b/src/components/chat/chat-sidebar.tsx
@@ -539,7 +539,7 @@ export function ChatSidebar({
         resetPagination()
           .then((result) => {
             if (result?.deletedIds.length && onChatsUpdated) {
-              onChatsUpdated()
+              return onChatsUpdated()
             }
           })
           .catch((error) => {
@@ -563,7 +563,7 @@ export function ChatSidebar({
       try {
         const result = await initPagination()
         if (result?.deletedIds.length && onChatsUpdated) {
-          onChatsUpdated()
+          await onChatsUpdated()
         }
       } catch (error) {
         logError('Failed to cleanup and initialize pagination', error, {
@@ -594,6 +594,14 @@ export function ChatSidebar({
           // count-increase effect never fires in that case, and a stuck
           // flag would permanently gate future pagination).
           await onChatsUpdated?.()
+        } catch (error) {
+          // The page fetch itself succeeded — don't let a reload failure
+          // fall through to the outer catch and read as a failed page
+          // (which would trip the caller's auto-top-up latch).
+          logError('Failed to reload chats after pagination', error, {
+            component: 'ChatSidebar',
+            action: 'loadMoreChats',
+          })
         } finally {
           setPendingChatsRender(false)
         }
@@ -730,8 +738,10 @@ export function ChatSidebar({
   // Latch that disables the automatic under-filled-viewport top-up after a
   // page request fails or adds nothing new. Without it, an error (retried
   // instantly by the effect re-run) or a run of zero-new-chat pages would
-  // loop through requests with no user interaction. A real scroll gesture
-  // re-arms it, making the next attempt deliberate.
+  // loop through requests with no user interaction. Any scroll event
+  // re-arms it (including programmatic ones from the accordion's
+  // scrollTo — acceptable, since those only follow deliberate clicks and
+  // re-arming costs at most one request).
   const autoTopUpDisabledRef = useRef(false)
 
   // Auto-load more chats when the user scrolls near the bottom of the

--- a/src/components/chat/chat-sidebar.tsx
+++ b/src/components/chat/chat-sidebar.tsx
@@ -235,6 +235,12 @@ export function ChatSidebar({
       if (expandSection === 'projects') {
         return false
       }
+      // Accordion invariant: Projects and Chats are never open together.
+      // Stored states predating the accordion (or written independently)
+      // can both be 'true'; Projects wins and Chats stays collapsed.
+      if (sessionStorage.getItem(UI_SIDEBAR_PROJECTS_EXPANDED) === 'true') {
+        return false
+      }
       const stored = sessionStorage.getItem(UI_SIDEBAR_CHAT_HISTORY_EXPANDED)
       if (stored !== null) {
         return stored === 'true'
@@ -1295,8 +1301,19 @@ export function ChatSidebar({
                 onDrop={() => {
                   setIsDropTargetProjectsHeader(false)
                 }}
+                style={{
+                  // Explicit height shared with the Chats header's stacking
+                  // offset so the pinned headers always sit flush; a
+                  // content-driven height can drift from the constant and
+                  // open a seam where scrolled content shows through.
+                  height: `${CONSTANTS.SIDEBAR_PINNED_HEADER_OFFSET_PX}px`,
+                }}
                 className={cn(
-                  'sticky top-0 z-30 flex w-full cursor-pointer items-center justify-between border-t border-border-subtle bg-surface-sidebar px-4 py-3 text-sm transition-colors',
+                  // flex-none is load-bearing: header and panel are direct
+                  // children of the flex-col scroll container, and without
+                  // it flexbox shrinks them to fit the viewport instead of
+                  // letting the container scroll.
+                  'sticky top-0 z-30 flex w-full flex-none cursor-pointer items-center justify-between border-t border-border-subtle bg-surface-sidebar px-4 text-sm transition-colors',
                   isDropTargetProjectsHeader
                     ? isDarkMode
                       ? 'border border-white/30 bg-white/10'
@@ -1325,7 +1342,11 @@ export function ChatSidebar({
                 </span>
               </button>
 
-              {/* Expanded projects list */}
+              {/* Expanded projects list. flex-none matters here too: this
+                  panel is a direct child of the flex-col scroll container,
+                  and overflow-hidden (required by the height animation)
+                  would otherwise clip the list when flexbox shrinks it to
+                  the viewport instead of letting the sidebar scroll. */}
               <AnimatePresence initial={false}>
                 {isProjectsExpanded && (
                   <motion.div
@@ -1336,7 +1357,7 @@ export function ChatSidebar({
                       duration: CONSTANTS.SIDEBAR_SECTION_ANIMATION_S,
                       ease: 'easeInOut',
                     }}
-                    className="overflow-hidden"
+                    className="flex-none overflow-hidden"
                   >
                     <div
                       className={cn('space-y-1 px-2 py-2', expandedPanelClass)}

--- a/src/components/chat/chat-utils.ts
+++ b/src/components/chat/chat-utils.ts
@@ -8,8 +8,10 @@ import type { Chat } from './types'
  * on error message text, which varies across browsers, SDKs, and locales.
  */
 export type ChatErrorCode =
-  // Transport/network failure, including exhausted retries.
+  // Transport/network failure (no HTTP response), including exhausted retries.
   | 'FETCH_ERROR'
+  // The server responded with a non-429 error status (5xx, 4xx).
+  | 'SERVER_ERROR'
   // Free-tier or per-request rate limit (HTTP 429 family).
   | 'RATE_LIMIT'
   // Per-account hourly usage cap.

--- a/src/components/chat/chat-utils.ts
+++ b/src/components/chat/chat-utils.ts
@@ -2,13 +2,31 @@ import { SYNC_CHATS } from '@/constants/storage-keys'
 import React from 'react'
 import type { Chat } from './types'
 
+/**
+ * Structured error classification for chat request failures. Control flow
+ * (retries, banners, rate-limit handling) must branch on these codes, never
+ * on error message text, which varies across browsers, SDKs, and locales.
+ */
+export type ChatErrorCode =
+  // Transport/network failure, including exhausted retries.
+  | 'FETCH_ERROR'
+  // Free-tier or per-request rate limit (HTTP 429 family).
+  | 'RATE_LIMIT'
+  // Per-account hourly usage cap.
+  | 'HOURLY_LIMIT'
+
 export class ChatError extends Error {
+  /** HTTP status of the failed request, when one was received. */
+  public status?: number
+
   constructor(
     message: string,
-    public code: string,
+    public code: ChatErrorCode,
+    options?: { status?: number },
   ) {
     super(message)
     this.name = 'ChatError'
+    this.status = options?.status
   }
 }
 

--- a/src/components/chat/constants.ts
+++ b/src/components/chat/constants.ts
@@ -49,6 +49,13 @@ export const CONSTANTS = {
   // overlap.
   CHAT_SIDEBAR_RAIL_FADE_IN_DURATION_S: 0.15,
   CHAT_SIDEBAR_RAIL_FADE_OUT_DURATION_S: 0.1,
+  // Height of a pinned sidebar section header (Projects/Chats). The Chats
+  // header offsets by this amount so it stacks below the pinned Projects
+  // header while scrolling.
+  SIDEBAR_PINNED_HEADER_OFFSET_PX: 44,
+  // Tolerance when checking whether the Chats header has reached its
+  // pinned position (fractional scroll positions on zoomed displays).
+  SIDEBAR_PINNED_HEADER_EPSILON_PX: 1,
   SETTINGS_SIDEBAR_WIDTH_PX: 345,
   VERIFIER_SIDEBAR_WIDTH_PX: 345,
   ASK_SIDEBAR_WIDTH_PX: 420,

--- a/src/components/chat/constants.ts
+++ b/src/components/chat/constants.ts
@@ -53,6 +53,14 @@ export const CONSTANTS = {
   // header offsets by this amount so it stacks below the pinned Projects
   // header while scrolling.
   SIDEBAR_PINNED_HEADER_OFFSET_PX: 44,
+  // Duration of a sidebar section expand/collapse animation (seconds),
+  // shared by the Projects and Chats height animations.
+  SIDEBAR_SECTION_ANIMATION_S: 0.2,
+  // How long the sidebar scrollbar stays hidden while sections animate.
+  // Slightly longer than the animation so the scrollbar reappears only
+  // once the scroll height has settled, instead of flickering as it
+  // changes mid-animation.
+  SIDEBAR_SECTION_SCROLLBAR_HIDE_MS: 300,
   SETTINGS_SIDEBAR_WIDTH_PX: 345,
   VERIFIER_SIDEBAR_WIDTH_PX: 345,
   ASK_SIDEBAR_WIDTH_PX: 420,

--- a/src/components/chat/constants.ts
+++ b/src/components/chat/constants.ts
@@ -53,6 +53,9 @@ export const CONSTANTS = {
   // header offsets by this amount so it stacks below the pinned Projects
   // header while scrolling.
   SIDEBAR_PINNED_HEADER_OFFSET_PX: 44,
+  // How close to the bottom of the sidebar scroll area (in px) a downward
+  // user scroll must get before the next page of chats is fetched.
+  SIDEBAR_AUTOLOAD_BOTTOM_THRESHOLD_PX: 200,
   // Duration of a sidebar section expand/collapse animation (seconds),
   // shared by the Projects and Chats height animations.
   SIDEBAR_SECTION_ANIMATION_S: 0.2,

--- a/src/components/chat/constants.ts
+++ b/src/components/chat/constants.ts
@@ -53,9 +53,6 @@ export const CONSTANTS = {
   // header offsets by this amount so it stacks below the pinned Projects
   // header while scrolling.
   SIDEBAR_PINNED_HEADER_OFFSET_PX: 44,
-  // Tolerance when checking whether the Chats header has reached its
-  // pinned position (fractional scroll positions on zoomed displays).
-  SIDEBAR_PINNED_HEADER_EPSILON_PX: 1,
   SETTINGS_SIDEBAR_WIDTH_PX: 345,
   VERIFIER_SIDEBAR_WIDTH_PX: 345,
   ASK_SIDEBAR_WIDTH_PX: 420,

--- a/src/components/chat/genui/GenUIToolCallRenderer.tsx
+++ b/src/components/chat/genui/GenUIToolCallRenderer.tsx
@@ -288,8 +288,10 @@ function ParseFailureCard({
   onRetryToolCall?: () => Promise<boolean>
 }) {
   const [isRetrying, setIsRetrying] = useState(false)
-  // Set when a widget-only retry failed; the card then falls back to
-  // offering the full-response regeneration.
+  // Set when a widget-only retry failed. The card then falls back to the
+  // full-response regeneration — unless no regenerate handler was provided,
+  // in which case widget-only retry stays available rather than leaving the
+  // card with no action at all.
   const [widgetRetryFailed, setWidgetRetryFailed] = useState(false)
 
   // Logging is a side effect — kept out of render so React's render-twice
@@ -307,7 +309,8 @@ function ParseFailureCard({
     )
   }, [toolName, hasInput])
 
-  const canRetryWidgetOnly = !!onRetryToolCall && !widgetRetryFailed
+  const canRetryWidgetOnly =
+    !!onRetryToolCall && (!widgetRetryFailed || !onRetry)
 
   const handleRetry = async () => {
     if (isRetrying) return
@@ -317,7 +320,9 @@ function ParseFailureCard({
     }
     setIsRetrying(true)
     try {
-      const repaired = await onRetryToolCall()
+      // A thrown repair (network failure etc.) is the same outcome as a
+      // clean `false` for this card: fall back to full regeneration.
+      const repaired = await onRetryToolCall().catch(() => false)
       if (!repaired) {
         setWidgetRetryFailed(true)
       }
@@ -330,17 +335,27 @@ function ParseFailureCard({
 
   const showRetryButton = canRetryWidgetOnly || !!onRetry
 
+  let retryLabel: string
+  if (isRetrying) {
+    retryLabel = 'Fixing widget...'
+  } else if (canRetryWidgetOnly) {
+    retryLabel = 'Retry widget'
+  } else {
+    retryLabel = 'Regenerate response'
+  }
+
+  const description =
+    widgetRetryFailed && onRetry
+      ? 'Retrying the widget alone didn\u2019t work. Trying again will regenerate the whole response.'
+      : `The response didn't match the ${toolName} widget's expected shape.`
+
   return (
     <div className="my-4 flex items-center justify-between gap-3 rounded-lg border border-border-subtle bg-surface-card px-4 py-3 text-sm">
       <div className="flex flex-col">
         <span className="font-medium text-content-primary">
           Couldn&apos;t display this widget
         </span>
-        <span className="text-xs text-content-muted">
-          {widgetRetryFailed
-            ? 'Retrying the widget alone didn\u2019t work. Trying again will regenerate the whole response.'
-            : `The response didn't match the ${toolName} widget's expected shape.`}
-        </span>
+        <span className="text-xs text-content-muted">{description}</span>
       </div>
       {showRetryButton && (
         <button
@@ -352,11 +367,7 @@ function ParseFailureCard({
           <RefreshCw
             className={`h-3.5 w-3.5 ${isRetrying ? 'animate-spin' : ''}`}
           />
-          {isRetrying
-            ? 'Fixing widget...'
-            : canRetryWidgetOnly
-              ? 'Retry widget'
-              : 'Regenerate response'}
+          {retryLabel}
         </button>
       )}
     </div>

--- a/src/components/chat/genui/GenUIToolCallRenderer.tsx
+++ b/src/components/chat/genui/GenUIToolCallRenderer.tsx
@@ -59,6 +59,13 @@ interface GenUIToolCallRendererProps {
    * call. Intended to be bound to the chat-level regenerate handler.
    */
   onRetry?: () => void
+  /**
+   * Widget-only retry: re-request just this tool call's arguments and patch
+   * the block in place, leaving the rest of the answer intact. Resolves
+   * false when the repair failed, in which case the card falls back to
+   * offering `onRetry` (full regeneration).
+   */
+  onRetryToolCall?: (toolCallId: string) => Promise<boolean>
 }
 
 function resolveInput(tc: GenUIToolCall): Record<string, unknown> | null {
@@ -79,6 +86,7 @@ export const GenUIToolCallRenderer = memo(function GenUIToolCallRenderer({
   isStreaming,
   isDarkMode,
   onRetry,
+  onRetryToolCall,
 }: GenUIToolCallRendererProps) {
   return (
     <React.Fragment>
@@ -97,9 +105,9 @@ export const GenUIToolCallRenderer = memo(function GenUIToolCallRenderer({
           const rendered = renderGenUIInline(tc.name, input, { isDarkMode })
           if (rendered) {
             return (
-              <div key={tc.id} className="my-4">
-                {rendered}
-              </div>
+              <GenUIWidgetErrorBoundary key={tc.id} toolName={tc.name}>
+                <div className="my-4">{rendered}</div>
+              </GenUIWidgetErrorBoundary>
             )
           }
         }
@@ -143,12 +151,69 @@ export const GenUIToolCallRenderer = memo(function GenUIToolCallRenderer({
             toolName={tc.name}
             hasInput={!!input}
             onRetry={onRetry}
+            onRetryToolCall={
+              onRetryToolCall ? () => onRetryToolCall(tc.id) : undefined
+            }
           />
         )
       })}
     </React.Fragment>
   )
 })
+
+interface GenUIWidgetErrorBoundaryProps {
+  toolName: string
+  children: React.ReactNode
+}
+
+/**
+ * Catches render-time throws inside a widget so a single bad widget shows
+ * a compact notice instead of crashing the whole message tree.
+ */
+class GenUIWidgetErrorBoundary extends React.Component<
+  GenUIWidgetErrorBoundaryProps,
+  { hasError: boolean }
+> {
+  constructor(props: GenUIWidgetErrorBoundaryProps) {
+    super(props)
+    this.state = { hasError: false }
+  }
+
+  static getDerivedStateFromError(): { hasError: boolean } {
+    return { hasError: true }
+  }
+
+  componentDidCatch(error: Error): void {
+    logError('GenUI widget crashed while rendering', error, {
+      component: 'GenUIWidgetErrorBoundary',
+      action: 'render',
+      metadata: { toolName: this.props.toolName },
+    })
+  }
+
+  render(): React.ReactNode {
+    if (this.state.hasError) {
+      return (
+        <div className="my-4 flex items-start gap-2.5 rounded-lg border border-orange-500/30 bg-orange-500/10 px-3 py-2.5 text-sm">
+          <Sparkles
+            className="mt-0.5 h-4 w-4 flex-shrink-0 text-orange-500"
+            aria-hidden
+          />
+          <div className="flex flex-col">
+            <span className="font-medium text-content-primary">
+              Couldn&apos;t display this widget
+            </span>
+            <span className="text-xs text-content-muted">
+              The {prettyWidgetName(this.props.toolName)} component ran into a
+              problem while rendering.
+            </span>
+          </div>
+        </div>
+      )
+    }
+    return this.props.children
+  }
+}
 
 /**
  * Live tracer shown while the model is streaming a GenUI tool call.
@@ -215,11 +280,18 @@ function ParseFailureCard({
   toolName,
   hasInput,
   onRetry,
+  onRetryToolCall,
 }: {
   toolName: string
   hasInput: boolean
   onRetry?: () => void
+  onRetryToolCall?: () => Promise<boolean>
 }) {
+  const [isRetrying, setIsRetrying] = useState(false)
+  // Set when a widget-only retry failed; the card then falls back to
+  // offering the full-response regeneration.
+  const [widgetRetryFailed, setWidgetRetryFailed] = useState(false)
+
   // Logging is a side effect — kept out of render so React's render-twice
   // strict mode and re-renders from parent state changes don't produce
   // duplicate log lines for the same failure.
@@ -235,6 +307,29 @@ function ParseFailureCard({
     )
   }, [toolName, hasInput])
 
+  const canRetryWidgetOnly = !!onRetryToolCall && !widgetRetryFailed
+
+  const handleRetry = async () => {
+    if (isRetrying) return
+    if (!canRetryWidgetOnly) {
+      onRetry?.()
+      return
+    }
+    setIsRetrying(true)
+    try {
+      const repaired = await onRetryToolCall()
+      if (!repaired) {
+        setWidgetRetryFailed(true)
+      }
+      // On success the patched arguments re-render the widget and this
+      // card unmounts on its own.
+    } finally {
+      setIsRetrying(false)
+    }
+  }
+
+  const showRetryButton = canRetryWidgetOnly || !!onRetry
+
   return (
     <div className="my-4 flex items-center justify-between gap-3 rounded-lg border border-border-subtle bg-surface-card px-4 py-3 text-sm">
       <div className="flex flex-col">
@@ -242,18 +337,26 @@ function ParseFailureCard({
           Couldn&apos;t display this widget
         </span>
         <span className="text-xs text-content-muted">
-          The response didn&apos;t match the {toolName} widget&apos;s expected
-          shape.
+          {widgetRetryFailed
+            ? 'Retrying the widget alone didn\u2019t work. Trying again will regenerate the whole response.'
+            : `The response didn't match the ${toolName} widget's expected shape.`}
         </span>
       </div>
-      {onRetry && (
+      {showRetryButton && (
         <button
           type="button"
-          onClick={onRetry}
-          className="inline-flex flex-shrink-0 items-center gap-1.5 rounded-md border border-border-subtle bg-surface-chat-background px-3 py-1.5 text-sm font-medium text-content-primary transition-colors hover:bg-surface-card"
+          onClick={() => void handleRetry()}
+          disabled={isRetrying}
+          className="inline-flex flex-shrink-0 items-center gap-1.5 rounded-md border border-border-subtle bg-surface-chat-background px-3 py-1.5 text-sm font-medium text-content-primary transition-colors hover:bg-surface-card disabled:cursor-default disabled:opacity-60"
         >
-          <RefreshCw className="h-3.5 w-3.5" />
-          Try again
+          <RefreshCw
+            className={`h-3.5 w-3.5 ${isRetrying ? 'animate-spin' : ''}`}
+          />
+          {isRetrying
+            ? 'Fixing widget...'
+            : canRetryWidgetOnly
+              ? 'Retry widget'
+              : 'Regenerate response'}
         </button>
       )}
     </div>

--- a/src/components/chat/genui/retry.ts
+++ b/src/components/chat/genui/retry.ts
@@ -13,7 +13,7 @@ import { sendStructuredCompletion } from '@/services/inference/inference-client'
 import { logError } from '@/utils/error-handling'
 import { zodToJsonSchema } from 'zod-to-json-schema'
 import type { Message } from '../types'
-import { GENUI_WIDGETS_BY_NAME } from './registry'
+import { GENUI_WIDGETS_BY_NAME, isGenUIToolName } from './registry'
 
 /** How many trailing conversation messages accompany the re-ask. */
 const RETRY_CONTEXT_MESSAGE_LIMIT = 8
@@ -44,20 +44,21 @@ function toPlainText(message: Message): string {
  */
 export async function regenerateToolCallArguments({
   toolName,
+  originalArguments,
   contextMessages,
   model,
 }: {
   toolName: string
+  /** The malformed argument JSON from the failed call, if any streamed. */
+  originalArguments?: string
   contextMessages: Message[]
   model: BaseModel
 }): Promise<string | null> {
+  // Own-property check: the tool name comes from the model, and a name
+  // like "toString" would otherwise pass a plain truthiness lookup via
+  // the object prototype.
+  if (!isGenUIToolName(toolName)) return null
   const widget = GENUI_WIDGETS_BY_NAME[toolName]
-  if (!widget) return null
-
-  const jsonSchema = zodToJsonSchema(widget.schema, {
-    target: 'openApi3',
-    $refStrategy: 'none',
-  }) as Record<string, unknown>
 
   const conversation = contextMessages
     .slice(-RETRY_CONTEXT_MESSAGE_LIMIT)
@@ -68,6 +69,22 @@ export async function regenerateToolCallArguments({
     .filter((message) => message.content.trim().length > 0)
 
   try {
+    const jsonSchema = zodToJsonSchema(widget.schema, {
+      target: 'openApi3',
+      $refStrategy: 'none',
+    }) as Record<string, unknown>
+
+    // The malformed arguments usually contain the intended data with a
+    // shape problem; giving them to the model preserves the widget's
+    // original content instead of asking it to reinvent the data from the
+    // conversation text alone.
+    const originalArgumentsHint = originalArguments?.trim()
+      ? ` The malformed arguments were: ${originalArguments.slice(
+          0,
+          RETRY_CONTEXT_MESSAGE_MAX_CHARS,
+        )}. Preserve their intent and data; fix only what is invalid.`
+      : ''
+
     const regenerated = await sendStructuredCompletion<unknown>({
       model,
       messages: [
@@ -76,7 +93,8 @@ export async function regenerateToolCallArguments({
           content:
             `You previously tried to render a "${toolName}" UI component (${widget.description}) ` +
             'in this conversation, but the arguments were malformed. Based on the conversation, ' +
-            'produce a valid set of arguments for that component. Respond with only the JSON arguments.',
+            'produce a valid set of arguments for that component. Respond with only the JSON arguments.' +
+            originalArgumentsHint,
         },
         ...conversation,
       ],

--- a/src/components/chat/genui/retry.ts
+++ b/src/components/chat/genui/retry.ts
@@ -1,0 +1,105 @@
+/**
+ * Widget-only retry.
+ *
+ * When a GenUI tool call fails validation (the model emitted arguments the
+ * widget's schema rejects), the whole assistant answer is usually fine —
+ * only the one widget is broken. This helper re-asks the model for just
+ * that tool call's arguments via a structured (JSON-schema constrained)
+ * completion, so the failed widget can be patched in place without
+ * regenerating the entire response.
+ */
+import type { BaseModel } from '@/config/models'
+import { sendStructuredCompletion } from '@/services/inference/inference-client'
+import { logError } from '@/utils/error-handling'
+import { zodToJsonSchema } from 'zod-to-json-schema'
+import type { Message } from '../types'
+import { GENUI_WIDGETS_BY_NAME } from './registry'
+
+/** How many trailing conversation messages accompany the re-ask. */
+const RETRY_CONTEXT_MESSAGE_LIMIT = 8
+
+/** Truncation cap for each context message sent with the re-ask. */
+const RETRY_CONTEXT_MESSAGE_MAX_CHARS = 4000
+
+function toPlainText(message: Message): string {
+  if (message.content) return message.content
+  // Assistant messages built from a timeline may keep their text in
+  // content blocks rather than the top-level `content` field.
+  if (message.timeline) {
+    return message.timeline
+      .filter((block) => block.type === 'content')
+      .map((block) => block.content)
+      .join('\n')
+  }
+  return ''
+}
+
+/**
+ * Ask the model to regenerate the arguments for a single widget and
+ * validate them against the widget's Zod schema.
+ *
+ * Returns the validated arguments serialized as a JSON string (the same
+ * format tool-call blocks store), or `null` when the widget is unknown,
+ * the request fails, or the regenerated arguments still don't validate.
+ */
+export async function regenerateToolCallArguments({
+  toolName,
+  contextMessages,
+  model,
+}: {
+  toolName: string
+  contextMessages: Message[]
+  model: BaseModel
+}): Promise<string | null> {
+  const widget = GENUI_WIDGETS_BY_NAME[toolName]
+  if (!widget) return null
+
+  const jsonSchema = zodToJsonSchema(widget.schema, {
+    target: 'openApi3',
+    $refStrategy: 'none',
+  }) as Record<string, unknown>
+
+  const conversation = contextMessages
+    .slice(-RETRY_CONTEXT_MESSAGE_LIMIT)
+    .map((message) => ({
+      role: message.role,
+      content: toPlainText(message).slice(0, RETRY_CONTEXT_MESSAGE_MAX_CHARS),
+    }))
+    .filter((message) => message.content.trim().length > 0)
+
+  try {
+    const regenerated = await sendStructuredCompletion<unknown>({
+      model,
+      messages: [
+        {
+          role: 'system',
+          content:
+            `You previously tried to render a "${toolName}" UI component (${widget.description}) ` +
+            'in this conversation, but the arguments were malformed. Based on the conversation, ' +
+            'produce a valid set of arguments for that component. Respond with only the JSON arguments.',
+        },
+        ...conversation,
+      ],
+      jsonSchema,
+    })
+
+    const parsed = widget.schema.safeParse(regenerated)
+    if (!parsed.success) {
+      logError('Regenerated widget arguments failed validation', parsed.error, {
+        component: 'genui-retry',
+        action: 'regenerateToolCallArguments',
+        metadata: { toolName },
+      })
+      return null
+    }
+
+    return JSON.stringify(parsed.data)
+  } catch (error) {
+    logError('Widget argument regeneration failed', error, {
+      component: 'genui-retry',
+      action: 'regenerateToolCallArguments',
+      metadata: { toolName },
+    })
+    return null
+  }
+}

--- a/src/components/chat/hooks/chat-persistence.ts
+++ b/src/components/chat/hooks/chat-persistence.ts
@@ -57,6 +57,7 @@ export function createUpdateChatWithHistoryCheck({
       webSearchEnabled: liveChat
         ? liveChat.webSearchEnabled
         : chatSnapshot.webSearchEnabled,
+      presetId: liveChat ? liveChat.presetId : chatSnapshot.presetId,
     }
 
     setChats((prevChats) => {

--- a/src/components/chat/hooks/use-chat-messaging.ts
+++ b/src/components/chat/hooks/use-chat-messaging.ts
@@ -53,6 +53,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { getMessageAttachments, getMessageImages } from '../attachment-helpers'
 import { ChatError } from '../chat-utils'
 import { CONSTANTS } from '../constants'
+import { regenerateToolCallArguments } from '../genui/retry'
 import type { Chat, LoadingState, Message } from '../types'
 import {
   createBlankChat,
@@ -122,6 +123,7 @@ interface UseChatMessagingReturn {
     resultText: string,
     resultData?: unknown,
   ) => void
+  retryToolCall: (messageIndex: number, toolCallId: string) => Promise<boolean>
 }
 
 type ActiveLiveGeneration = {
@@ -1424,6 +1426,86 @@ export function useChatMessaging({
     [loadingState, currentChat, setChats, setCurrentChat, handleQuery],
   )
 
+  /**
+   * Retry a single failed GenUI tool call without regenerating the whole
+   * assistant response. Re-asks the model for just that widget's arguments
+   * via a structured completion, validates them against the widget schema,
+   * and patches the failed block (and its `toolCalls` mirror) in place.
+   *
+   * Returns true when the widget was repaired; false lets the caller fall
+   * back to a full regeneration.
+   */
+  const retryToolCall = useCallback(
+    async (messageIndex: number, toolCallId: string): Promise<boolean> => {
+      if (loadingState !== 'idle' || !currentChat) return false
+
+      const message = currentChat.messages[messageIndex]
+      if (!message || message.role !== 'assistant') return false
+      const block = message.timeline?.find(
+        (candidate) =>
+          candidate.type === 'tool_call' && candidate.toolCallId === toolCallId,
+      )
+      if (!block || block.type !== 'tool_call') return false
+
+      const { model } = resolveModelSelection(selectedModel, models, {})
+      if (!model) return false
+
+      const newArguments = await regenerateToolCallArguments({
+        toolName: block.name,
+        contextMessages: currentChat.messages.slice(0, messageIndex + 1),
+        model,
+      })
+      if (newArguments === null) return false
+
+      const patchMessage = (msg: Message): Message => ({
+        ...msg,
+        timeline: msg.timeline?.map((candidate) =>
+          candidate.type === 'tool_call' && candidate.toolCallId === toolCallId
+            ? { ...candidate, arguments: newArguments }
+            : candidate,
+        ),
+        toolCalls: msg.toolCalls?.map((tc) =>
+          tc.id === toolCallId ? { ...tc, arguments: newArguments } : tc,
+        ),
+      })
+
+      const patchedMessages = currentChat.messages.map((msg, index) =>
+        index === messageIndex ? patchMessage(msg) : msg,
+      )
+      const patchedChat: Chat = { ...currentChat, messages: patchedMessages }
+
+      setCurrentChat(patchedChat)
+      setChats((prevChats) =>
+        prevChats.map((c) => (c.id === patchedChat.id ? patchedChat : c)),
+      )
+
+      if (!patchedChat.isTemporary) {
+        if (storeHistory) {
+          chatStorage.saveChatAndSync(patchedChat).catch((error) => {
+            logError('Failed to persist repaired widget', error, {
+              component: 'useChatMessaging',
+              action: 'retryToolCall',
+              metadata: { chatId: patchedChat.id, toolCallId },
+            })
+          })
+        } else {
+          sessionChatStorage.saveChat(patchedChat)
+        }
+      }
+
+      return true
+    },
+    [
+      loadingState,
+      currentChat,
+      selectedModel,
+      models,
+      storeHistory,
+      setChats,
+      setCurrentChat,
+    ],
+  )
+
   // Tracks a regenerate request issued while a stream is in flight. Once
   // the in-progress generation has been cancelled and `loadingState`
   // settles back to 'idle', the deferred request is fired by the effect
@@ -1554,5 +1636,6 @@ export function useChatMessaging({
     regenerateMessage,
     retryLastMessage,
     resolveInputToolCall,
+    retryToolCall,
   }
 }

--- a/src/components/chat/hooks/use-chat-messaging.ts
+++ b/src/components/chat/hooks/use-chat-messaging.ts
@@ -242,6 +242,8 @@ export function useChatMessaging({
     moveStatus,
     registerController,
     clearController,
+    ownsController,
+    hasActiveController,
     abort,
   } = useChatStreams()
 
@@ -310,8 +312,13 @@ export function useChatMessaging({
   const cancelGeneration = useCallback(
     (chatId?: string) => {
       const targetId = chatId ?? viewedChatIdRef.current
+      // Dedupe repeated stop presses for the same stream, but not when a
+      // newer stream has registered a controller since: its abort must not
+      // be swallowed by a previous cancellation still finishing its tail.
       const existingCancellation = cancellationPromisesRef.current.get(targetId)
-      if (existingCancellation) return existingCancellation
+      if (existingCancellation && !hasActiveController(targetId)) {
+        return existingCancellation
+      }
 
       const cancellation = (async () => {
         const activeGeneration = activeLiveGenerationsRef.current.get(targetId)
@@ -420,8 +427,15 @@ export function useChatMessaging({
           }
         }
 
-        streamingTracker.endStreaming(targetId)
-        patchStatus(targetId, { loadingState: 'idle' })
+        // A new stream may have started on this chat while the async saves
+        // above were in flight (e.g. the user quickly resumed). Its
+        // controller registration marks ownership; in that case leave the
+        // streaming marker and status alone so the tail of this cancel
+        // can't idle the successor mid-stream.
+        if (!hasActiveController(targetId)) {
+          streamingTracker.endStreaming(targetId)
+          patchStatus(targetId, { loadingState: 'idle' })
+        }
       })()
 
       cancellationPromisesRef.current.set(targetId, cancellation)
@@ -433,7 +447,14 @@ export function useChatMessaging({
       void cancellation.then(clearCancellation, clearCancellation)
       return cancellation
     },
-    [abort, patchStatus, storeHistory, setChats, setCurrentChat],
+    [
+      abort,
+      hasActiveController,
+      patchStatus,
+      storeHistory,
+      setChats,
+      setCurrentChat,
+    ],
   )
 
   // Handle chat query
@@ -516,6 +537,20 @@ export function useChatMessaging({
         isStreaming: true,
       })
 
+      // Mark the pre-stream phase (saves, token fetches) so storage reloads
+      // don't adopt a stale stored copy of this chat before the stream's
+      // first flush. Follows the stream's id across blank-chat conversions.
+      let pendingStreamId: string | null = null
+      const markPendingStream = (id: string) => {
+        if (pendingStreamId === id) return
+        if (pendingStreamId !== null) {
+          streamingTracker.endPendingStream(pendingStreamId)
+        }
+        pendingStreamId = id
+        streamingTracker.beginPendingStream(id)
+      }
+      markPendingStream(streamChatIdRef.current)
+
       // Only create a user message if there's actual query content
       // When using system prompt override with empty query, skip user message
       const hasUserContent =
@@ -561,6 +596,7 @@ export function useChatMessaging({
 
         moveStatus(streamChatIdRef.current, updatedChat.id)
         streamChatIdRef.current = updatedChat.id
+        markPendingStream(updatedChat.id)
         setCurrentChat(updatedChat)
         setChats((prevChats) =>
           prevChats.map((c) => (c.id === updatedChat.id ? updatedChat : c)),
@@ -602,6 +638,7 @@ export function useChatMessaging({
         // Update state immediately for instant UI feedback
         moveStatus(streamChatIdRef.current, chatId)
         streamChatIdRef.current = chatId
+        markPendingStream(chatId)
         setCurrentChat(updatedChat)
 
         // Replace the blank chat with the new real chat
@@ -675,6 +712,7 @@ export function useChatMessaging({
 
         moveStatus(streamChatIdRef.current, updatedChat.id)
         streamChatIdRef.current = updatedChat.id
+        markPendingStream(updatedChat.id)
         setCurrentChat(updatedChat)
 
         // Replace blank chat with the new chat
@@ -1153,11 +1191,16 @@ export function useChatMessaging({
             void scanPendingChatRecoveries(userId)
           }
         }
-        // Ensure UI loading flags are reset on pre-stream errors
-        setIsWaitingForResponseFor(false)
-        setIsStreamingFor(false)
-        if (!wasAborted) setLoadingStateFor('idle')
-        setIsThinkingFor(false)
+        // Ensure UI loading flags are reset on pre-stream errors. Skip if a
+        // newer stream owns this chat's controller slot (this stream was
+        // aborted and superseded); resetting then would clear the
+        // successor's flags mid-stream.
+        if (ownsController(streamChatIdRef.current, controller)) {
+          setIsWaitingForResponseFor(false)
+          setIsStreamingFor(false)
+          if (!wasAborted) setLoadingStateFor('idle')
+          setIsThinkingFor(false)
+        }
         thinkingStartTimeRef.current = null
         if (!wasAborted) {
           logError('Chat query failed', error, {
@@ -1203,6 +1246,10 @@ export function useChatMessaging({
           }
         }
       } finally {
+        if (pendingStreamId !== null) {
+          streamingTracker.endPendingStream(pendingStreamId)
+        }
+
         // Refresh rate limit from server for free-tier users so the
         // banner/send-blocking reflects the server's actual count
         // (covers both success and error paths, e.g. 429 responses).
@@ -1211,22 +1258,29 @@ export function useChatMessaging({
         }
 
         // Settle this stream's status (preserving any streamError so the
-        // banner can surface when the user returns to the chat).
-        patchStatus(streamChatIdRef.current, {
-          ...(controller.signal.aborted ? {} : { loadingState: 'idle' }),
-          retryInfo: null,
-          isWaitingForResponse: false,
-          isStreaming: false,
-          isThinking: false,
-        })
-        clearController(streamChatIdRef.current)
+        // banner can surface when the user returns to the chat). Only if
+        // this stream still owns the chat's controller slot: an aborted
+        // stream can reach this finally block after a newer stream has
+        // registered its own controller for the same chat, and patching
+        // then would stomp the successor's flags mid-stream.
+        const ownsStream = ownsController(streamChatIdRef.current, controller)
+        if (ownsStream) {
+          patchStatus(streamChatIdRef.current, {
+            ...(controller.signal.aborted ? {} : { loadingState: 'idle' }),
+            retryInfo: null,
+            isWaitingForResponse: false,
+            isStreaming: false,
+            isThinking: false,
+          })
+        }
+        clearController(streamChatIdRef.current, controller)
         if (
           activeLiveGenerationsRef.current.get(startingChatId) ===
           activeGeneration
         ) {
           activeLiveGenerationsRef.current.delete(startingChatId)
         }
-        if (!controller.signal.aborted) {
+        if (!controller.signal.aborted && ownsStream) {
           // Covers pre-stream failures where the processor (which normally
           // ends streaming) never ran. Idempotent if already ended.
           streamingTracker.endStreaming(streamChatIdRef.current)
@@ -1261,6 +1315,7 @@ export function useChatMessaging({
       moveStatus,
       registerController,
       clearController,
+      ownsController,
     ],
   )
 

--- a/src/components/chat/hooks/use-chat-messaging.ts
+++ b/src/components/chat/hooks/use-chat-messaging.ts
@@ -29,6 +29,7 @@ import {
   abandonChatRecoveryAttempt,
   cancelChatRecovery,
   completeLiveChatRecovery,
+  markChatRecoveryTurnCancelled,
   persistChatRecoveryToken,
   releaseActiveChatRecovery,
   scanPendingChatRecoveries,
@@ -328,6 +329,14 @@ export function useChatMessaging({
         const activeGeneration = activeLiveGenerationsRef.current.get(targetId)
 
         abort(targetId)
+        // Mark the recovery turn cancelled synchronously with the abort.
+        // When stop lands before the first token, the recovery attempt may
+        // still be registering (token capture races the abort); the mark
+        // makes persistChatRecoveryToken discard its envelope instead of
+        // surfacing "Recovering stream..." for a turn the user just stopped.
+        if (activeGeneration?.turnId) {
+          markChatRecoveryTurnCancelled(targetId, activeGeneration.turnId)
+        }
         const interruptedMessage =
           activeGeneration?.latestAssistantMessage &&
           hasVisibleAssistantMessage(activeGeneration.latestAssistantMessage)

--- a/src/components/chat/hooks/use-chat-messaging.ts
+++ b/src/components/chat/hooks/use-chat-messaging.ts
@@ -51,6 +51,7 @@ import { generateReverseId } from '@/utils/reverse-id'
 import { useAuth } from '@clerk/nextjs'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { getMessageAttachments, getMessageImages } from '../attachment-helpers'
+import { ChatError } from '../chat-utils'
 import { CONSTANTS } from '../constants'
 import type { Chat, LoadingState, Message } from '../types'
 import {
@@ -68,6 +69,7 @@ import {
   IDLE_STREAM_STATUS,
   useChatStreams,
   type RetryInfo,
+  type StreamErrorInfo,
 } from './use-chat-streams'
 import type { ReasoningEffort } from './use-reasoning-effort'
 
@@ -100,7 +102,7 @@ interface UseChatMessagingReturn {
   isThinking: boolean
   isWaitingForResponse: boolean
   isStreaming: boolean
-  streamError: string | null
+  streamError: StreamErrorInfo | null
   dismissStreamError: () => void
   setInput: (input: string) => void
   handleSubmit: (e: React.FormEvent) => void
@@ -526,7 +528,7 @@ export function useChatMessaging({
         patchStatus(streamChatIdRef.current, { isWaitingForResponse: v })
       const setIsStreamingFor = (v: boolean) =>
         patchStatus(streamChatIdRef.current, { isStreaming: v })
-      const setStreamErrorFor = (e: string | null) =>
+      const setStreamErrorFor = (e: StreamErrorInfo | null) =>
         patchStatus(streamChatIdRef.current, { streamError: e })
 
       const controller = new AbortController()
@@ -1210,15 +1212,15 @@ export function useChatMessaging({
 
           const errorMsg =
             error instanceof Error ? error.message : 'Unknown error occurred'
-          const lowerMsg = errorMsg.toLowerCase()
-          const isHourlyRateLimitError =
-            lowerMsg.includes('hourly usage limit') ||
-            lowerMsg.includes('hourly limit')
+          // Classify by structured signals only (error codes and HTTP
+          // status), never by message text.
+          const chatError = error instanceof ChatError ? error : null
+          const status = (error as { status?: unknown })?.status
+          const isHourlyRateLimitError = chatError?.code === 'HOURLY_LIMIT'
           const isRateLimitError =
-            lowerMsg.includes('rate limit') ||
-            lowerMsg.includes('request limit') ||
-            lowerMsg.includes('usage limit') ||
-            lowerMsg.includes('insufficient_quota')
+            isHourlyRateLimitError ||
+            chatError?.code === 'RATE_LIMIT' ||
+            status === 429
 
           if (isRateLimitError) {
             const errorMessage: Message = {
@@ -1242,7 +1244,10 @@ export function useChatMessaging({
             )
           } else {
             // Surface as a dismissable floating banner instead of a chat message
-            setStreamErrorFor(errorMsg)
+            setStreamErrorFor({
+              message: errorMsg,
+              code: chatError?.code ?? null,
+            })
           }
         }
       } finally {

--- a/src/components/chat/hooks/use-chat-messaging.ts
+++ b/src/components/chat/hooks/use-chat-messaging.ts
@@ -1448,6 +1448,7 @@ export function useChatMessaging({
     async (messageIndex: number, toolCallId: string): Promise<boolean> => {
       if (loadingState !== 'idle' || !currentChat) return false
 
+      const chatId = currentChat.id
       const message = currentChat.messages[messageIndex]
       if (!message || message.role !== 'assistant') return false
       const block = message.timeline?.find(
@@ -1461,6 +1462,7 @@ export function useChatMessaging({
 
       const newArguments = await regenerateToolCallArguments({
         toolName: block.name,
+        originalArguments: block.arguments,
         contextMessages: currentChat.messages.slice(0, messageIndex + 1),
         model,
       })
@@ -1478,27 +1480,45 @@ export function useChatMessaging({
         ),
       })
 
-      const patchedMessages = currentChat.messages.map((msg, index) =>
-        index === messageIndex ? patchMessage(msg) : msg,
-      )
-      const patchedChat: Chat = { ...currentChat, messages: patchedMessages }
+      // The model call above can take seconds; the chat may have gained
+      // messages (or the user may have switched away) since the closure
+      // captured `currentChat`. Patch the tool-call block by id against
+      // the *live* state instead of writing the snapshot back, so the
+      // repair can never roll back newer chat content.
+      const patchChat = (chat: Chat): Chat => ({
+        ...chat,
+        messages: chat.messages.map((msg) =>
+          msg.role === 'assistant' &&
+          msg.timeline?.some(
+            (candidate) =>
+              candidate.type === 'tool_call' &&
+              candidate.toolCallId === toolCallId,
+          )
+            ? patchMessage(msg)
+            : msg,
+        ),
+      })
 
-      setCurrentChat(patchedChat)
       setChats((prevChats) =>
-        prevChats.map((c) => (c.id === patchedChat.id ? patchedChat : c)),
+        prevChats.map((c) => (c.id === chatId ? patchChat(c) : c)),
       )
+      setCurrentChat((prev) => (prev.id === chatId ? patchChat(prev) : prev))
 
-      if (!patchedChat.isTemporary) {
+      const liveChat =
+        chatsRef.current.find((c) => c.id === chatId) ??
+        (currentChat.id === chatId ? currentChat : null)
+      const chatToSave = liveChat ? patchChat(liveChat) : null
+      if (chatToSave && !chatToSave.isTemporary) {
         if (storeHistory) {
-          chatStorage.saveChatAndSync(patchedChat).catch((error) => {
+          chatStorage.saveChatAndSync(chatToSave).catch((error) => {
             logError('Failed to persist repaired widget', error, {
               component: 'useChatMessaging',
               action: 'retryToolCall',
-              metadata: { chatId: patchedChat.id, toolCallId },
+              metadata: { chatId, toolCallId },
             })
           })
         } else {
-          sessionChatStorage.saveChat(patchedChat)
+          sessionChatStorage.saveChat(chatToSave)
         }
       }
 

--- a/src/components/chat/hooks/use-chat-state.ts
+++ b/src/components/chat/hooks/use-chat-state.ts
@@ -80,6 +80,7 @@ interface UseChatStateReturn {
     resultText: string,
     resultData?: unknown,
   ) => void
+  retryToolCall: (messageIndex: number, toolCallId: string) => Promise<boolean>
   initialChatDecryptionFailed: boolean
   clearInitialChatDecryptionFailed: () => void
   localChatNotFound: boolean
@@ -236,6 +237,7 @@ export function useChatState({
     regenerateMessage,
     retryLastMessage,
     resolveInputToolCall,
+    retryToolCall,
   } = useChatMessaging({
     systemPrompt,
     rules,
@@ -384,6 +386,7 @@ export function useChatState({
     regenerateMessage,
     retryLastMessage,
     resolveInputToolCall,
+    retryToolCall,
     initialChatDecryptionFailed,
     clearInitialChatDecryptionFailed,
     localChatNotFound,

--- a/src/components/chat/hooks/use-chat-state.ts
+++ b/src/components/chat/hooks/use-chat-state.ts
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useMemo, useRef } from 'react'
 import type { AIModel, Chat, LabelType, LoadingState, Message } from '../types'
 import { useChatMessaging } from './use-chat-messaging'
 import { useChatStorage } from './use-chat-storage'
+import type { StreamErrorInfo } from './use-chat-streams'
 import { resolveChatModel, useModelManagement } from './use-model-management'
 import type { ReasoningEffort } from './use-reasoning-effort'
 import { useUIState, type ThemeMode } from './use-ui-state'
@@ -29,7 +30,7 @@ interface UseChatStateReturn {
   verificationSuccess: boolean
   isWaitingForResponse: boolean
   isStreaming: boolean
-  streamError: string | null
+  streamError: StreamErrorInfo | null
   dismissStreamError: () => void
   selectedModel: AIModel
   hasValidatedModel: boolean

--- a/src/components/chat/hooks/use-chat-storage.ts
+++ b/src/components/chat/hooks/use-chat-storage.ts
@@ -217,6 +217,7 @@ export function useChatStorage({
             if (
               prev.syncedAt !== existingChat.syncedAt ||
               prev.title !== existingChat.title ||
+              prev.presetId !== existingChat.presetId ||
               !pendingRecoveriesMatch(
                 prev.pendingRecoveries,
                 existingChat.pendingRecoveries,
@@ -226,6 +227,7 @@ export function useChatStorage({
                 ...prev,
                 syncedAt: existingChat.syncedAt,
                 title: existingChat.title,
+                presetId: existingChat.presetId,
                 pendingRecoveries: existingChat.pendingRecoveries,
               }
             }
@@ -595,6 +597,8 @@ export function useChatStorage({
           projectId: downloadedChat.projectId,
           model: downloadedChat.model,
           pendingRecoveries: downloadedChat.pendingRecoveries,
+          presetId: downloadedChat.presetId,
+          webSearchEnabled: downloadedChat.webSearchEnabled,
         }
 
         if (storeHistory) {

--- a/src/components/chat/hooks/use-chat-storage.ts
+++ b/src/components/chat/hooks/use-chat-storage.ts
@@ -1,5 +1,6 @@
 import { cloudStorage } from '@/services/cloud/cloud-storage'
 import { streamingTracker } from '@/services/cloud/streaming-tracker'
+import { isChatRecoveryTurnCancelled } from '@/services/inference/chat-recovery'
 import { sameRecoveredResponse } from '@/services/inference/chat-recovery-sync'
 import { chatEvents } from '@/services/storage/chat-events'
 import { chatStorage } from '@/services/storage/chat-storage'
@@ -64,6 +65,23 @@ function pendingRecoveriesMatch(
         : false,
     )
   )
+}
+
+/**
+ * Drop envelopes for turns the user explicitly stopped. An envelope can
+ * land in storage in the window between the stop press and the async
+ * envelope removal completing; adopting it into the on-screen chat would
+ * flash "Recovering stream..." for a turn that is not coming back.
+ */
+function withoutCancelledRecoveries(
+  chatId: string,
+  envelopes: readonly PendingRecoveryEnvelope[] | undefined,
+): PendingRecoveryEnvelope[] | undefined {
+  if (!envelopes?.length) return undefined
+  const remaining = envelopes.filter(
+    (envelope) => !isChatRecoveryTurnCancelled(chatId, envelope.turnId),
+  )
+  return remaining.length > 0 ? remaining : undefined
 }
 
 export function useChatStorage({
@@ -166,6 +184,10 @@ export function useChatStorage({
           // Only update metadata (syncedAt, title) if the same chat exists in storage
           const existingChat = loadedChats.find((c) => c.id === prev.id)
           if (existingChat) {
+            const storedRecoveries = withoutCancelledRecoveries(
+              prev.id,
+              existingChat.pendingRecoveries,
+            )
             // Include sends still in their pre-stream phase: a recovery
             // reload racing a just-resumed generation must not adopt the
             // stored copy (which still holds the previous interrupted
@@ -175,7 +197,7 @@ export function useChatStorage({
             if (isRecoveryReload && isStreaming) {
               return {
                 ...prev,
-                pendingRecoveries: existingChat.pendingRecoveries,
+                pendingRecoveries: storedRecoveries,
               }
             }
             // A turn this view still tracks as pending recovery may have been
@@ -215,6 +237,7 @@ export function useChatStorage({
             ) {
               return {
                 ...existingChat,
+                pendingRecoveries: storedRecoveries,
                 pendingSave: prev.pendingSave,
               }
             }
@@ -222,17 +245,14 @@ export function useChatStorage({
               prev.syncedAt !== existingChat.syncedAt ||
               prev.title !== existingChat.title ||
               prev.presetId !== existingChat.presetId ||
-              !pendingRecoveriesMatch(
-                prev.pendingRecoveries,
-                existingChat.pendingRecoveries,
-              )
+              !pendingRecoveriesMatch(prev.pendingRecoveries, storedRecoveries)
             ) {
               return {
                 ...prev,
                 syncedAt: existingChat.syncedAt,
                 title: existingChat.title,
                 presetId: existingChat.presetId,
-                pendingRecoveries: existingChat.pendingRecoveries,
+                pendingRecoveries: storedRecoveries,
               }
             }
           }

--- a/src/components/chat/hooks/use-chat-storage.ts
+++ b/src/components/chat/hooks/use-chat-storage.ts
@@ -166,7 +166,11 @@ export function useChatStorage({
           // Only update metadata (syncedAt, title) if the same chat exists in storage
           const existingChat = loadedChats.find((c) => c.id === prev.id)
           if (existingChat) {
-            const isStreaming = streamingTracker.isStreaming(prev.id)
+            // Include sends still in their pre-stream phase: a recovery
+            // reload racing a just-resumed generation must not adopt the
+            // stored copy (which still holds the previous interrupted
+            // answer) over the messages the new stream is about to write.
+            const isStreaming = streamingTracker.isStreamingOrPending(prev.id)
             const isRecoveryReload = pendingRecoveryIds.includes(prev.id)
             if (isRecoveryReload && isStreaming) {
               return {

--- a/src/components/chat/hooks/use-chat-storage.ts
+++ b/src/components/chat/hooks/use-chat-storage.ts
@@ -158,9 +158,24 @@ export function useChatStorage({
           // reload's loadChats() snapshot resolved but before this setChats runs.
           // Without this re-filter, an in-flight reload would resurrect a chat
           // the user just deleted until the next page refresh.
-          const nonBlankChats = loadedChats.filter(
-            (c) => !c.isBlankChat && !deletedChatsTracker.isDeleted(c.id),
-          )
+          // Cancelled recoveries are stripped here too, not just on
+          // currentChat: switching to a chat adopts its entry from this
+          // list, which must not reintroduce a stopped turn's envelope.
+          const nonBlankChats = loadedChats
+            .filter(
+              (c) => !c.isBlankChat && !deletedChatsTracker.isDeleted(c.id),
+            )
+            .map((c) =>
+              c.pendingRecoveries?.length
+                ? {
+                    ...c,
+                    pendingRecoveries: withoutCancelledRecoveries(
+                      c.id,
+                      c.pendingRecoveries,
+                    ),
+                  }
+                : c,
+            )
 
           // Combine blank chats with loaded chats and sort
           const finalChats = sortChats([
@@ -609,20 +624,13 @@ export function useChatStorage({
           return
         }
 
-        // Convert StoredChat to Chat type
+        // Convert StoredChat to Chat. Spread everything through — an
+        // explicit field list here silently dropped presetId and
+        // webSearchEnabled in the past (chats lost their prompt preset on
+        // refresh); only createdAt needs transforming.
         const chat: Chat = {
-          id: downloadedChat.id,
-          title: downloadedChat.title,
-          messages: downloadedChat.messages,
+          ...downloadedChat,
           createdAt: new Date(downloadedChat.createdAt),
-          syncedAt: downloadedChat.syncedAt,
-          locallyModified: downloadedChat.locallyModified,
-          decryptionFailed: downloadedChat.decryptionFailed,
-          projectId: downloadedChat.projectId,
-          model: downloadedChat.model,
-          pendingRecoveries: downloadedChat.pendingRecoveries,
-          presetId: downloadedChat.presetId,
-          webSearchEnabled: downloadedChat.webSearchEnabled,
         }
 
         if (storeHistory) {

--- a/src/components/chat/hooks/use-chat-streams.ts
+++ b/src/components/chat/hooks/use-chat-streams.ts
@@ -43,7 +43,17 @@ export interface UseChatStreamsReturn {
   /** Re-key a chat's status and abort controller after a server id swap. */
   moveStatus: (fromId: string, toId: string) => void
   registerController: (chatId: string, controller: AbortController) => void
-  clearController: (chatId: string) => void
+  /**
+   * Remove a chat's controller, but only if `controller` is still the one
+   * registered. A stream that was aborted (and possibly superseded by a
+   * newer stream on the same chat) must never delete its successor's
+   * controller, or the next stop press would silently fail to abort.
+   */
+  clearController: (chatId: string, controller: AbortController) => void
+  /** True if `controller` is still the registered controller for the chat. */
+  ownsController: (chatId: string, controller: AbortController) => boolean
+  /** True if any stream currently holds a controller for the chat. */
+  hasActiveController: (chatId: string) => boolean
   /** Abort the stream for a chat. Returns true if a controller existed. */
   abort: (chatId: string) => boolean
 }
@@ -107,9 +117,25 @@ export function useChatStreams(): UseChatStreamsReturn {
     [],
   )
 
-  const clearController = useCallback((chatId: string) => {
-    abortControllersRef.current.delete(chatId)
-  }, [])
+  const clearController = useCallback(
+    (chatId: string, controller: AbortController) => {
+      if (abortControllersRef.current.get(chatId) === controller) {
+        abortControllersRef.current.delete(chatId)
+      }
+    },
+    [],
+  )
+
+  const ownsController = useCallback(
+    (chatId: string, controller: AbortController): boolean =>
+      abortControllersRef.current.get(chatId) === controller,
+    [],
+  )
+
+  const hasActiveController = useCallback(
+    (chatId: string): boolean => abortControllersRef.current.has(chatId),
+    [],
+  )
 
   const abort = useCallback((chatId: string): boolean => {
     const controller = abortControllersRef.current.get(chatId)
@@ -126,6 +152,8 @@ export function useChatStreams(): UseChatStreamsReturn {
     moveStatus,
     registerController,
     clearController,
+    ownsController,
+    hasActiveController,
     abort,
   }
 }

--- a/src/components/chat/hooks/use-chat-streams.ts
+++ b/src/components/chat/hooks/use-chat-streams.ts
@@ -1,10 +1,21 @@
 import { useCallback, useRef, useState } from 'react'
+import type { ChatErrorCode } from '../chat-utils'
 import type { LoadingState } from '../types'
 
 export interface RetryInfo {
   attempt: number
   maxRetries: number
   error?: string
+}
+
+/**
+ * A stream failure surfaced to the UI. `code` carries the structured
+ * classification (when the failure produced a ChatError) so the error
+ * banner can choose retry semantics without inspecting message text.
+ */
+export interface StreamErrorInfo {
+  message: string
+  code: ChatErrorCode | null
 }
 
 /**
@@ -22,7 +33,7 @@ export interface ChatStreamStatus {
   isThinking: boolean
   isWaitingForResponse: boolean
   isStreaming: boolean
-  streamError: string | null
+  streamError: StreamErrorInfo | null
 }
 
 export const IDLE_STREAM_STATUS: ChatStreamStatus = {

--- a/src/components/chat/hooks/use-chat-streams.ts
+++ b/src/components/chat/hooks/use-chat-streams.ts
@@ -61,9 +61,7 @@ export interface UseChatStreamsReturn {
    * controller, or the next stop press would silently fail to abort.
    */
   clearController: (chatId: string, controller: AbortController) => void
-  /** True if `controller` is still the registered controller for the chat. */
   ownsController: (chatId: string, controller: AbortController) => boolean
-  /** True if any stream currently holds a controller for the chat. */
   hasActiveController: (chatId: string) => boolean
   /** Abort the stream for a chat. Returns true if a controller existed. */
   abort: (chatId: string) => boolean

--- a/src/components/chat/renderers/default/DefaultMessageRenderer.tsx
+++ b/src/components/chat/renderers/default/DefaultMessageRenderer.tsx
@@ -34,6 +34,7 @@ const DefaultMessageComponent = ({
   hideActions,
   onEditMessage,
   onRegenerateMessage,
+  onRetryToolCall,
 }: MessageRenderProps) => {
   const isUser = message.role === 'user'
   const [isEditing, setIsEditing] = React.useState(false)
@@ -342,6 +343,12 @@ const DefaultMessageComponent = ({
                     onRetry={
                       onRegenerateMessage && messageIndex > 0
                         ? () => onRegenerateMessage(messageIndex - 1)
+                        : undefined
+                    }
+                    onRetryToolCall={
+                      onRetryToolCall
+                        ? (toolCallId) =>
+                            onRetryToolCall(messageIndex, toolCallId)
                         : undefined
                     }
                   />

--- a/src/components/chat/renderers/types.ts
+++ b/src/components/chat/renderers/types.ts
@@ -28,6 +28,15 @@ export interface MessageRenderProps {
   hideActions?: boolean
   onEditMessage?: (messageIndex: number, newContent: string) => void
   onRegenerateMessage?: (messageIndex: number) => void
+  /**
+   * Retry a single failed GenUI tool call in place. Resolves true when the
+   * widget was repaired; false signals the caller may fall back to a full
+   * regeneration.
+   */
+  onRetryToolCall?: (
+    messageIndex: number,
+    toolCallId: string,
+  ) => Promise<boolean>
 }
 
 export interface InputRenderProps {

--- a/src/components/chat/stream-error-banner.tsx
+++ b/src/components/chat/stream-error-banner.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import type { StreamErrorInfo } from '@/components/chat/hooks/use-chat-streams'
 import { cn } from '@/components/ui/utils'
 import {
   ArrowPathIcon,
@@ -9,7 +10,7 @@ import {
 import { useState } from 'react'
 
 interface StreamErrorBannerProps {
-  message: string
+  error: StreamErrorInfo
   onDismiss: () => void
   onRetry?: () => void
   isDarkMode: boolean
@@ -20,9 +21,26 @@ type ErrorExplanation = {
   suggestion: string
 }
 
-// Map raw backend/SDK error text to a human-readable explanation. The raw
-// message stays available in the expandable details section.
-function explainError(message: string): ErrorExplanation {
+// Map a stream failure to a human-readable explanation. The structured
+// code is authoritative when present; the message-text heuristics below
+// are a display-only fallback for errors that carry no classification.
+// The raw message stays available in the expandable details section.
+function explainError({ message, code }: StreamErrorInfo): ErrorExplanation {
+  if (code === 'FETCH_ERROR') {
+    return {
+      title: 'Connection problem',
+      suggestion:
+        'Check your internet connection, then resend your message. Your message was not lost.',
+    }
+  }
+
+  if (code === 'RATE_LIMIT' || code === 'HOURLY_LIMIT') {
+    return {
+      title: 'Usage limit reached',
+      suggestion: 'Please wait for the limit to reset before trying again.',
+    }
+  }
+
   const lower = message.toLowerCase()
 
   if (
@@ -95,13 +113,13 @@ function explainError(message: string): ErrorExplanation {
  * expandable details section. Stays visible until dismissed or retried.
  */
 export function StreamErrorBanner({
-  message,
+  error,
   onDismiss,
   onRetry,
   isDarkMode,
 }: StreamErrorBannerProps) {
   const [isExpanded, setIsExpanded] = useState(false)
-  const { title, suggestion } = explainError(message)
+  const { title, suggestion } = explainError(error)
 
   const handleDismiss = (e: React.MouseEvent) => {
     e.stopPropagation()
@@ -187,7 +205,7 @@ export function StreamErrorBanner({
             isDarkMode ? 'border-red-500/30' : 'border-red-300',
           )}
         >
-          <p className="whitespace-pre-wrap break-words">{message}</p>
+          <p className="whitespace-pre-wrap break-words">{error.message}</p>
         </div>
       )}
     </div>

--- a/src/components/chat/stream-error-banner.tsx
+++ b/src/components/chat/stream-error-banner.tsx
@@ -7,7 +7,7 @@ import {
   ChevronDownIcon,
   XMarkIcon,
 } from '@heroicons/react/24/outline'
-import { useState } from 'react'
+import { useState, useSyncExternalStore } from 'react'
 
 interface StreamErrorBannerProps {
   error: StreamErrorInfo
@@ -19,6 +19,24 @@ interface StreamErrorBannerProps {
 type ErrorExplanation = {
   title: string
   suggestion: string
+}
+
+function subscribeToConnectivity(onChange: () => void): () => void {
+  window.addEventListener('online', onChange)
+  window.addEventListener('offline', onChange)
+  return () => {
+    window.removeEventListener('online', onChange)
+    window.removeEventListener('offline', onChange)
+  }
+}
+
+function getIsOnline(): boolean {
+  return typeof navigator === 'undefined' ? true : navigator.onLine !== false
+}
+
+/** Live `navigator.onLine` mirror; updates as connectivity changes. */
+function useIsOnline(): boolean {
+  return useSyncExternalStore(subscribeToConnectivity, getIsOnline, () => true)
 }
 
 // Map a stream failure to a human-readable explanation. The structured
@@ -119,7 +137,21 @@ export function StreamErrorBanner({
   isDarkMode,
 }: StreamErrorBannerProps) {
   const [isExpanded, setIsExpanded] = useState(false)
+  const isOnline = useIsOnline()
   const { title, suggestion } = explainError(error)
+
+  // Retrying always re-sends the last message; make the label say so for
+  // connection failures instead of the ambiguous "Try again" (which reads
+  // like it might just reconnect). While offline the resend is gated —
+  // it would only burn the automatic in-request retries and fail again.
+  const isConnectionError = error.code === 'FETCH_ERROR'
+  // A rate-limited request will fail identically until the limit resets,
+  // so a retry button is just an invitation to frustration.
+  const isLimitError =
+    error.code === 'RATE_LIMIT' || error.code === 'HOURLY_LIMIT'
+  const retryLabel = isConnectionError ? 'Resend message' : 'Try again'
+  const retryDisabled = isConnectionError && !isOnline
+  const showRetry = !!onRetry && !isLimitError
 
   const handleDismiss = (e: React.MouseEvent) => {
     e.stopPropagation()
@@ -149,22 +181,26 @@ export function StreamErrorBanner({
           </p>
         </div>
         <div className="flex flex-shrink-0 items-center gap-1">
-          {onRetry && (
+          {showRetry && (
             <button
               type="button"
+              disabled={retryDisabled}
+              title={retryDisabled ? 'Waiting for connection...' : undefined}
               onClick={(e) => {
                 e.stopPropagation()
-                onRetry()
+                onRetry?.()
               }}
               className={cn(
                 'flex items-center gap-1 rounded-lg border px-2 py-1 text-xs font-medium transition-colors',
                 isDarkMode
                   ? 'border-red-500/40 hover:bg-red-500/20'
                   : 'border-red-300 hover:bg-red-500/10',
+                retryDisabled &&
+                  'cursor-default opacity-50 hover:bg-transparent',
               )}
             >
               <ArrowPathIcon className="h-3.5 w-3.5" aria-hidden="true" />
-              Try again
+              {retryDisabled ? 'Offline' : retryLabel}
             </button>
           )}
           <button

--- a/src/components/chat/stream-error-banner.tsx
+++ b/src/components/chat/stream-error-banner.tsx
@@ -16,7 +16,19 @@ interface StreamErrorBannerProps {
   isDarkMode: boolean
 }
 
-type ErrorExplanation = {
+// Behavioral class of a stream failure. Drives both the explanation copy
+// and the retry affordance so the same error always produces a coherent
+// combination of message and action.
+type ErrorKind =
+  | 'connection'
+  | 'rate-limit'
+  | 'timeout'
+  | 'context-length'
+  | 'server'
+  | 'unknown'
+
+type ErrorClassification = {
+  kind: ErrorKind
   title: string
   suggestion: string
 }
@@ -31,7 +43,7 @@ function subscribeToConnectivity(onChange: () => void): () => void {
 }
 
 function getIsOnline(): boolean {
-  return typeof navigator === 'undefined' ? true : navigator.onLine !== false
+  return navigator.onLine !== false
 }
 
 /** Live `navigator.onLine` mirror; updates as connectivity changes. */
@@ -39,25 +51,56 @@ function useIsOnline(): boolean {
   return useSyncExternalStore(subscribeToConnectivity, getIsOnline, () => true)
 }
 
-// Map a stream failure to a human-readable explanation. The structured
-// code is authoritative when present; the message-text heuristics below
-// are a display-only fallback for errors that carry no classification.
-// The raw message stays available in the expandable details section.
-function explainError({ message, code }: StreamErrorInfo): ErrorExplanation {
-  if (code === 'FETCH_ERROR') {
-    return {
-      title: 'Connection problem',
-      suggestion:
-        'Check your internet connection, then resend your message. Your message was not lost.',
-    }
-  }
+const CLASSIFICATIONS: Record<
+  Exclude<ErrorKind, 'unknown'>,
+  ErrorClassification
+> = {
+  connection: {
+    kind: 'connection',
+    title: 'Connection problem',
+    suggestion:
+      'Check your internet connection, then resend your message. Your message was not lost.',
+  },
+  'rate-limit': {
+    kind: 'rate-limit',
+    title: 'Usage limit reached',
+    suggestion: 'Please wait for the limit to reset before trying again.',
+  },
+  timeout: {
+    kind: 'timeout',
+    title: 'The model took too long to respond',
+    suggestion:
+      'This is usually a temporary problem on our side. Please try again in a moment.',
+  },
+  'context-length': {
+    kind: 'context-length',
+    title: 'This conversation is too long for the model',
+    suggestion:
+      'Remove an attachment, shorten your message, or switch to a model with a larger context window.',
+  },
+  server: {
+    kind: 'server',
+    title: 'The service is having trouble right now',
+    suggestion:
+      'Our servers may be briefly overloaded. Please try again, or switch to a different model.',
+  },
+}
 
+// Map a stream failure to a behavioral kind plus human-readable copy. The
+// structured code is authoritative when present; the message-text
+// heuristics below are display-only fallbacks for errors that carry no
+// classification, and both the copy and the retry affordance derive from
+// the same result so they can never disagree. The raw message stays
+// available in the expandable details section.
+function classifyError({
+  message,
+  code,
+}: StreamErrorInfo): ErrorClassification {
+  if (code === 'FETCH_ERROR') return CLASSIFICATIONS.connection
   if (code === 'RATE_LIMIT' || code === 'HOURLY_LIMIT') {
-    return {
-      title: 'Usage limit reached',
-      suggestion: 'Please wait for the limit to reset before trying again.',
-    }
+    return CLASSIFICATIONS['rate-limit']
   }
+  if (code === 'SERVER_ERROR') return CLASSIFICATIONS.server
 
   const lower = message.toLowerCase()
 
@@ -68,11 +111,7 @@ function explainError({ message, code }: StreamErrorInfo): ErrorExplanation {
     lower.includes('timeout') ||
     lower.includes('etimedout')
   ) {
-    return {
-      title: 'The model took too long to respond',
-      suggestion:
-        'This is usually a temporary problem on our side. Please try again in a moment.',
-    }
+    return CLASSIFICATIONS.timeout
   }
 
   if (
@@ -83,11 +122,7 @@ function explainError({ message, code }: StreamErrorInfo): ErrorExplanation {
     lower.includes('token limit') ||
     lower.includes('input is too long')
   ) {
-    return {
-      title: 'This conversation is too long for the model',
-      suggestion:
-        'Remove an attachment, shorten your message, or switch to a model with a larger context window.',
-    }
+    return CLASSIFICATIONS['context-length']
   }
 
   if (
@@ -98,11 +133,7 @@ function explainError({ message, code }: StreamErrorInfo): ErrorExplanation {
     lower.includes('internal server error') ||
     /\b5\d\d\b/.test(lower)
   ) {
-    return {
-      title: 'The service is having trouble right now',
-      suggestion:
-        'Our servers may be briefly overloaded. Please try again, or switch to a different model.',
-    }
+    return CLASSIFICATIONS.server
   }
 
   if (
@@ -113,13 +144,11 @@ function explainError({ message, code }: StreamErrorInfo): ErrorExplanation {
     lower.includes('econnreset') ||
     lower.includes('offline')
   ) {
-    return {
-      title: 'Connection problem',
-      suggestion: 'Check your internet connection and try again.',
-    }
+    return CLASSIFICATIONS.connection
   }
 
   return {
+    kind: 'unknown',
     title: 'Something went wrong',
     suggestion: 'Please try again. If the problem persists, contact support.',
   }
@@ -138,17 +167,16 @@ export function StreamErrorBanner({
 }: StreamErrorBannerProps) {
   const [isExpanded, setIsExpanded] = useState(false)
   const isOnline = useIsOnline()
-  const { title, suggestion } = explainError(error)
+  const { kind, title, suggestion } = classifyError(error)
 
   // Retrying always re-sends the last message; make the label say so for
   // connection failures instead of the ambiguous "Try again" (which reads
   // like it might just reconnect). While offline the resend is gated —
   // it would only burn the automatic in-request retries and fail again.
-  const isConnectionError = error.code === 'FETCH_ERROR'
+  const isConnectionError = kind === 'connection'
   // A rate-limited request will fail identically until the limit resets,
   // so a retry button is just an invitation to frustration.
-  const isLimitError =
-    error.code === 'RATE_LIMIT' || error.code === 'HOURLY_LIMIT'
+  const isLimitError = kind === 'rate-limit'
   const retryLabel = isConnectionError ? 'Resend message' : 'Try again'
   const retryDisabled = isConnectionError && !isOnline
   const showRetry = !!onRetry && !isLimitError

--- a/src/components/project/project-sidebar.tsx
+++ b/src/components/project/project-sidebar.tsx
@@ -797,8 +797,10 @@ export function ProjectSidebar({
           </div>
         </div>
 
-        {/* Main sidebar content */}
-        <div className="relative flex h-full flex-col overflow-hidden">
+        {/* Main sidebar content - a single scroll area so tall sections
+            (like the expanded Project Settings panel) can never clip
+            content such as the Save button out of reach. */}
+        <div className="relative flex min-h-0 flex-1 flex-col overflow-y-auto">
           {/* Project header with exit button and editable title */}
           <div className="relative z-10 flex-none p-3">
             <button
@@ -1196,12 +1198,7 @@ export function ProjectSidebar({
                   transition={{ duration: 0.2, ease: 'easeInOut' }}
                   className="overflow-hidden"
                 >
-                  <div
-                    className={cn(
-                      'max-h-64 overflow-y-auto px-2 py-2',
-                      expandedPanelClass,
-                    )}
-                  >
+                  <div className={cn('px-2 py-2', expandedPanelClass)}>
                     {/* Drag and drop zone - at top */}
                     <button
                       type="button"
@@ -1374,7 +1371,7 @@ export function ProjectSidebar({
               clearDragState()
             }}
             className={cn(
-              'relative z-10 flex-1 overflow-y-auto',
+              'relative z-10 flex-1',
               isDropTargetChatList &&
                 (isDarkMode
                   ? 'border border-white/30 bg-white/10'
@@ -1417,34 +1414,34 @@ export function ProjectSidebar({
               onRemoveFromProject={onRemoveChatFromProject}
             />
           </div>
+        </div>
 
-          {/* Terms and privacy policy */}
-          <div className="relative z-10 flex h-[56px] flex-none items-center justify-center border-t border-border-subtle p-3">
-            <p className="text-center text-xs leading-relaxed text-content-secondary">
-              By using this service, you agree to Tinfoil&apos;s{' '}
-              <Link
-                href="https://tinfoil.sh/terms"
-                className={
-                  isDarkMode
-                    ? 'text-white underline hover:text-content-secondary'
-                    : 'text-brand-accent-dark underline hover:text-brand-accent-dark/80'
-                }
-              >
-                Terms of Service
-              </Link>{' '}
-              and{' '}
-              <Link
-                href="https://tinfoil.sh/privacy"
-                className={
-                  isDarkMode
-                    ? 'text-white underline hover:text-content-secondary'
-                    : 'text-brand-accent-dark underline hover:text-brand-accent-dark/80'
-                }
-              >
-                Privacy Policy
-              </Link>
-            </p>
-          </div>
+        {/* Terms and privacy policy - pinned below the scroll area */}
+        <div className="relative z-10 flex h-[56px] flex-none items-center justify-center border-t border-border-subtle p-3">
+          <p className="text-center text-xs leading-relaxed text-content-secondary">
+            By using this service, you agree to Tinfoil&apos;s{' '}
+            <Link
+              href="https://tinfoil.sh/terms"
+              className={
+                isDarkMode
+                  ? 'text-white underline hover:text-content-secondary'
+                  : 'text-brand-accent-dark underline hover:text-brand-accent-dark/80'
+              }
+            >
+              Terms of Service
+            </Link>{' '}
+            and{' '}
+            <Link
+              href="https://tinfoil.sh/privacy"
+              className={
+                isDarkMode
+                  ? 'text-white underline hover:text-content-secondary'
+                  : 'text-brand-accent-dark underline hover:text-brand-accent-dark/80'
+              }
+            >
+              Privacy Policy
+            </Link>
+          </p>
         </div>
       </div>
 

--- a/src/services/cloud/streaming-tracker.ts
+++ b/src/services/cloud/streaming-tracker.ts
@@ -20,11 +20,40 @@ class StreamingTracker {
   // Immutable snapshot handed to React via useSyncExternalStore. A fresh
   // Set is published on every change so referential identity tracks state.
   private snapshot: ReadonlySet<string> = new Set()
+  // Chats with a send in flight that has not yet reached `startStreaming`
+  // (the pre-stream phase awaits saves and token fetches). Kept separate
+  // from `streamingChats` so cloud-sync gating and the sidebar indicator
+  // are unaffected; only `isStreamingOrPending` consumers observe it.
+  // Ref-counted because a chat id can briefly be shared (blank chats).
+  private pendingStreams = new Map<string, number>()
 
   startStreaming(chatId: string): void {
     if (this.streamingChats.has(chatId)) return
     this.streamingChats.add(chatId)
     this.publish()
+  }
+
+  beginPendingStream(chatId: string): void {
+    this.pendingStreams.set(chatId, (this.pendingStreams.get(chatId) ?? 0) + 1)
+  }
+
+  endPendingStream(chatId: string): void {
+    const count = this.pendingStreams.get(chatId)
+    if (!count) return
+    if (count === 1) {
+      this.pendingStreams.delete(chatId)
+    } else {
+      this.pendingStreams.set(chatId, count - 1)
+    }
+  }
+
+  /**
+   * True while the chat has a live stream OR a send that is still in its
+   * pre-stream phase. Storage reloads use this to avoid adopting a stale
+   * stored copy of a chat that is about to be rewritten by a new stream.
+   */
+  isStreamingOrPending(chatId: string): boolean {
+    return this.streamingChats.has(chatId) || this.pendingStreams.has(chatId)
   }
 
   endStreaming(chatId: string): void {

--- a/src/services/inference/chat-recovery.ts
+++ b/src/services/inference/chat-recovery.ts
@@ -286,7 +286,11 @@ export async function persistChatRecoveryToken(args: {
         sessionId: args.sessionId,
         recoveryToken,
       })
-  if (!isCurrentAttempt()) {
+  // Re-check the cancelled set as well: a stop pressed while this token
+  // capture was in flight marks the turn cancelled before the (later)
+  // cancelChatRecovery call deregisters the attempt, so isCurrentAttempt
+  // alone would still pass here and write an envelope for a stopped turn.
+  if (!isCurrentAttempt() || cancelledTurns.has(key)) {
     await deleteRecoveryQuietly(args.sessionId)
     throw new DOMException('Aborted', 'AbortError')
   }
@@ -437,6 +441,28 @@ export async function cancelChatRecovery(
   return assistantMessage?.turnId
     ? envelopeTurns.has(assistantMessage.turnId)
     : envelopeTurns.size > 0
+}
+
+/**
+ * Mark a turn's recovery as cancelled before the async cancellation work
+ * runs. Stopping a generation before the first token races the recovery
+ * registration (the token is captured when response headers arrive):
+ * without this early mark, an in-flight persistChatRecoveryToken would
+ * still write its envelope, briefly surfacing the stopped turn as a
+ * recoverable stream until the envelope removal round-trips.
+ */
+export function markChatRecoveryTurnCancelled(
+  chatId: string,
+  turnId: string,
+): void {
+  cancelledTurns.add(turnKey(chatId, turnId))
+}
+
+export function isChatRecoveryTurnCancelled(
+  chatId: string,
+  turnId: string,
+): boolean {
+  return cancelledTurns.has(turnKey(chatId, turnId))
 }
 
 export function releaseActiveChatRecovery(chatId: string): void {

--- a/src/services/inference/inference-client.ts
+++ b/src/services/inference/inference-client.ts
@@ -586,8 +586,10 @@ export async function sendChatStream(
 /**
  * Wraps a failed request's error into a typed ChatError, preserving any
  * classification already attached (our own ChatErrors pass through, HTTP
- * 429 maps to RATE_LIMIT) so downstream handling can branch on codes
- * instead of message text.
+ * 429 maps to RATE_LIMIT). FETCH_ERROR is reserved for failures with no
+ * HTTP response at all — a request that reached the server and got an
+ * error status is a SERVER_ERROR, and telling the user to check their
+ * internet for a 500 would be misleading.
  */
 function toTerminalChatError(err: unknown, retries?: number): ChatError {
   if (err instanceof ChatError) {
@@ -599,14 +601,11 @@ function toTerminalChatError(err: unknown, retries?: number): ChatError {
   if (status === 429) {
     return new ChatError(msg, 'RATE_LIMIT', { status })
   }
+  if (status !== undefined) {
+    return new ChatError(msg, 'SERVER_ERROR', { status })
+  }
   const suffix = retries !== undefined ? ` after ${retries} retries` : ''
-  return new ChatError(
-    `Network request failed${suffix}: ${msg}`,
-    'FETCH_ERROR',
-    {
-      status,
-    },
-  )
+  return new ChatError(`Network request failed${suffix}: ${msg}`, 'FETCH_ERROR')
 }
 
 export interface StructuredCompletionParams {

--- a/src/services/inference/inference-client.ts
+++ b/src/services/inference/inference-client.ts
@@ -164,6 +164,12 @@ export function isRetryableError(error: unknown): boolean {
     return false
   }
 
+  // ChatErrors are terminal classifications produced by our own layers
+  // (e.g. the hourly usage cap); retrying them cannot succeed.
+  if (error instanceof ChatError) {
+    return false
+  }
+
   // Transport failures raised by the SDK, including its request timeout
   // (APIConnectionTimeoutError extends APIConnectionError).
   if (error instanceof APIConnectionError) {
@@ -568,18 +574,38 @@ export async function sendChatStream(
         },
       })
 
-      const msg = anyErr?.message || 'Unknown network error'
-      throw new ChatError(`Network request failed: ${msg}`, 'FETCH_ERROR')
+      throw toTerminalChatError(err)
     }
   }
 
   // Fallback: every branch above should already have thrown, but if the
   // retry loop exits without doing so we still need to surface an error.
-  const anyErr = lastError as any
+  throw toTerminalChatError(lastError, maxRetries)
+}
+
+/**
+ * Wraps a failed request's error into a typed ChatError, preserving any
+ * classification already attached (our own ChatErrors pass through, HTTP
+ * 429 maps to RATE_LIMIT) so downstream handling can branch on codes
+ * instead of message text.
+ */
+function toTerminalChatError(err: unknown, retries?: number): ChatError {
+  if (err instanceof ChatError) {
+    return err
+  }
+  const anyErr = err as { message?: string; status?: unknown }
   const msg = anyErr?.message || 'Unknown network error'
-  throw new ChatError(
-    `Network request failed after ${maxRetries} retries: ${msg}`,
+  const status = typeof anyErr?.status === 'number' ? anyErr.status : undefined
+  if (status === 429) {
+    return new ChatError(msg, 'RATE_LIMIT', { status })
+  }
+  const suffix = retries !== undefined ? ` after ${retries} retries` : ''
+  return new ChatError(
+    `Network request failed${suffix}: ${msg}`,
     'FETCH_ERROR',
+    {
+      status,
+    },
   )
 }
 

--- a/src/services/inference/tinfoil-client.ts
+++ b/src/services/inference/tinfoil-client.ts
@@ -1,3 +1,4 @@
+import { ChatError } from '@/components/chat/chat-utils'
 import { API_BASE_URL, DEV_API_KEY, IS_DEV } from '@/config'
 import { AUTH_ACTIVE_USER_ID } from '@/constants/storage-keys'
 import { logError } from '@/utils/error-handling'
@@ -77,8 +78,8 @@ function isHourlyLimit(
 }
 
 // Surfaces the per-account hourly usage cap through the shared rate-limit
-// channel (so the banner renders) and throws a message the chat recognizes as a
-// rate limit rather than a generic failure. Never returns.
+// channel (so the banner renders) and throws a typed error the chat
+// classifies as a rate limit rather than a generic failure. Never returns.
 function surfaceHourlyLimit(parsedError: ServerErrorBody | null): never {
   cachedRateLimit = {
     maxRequests: 0,
@@ -87,8 +88,10 @@ function surfaceHourlyLimit(parsedError: ServerErrorBody | null): never {
     kind: 'hourly',
   }
   dispatchRateLimitUpdate()
-  throw new Error(
+  throw new ChatError(
     parsedError?.error ?? 'You have reached your hourly usage limit.',
+    'HOURLY_LIMIT',
+    { status: 429 },
   )
 }
 

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -177,15 +177,19 @@
       opacity: 1;
     }
 
+    /* Reveal on hover, or on keyboard focus only (:focus-visible).
+       Plain :focus-within would also match mouse-initiated focus, which
+       gets parked inside the region after a drag-and-drop and would keep
+       every title revealed until focus leaves the sidebar. */
     .chat-title-privacy-region:hover .pixelated-text .pixelated-text-source,
-    .chat-title-privacy-region:focus-within
+    .chat-title-privacy-region:has(:focus-visible)
       .pixelated-text
       .pixelated-text-source {
       opacity: 1;
     }
 
     .chat-title-privacy-region:hover .pixelated-text .pixelated-text-canvas,
-    .chat-title-privacy-region:focus-within
+    .chat-title-privacy-region:has(:focus-visible)
       .pixelated-text
       .pixelated-text-canvas {
       opacity: 0;

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -177,19 +177,24 @@
       opacity: 1;
     }
 
-    /* Reveal on hover, or on keyboard focus only (:focus-visible).
-       Plain :focus-within would also match mouse-initiated focus, which
-       gets parked inside the region after a drag-and-drop and would keep
-       every title revealed until focus leaves the sidebar. */
+    /* Reveal on hover, or on keyboard focus only (:focus-visible) of the
+       row containing the title. Plain :focus-within would also match
+       mouse-initiated focus, which gets parked inside the region after a
+       drag-and-drop and would keep titles revealed until focus leaves the
+       sidebar. Deliberately NOT :has(:focus-visible) on the region: :has()
+       invalidation in Firefox re-evaluates the whole (large) chat list
+       subtree on every interaction and can freeze the page. */
     .chat-title-privacy-region:hover .pixelated-text .pixelated-text-source,
-    .chat-title-privacy-region:has(:focus-visible)
+    .chat-title-privacy-region
+      :focus-visible
       .pixelated-text
       .pixelated-text-source {
       opacity: 1;
     }
 
     .chat-title-privacy-region:hover .pixelated-text .pixelated-text-canvas,
-    .chat-title-privacy-region:has(:focus-visible)
+    .chat-title-privacy-region
+      :focus-visible
       .pixelated-text
       .pixelated-text-canvas {
       opacity: 0;

--- a/tests/components/chat/genui/retry.test.ts
+++ b/tests/components/chat/genui/retry.test.ts
@@ -1,0 +1,86 @@
+import { regenerateToolCallArguments } from '@/components/chat/genui/retry'
+import type { Message } from '@/components/chat/types'
+import type { BaseModel } from '@/config/models'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { sendStructuredCompletionMock } = vi.hoisted(() => ({
+  sendStructuredCompletionMock: vi.fn(),
+}))
+
+vi.mock('@/services/inference/inference-client', () => ({
+  sendStructuredCompletion: sendStructuredCompletionMock,
+}))
+
+const model = { modelName: 'gpt-oss-120b' } as BaseModel
+
+function userMessage(content: string): Message {
+  return { role: 'user', content, timestamp: new Date() }
+}
+
+describe('regenerateToolCallArguments', () => {
+  beforeEach(() => {
+    sendStructuredCompletionMock.mockReset()
+  })
+
+  it('returns validated arguments serialized for the tool-call block', async () => {
+    const regenerated = {
+      type: 'bar',
+      data: [{ label: 'A', value: 10 }],
+      title: 'Sales',
+    }
+    sendStructuredCompletionMock.mockResolvedValueOnce(regenerated)
+
+    const result = await regenerateToolCallArguments({
+      toolName: 'render_chart',
+      contextMessages: [userMessage('Chart my sales data')],
+      model,
+    })
+
+    expect(result).not.toBeNull()
+    expect(JSON.parse(result as string)).toMatchObject(regenerated)
+    // The re-ask must be constrained by the widget's JSON schema.
+    const call = sendStructuredCompletionMock.mock.calls[0][0]
+    expect(call.jsonSchema).toBeTruthy()
+    expect(call.model).toBe(model)
+  })
+
+  it('returns null when regenerated arguments still fail validation', async () => {
+    sendStructuredCompletionMock.mockResolvedValueOnce({
+      type: 'donut', // not a valid chart type
+      data: [],
+    })
+
+    const result = await regenerateToolCallArguments({
+      toolName: 'render_chart',
+      contextMessages: [userMessage('Chart my sales data')],
+      model,
+    })
+
+    expect(result).toBeNull()
+  })
+
+  it('returns null for unknown widgets without calling the model', async () => {
+    const result = await regenerateToolCallArguments({
+      toolName: 'render_nonexistent',
+      contextMessages: [userMessage('Hello')],
+      model,
+    })
+
+    expect(result).toBeNull()
+    expect(sendStructuredCompletionMock).not.toHaveBeenCalled()
+  })
+
+  it('returns null when the structured completion fails', async () => {
+    sendStructuredCompletionMock.mockRejectedValueOnce(
+      new Error('network down'),
+    )
+
+    const result = await regenerateToolCallArguments({
+      toolName: 'render_chart',
+      contextMessages: [userMessage('Chart my sales data')],
+      model,
+    })
+
+    expect(result).toBeNull()
+  })
+})

--- a/tests/components/chat/use-chat-messaging.cancel-generation.test.tsx
+++ b/tests/components/chat/use-chat-messaging.cancel-generation.test.tsx
@@ -75,6 +75,7 @@ vi.mock('@/services/inference/chat-recovery', () => ({
   abandonChatRecoveryAttempt: vi.fn(),
   cancelChatRecovery: cancelChatRecoveryMock,
   completeLiveChatRecovery: vi.fn(),
+  markChatRecoveryTurnCancelled: vi.fn(),
   persistChatRecoveryToken: vi.fn(),
   releaseActiveChatRecovery: vi.fn(),
   scanPendingChatRecoveries: scanPendingChatRecoveriesMock,

--- a/tests/components/chat/use-chat-messaging.cancel-generation.test.tsx
+++ b/tests/components/chat/use-chat-messaging.cancel-generation.test.tsx
@@ -51,6 +51,9 @@ vi.mock('@/services/cloud/streaming-tracker', () => ({
   streamingTracker: {
     isStreaming: vi.fn(() => false),
     endStreaming: vi.fn(),
+    beginPendingStream: vi.fn(),
+    endPendingStream: vi.fn(),
+    isStreamingOrPending: vi.fn(() => false),
   },
 }))
 
@@ -92,6 +95,8 @@ vi.mock('@/components/chat/hooks/use-chat-streams', async () => {
       moveStatus: moveStatusMock,
       registerController: registerControllerMock,
       clearController: clearControllerMock,
+      ownsController: () => true,
+      hasActiveController: () => false,
       abort: abortMock,
     }),
   }

--- a/tests/components/chat/use-chat-messaging.retry.test.tsx
+++ b/tests/components/chat/use-chat-messaging.retry.test.tsx
@@ -30,6 +30,9 @@ vi.mock('@/services/cloud/streaming-tracker', () => ({
     endStreaming: vi.fn(),
     startStreaming: vi.fn(),
     onStreamEnd: vi.fn(),
+    beginPendingStream: vi.fn(),
+    endPendingStream: vi.fn(),
+    isStreamingOrPending: vi.fn(() => false),
   },
 }))
 
@@ -47,6 +50,8 @@ vi.mock('@/components/chat/hooks/use-chat-streams', async () => {
       moveStatus: moveStatusMock,
       registerController: registerControllerMock,
       clearController: clearControllerMock,
+      ownsController: () => true,
+      hasActiveController: () => false,
       abort: abortMock,
     }),
   }

--- a/tests/components/chat/use-chat-messaging.stop-stream.test.tsx
+++ b/tests/components/chat/use-chat-messaging.stop-stream.test.tsx
@@ -104,6 +104,7 @@ vi.mock('@/services/inference/chat-recovery', () => ({
   cancelChatRecovery: (...args: unknown[]) => cancelChatRecoveryMock(...args),
   completeLiveChatRecovery: (...args: unknown[]) =>
     completeLiveChatRecoveryMock(...args),
+  markChatRecoveryTurnCancelled: vi.fn(),
   persistChatRecoveryToken: vi.fn(),
   releaseActiveChatRecovery: vi.fn(),
   scanPendingChatRecoveries: vi.fn(),

--- a/tests/components/chat/use-chat-messaging.stop-stream.test.tsx
+++ b/tests/components/chat/use-chat-messaging.stop-stream.test.tsx
@@ -57,6 +57,9 @@ vi.mock('@/services/cloud/streaming-tracker', () => ({
     startStreaming: (chatId: string) => streamingChats.add(chatId),
     endStreaming: (chatId: string) => streamingChats.delete(chatId),
     isStreaming: (chatId: string) => streamingChats.has(chatId),
+    beginPendingStream: vi.fn(),
+    endPendingStream: vi.fn(),
+    isStreamingOrPending: (chatId: string) => streamingChats.has(chatId),
   },
 }))
 
@@ -78,8 +81,21 @@ vi.mock('@/components/chat/hooks/use-chat-streams', async (importOriginal) => ({
     registerController: (chatId: string, controller: AbortController) => {
       streamControllers.set(chatId, controller)
     },
-    clearController: (chatId: string) => streamControllers.delete(chatId),
-    abort: (chatId: string) => streamControllers.get(chatId)?.abort(),
+    clearController: (chatId: string, controller: AbortController) => {
+      if (streamControllers.get(chatId) === controller) {
+        streamControllers.delete(chatId)
+      }
+    },
+    ownsController: (chatId: string, controller: AbortController) =>
+      streamControllers.get(chatId) === controller,
+    hasActiveController: (chatId: string) => streamControllers.has(chatId),
+    abort: (chatId: string) => {
+      const controller = streamControllers.get(chatId)
+      if (!controller) return false
+      controller.abort()
+      streamControllers.delete(chatId)
+      return true
+    },
   }),
 }))
 

--- a/tests/components/chat/use-chat-storage.reloadChats.test.tsx
+++ b/tests/components/chat/use-chat-storage.reloadChats.test.tsx
@@ -39,6 +39,7 @@ vi.mock('@/components/chat/hooks/chat-operations', async () => {
 vi.mock('@/services/cloud/streaming-tracker', () => ({
   streamingTracker: {
     isStreaming: mockIsStreaming,
+    isStreamingOrPending: mockIsStreaming,
   },
 }))
 

--- a/tests/services/inference/chat-recovery.test.ts
+++ b/tests/services/inference/chat-recovery.test.ts
@@ -122,6 +122,7 @@ vi.mock('@/utils/error-handling', () => ({
 import {
   abandonChatRecoveryAttempt,
   cancelChatRecovery,
+  markChatRecoveryTurnCancelled,
   persistChatRecoveryToken,
   resetChatRecoveryState,
   scanPendingChatRecoveries,
@@ -191,6 +192,57 @@ describe('chat recovery lifecycle', () => {
     await expect(cancellation).resolves.toBe(false)
 
     expect(encryptRecoveryEnvelope).not.toHaveBeenCalled()
+    expect(addPendingRecovery).not.toHaveBeenCalled()
+    expect(deleteChatRecovery).toHaveBeenCalledWith(SESSION_ID)
+  })
+
+  it('discards a token captured after the turn was marked cancelled', async () => {
+    // Stop pressed before the first token: cancelGeneration marks the turn
+    // cancelled synchronously with the abort, while the in-flight request's
+    // token capture races it. The late token must not register an envelope
+    // (which would surface "Recovering stream..." for a stopped turn).
+    startChatRecoveryAttempt('chat-1', 'turn-1', SESSION_ID)
+    markChatRecoveryTurnCancelled('chat-1', 'turn-1')
+
+    await expect(
+      persistChatRecoveryToken({
+        userId: 'user-1',
+        chatId: 'chat-1',
+        turnId: 'turn-1',
+        sessionId: SESSION_ID,
+        token: {
+          exportedSecret: new Uint8Array(32),
+          requestEnc: new Uint8Array(32),
+        },
+      }),
+    ).rejects.toMatchObject({ name: 'AbortError' })
+
+    expect(addPendingRecovery).not.toHaveBeenCalled()
+    expect(deleteChatRecovery).toHaveBeenCalledWith(SESSION_ID)
+  })
+
+  it('discards a cancelled-turn token even when the mark lands mid-persist', async () => {
+    // Narrower window: the cancel mark arrives after persistChatRecoveryToken
+    // already passed its entry checks and is awaiting envelope encryption.
+    startChatRecoveryAttempt('chat-1', 'turn-1', SESSION_ID)
+    encryptRecoveryEnvelope.mockImplementationOnce(async () => {
+      markChatRecoveryTurnCancelled('chat-1', 'turn-1')
+      return envelope
+    })
+
+    await expect(
+      persistChatRecoveryToken({
+        userId: 'user-1',
+        chatId: 'chat-1',
+        turnId: 'turn-1',
+        sessionId: SESSION_ID,
+        token: {
+          exportedSecret: new Uint8Array(32),
+          requestEnc: new Uint8Array(32),
+        },
+      }),
+    ).rejects.toMatchObject({ name: 'AbortError' })
+
     expect(addPendingRecovery).not.toHaveBeenCalled()
     expect(deleteChatRecovery).toHaveBeenCalledWith(SESSION_ID)
   })

--- a/tests/ui/smoke.test.ts
+++ b/tests/ui/smoke.test.ts
@@ -115,18 +115,14 @@ test.describe('Smoke Tests', () => {
     await expect(textarea).toHaveValue('Hello, this is a test message')
   })
 
-  test('document upload button exists', async ({ page }) => {
-    test.skip(
-      page.viewportSize()?.width !== undefined &&
-        page.viewportSize()!.width < 768,
-      'Upload button is hidden on mobile viewports',
-    )
-
+  test('input options menu offers file upload', async ({ page }) => {
     await page.goto('/')
     await page.waitForLoadState('networkidle')
 
-    const uploadButton = page.locator('#upload-button')
-    await expect(uploadButton).toBeVisible({ timeout: 10000 })
+    const optionsButton = page.locator('#input-options-button')
+    await expect(optionsButton).toBeVisible({ timeout: 10000 })
+    await optionsButton.click()
+    await expect(page.getByText('Add files or photos')).toBeVisible()
   })
 
   test('send button is present', async ({ page }) => {


### PR DESCRIPTION
## Summary

Fixes seven user-reported issues across the web app, one commit per fix.

### Bug fixes

- **Custom system prompt resets on page refresh** — the cloud deep-link hydration path (`loadChatById`) converted `StoredChat → Chat` with an explicit field list that dropped `presetId` (and `webSearchEnabled`); the next message save then persisted the stripped chat, permanently erasing the preset. The conversion now carries both fields, `reloadChats`' metadata merge heals `presetId`, and mid-stream persistence re-reads it from live state. Also guards the preset handler against overwriting both blank-chat entries (they share id `''`).
- **Blurred titles revealed permanently after dragging a chat** — the mousedown that initiates a drag focuses the row link; the drag suppresses the click so focus stays parked inside the list, and the `:focus-within` CSS reveal rule kept every pixelated title visible. The reveal is now scoped to keyboard focus (`:has(:focus-visible)`), and drag start blurs the active element.
- **Project Settings Save button unreachable on mobile** — the expanded settings panel lived in a `flex-none` section inside an `overflow-hidden` column with no scroll container, so content past the viewport was clipped. The project sidebar content is now one scroll area with the footer pinned.
- **Flicker when pausing and quickly resuming a generation** — no per-stream ownership fencing: an aborted stream's `finally` block and `cancelGeneration`'s async tail patched status and deleted the abort controller keyed only by chat id, clobbering a successor stream. The next stop press then silently failed, leaving two live streams interleaving UI flushes. Controller clearing/status patches are now ownership-guarded, cancel tails check for an active successor before idling, and storage reloads won't adopt a stale stored copy while a send is in its pre-stream phase.
- **Network-error "Try again" semantics** — the button is labeled "Resend message" for connection failures (and disabled while offline), and hidden for rate-limit errors where retrying can't succeed.

### UX improvements

- **Unified sidebar scrolling** — the main sidebar (upsell box, New Chat, Projects, Chats) is now one scrollable area with sticky section headers, so long project lists can no longer squeeze the chat list into an unscrollable sliver. The infinite-scroll observer was re-rooted to the new scroll container.
- **Widget-only retry** — a failed GenUI widget's "Try again" no longer regenerates the entire assistant response. It re-asks the model for just that widget's arguments via a schema-constrained structured completion, validates with the widget's Zod schema, and patches the block in place (falling back to full regeneration if the repair fails). Also adds a React error boundary around widget renders so a crashing widget shows a notice instead of taking down the message tree.

### Refactoring

- **Structured error classification** — replaces string-matching on error messages (rate limit / hourly limit / network detection) with typed `ChatError` codes propagated through `streamError`, per the repo's error-classification policy.

## Testing

- `vitest`: 113 files, 1340 tests pass (includes new tests for widget-argument regeneration)
- `eslint` and `next build` pass
- Manual testing recommended for:
  - Pause → quickly resume/regenerate a streaming response (racing paths: stop button, regenerate, queued messages)
  - Custom prompt survives refresh on a cloud chat deep link
  - Drag a chat into a project with title pixelation enabled
  - Project settings on a small viewport (Save reachable, single scroll)
  - Sidebar scrolling with many projects + many chats (incl. infinite scroll loading)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes multiple UX bugs across chat and sidebar, improves retry and error handling, and adds widget-only retry so a broken GenUI widget can be repaired without regenerating the whole response. Also adds a single “+” input options menu and restores focus when it closes, smooths sidebar animations, fixes the mobile prompt tab, prevents “Recovering stream…” when a stream is stopped before the first token, prevents sidebar auto-load loops or wedged pagination, keeps pagination usable when a post-page reload fails, and makes the input options menu keyboard accessible.

- **Bug Fixes**
  - Preserve custom system prompt (`presetId`) and `webSearchEnabled` across refresh/deep links; avoid overwriting the other blank chat entry.
  - Keep pixelated titles blurred after drag by blurring the focused element, revealing only on keyboard focus, and avoiding a Firefox-freezing selector.
  - Sidebar reliability: one scroll area with pinned, accordion section headers that auto-collapse the other section and reset scroll; ensures opening Projects/Chats always shows content, stops sections from being squeezed, hides the scrollbar during section animations, only auto-loads near the bottom, and prevents auto-load loops or wedged pagination (pagination stays usable if the post-page reload fails).
  - Eliminate flicker when stopping then quickly resuming by adding per-stream controller ownership, guarding cancel tails, and tracking pre-stream sends.
  - Clarify retry: show “Resend message” for connection errors (disabled offline), hide retry for rate-limit/hourly-limit errors, and stop presenting server errors as connection problems.
  - Attach the active prompt tab to the input card on mobile; input options menu now restores focus consistently when it closes.

- **New Features**
  - Widget-only retry for GenUI: re-asks the model for just the widget’s arguments via schema-constrained structured completion, validates, and patches in place; hardened against stale state and failed repairs, with a fallback to full regeneration. Adds a React error boundary so a crashing widget shows a notice instead of breaking the message.
  - Structured error codes via `ChatError` (`FETCH_ERROR`, `SERVER_ERROR`, `RATE_LIMIT`, `HOURLY_LIMIT`) are classified centrally and used by the error banner for correct labels and retry behavior.
  - Consolidated input actions into a single “+” menu with file/photo upload and other options, simplifying the input bar on all viewports. Keeps input toggles inside the menu, uses a state-aware icon, is fully keyboard accessible, and restores focus on close.

<sup>Written for commit fa7a7d064aae8bf725b1312ace8659fb3e2086dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/462?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

