### PR TITLE
feat: show model and encryption details on messages

### DIFF
--- a/src/components/chat/PrintableChat.tsx
+++ b/src/components/chat/PrintableChat.tsx
@@ -213,6 +213,7 @@ const PrintableMessage = memo(function PrintableMessage({
   }
 
   const isUser = message.role === 'user'
+  const modelDisplayName = message.modelDisplayName?.trim()
 
   return (
     <div className="printable-message">
@@ -251,9 +252,7 @@ const PrintableMessage = memo(function PrintableMessage({
         </div>
       )}
       <div className="flex items-center gap-1 text-xs text-gray-500">
-        {!isUser && message.modelDisplayName
-          ? `${message.modelDisplayName} · `
-          : ''}
+        {!isUser && modelDisplayName ? `${modelDisplayName} · ` : ''}
         <LockClosedIcon className="h-3 w-3" aria-hidden="true" />
         Encrypted
       </div>

--- a/src/components/chat/PrintableChat.tsx
+++ b/src/components/chat/PrintableChat.tsx
@@ -5,6 +5,7 @@ import {
 } from '@/utils/latex-processing'
 import { preprocessMarkdown } from '@/utils/markdown-preprocessing'
 import { sanitizeUrl } from '@braintree/sanitize-url'
+import { LockClosedIcon } from '@heroicons/react/24/outline'
 import { memo } from 'react'
 import ReactMarkdown from 'react-markdown'
 import {
@@ -249,6 +250,13 @@ const PrintableMessage = memo(function PrintableMessage({
           {renderContent(message.content, isUser)}
         </div>
       )}
+      <div className="flex items-center gap-1 text-xs text-gray-500">
+        {!isUser && message.modelDisplayName
+          ? `${message.modelDisplayName} · `
+          : ''}
+        <LockClosedIcon className="h-3 w-3" aria-hidden="true" />
+        Encrypted
+      </div>
     </div>
   )
 })

--- a/src/components/chat/chat-list-item.tsx
+++ b/src/components/chat/chat-list-item.tsx
@@ -323,23 +323,21 @@ export function ChatListItem({
     onDragEnd?.()
   }
 
-  const createdAtInput =
-    chat.createdAt instanceof Date
-      ? chat.createdAt.toISOString()
-      : chat.createdAt
-  const { createdAt, timestamp, createdRelativeTime, updatedRelativeTime } =
-    useMemo(() => {
-      const created = toDate(createdAtInput)
-      const updated = toDate(chat.updatedAt) ?? created
-      return {
-        createdAt: created,
-        timestamp: updated,
-        createdRelativeTime: updated
-          ? formatRelativeTime(created ?? updated)
-          : null,
-        updatedRelativeTime: updated ? formatRelativeTime(updated) : null,
-      }
-    }, [chat.updatedAt, createdAtInput])
+  const createdAt = toDate(chat.createdAt)
+  const timestamp = toDate(chat.updatedAt) ?? createdAt
+  const relativeTimePhase = useMemo(
+    () => ({ isStreaming, referenceTime: Date.now() }),
+    [isStreaming],
+  )
+  const createdRelativeTime = timestamp
+    ? formatRelativeTime(
+        createdAt ?? timestamp,
+        relativeTimePhase.isStreaming
+          ? relativeTimePhase.referenceTime
+          : Date.now(),
+      )
+    : null
+  const updatedRelativeTime = timestamp ? formatRelativeTime(timestamp) : null
   // Skip the updated time when it would read the same as the created
   // time, so rows don't repeat "9h ago · Updated 9h ago". Without a
   // createdAt there is nothing to compare against and the timestamp

--- a/src/components/chat/chat-list-item.tsx
+++ b/src/components/chat/chat-list-item.tsx
@@ -14,7 +14,7 @@ import {
   XMarkIcon,
 } from '@heroicons/react/24/outline'
 import Link from 'next/link'
-import { useEffect, useId, useRef, useState } from 'react'
+import { useEffect, useId, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { CiFloppyDisk } from 'react-icons/ci'
 import { FaLock } from '../icons/lazy-icons'
@@ -56,6 +56,11 @@ export function getChatKey(chat: ChatItemData): string {
  */
 export function getBlankChatSelectId(chat: ChatItemData): string {
   return getBlankQueueId(chat.isLocalOnly === true)
+}
+
+const toDate = (value?: Date | string): Date | null => {
+  if (!value) return null
+  return value instanceof Date ? value : new Date(value)
 }
 
 export interface ProjectOption {
@@ -318,13 +323,28 @@ export function ChatListItem({
     onDragEnd?.()
   }
 
-  const toDate = (value?: Date | string): Date | null => {
-    if (!value) return null
-    return value instanceof Date ? value : new Date(value)
-  }
-
-  const createdAt = toDate(chat.createdAt)
-  const timestamp = toDate(chat.updatedAt) ?? createdAt
+  const createdAtInput =
+    chat.createdAt instanceof Date
+      ? chat.createdAt.toISOString()
+      : chat.createdAt
+  const { createdAt, timestamp, createdRelativeTime, updatedRelativeTime } =
+    useMemo(() => {
+      const created = toDate(createdAtInput)
+      const updated = toDate(chat.updatedAt) ?? created
+      return {
+        createdAt: created,
+        timestamp: updated,
+        createdRelativeTime: updated
+          ? formatRelativeTime(created ?? updated)
+          : null,
+        updatedRelativeTime: updated ? formatRelativeTime(updated) : null,
+      }
+    }, [chat.updatedAt, createdAtInput])
+  // Skip the updated time when it would read the same as the created
+  // time, so rows don't repeat "9h ago · Updated 9h ago". Without a
+  // createdAt there is nothing to compare against and the timestamp
+  // may itself be the creation time, so show it unlabeled instead of
+  // claiming "Updated".
   // The first user/assistant turn creates the chat, so its persistence
   // updates are not meaningful history updates. Later turns can show the
   // updated time once streaming has settled.
@@ -333,7 +353,7 @@ export function ChatListItem({
     messageCount > INITIAL_TURN_MESSAGE_COUNT &&
     timestamp !== null &&
     createdAt !== null &&
-    formatRelativeTime(timestamp) !== formatRelativeTime(createdAt)
+    updatedRelativeTime !== createdRelativeTime
 
   return (
     <div
@@ -465,11 +485,9 @@ export function ChatListItem({
                 ) : messageCount > 0 && timestamp ? (
                   <span className="text-xs leading-none text-content-muted">
                     <span className="text-content-secondary">
-                      {formatRelativeTime(createdAt ?? timestamp)}
+                      {createdRelativeTime}
                     </span>
-                    {showUpdatedTime && (
-                      <> · Updated {formatRelativeTime(timestamp)}</>
-                    )}
+                    {showUpdatedTime && <> · Updated {updatedRelativeTime}</>}
                   </span>
                 ) : null}
                 {showSyncStatus && (

--- a/src/components/chat/chat-list-utils.ts
+++ b/src/components/chat/chat-list-utils.ts
@@ -1,9 +1,11 @@
 /**
  * Formats a date as a relative time string (e.g., "2h ago", "3d ago")
  */
-export function formatRelativeTime(date: Date): string {
-  const now = new Date()
-  const seconds = Math.floor((now.getTime() - date.getTime()) / 1000)
+export function formatRelativeTime(
+  date: Date,
+  referenceTime = Date.now(),
+): string {
+  const seconds = Math.floor((referenceTime - date.getTime()) / 1000)
 
   if (seconds < 60) {
     return `${seconds}s ago`

--- a/src/components/chat/hooks/streaming/message-assembler.ts
+++ b/src/components/chat/hooks/streaming/message-assembler.ts
@@ -31,9 +31,7 @@ export class MessageAssembler {
   constructor(private modelDisplayName?: string) {}
 
   setModelDisplayName(modelDisplayName: string): void {
-    if (!modelDisplayName || modelDisplayName === this.modelDisplayName) {
-      return
-    }
+    if (!modelDisplayName) return
     this.modelDisplayName = modelDisplayName
   }
 

--- a/src/components/chat/hooks/streaming/message-assembler.ts
+++ b/src/components/chat/hooks/streaming/message-assembler.ts
@@ -30,12 +30,11 @@ export class MessageAssembler {
 
   constructor(private modelDisplayName?: string) {}
 
-  setModelDisplayName(modelDisplayName: string): boolean {
+  setModelDisplayName(modelDisplayName: string): void {
     if (!modelDisplayName || modelDisplayName === this.modelDisplayName) {
-      return false
+      return
     }
     this.modelDisplayName = modelDisplayName
-    return true
   }
 
   addAnnotation(url: string, title: string): void {

--- a/src/components/chat/hooks/streaming/message-assembler.ts
+++ b/src/components/chat/hooks/streaming/message-assembler.ts
@@ -28,6 +28,16 @@ export class MessageAssembler {
   private searchReasoning = ''
   private timestamp = new Date()
 
+  constructor(private modelDisplayName?: string) {}
+
+  setModelDisplayName(modelDisplayName: string): boolean {
+    if (!modelDisplayName || modelDisplayName === this.modelDisplayName) {
+      return false
+    }
+    this.modelDisplayName = modelDisplayName
+    return true
+  }
+
   addAnnotation(url: string, title: string): void {
     this.sources.push({ title, url })
     this.annotations.push({
@@ -99,6 +109,7 @@ export class MessageAssembler {
       role: 'assistant',
       content,
       timestamp: this.timestamp,
+      modelDisplayName: this.modelDisplayName,
       thoughts: firstThinkingIdx >= 0 ? thoughts : undefined,
       isThinking,
       thinkingDuration,

--- a/src/components/chat/hooks/streaming/process-stream.ts
+++ b/src/components/chat/hooks/streaming/process-stream.ts
@@ -23,6 +23,8 @@ export async function processStreamingResponse(
     trackThinkingDuration: true,
     onFirstEvent: () => ctx.setIsWaitingForResponse(false),
     onThinkingChange: ctx.setIsThinking,
+    modelDisplayName: ctx.modelDisplayName,
+    resolveModelDisplayName: ctx.resolveModelDisplayName,
   })
   const publisher = new AnimationFramePublisher(ctx.onUpdate)
   let interruptionPublished = false

--- a/src/components/chat/hooks/streaming/rich-response-parser.ts
+++ b/src/components/chat/hooks/streaming/rich-response-parser.ts
@@ -7,6 +7,8 @@ export interface RichResponseParserOptions {
   onUpdate?: (message: Message) => void
   onFirstEvent?: () => void
   onThinkingChange?: (isThinking: boolean) => void
+  modelDisplayName?: string
+  resolveModelDisplayName?: (modelName: string) => string | undefined
 }
 
 export async function parseRichStreamingResponse(

--- a/src/components/chat/hooks/streaming/rich-stream-session.ts
+++ b/src/components/chat/hooks/streaming/rich-stream-session.ts
@@ -37,17 +37,16 @@ export class RichStreamSession {
           ? this.options.resolveModelDisplayName(chunk.model)
           : chunk.model
         : undefined
-    const modelChanged =
-      resolvedModelDisplayName !== undefined &&
+    if (resolvedModelDisplayName !== undefined) {
       this.assembler.setModelDisplayName(resolvedModelDisplayName)
+    }
     const events = this.normalizer.processChunk(
       chunk,
       this.preprocessor,
       streamLogger,
     )
     for (const event of events) this.applyEvent(event)
-    if (modelChanged) this.changed = true
-    return modelChanged || events.length > 0
+    return events.length > 0
   }
 
   snapshot(turnId?: string): Message {

--- a/src/components/chat/hooks/streaming/rich-stream-session.ts
+++ b/src/components/chat/hooks/streaming/rich-stream-session.ts
@@ -12,28 +12,42 @@ interface RichStreamSessionOptions {
   trackThinkingDuration?: boolean
   onFirstEvent?: () => void
   onThinkingChange?: (isThinking: boolean) => void
+  modelDisplayName?: string
+  resolveModelDisplayName?: (modelName: string) => string | undefined
 }
 
 export class RichStreamSession {
   private readonly preprocessor = createContentPreprocessor()
   private readonly normalizer = createEventNormalizer()
   private readonly timeline = new TimelineBuilder()
-  private readonly assembler = new MessageAssembler()
+  private readonly assembler: MessageAssembler
   private readonly webSearchBlocks = new Map<string, string>()
   private firstEventSeen = false
   private changed = false
   private thinkingStartedAt: number | null = null
 
-  constructor(private readonly options: RichStreamSessionOptions = {}) {}
+  constructor(private readonly options: RichStreamSessionOptions = {}) {
+    this.assembler = new MessageAssembler(options.modelDisplayName)
+  }
 
   processChunk(chunk: ChatChunk, streamLogger?: StreamLogger): boolean {
+    const resolvedModelDisplayName =
+      typeof chunk.model === 'string'
+        ? this.options.resolveModelDisplayName
+          ? this.options.resolveModelDisplayName(chunk.model)
+          : chunk.model
+        : undefined
+    const modelChanged =
+      resolvedModelDisplayName !== undefined &&
+      this.assembler.setModelDisplayName(resolvedModelDisplayName)
     const events = this.normalizer.processChunk(
       chunk,
       this.preprocessor,
       streamLogger,
     )
     for (const event of events) this.applyEvent(event)
-    return events.length > 0
+    if (modelChanged) this.changed = true
+    return modelChanged || events.length > 0
   }
 
   snapshot(turnId?: string): Message {

--- a/src/components/chat/hooks/streaming/types.ts
+++ b/src/components/chat/hooks/streaming/types.ts
@@ -105,5 +105,7 @@ export interface StreamingContext {
   deferStreamCleanup?: boolean
   signal?: AbortSignal
   turnId?: string
+  modelDisplayName?: string
+  resolveModelDisplayName?: (modelName: string) => string | undefined
   onInterrupted?: (message: Message | null) => void
 }

--- a/src/components/chat/hooks/use-chat-messaging.ts
+++ b/src/components/chat/hooks/use-chat-messaging.ts
@@ -225,7 +225,7 @@ export function useChatMessaging({
       .join('\u0000') ?? ''
 
   useEffect(() => {
-    if (!isSignedIn || !userId || !storeHistory || models.length === 0) return
+    if (!isSignedIn || !userId || !storeHistory) return
 
     const scan = (refreshPending = false) => {
       if (!canUseChatRecovery({ isSignedIn, userId, storeHistory })) return
@@ -251,13 +251,12 @@ export function useChatMessaging({
       unsubscribe()
       window.clearInterval(interval)
     }
-  }, [isSignedIn, models.length, storeHistory, userId])
+  }, [isSignedIn, storeHistory, userId])
 
   useEffect(() => {
     if (
       !recoveryScanKey ||
       !userId ||
-      models.length === 0 ||
       !canUseChatRecovery({
         isSignedIn,
         userId,
@@ -274,7 +273,6 @@ export function useChatMessaging({
     currentChatId,
     currentChatIsTemporary,
     isSignedIn,
-    models.length,
     recoveryScanKey,
     storeHistory,
     userId,

--- a/src/components/chat/hooks/use-chat-messaging.ts
+++ b/src/components/chat/hooks/use-chat-messaging.ts
@@ -18,7 +18,11 @@
  *   this hook are derived for the currently-viewed chat
  */
 import { useProject } from '@/components/project'
-import { resolveModelSelection, type BaseModel } from '@/config/models'
+import {
+  getKnownModelDisplayName,
+  resolveModelSelection,
+  type BaseModel,
+} from '@/config/models'
 import { DEFAULT_CHAT_TITLE, TEMPORARY_CHAT_TITLE } from '@/constants/chat'
 import { REQUEST_UPGRADE_EVENT } from '@/constants/chat-events'
 import { useChatRecoveryActive } from '@/hooks/use-chat-recovery-drafts'
@@ -221,7 +225,7 @@ export function useChatMessaging({
       .join('\u0000') ?? ''
 
   useEffect(() => {
-    if (!isSignedIn || !userId || !storeHistory) return
+    if (!isSignedIn || !userId || !storeHistory || models.length === 0) return
 
     const scan = (refreshPending = false) => {
       if (!canUseChatRecovery({ isSignedIn, userId, storeHistory })) return
@@ -247,12 +251,13 @@ export function useChatMessaging({
       unsubscribe()
       window.clearInterval(interval)
     }
-  }, [isSignedIn, storeHistory, userId])
+  }, [isSignedIn, models.length, storeHistory, userId])
 
   useEffect(() => {
     if (
       !recoveryScanKey ||
       !userId ||
+      models.length === 0 ||
       !canUseChatRecovery({
         isSignedIn,
         userId,
@@ -269,6 +274,7 @@ export function useChatMessaging({
     currentChatId,
     currentChatIsTemporary,
     isSignedIn,
+    models.length,
     recoveryScanKey,
     storeHistory,
     userId,
@@ -1277,8 +1283,7 @@ export function useChatMessaging({
           signal: controller.signal,
           turnId: turnId ?? undefined,
           modelDisplayName: model.name,
-          resolveModelDisplayName: (modelName) =>
-            models.find((candidate) => candidate.modelName === modelName)?.name,
+          resolveModelDisplayName: getKnownModelDisplayName,
           onInterrupted: (message) => {
             activeGeneration.latestAssistantMessage = message
           },

--- a/src/components/chat/hooks/use-chat-messaging.ts
+++ b/src/components/chat/hooks/use-chat-messaging.ts
@@ -1276,6 +1276,9 @@ export function useChatMessaging({
           deferStreamCleanup: recoveryEnabled,
           signal: controller.signal,
           turnId: turnId ?? undefined,
+          modelDisplayName: model.name,
+          resolveModelDisplayName: (modelName) =>
+            models.find((candidate) => candidate.modelName === modelName)?.name,
           onInterrupted: (message) => {
             activeGeneration.latestAssistantMessage = message
           },

--- a/src/components/chat/hooks/use-sidebar-chat.ts
+++ b/src/components/chat/hooks/use-sidebar-chat.ts
@@ -10,7 +10,11 @@
  * in-memory messages. This keeps parsing, thinking mode, web search, and
  * citation processing identical to the main chat view.
  */
-import { resolveModelSelection, type BaseModel } from '@/config/models'
+import {
+  getKnownModelDisplayName,
+  resolveModelSelection,
+  type BaseModel,
+} from '@/config/models'
 import { streamingTracker } from '@/services/cloud/streaming-tracker'
 import { sendChatStream } from '@/services/inference/inference-client'
 import { logError } from '@/utils/error-handling'
@@ -229,9 +233,7 @@ export function useSidebarChat({
             },
             signal: controller.signal,
             modelDisplayName: model.name,
-            resolveModelDisplayName: (modelName) =>
-              models.find((candidate) => candidate.modelName === modelName)
-                ?.name,
+            resolveModelDisplayName: getKnownModelDisplayName,
           })
 
           if (assistantMessage && abortControllerRef.current === controller) {

--- a/src/components/chat/hooks/use-sidebar-chat.ts
+++ b/src/components/chat/hooks/use-sidebar-chat.ts
@@ -228,6 +228,10 @@ export function useSidebarChat({
                 setLoadingState(value)
             },
             signal: controller.signal,
+            modelDisplayName: model.name,
+            resolveModelDisplayName: (modelName) =>
+              models.find((candidate) => candidate.modelName === modelName)
+                ?.name,
           })
 
           if (assistantMessage && abortControllerRef.current === controller) {

--- a/src/components/chat/renderers/default/DefaultMessageRenderer.tsx
+++ b/src/components/chat/renderers/default/DefaultMessageRenderer.tsx
@@ -73,7 +73,7 @@ const DefaultMessageComponent = ({
   const isLimitError =
     message.isRateLimitError || message.isHourlyRateLimitError
   const modelDisplayName = message.modelDisplayName?.trim()
-  const showMetadata = isUser || hasVisibleAssistantMessage(message)
+  const showMetadata = hasVisibleAssistantMessage(message)
 
   const citationUrlTitles = React.useMemo(() => {
     if (!message.annotations || message.annotations.length === 0)
@@ -458,22 +458,17 @@ const DefaultMessageComponent = ({
           <>
             {!(isUser && isEditing) && (
               <div
-                className={`w-full ${isUser ? 'flex justify-end px-4 pb-8 pt-8' : 'px-4 py-2'}`}
+                className={`w-full ${isUser ? 'flex justify-end px-4 pb-8 pt-2' : 'px-4 py-2'}`}
               >
                 <div
                   className={cn(
-                    isUser ? 'relative max-w-[95%]' : 'w-full',
+                    isUser ? 'max-w-[95%]' : 'w-full',
                     isUser &&
                       'rounded-site-lg bg-surface-message-user/90 px-4 py-2 shadow-sm backdrop-blur-sm',
                     isLimitError &&
                       'rounded-lg border-2 border-brand-accent-dark/30 bg-brand-accent-dark/5 px-4 py-3',
                   )}
                 >
-                  {isUser && (
-                    <div className="absolute right-0 top-px -translate-y-full rounded-t-site-tab bg-surface-message-user/90 px-2.5 py-1 backdrop-blur-sm">
-                      <MessageMetadata />
-                    </div>
-                  )}
                   {message.isHourlyRateLimitError && (
                     <div className="flex flex-col gap-3">
                       <div className="flex items-center gap-2">

--- a/src/components/chat/renderers/default/DefaultMessageRenderer.tsx
+++ b/src/components/chat/renderers/default/DefaultMessageRenderer.tsx
@@ -239,7 +239,7 @@ const DefaultMessageComponent = ({
     }
   }, [message.timestamp])
   const showAssistantFooter =
-    !isUser && showMetadata && !hideActions && !(isStreaming && isLastMessage)
+    !isUser && showMetadata && !(isStreaming && isLastMessage)
 
   return (
     <div
@@ -718,7 +718,7 @@ const DefaultMessageComponent = ({
               showActions ? 'opacity-100' : 'pointer-events-none opacity-0'
             }`}
           >
-            {message.content && (
+            {!hideActions && message.content && (
               <>
                 {message.webSearch?.sources &&
                   message.webSearch.sources.length > 0 &&

--- a/src/components/chat/renderers/default/DefaultMessageRenderer.tsx
+++ b/src/components/chat/renderers/default/DefaultMessageRenderer.tsx
@@ -7,6 +7,7 @@ import {
   ArrowUturnLeftIcon,
   ChevronDownIcon,
   InformationCircleIcon,
+  LockClosedIcon,
   PencilSquareIcon,
 } from '@heroicons/react/24/outline'
 import React, { memo, useState, type JSX } from 'react'
@@ -29,6 +30,7 @@ import type { MessageRenderer, MessageRenderProps } from '../types'
 const DefaultMessageComponent = ({
   message,
   messageIndex,
+  model,
   isDarkMode,
   isLastMessage,
   isStreaming,
@@ -689,6 +691,24 @@ const DefaultMessageComponent = ({
             )}
           </>
         )}
+
+      <div
+        className={cn(
+          'flex w-full items-center gap-1.5 px-4 text-xs text-content-muted',
+          isUser ? '-mt-6 justify-end pb-1' : 'mt-1 justify-start',
+        )}
+      >
+        {!isUser && (
+          <>
+            <span>{message.modelDisplayName ?? model.name}</span>
+            <span aria-hidden="true">·</span>
+          </>
+        )}
+        <span className="flex items-center gap-1">
+          <LockClosedIcon className="h-3 w-3" aria-hidden="true" />
+          Encrypted
+        </span>
+      </div>
 
       {/* Actions for assistant messages - hidden while streaming the last response */}
       {showAssistantActions && (

--- a/src/components/chat/renderers/default/DefaultMessageRenderer.tsx
+++ b/src/components/chat/renderers/default/DefaultMessageRenderer.tsx
@@ -40,7 +40,7 @@ const MessageMetadata = ({
         <span aria-hidden="true">·</span>
       </>
     )}
-    <span className="flex items-center gap-1">
+    <span className="flex items-center gap-1 text-[10px]">
       <LockClosedIcon className="h-3 w-3" aria-hidden="true" />
       Encrypted
     </span>
@@ -470,7 +470,7 @@ const DefaultMessageComponent = ({
                   )}
                 >
                   {isUser && (
-                    <div className="absolute right-3 top-px -translate-y-full rounded-t-site-tab bg-surface-message-user/90 px-2.5 py-1 backdrop-blur-sm">
+                    <div className="absolute right-0 top-px -translate-y-full rounded-t-site-tab bg-surface-message-user/90 px-2.5 py-1 backdrop-blur-sm">
                       <MessageMetadata />
                     </div>
                   )}

--- a/src/components/chat/renderers/default/DefaultMessageRenderer.tsx
+++ b/src/components/chat/renderers/default/DefaultMessageRenderer.tsx
@@ -15,6 +15,7 @@ import { BsCheckLg } from 'react-icons/bs'
 import { GoClockFill } from 'react-icons/go'
 import { RxCopy } from 'react-icons/rx'
 import { hasMessageAttachments } from '../../attachment-helpers'
+import { hasVisibleAssistantMessage } from '../../hooks/streaming/interrupted-message'
 import { CodeExecProcess } from '../components/CodeExecProcess'
 import { DocumentList } from '../components/DocumentList'
 import { MessageActions } from '../components/MessageActions'
@@ -26,6 +27,25 @@ import { ThoughtProcess } from '../components/ThoughtProcess'
 import { URLFetchProcess } from '../components/URLFetchProcess'
 import { WebSearchProcess } from '../components/WebSearchProcess'
 import type { MessageRenderer, MessageRenderProps } from '../types'
+
+const MessageMetadata = ({
+  modelDisplayName,
+}: {
+  modelDisplayName?: string
+}) => (
+  <div className="flex shrink-0 items-center gap-1.5 text-xs text-content-muted">
+    {modelDisplayName && (
+      <>
+        <span>{modelDisplayName}</span>
+        <span aria-hidden="true">·</span>
+      </>
+    )}
+    <span className="flex items-center gap-1">
+      <LockClosedIcon className="h-3 w-3" aria-hidden="true" />
+      Encrypted
+    </span>
+  </div>
+)
 
 const DefaultMessageComponent = ({
   message,
@@ -53,6 +73,7 @@ const DefaultMessageComponent = ({
   const isLimitError =
     message.isRateLimitError || message.isHourlyRateLimitError
   const modelDisplayName = message.modelDisplayName?.trim()
+  const showMetadata = isUser || hasVisibleAssistantMessage(message)
 
   const citationUrlTitles = React.useMemo(() => {
     if (!message.annotations || message.annotations.length === 0)
@@ -217,11 +238,8 @@ const DefaultMessageComponent = ({
       }),
     }
   }, [message.timestamp])
-  const showAssistantActions =
-    !isUser &&
-    message.content &&
-    !hideActions &&
-    !(isStreaming && isLastMessage)
+  const showAssistantFooter =
+    !isUser && showMetadata && !hideActions && !(isStreaming && isLastMessage)
 
   return (
     <div
@@ -440,17 +458,22 @@ const DefaultMessageComponent = ({
           <>
             {!(isUser && isEditing) && (
               <div
-                className={`w-full ${isUser ? 'flex justify-end px-4 pb-8 pt-2' : 'px-4 py-2'}`}
+                className={`w-full ${isUser ? 'flex justify-end px-4 pb-8 pt-8' : 'px-4 py-2'}`}
               >
                 <div
                   className={cn(
-                    isUser ? 'max-w-[95%]' : 'w-full',
+                    isUser ? 'relative max-w-[95%]' : 'w-full',
                     isUser &&
                       'rounded-site-lg bg-surface-message-user/90 px-4 py-2 shadow-sm backdrop-blur-sm',
                     isLimitError &&
                       'rounded-lg border-2 border-brand-accent-dark/30 bg-brand-accent-dark/5 px-4 py-3',
                   )}
                 >
+                  {isUser && (
+                    <div className="absolute right-3 top-px -translate-y-full rounded-t-site-tab bg-surface-message-user/90 px-2.5 py-1 backdrop-blur-sm">
+                      <MessageMetadata />
+                    </div>
+                  )}
                   {message.isHourlyRateLimitError && (
                     <div className="flex flex-col gap-3">
                       <div className="flex items-center gap-2">
@@ -692,58 +715,47 @@ const DefaultMessageComponent = ({
           </>
         )}
 
-      <div
-        className={cn(
-          'flex w-full items-center gap-1.5 px-4 text-xs text-content-muted',
-          isUser
-            ? isEditing
-              ? 'justify-end pb-1'
-              : '-mt-6 justify-end pb-1'
-            : 'mt-1 justify-end',
-        )}
-      >
-        {!isUser && modelDisplayName && (
-          <>
-            <span>{modelDisplayName}</span>
-            <span aria-hidden="true">·</span>
-          </>
-        )}
-        <span className="flex items-center gap-1">
-          <LockClosedIcon className="h-3 w-3" aria-hidden="true" />
-          Encrypted
-        </span>
-      </div>
-
       {/* Actions for assistant messages - hidden while streaming the last response */}
-      {showAssistantActions && (
-        <div
-          className={`mt-4 flex items-center justify-between gap-3 px-4 transition-opacity duration-500 ease-in-out ${
-            showActions ? 'opacity-100' : 'pointer-events-none opacity-0'
-          }`}
-        >
-          <div className="flex items-center gap-1">
-            {message.webSearch?.sources &&
-              message.webSearch.sources.length > 0 &&
-              !(isStreaming && isLastMessage) && (
-                <SourcesButton sources={message.webSearch.sources} />
-              )}
-            <MessageActions content={message.content} isDarkMode={isDarkMode} />
-            {/* Regenerate button - only on last assistant message */}
-            {isLastMessage && onRegenerateMessage && messageIndex > 0 && (
-              <div className="group/regen relative">
-                <button
-                  onClick={() => onRegenerateMessage(messageIndex - 1)}
-                  aria-label="Regenerate response"
-                  className="flex items-center gap-1.5 rounded px-2 py-2 text-xs font-medium text-content-secondary transition-all hover:bg-surface-chat-background hover:text-content-primary"
-                >
-                  <ArrowPathIcon className="h-3.5 w-3.5" aria-hidden="true" />
-                </button>
-                <span className="pointer-events-none absolute -bottom-8 left-1/2 -translate-x-1/2 whitespace-nowrap rounded border border-border-subtle bg-surface-chat-background px-2 py-1 text-xs text-content-primary opacity-0 shadow-sm transition-opacity group-hover/regen:opacity-100">
-                  Regenerate
-                </span>
-              </div>
+      {showAssistantFooter && (
+        <div className="mt-4 flex w-full items-center justify-between gap-3 px-4">
+          <div
+            className={`flex items-center gap-1 transition-opacity duration-500 ease-in-out ${
+              showActions ? 'opacity-100' : 'pointer-events-none opacity-0'
+            }`}
+          >
+            {message.content && (
+              <>
+                {message.webSearch?.sources &&
+                  message.webSearch.sources.length > 0 &&
+                  !(isStreaming && isLastMessage) && (
+                    <SourcesButton sources={message.webSearch.sources} />
+                  )}
+                <MessageActions
+                  content={message.content}
+                  isDarkMode={isDarkMode}
+                />
+                {/* Regenerate button - only on last assistant message */}
+                {isLastMessage && onRegenerateMessage && messageIndex > 0 && (
+                  <div className="group/regen relative">
+                    <button
+                      onClick={() => onRegenerateMessage(messageIndex - 1)}
+                      aria-label="Regenerate response"
+                      className="flex items-center gap-1.5 rounded px-2 py-2 text-xs font-medium text-content-secondary transition-all hover:bg-surface-chat-background hover:text-content-primary"
+                    >
+                      <ArrowPathIcon
+                        className="h-3.5 w-3.5"
+                        aria-hidden="true"
+                      />
+                    </button>
+                    <span className="pointer-events-none absolute -bottom-8 left-1/2 -translate-x-1/2 whitespace-nowrap rounded border border-border-subtle bg-surface-chat-background px-2 py-1 text-xs text-content-primary opacity-0 shadow-sm transition-opacity group-hover/regen:opacity-100">
+                      Regenerate
+                    </span>
+                  </div>
+                )}
+              </>
             )}
           </div>
+          <MessageMetadata modelDisplayName={modelDisplayName} />
         </div>
       )}
     </div>

--- a/src/components/chat/renderers/default/DefaultMessageRenderer.tsx
+++ b/src/components/chat/renderers/default/DefaultMessageRenderer.tsx
@@ -699,7 +699,7 @@ const DefaultMessageComponent = ({
             ? isEditing
               ? 'justify-end pb-1'
               : '-mt-6 justify-end pb-1'
-            : 'mt-1 justify-start',
+            : 'mt-1 justify-end',
         )}
       >
         {!isUser && modelDisplayName && (

--- a/src/components/chat/renderers/default/DefaultMessageRenderer.tsx
+++ b/src/components/chat/renderers/default/DefaultMessageRenderer.tsx
@@ -30,7 +30,6 @@ import type { MessageRenderer, MessageRenderProps } from '../types'
 const DefaultMessageComponent = ({
   message,
   messageIndex,
-  model,
   isDarkMode,
   isLastMessage,
   isStreaming,
@@ -53,6 +52,7 @@ const DefaultMessageComponent = ({
   const editButtonRef = React.useRef<HTMLButtonElement>(null)
   const isLimitError =
     message.isRateLimitError || message.isHourlyRateLimitError
+  const modelDisplayName = message.modelDisplayName?.trim()
 
   const citationUrlTitles = React.useMemo(() => {
     if (!message.annotations || message.annotations.length === 0)
@@ -695,12 +695,16 @@ const DefaultMessageComponent = ({
       <div
         className={cn(
           'flex w-full items-center gap-1.5 px-4 text-xs text-content-muted',
-          isUser ? '-mt-6 justify-end pb-1' : 'mt-1 justify-start',
+          isUser
+            ? isEditing
+              ? 'justify-end pb-1'
+              : '-mt-6 justify-end pb-1'
+            : 'mt-1 justify-start',
         )}
       >
-        {!isUser && (
+        {!isUser && modelDisplayName && (
           <>
-            <span>{message.modelDisplayName ?? model.name}</span>
+            <span>{modelDisplayName}</span>
             <span aria-hidden="true">·</span>
           </>
         )}

--- a/src/components/chat/share-modal.tsx
+++ b/src/components/chat/share-modal.tsx
@@ -217,6 +217,7 @@ export function ShareModal({
         messages: messages.map((m) => ({
           role: m.role,
           content: m.content,
+          modelDisplayName: m.modelDisplayName,
           documentContent:
             m.documentContent ??
             (m.attachments

--- a/src/components/chat/shared-chat-view.tsx
+++ b/src/components/chat/shared-chat-view.tsx
@@ -62,19 +62,18 @@ export function SharedChatView({
       chatData.messages.map((m) => ({
         role: m.role,
         content: m.content,
+        modelDisplayName: m.modelDisplayName,
         documentContent: m.documentContent,
         documents: m.documents,
         timestamp: new Date(m.timestamp),
         thoughts: m.thoughts,
         thinkingDuration: m.thinkingDuration,
         isError: m.isError,
-        attachments: m.attachments?.map(
-          (a): Attachment => ({
-            ...a,
-            // Use thumbnail as initial display image until full-res loads
-            base64: a.thumbnailBase64,
-          }),
-        ),
+        attachments: m.attachments?.map((a): Attachment => ({
+          ...a,
+          // Use thumbnail as initial display image until full-res loads
+          base64: a.thumbnailBase64,
+        })),
         timeline: m.timeline,
         annotations: m.annotations,
         webSearch: m.webSearch,

--- a/src/components/chat/types.ts
+++ b/src/components/chat/types.ts
@@ -135,6 +135,7 @@ export type Message = {
   role: 'user' | 'assistant'
   content: string
   turnId?: string
+  modelDisplayName?: string
   attachments?: Attachment[]
   // Legacy fields — kept for reading old messages, not written for new ones
   documentContent?: string

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -62,6 +62,19 @@ const DEV_MODELS: BaseModel[] = [
   },
 ]
 
+const modelDisplayNames = new Map<string, string>()
+
+const rememberModelDisplayNames = (models: BaseModel[]): BaseModel[] => {
+  for (const model of [...models, ...getAutoModels(models)]) {
+    modelDisplayNames.set(model.modelName, model.name)
+  }
+  return models
+}
+
+export const getKnownModelDisplayName = (
+  modelName: string,
+): string | undefined => modelDisplayNames.get(modelName)
+
 /**
  * Per-endpoint enable/disable parameter blocks for thinking mode.
  * Keyed by full endpoint path (e.g. "/v1/chat/completions", "/v1/responses").
@@ -326,7 +339,7 @@ export const getAIModels = async (): Promise<BaseModel[]> => {
 
   // In dev mode on localhost, return hardcoded models instead of fetching
   if (IS_DEV && isLocalDev) {
-    return [...DEV_MODELS, DEV_SIMULATOR_MODEL]
+    return rememberModelDisplayNames([...DEV_MODELS, DEV_SIMULATOR_MODEL])
   }
 
   try {
@@ -349,7 +362,7 @@ export const getAIModels = async (): Promise<BaseModel[]> => {
       models.unshift(DEV_SIMULATOR_MODEL)
     }
 
-    return models
+    return rememberModelDisplayNames(models)
   } catch (error) {
     logError('Failed to fetch AI models', error, {
       component: 'getAIModels',

--- a/src/services/cloud/schemas.ts
+++ b/src/services/cloud/schemas.ts
@@ -31,6 +31,7 @@ const MessageSchema = z
     role: z.enum(['user', 'assistant']),
     content: z.string(),
     turnId: RecoveryIdSchema.optional(),
+    modelDisplayName: z.string().min(1).optional(),
   })
   .passthrough()
 

--- a/src/services/cloud/schemas.ts
+++ b/src/services/cloud/schemas.ts
@@ -31,7 +31,7 @@ const MessageSchema = z
     role: z.enum(['user', 'assistant']),
     content: z.string(),
     turnId: RecoveryIdSchema.optional(),
-    modelDisplayName: z.string().min(1).optional(),
+    modelDisplayName: z.string().optional(),
   })
   .passthrough()
 

--- a/src/services/inference/chat-recovery-sync.ts
+++ b/src/services/inference/chat-recovery-sync.ts
@@ -401,6 +401,7 @@ export function sameRecoveredResponse(
   const snapshot = (message: Message) =>
     JSON.stringify({
       content: message.content,
+      modelDisplayName: message.modelDisplayName ?? null,
       thoughts: message.thoughts ?? null,
       isThinking: message.isThinking ?? false,
       thinkingDuration: message.thinkingDuration ?? null,

--- a/src/services/inference/chat-recovery.ts
+++ b/src/services/inference/chat-recovery.ts
@@ -4,6 +4,7 @@ import {
   parseRichStreamingResponse,
 } from '@/components/chat/hooks/streaming'
 import type { Chat, Message } from '@/components/chat/types'
+import { getKnownModelDisplayName } from '@/config/models'
 import { DEFAULT_CHAT_TITLE } from '@/constants/chat'
 import { retryDeferredAlternativesFinalization } from '@/services/cloud/legacy-blob-migration'
 import { encryptionService } from '@/services/encryption/encryption-service'
@@ -695,14 +696,17 @@ async function processEnvelope(
     return draftMessage
   }
   try {
+    const storedChat = await indexedDBStorage.getChat(chatId)
+    if (!isRecoveryCurrent()) return
+    const fallbackModelDisplayName = storedChat?.model
+      ? getKnownModelDisplayName(storedChat.model)
+      : undefined
     const recoveryDraft = getChatRecoveryDraft(chatId, envelope.turnId)
     let presentationCheckpoint =
       recoveryDraft?.sessionId === payload.sessionId
         ? recoveryDraft.message
         : undefined
     if (!presentationCheckpoint) {
-      const storedChat = await indexedDBStorage.getChat(chatId)
-      if (!isRecoveryCurrent()) return
       presentationCheckpoint = (storedChat?.messages ?? []).find(
         (message) =>
           message.role === 'assistant' && message.turnId === envelope.turnId,
@@ -749,6 +753,8 @@ async function processEnvelope(
         assistantMessage = await parseRichStreamingResponse(
           chatChunkStreamFromSSE(response),
           {
+            modelDisplayName: fallbackModelDisplayName,
+            resolveModelDisplayName: getKnownModelDisplayName,
             onUpdate: (message) => {
               if (!isRecoveryCurrent()) return
               if (!checkpointReached && attemptCheckpoint) {

--- a/src/services/inference/chat-stream.ts
+++ b/src/services/inference/chat-stream.ts
@@ -30,6 +30,7 @@ export interface ChatChunk {
     [key: string]: unknown
   }>
   id?: string
+  model?: string
   status?: string
   action?: { query?: string }
   reason?: string

--- a/src/utils/compression.ts
+++ b/src/utils/compression.ts
@@ -101,9 +101,7 @@ export function validateShareableChatData(
       typeof (msg as Record<string, unknown>).content !== 'string' ||
       typeof (msg as Record<string, unknown>).timestamp !== 'number' ||
       ('modelDisplayName' in msg &&
-        (typeof (msg as Record<string, unknown>).modelDisplayName !==
-          'string' ||
-          (msg as Record<string, string>).modelDisplayName.length === 0))
+        typeof (msg as Record<string, unknown>).modelDisplayName !== 'string')
     ) {
       logWarning('Invalid message in shareable chat data', {
         component: 'CompressionUtil',

--- a/src/utils/compression.ts
+++ b/src/utils/compression.ts
@@ -27,6 +27,7 @@ export type ShareableChatData = {
   messages: Array<{
     role: 'user' | 'assistant'
     content: string
+    modelDisplayName?: string
     documentContent?: string
     documents?: Array<{ name: string }>
     timestamp: number
@@ -98,7 +99,11 @@ export function validateShareableChatData(
       ((msg as Record<string, unknown>).role !== 'user' &&
         (msg as Record<string, unknown>).role !== 'assistant') ||
       typeof (msg as Record<string, unknown>).content !== 'string' ||
-      typeof (msg as Record<string, unknown>).timestamp !== 'number'
+      typeof (msg as Record<string, unknown>).timestamp !== 'number' ||
+      ('modelDisplayName' in msg &&
+        (typeof (msg as Record<string, unknown>).modelDisplayName !==
+          'string' ||
+          (msg as Record<string, string>).modelDisplayName.length === 0))
     ) {
       logWarning('Invalid message in shareable chat data', {
         component: 'CompressionUtil',

--- a/tests/components/chat/chat-list-item.test.tsx
+++ b/tests/components/chat/chat-list-item.test.tsx
@@ -249,10 +249,19 @@ describe('ChatListItem streaming timestamp', () => {
       expect(screen.queryByText(/Updated/)).not.toBeInTheDocument()
 
       vi.advanceTimersByTime(5_000)
-      rerenderChat({ ...chat, messageCount: 3 })
+      rerenderChat({
+        ...chat,
+        messageCount: 3,
+        updatedAt: '2026-08-07T00:00:10.000Z',
+      })
 
       expect(screen.getByText('10s ago')).toBeInTheDocument()
       expect(screen.queryByText(/Updated/)).not.toBeInTheDocument()
+
+      rerenderChat(chat, false)
+
+      expect(screen.getByText('15s ago')).toBeInTheDocument()
+      expect(screen.getByText(/Updated 10s ago/)).toBeInTheDocument()
     } finally {
       vi.useRealTimers()
     }

--- a/tests/components/chat/chat-list-item.test.tsx
+++ b/tests/components/chat/chat-list-item.test.tsx
@@ -258,10 +258,17 @@ describe('ChatListItem streaming timestamp', () => {
       expect(screen.getByText('10s ago')).toBeInTheDocument()
       expect(screen.queryByText(/Updated/)).not.toBeInTheDocument()
 
-      rerenderChat(chat, false)
+      rerenderChat(
+        {
+          ...chat,
+          messageCount: 3,
+          updatedAt: '2026-08-07T00:00:10.000Z',
+        },
+        false,
+      )
 
       expect(screen.getByText('15s ago')).toBeInTheDocument()
-      expect(screen.getByText(/Updated 10s ago/)).toBeInTheDocument()
+      expect(screen.getByText(/Updated 5s ago/)).toBeInTheDocument()
     } finally {
       vi.useRealTimers()
     }

--- a/tests/components/chat/chat-list-item.test.tsx
+++ b/tests/components/chat/chat-list-item.test.tsx
@@ -28,7 +28,7 @@ function renderChatListItem({
   enableTitleAnimation?: boolean
   isStreaming?: boolean
 } = {}) {
-  const renderItem = (item: ChatItemData) => (
+  const renderItem = (item: ChatItemData, streaming: boolean) => (
     <ChatListItem
       chat={item}
       href={href}
@@ -38,7 +38,7 @@ function renderChatListItem({
       isDarkMode={false}
       pixelateSidebarChatTitles={pixelateSidebarChatTitles}
       enableTitleAnimation={enableTitleAnimation}
-      isStreaming={isStreaming}
+      isStreaming={streaming}
       onSelect={onSelect}
       onStartEdit={vi.fn()}
       onTitleChange={vi.fn()}
@@ -47,11 +47,11 @@ function renderChatListItem({
       onRequestDelete={vi.fn()}
     />
   )
-  const view = render(renderItem(chat))
+  const view = render(renderItem(chat, isStreaming))
   return {
     onSelect,
-    rerenderChat: (updatedChat: ChatItemData) =>
-      view.rerender(renderItem(updatedChat)),
+    rerenderChat: (updatedChat: ChatItemData, streaming = isStreaming) =>
+      view.rerender(renderItem(updatedChat, streaming)),
   }
 }
 
@@ -230,5 +230,31 @@ describe('ChatListItem timestamps', () => {
     })
 
     expect(screen.getByTitle('New chat')).toBeInTheDocument()
+  })
+})
+
+describe('ChatListItem streaming timestamp', () => {
+  it('keeps relative time stable and hides updated time while streaming', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-08-07T00:00:10.000Z'))
+    const chat = {
+      ...savedChat,
+      createdAt: '2026-08-07T00:00:00.000Z',
+      updatedAt: '2026-08-07T00:00:05.000Z',
+    }
+
+    try {
+      const { rerenderChat } = renderChatListItem({ chat, isStreaming: true })
+      expect(screen.getByText('10s ago')).toBeInTheDocument()
+      expect(screen.queryByText(/Updated/)).not.toBeInTheDocument()
+
+      vi.advanceTimersByTime(5_000)
+      rerenderChat({ ...chat, messageCount: 3 })
+
+      expect(screen.getByText('10s ago')).toBeInTheDocument()
+      expect(screen.queryByText(/Updated/)).not.toBeInTheDocument()
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/tests/components/chat/default-message-renderer.test.tsx
+++ b/tests/components/chat/default-message-renderer.test.tsx
@@ -35,6 +35,9 @@ describe('DefaultMessageRenderer metadata', () => {
 
     expect(screen.getByText('Encrypted')).toBeInTheDocument()
     expect(screen.queryByText('Current Model')).not.toBeInTheDocument()
+    expect(
+      screen.getByText('Encrypted').parentElement?.parentElement,
+    ).toHaveClass('rounded-t-site-tab')
   })
 
   it('shows the persisted model name and encrypted under responses', () => {
@@ -48,9 +51,9 @@ describe('DefaultMessageRenderer metadata', () => {
     expect(screen.getByText('Retired Model')).toBeInTheDocument()
     expect(screen.getByText('Encrypted')).toBeInTheDocument()
     expect(screen.queryByText('Current Model')).not.toBeInTheDocument()
-    expect(screen.getByText('Retired Model').parentElement).toHaveClass(
-      'justify-end',
-    )
+    expect(
+      screen.getByText('Retired Model').parentElement?.parentElement,
+    ).toContainElement(screen.getByRole('button', { name: 'Copy message' }))
   })
 
   it('does not attribute legacy responses to the current model', () => {
@@ -62,5 +65,17 @@ describe('DefaultMessageRenderer metadata', () => {
 
     expect(screen.queryByText('Current Model')).not.toBeInTheDocument()
     expect(screen.getByText('Encrypted')).toBeInTheDocument()
+  })
+
+  it('does not show metadata for an empty cancelled response', () => {
+    renderMessage({
+      role: 'assistant',
+      content: '',
+      modelDisplayName: 'Retired Model',
+      timestamp: new Date('2026-08-07T00:00:01.000Z'),
+    })
+
+    expect(screen.queryByText('Retired Model')).not.toBeInTheDocument()
+    expect(screen.queryByText('Encrypted')).not.toBeInTheDocument()
   })
 })

--- a/tests/components/chat/default-message-renderer.test.tsx
+++ b/tests/components/chat/default-message-renderer.test.tsx
@@ -15,13 +15,14 @@ const model = {
 
 const Renderer = DefaultMessageRenderer.render
 
-const renderMessage = (message: Message) =>
+const renderMessage = (message: Message, hideActions = false) =>
   render(
     <Renderer
       message={message}
       messageIndex={0}
       model={model}
       isDarkMode={false}
+      hideActions={hideActions}
     />,
   )
 
@@ -74,5 +75,23 @@ describe('DefaultMessageRenderer metadata', () => {
 
     expect(screen.queryByText('Retired Model')).not.toBeInTheDocument()
     expect(screen.queryByText('Encrypted')).not.toBeInTheDocument()
+  })
+
+  it('shows response metadata when actions are hidden', () => {
+    renderMessage(
+      {
+        role: 'assistant',
+        content: 'Hello',
+        modelDisplayName: 'Retired Model',
+        timestamp: new Date('2026-08-07T00:00:01.000Z'),
+      },
+      true,
+    )
+
+    expect(screen.getByText('Retired Model')).toBeInTheDocument()
+    expect(screen.getByText('Encrypted')).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'Copy message' }),
+    ).not.toBeInTheDocument()
   })
 })

--- a/tests/components/chat/default-message-renderer.test.tsx
+++ b/tests/components/chat/default-message-renderer.test.tsx
@@ -49,4 +49,15 @@ describe('DefaultMessageRenderer metadata', () => {
     expect(screen.getByText('Encrypted')).toBeInTheDocument()
     expect(screen.queryByText('Current Model')).not.toBeInTheDocument()
   })
+
+  it('does not attribute legacy responses to the current model', () => {
+    renderMessage({
+      role: 'assistant',
+      content: 'Hello',
+      timestamp: new Date('2026-08-07T00:00:01.000Z'),
+    })
+
+    expect(screen.queryByText('Current Model')).not.toBeInTheDocument()
+    expect(screen.getByText('Encrypted')).toBeInTheDocument()
+  })
 })

--- a/tests/components/chat/default-message-renderer.test.tsx
+++ b/tests/components/chat/default-message-renderer.test.tsx
@@ -26,18 +26,15 @@ const renderMessage = (message: Message) =>
   )
 
 describe('DefaultMessageRenderer metadata', () => {
-  it('shows encrypted under user messages', () => {
+  it('does not show assistant metadata on user messages', () => {
     renderMessage({
       role: 'user',
       content: 'Hello',
       timestamp: new Date('2026-08-07T00:00:00.000Z'),
     })
 
-    expect(screen.getByText('Encrypted')).toBeInTheDocument()
+    expect(screen.queryByText('Encrypted')).not.toBeInTheDocument()
     expect(screen.queryByText('Current Model')).not.toBeInTheDocument()
-    expect(
-      screen.getByText('Encrypted').parentElement?.parentElement,
-    ).toHaveClass('rounded-t-site-tab')
   })
 
   it('shows the persisted model name and encrypted under responses', () => {

--- a/tests/components/chat/default-message-renderer.test.tsx
+++ b/tests/components/chat/default-message-renderer.test.tsx
@@ -48,6 +48,9 @@ describe('DefaultMessageRenderer metadata', () => {
     expect(screen.getByText('Retired Model')).toBeInTheDocument()
     expect(screen.getByText('Encrypted')).toBeInTheDocument()
     expect(screen.queryByText('Current Model')).not.toBeInTheDocument()
+    expect(screen.getByText('Retired Model').parentElement).toHaveClass(
+      'justify-end',
+    )
   })
 
   it('does not attribute legacy responses to the current model', () => {

--- a/tests/components/chat/default-message-renderer.test.tsx
+++ b/tests/components/chat/default-message-renderer.test.tsx
@@ -1,0 +1,52 @@
+import { DefaultMessageRenderer } from '@/components/chat/renderers/default/DefaultMessageRenderer'
+import type { Message } from '@/components/chat/types'
+import type { BaseModel } from '@/config/models'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+const model = {
+  modelName: 'current-model',
+  name: 'Current Model',
+  nameShort: 'Current',
+  image: '',
+  description: '',
+  type: 'chat',
+} satisfies BaseModel
+
+const Renderer = DefaultMessageRenderer.render
+
+const renderMessage = (message: Message) =>
+  render(
+    <Renderer
+      message={message}
+      messageIndex={0}
+      model={model}
+      isDarkMode={false}
+    />,
+  )
+
+describe('DefaultMessageRenderer metadata', () => {
+  it('shows encrypted under user messages', () => {
+    renderMessage({
+      role: 'user',
+      content: 'Hello',
+      timestamp: new Date('2026-08-07T00:00:00.000Z'),
+    })
+
+    expect(screen.getByText('Encrypted')).toBeInTheDocument()
+    expect(screen.queryByText('Current Model')).not.toBeInTheDocument()
+  })
+
+  it('shows the persisted model name and encrypted under responses', () => {
+    renderMessage({
+      role: 'assistant',
+      content: 'Hello',
+      modelDisplayName: 'Retired Model',
+      timestamp: new Date('2026-08-07T00:00:01.000Z'),
+    })
+
+    expect(screen.getByText('Retired Model')).toBeInTheDocument()
+    expect(screen.getByText('Encrypted')).toBeInTheDocument()
+    expect(screen.queryByText('Current Model')).not.toBeInTheDocument()
+  })
+})

--- a/tests/components/chat/streaming/message-assembler.test.ts
+++ b/tests/components/chat/streaming/message-assembler.test.ts
@@ -16,6 +16,12 @@ describe('MessageAssembler', () => {
       expect(msg.role).toBe('assistant')
     })
 
+    it('stores the model display name on the message', () => {
+      const asm = new MessageAssembler('Kimi K2.6')
+
+      expect(asm.toMessage([]).modelDisplayName).toBe('Kimi K2.6')
+    })
+
     it('derives thoughts from thinking blocks', () => {
       const asm = new MessageAssembler()
       const timeline: TimelineBlock[] = [

--- a/tests/components/chat/streaming/process-stream.test.ts
+++ b/tests/components/chat/streaming/process-stream.test.ts
@@ -104,6 +104,27 @@ describe('processStreamingResponse lifecycle', () => {
     expect(endStreamingMock).not.toHaveBeenCalled()
   })
 
+  it('stores the routed model display name in the response', async () => {
+    const stream = (async function* (): ChatChunkStream {
+      yield {
+        model: 'kimi-k2-6',
+        choices: [{ delta: { content: 'Hello' } }],
+      }
+      yield { choices: [{ delta: {}, finish_reason: 'stop' }] }
+    })()
+
+    const message = await processStreamingResponse(
+      stream,
+      createContext({
+        modelDisplayName: 'Auto · Smart',
+        resolveModelDisplayName: (modelName) =>
+          modelName === 'kimi-k2-6' ? 'Kimi K2.6' : undefined,
+      }),
+    )
+
+    expect(message?.modelDisplayName).toBe('Kimi K2.6')
+  })
+
   it('does not start tracking an already-aborted stream', async () => {
     const controller = new AbortController()
     controller.abort()

--- a/tests/components/chat/streaming/process-stream.test.ts
+++ b/tests/components/chat/streaming/process-stream.test.ts
@@ -125,6 +125,22 @@ describe('processStreamingResponse lifecycle', () => {
     expect(message?.modelDisplayName).toBe('Kimi K2.6')
   })
 
+  it('does not publish a model-only assistant snapshot', async () => {
+    const stream = (async function* (): ChatChunkStream {
+      yield { model: 'kimi-k2-6', choices: [{ delta: { role: 'assistant' } }] }
+      yield { choices: [{ delta: {}, finish_reason: 'stop' }] }
+    })()
+    const context = createContext({
+      modelDisplayName: 'Kimi K2.6',
+      resolveModelDisplayName: () => 'Kimi K2.6',
+    })
+
+    const message = await processStreamingResponse(stream, context)
+
+    expect(message?.modelDisplayName).toBe('Kimi K2.6')
+    expect(context.onUpdate).not.toHaveBeenCalled()
+  })
+
   it('does not start tracking an already-aborted stream', async () => {
     const controller = new AbortController()
     controller.abort()

--- a/tests/components/chat/use-chat-messaging.cancel-generation.test.tsx
+++ b/tests/components/chat/use-chat-messaging.cancel-generation.test.tsx
@@ -1,5 +1,6 @@
 import { useChatMessaging } from '@/components/chat/hooks/use-chat-messaging'
 import type { Chat } from '@/components/chat/types'
+import type { BaseModel } from '@/config/models'
 import {
   clearActiveChatRecoveries,
   setChatRecoveryActive,
@@ -16,6 +17,16 @@ const moveStatusMock = vi.fn()
 const registerControllerMock = vi.fn()
 const clearControllerMock = vi.fn()
 const streamStatuses: Record<string, object> = {}
+const testModels = [
+  {
+    modelName: 'test-model',
+    image: '',
+    name: 'Test Model',
+    nameShort: 'Test',
+    description: '',
+    type: 'chat',
+  },
+] satisfies BaseModel[]
 const {
   authState,
   cancelChatRecoveryMock,
@@ -321,7 +332,7 @@ describe('useChatMessaging cancelGeneration', () => {
         systemPrompt: '',
         rules: '',
         storeHistory: true,
-        models: [],
+        models: testModels,
         selectedModel: 'test-model',
         chats: [chat],
         currentChat: chat,
@@ -348,7 +359,7 @@ describe('useChatMessaging cancelGeneration', () => {
         systemPrompt: '',
         rules: '',
         storeHistory: true,
-        models: [],
+        models: testModels,
         selectedModel: 'test-model',
         chats: [chat],
         currentChat: chat,
@@ -377,7 +388,7 @@ describe('useChatMessaging cancelGeneration', () => {
         systemPrompt: '',
         rules: '',
         storeHistory: true,
-        models: [],
+        models: testModels,
         selectedModel: 'test-model',
         chats: [chat],
         currentChat: chat,
@@ -400,7 +411,7 @@ describe('useChatMessaging cancelGeneration', () => {
           systemPrompt: '',
           rules: '',
           storeHistory: true,
-          models: [],
+          models: testModels,
           selectedModel: 'test-model',
           chats: [currentChat],
           currentChat,

--- a/tests/components/chat/use-chat-messaging.metadata-only-send.test.tsx
+++ b/tests/components/chat/use-chat-messaging.metadata-only-send.test.tsx
@@ -30,8 +30,9 @@ vi.mock('@/components/project', () => ({
 }))
 
 vi.mock('@/config/models', () => ({
+  getKnownModelDisplayName: () => 'Test Model',
   resolveModelSelection: () => ({
-    model: { modelName: 'test-model' },
+    model: { modelName: 'test-model', name: 'Test Model' },
     autoCandidates: undefined,
   }),
 }))

--- a/tests/components/chat/use-chat-messaging.stop-stream.test.tsx
+++ b/tests/components/chat/use-chat-messaging.stop-stream.test.tsx
@@ -78,8 +78,9 @@ vi.mock('@/components/project', () => ({
 }))
 
 vi.mock('@/config/models', () => ({
+  getKnownModelDisplayName: () => 'Test Model',
   resolveModelSelection: () => ({
-    model: { modelName: 'test-model' },
+    model: { modelName: 'test-model', name: 'Test Model' },
     autoCandidates: undefined,
   }),
 }))

--- a/tests/components/chat/use-sidebar-chat.test.tsx
+++ b/tests/components/chat/use-sidebar-chat.test.tsx
@@ -21,7 +21,10 @@ vi.mock('@/services/cloud/streaming-tracker', () => ({
 }))
 
 vi.mock('@/config/models', () => ({
-  resolveModelSelection: () => ({ model: { modelName: 'test-model' } }),
+  getKnownModelDisplayName: () => 'Test Model',
+  resolveModelSelection: () => ({
+    model: { modelName: 'test-model', name: 'Test Model' },
+  }),
 }))
 
 vi.mock('@/services/inference/inference-client', () => ({

--- a/tests/services/cloud/chat-codec.test.ts
+++ b/tests/services/cloud/chat-codec.test.ts
@@ -50,6 +50,23 @@ describe('Chat Codec - processRemoteChat', () => {
       expect(result.chat.decryptionFailed).toBeUndefined()
     })
 
+    it('preserves assistant model display names', async () => {
+      const result = await processRemoteChat({
+        ...baseRemoteChat,
+        plaintext: basePlaintext({
+          messages: [
+            {
+              role: 'assistant',
+              content: 'Hello',
+              modelDisplayName: 'GPT-OSS 120B',
+            },
+          ],
+        }),
+      })
+
+      expect(result.chat.messages[0].modelDisplayName).toBe('GPT-OSS 120B')
+    })
+
     it('sets sync metadata on decoded chat', async () => {
       const result = await processRemoteChat({
         ...baseRemoteChat,

--- a/tests/services/inference/chat-recovery-sync.test.ts
+++ b/tests/services/inference/chat-recovery-sync.test.ts
@@ -97,6 +97,7 @@ import {
   removePendingRecovery,
   replacePendingRecovery,
   resetChatRecoverySyncState,
+  sameRecoveredResponse,
 } from '@/services/inference/chat-recovery-sync'
 
 function message(
@@ -120,6 +121,16 @@ function envelope(turnId: string): PendingRecoveryEnvelope {
     ciphertext: 'AAAAAAAAAAAAAAAAAAAAAAAA',
   }
 }
+
+it('compares recovered model display names', () => {
+  const existing = {
+    ...message('assistant', 'Answer', 'turn-1'),
+    modelDisplayName: 'Model A',
+  }
+  const recovered = { ...existing, modelDisplayName: 'Model B' }
+
+  expect(sameRecoveredResponse(existing, recovered)).toBe(false)
+})
 
 function currentEnvelope(turnId: string): PendingRecoveryEnvelope {
   return (

--- a/tests/utils/compression.test.ts
+++ b/tests/utils/compression.test.ts
@@ -264,6 +264,13 @@ describe('compression', () => {
       expect(parseShareableChatData(jsonString)).toBeNull()
     })
 
+    it('should return null for an invalid model display name', () => {
+      const data = createValidShareableChatData()
+      ;(data.messages[1] as Record<string, unknown>).modelDisplayName = 42
+
+      expect(parseShareableChatData(JSON.stringify(data))).toBeNull()
+    })
+
     it('should return null for missing message content', () => {
       const chatData = createValidShareableChatData()
       delete (chatData.messages[0] as any).content


### PR DESCRIPTION
## Summary
- persist each assistant response's model display name, including Auto-routed and recovered streams
- show encrypted metadata beneath user and assistant messages across chat, shared, and printable views
- validate and preserve model metadata through cloud sync and sharing

## Testing
- `npx tsc --noEmit`
- targeted Vitest suites (129 tests)
- ESLint and Prettier checks for changed files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the assistant’s model name and an Encrypted badge under assistant messages, and stabilize chat timestamps while streaming. Previously, user messages were labeled as encrypted and model names could shift during streaming/recovery; now chat/shared only badge assistant messages and persist accurate model attribution.

- Persist and resolve model attribution: store `modelDisplayName` on assistant messages (including auto-routed and recovered streams); resolve streamed model IDs via a cached map in `config/models` with a stored-model fallback; skip publishing model‑only snapshots.
- UI: right-align “Model · Encrypted” under assistant messages; hide metadata for empty/cancelled responses and keep it visible when actions are hidden; in printable, always show “Encrypted” and include the model for assistant messages; remove the encryption badge from user messages in chat/shared.
- Data compatibility: add optional `modelDisplayName` to cloud sync and share/compression schemas.
- Chat list timestamps: keep relative time fixed while streaming, hide “Updated” until streaming ends, and omit “Updated” when equal to created.

<sup>Written for commit c9dbf6d6ca83143144c31255ed5d20e82ea98913. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/465?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

