### PR TITLE
fix: preserve model reasoning according to history policy

### DIFF
--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -1,9 +1,9 @@
 import {
   findSelectableModel,
   getAIModels,
+  getReasoningHistoryPolicy,
   getResolvedModelContextWindow,
   getSystemPromptAndRules,
-  requiresCompleteReasoningHistory,
   resolveModelSelection,
   type BaseModel,
 } from '@/config/models'
@@ -1452,7 +1452,7 @@ export function ChatInterface({
     preferToolCalling:
       effectiveWebSearchEnabled || codeExecutionEnabled || genUIEnabled,
   })
-  const includeReasoningInContext = requiresCompleteReasoningHistory(
+  const reasoningHistoryPolicy = getReasoningHistoryPolicy(
     contextModelSelection,
   )
   const contextWindow = getResolvedModelContextWindow(contextModelSelection)
@@ -2401,12 +2401,12 @@ export function ChatInterface({
         pendingContextTokens,
       )
       const startIndex = findContextStartIndex(messages, historyBudget, {
-        includeReasoning: includeReasoningInContext,
+        reasoningHistoryPolicy,
         keepMostRecent: pendingContextTokens === 0,
       })
       for (let i = startIndex; i < messages.length; i++) {
         usedTokens += estimateMessageTokens(messages[i], {
-          includeReasoning: includeReasoningInContext,
+          reasoningHistoryPolicy,
         })
       }
     }
@@ -2419,7 +2419,7 @@ export function ChatInterface({
   }, [
     currentChat?.messages,
     contextWindow,
-    includeReasoningInContext,
+    reasoningHistoryPolicy,
     pendingContextTokens,
   ])
 
@@ -3493,7 +3493,7 @@ export function ChatInterface({
                     pendingRecoveries={currentChat?.pendingRecoveries}
                     recoveryDrafts={recoveryDrafts}
                     activeRecoveryTurnIds={activeRecoveryTurnIds}
-                    includeReasoningInContext={includeReasoningInContext}
+                    reasoningHistoryPolicy={reasoningHistoryPolicy}
                     contextWindow={contextWindow}
                     pendingContextTokens={pendingContextTokens}
                     isDarkMode={isDarkMode}

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -1440,8 +1440,8 @@ export function ChatInterface({
   // Get the selected model details
   const selectedModelDetails = findSelectableModel(selectedModel, models) as
     BaseModel | undefined
-  const contextModelSelection = resolveModelSelection(selectedModel, models, {
-    preferMultimodal:
+  const prefersMultimodalContext = useMemo(
+    () =>
       currentChat?.messages.some(
         (message) => getMessageImages(message).length > 0,
       ) ||
@@ -1449,6 +1449,10 @@ export function ChatInterface({
         (document) =>
           Boolean(document.imageData) || document.attachment?.type === 'image',
       ),
+    [currentChat?.messages, processedDocuments],
+  )
+  const contextModelSelection = resolveModelSelection(selectedModel, models, {
+    preferMultimodal: prefersMultimodalContext,
     preferToolCalling:
       effectiveWebSearchEnabled || codeExecutionEnabled || genUIEnabled,
   })
@@ -2462,23 +2466,16 @@ export function ChatInterface({
       return
     }
 
-    // Filter out documents that are still uploading or generating descriptions
-    const completedDocuments = processedDocuments.filter(
-      (doc) =>
-        !doc.isUploading && !doc.isGeneratingDescription && !doc.isUnsupported,
-    )
-
     const messageText = input.trim()
+    const attachments = buildCompletedAttachments(processedDocuments)
 
     // Don't proceed if there's no input text, no quote, and no documents
-    if (!messageText && !quote && completedDocuments.length === 0) {
+    if (!messageText && !quote && attachments.length === 0) {
       return
     }
 
     // Don't auto-scroll here - let the message append handler do it
     // This prevents the dip when thoughts start streaming
-
-    const attachments = buildCompletedAttachments(completedDocuments)
 
     setInput('')
     submitMessage({

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -1,7 +1,10 @@
 import {
   findSelectableModel,
   getAIModels,
+  getResolvedModelContextWindow,
   getSystemPromptAndRules,
+  requiresCompleteReasoningHistory,
+  resolveModelSelection,
   type BaseModel,
 } from '@/config/models'
 import { DEFAULT_CHAT_TITLE, TEMPORARY_CHAT_TITLE } from '@/constants/chat'
@@ -46,6 +49,7 @@ import { GoSidebarCollapse } from 'react-icons/go'
 import { IoShareOutline } from 'react-icons/io5'
 import { PiFilePlusLight, PiNotePencilLight, PiSpinner } from 'react-icons/pi'
 import { SlGhost } from 'react-icons/sl'
+import { getMessageImages } from './attachment-helpers'
 
 import {
   RateLimitBanner,
@@ -90,6 +94,7 @@ import {
   estimateTokenCount,
   findContextStartIndex,
   getContextTokenBudget,
+  getHistoryTokenBudget,
 } from '@/utils/token-estimation'
 import { TfTinSad } from '@tinfoilsh/tinfoil-icons'
 import dynamic from 'next/dynamic'
@@ -239,6 +244,40 @@ function buildAttachment(opts: {
     }
   }
   return undefined
+}
+
+function buildCompletedAttachments(
+  documents: ProcessedDocument[],
+): Attachment[] {
+  return documents
+    .filter(
+      (document) =>
+        !document.isUploading &&
+        !document.isGeneratingDescription &&
+        !document.isUnsupported &&
+        (!document.isImageDescription ||
+          document.imageData ||
+          document.attachment),
+    )
+    .map((document) => {
+      if (document.attachment) return document.attachment
+      return (
+        buildAttachment({
+          id: document.id,
+          fileName: document.name,
+          imageData: document.imageData ?? undefined,
+          textContent: document.content ?? undefined,
+          description:
+            document.isImageDescription && document.content
+              ? document.content
+              : undefined,
+        }) ?? {
+          id: document.id,
+          type: 'document' as const,
+          fileName: document.name,
+        }
+      )
+    })
 }
 
 export function ChatInterface({
@@ -1401,6 +1440,30 @@ export function ChatInterface({
   // Get the selected model details
   const selectedModelDetails = findSelectableModel(selectedModel, models) as
     BaseModel | undefined
+  const contextModelSelection = resolveModelSelection(selectedModel, models, {
+    preferMultimodal:
+      currentChat?.messages.some(
+        (message) => getMessageImages(message).length > 0,
+      ) ||
+      processedDocuments.some(
+        (document) =>
+          Boolean(document.imageData) || document.attachment?.type === 'image',
+      ),
+    preferToolCalling:
+      effectiveWebSearchEnabled || codeExecutionEnabled || genUIEnabled,
+  })
+  const includeReasoningInContext = requiresCompleteReasoningHistory(
+    contextModelSelection,
+  )
+  const contextWindow = getResolvedModelContextWindow(contextModelSelection)
+  const pendingAttachments = buildCompletedAttachments(processedDocuments)
+  const pendingContextTokens = estimateMessageTokens({
+    role: 'user',
+    content: input.trim(),
+    attachments: pendingAttachments,
+    quote: quote ?? undefined,
+    timestamp: new Date(),
+  })
 
   // Initialize document uploader hook
   const { handleDocumentUpload, describeImageWithMultimodal } =
@@ -2325,27 +2388,27 @@ export function ChatInterface({
 
   // Calculate context usage (memoized to prevent re-calculation during streaming)
   const contextUsage = useMemo(() => {
-    const limitTokens = getContextTokenBudget(
-      selectedModelDetails?.contextWindow,
-    )
+    const limitTokens = getContextTokenBudget(contextWindow)
 
-    let usedTokens = estimateTokenCount(input)
+    let usedTokens = pendingContextTokens
 
     // Count tokens from messages (including their attachments), skipping
     // archived messages that are excluded from the prompt
     if (currentChat?.messages) {
       const messages = currentChat.messages
-      const startIndex = findContextStartIndex(messages, limitTokens)
-      for (let i = startIndex; i < messages.length; i++) {
-        usedTokens += estimateMessageTokens(messages[i])
-      }
-    }
-
-    // Count tokens from pending documents not yet attached to a message
-    if (processedDocuments) {
-      processedDocuments.forEach((doc) => {
-        usedTokens += estimateTokenCount(doc.content)
+      const historyBudget = getHistoryTokenBudget(
+        contextWindow,
+        pendingContextTokens,
+      )
+      const startIndex = findContextStartIndex(messages, historyBudget, {
+        includeReasoning: includeReasoningInContext,
+        keepMostRecent: pendingContextTokens === 0,
       })
+      for (let i = startIndex; i < messages.length; i++) {
+        usedTokens += estimateMessageTokens(messages[i], {
+          includeReasoning: includeReasoningInContext,
+        })
+      }
     }
 
     return {
@@ -2354,10 +2417,10 @@ export function ChatInterface({
       limitTokens,
     }
   }, [
-    input,
     currentChat?.messages,
-    processedDocuments,
-    selectedModelDetails?.contextWindow,
+    contextWindow,
+    includeReasoningInContext,
+    pendingContextTokens,
   ])
 
   // Tracks whether the user already saw and dismissed the rate-limit modal
@@ -2415,27 +2478,7 @@ export function ChatInterface({
     // Don't auto-scroll here - let the message append handler do it
     // This prevents the dip when thoughts start streaming
 
-    // Build unified attachments array from completed documents
-    const attachments: Attachment[] = completedDocuments
-      .filter(
-        (doc) => !doc.isImageDescription || doc.imageData || doc.attachment,
-      )
-      .map((doc) => {
-        // Use pre-built attachment if available
-        if (doc.attachment) return doc.attachment
-
-        // Build attachment from legacy ProcessedDocument fields
-        return (
-          buildAttachment({
-            id: doc.id,
-            fileName: doc.name,
-            imageData: doc.imageData ?? undefined,
-            textContent: doc.content ?? undefined,
-            description:
-              doc.isImageDescription && doc.content ? doc.content : undefined,
-          }) ?? { id: doc.id, type: 'document' as const, fileName: doc.name }
-        )
-      })
+    const attachments = buildCompletedAttachments(completedDocuments)
 
     setInput('')
     submitMessage({
@@ -3450,6 +3493,9 @@ export function ChatInterface({
                     pendingRecoveries={currentChat?.pendingRecoveries}
                     recoveryDrafts={recoveryDrafts}
                     activeRecoveryTurnIds={activeRecoveryTurnIds}
+                    includeReasoningInContext={includeReasoningInContext}
+                    contextWindow={contextWindow}
+                    pendingContextTokens={pendingContextTokens}
                     isDarkMode={isDarkMode}
                     chatId={currentChat.id}
                     isWaitingForResponse={isWaitingForResponse}

--- a/src/components/chat/chat-messages.tsx
+++ b/src/components/chat/chat-messages.tsx
@@ -2,6 +2,10 @@ import { GridTexture } from '@/components/ui/grid-texture'
 import { findSelectableModel, type BaseModel } from '@/config/models'
 import { useChatPrint } from '@/hooks/use-chat-print'
 import {
+  REASONING_HISTORY_POLICIES,
+  type ReasoningHistoryPolicy,
+} from '@/utils/reasoning-history'
+import {
   findContextStartIndex,
   getHistoryTokenBudget,
 } from '@/utils/token-estimation'
@@ -23,7 +27,7 @@ type ChatMessagesProps = {
   pendingRecoveries?: PendingRecoveryEnvelope[]
   recoveryDrafts?: ReadonlyArray<{ turnId: string; message: Message }>
   activeRecoveryTurnIds?: readonly string[]
-  includeReasoningInContext?: boolean
+  reasoningHistoryPolicy?: ReasoningHistoryPolicy
   contextWindow?: string
   pendingContextTokens?: number
   isDarkMode: boolean
@@ -241,7 +245,7 @@ export function ChatMessages({
   pendingRecoveries = [],
   recoveryDrafts = [],
   activeRecoveryTurnIds = [],
-  includeReasoningInContext = false,
+  reasoningHistoryPolicy = REASONING_HISTORY_POLICIES.none,
   contextWindow,
   pendingContextTokens = 0,
   isDarkMode,
@@ -345,7 +349,7 @@ export function ChatMessages({
       pendingContextTokens,
     )
     const startIndex = findContextStartIndex(messages, budget, {
-      includeReasoning: includeReasoningInContext,
+      reasoningHistoryPolicy,
       keepMostRecent: pendingContextTokens === 0,
     })
     return {
@@ -356,7 +360,7 @@ export function ChatMessages({
     messages,
     contextWindow,
     currentModel?.contextWindow,
-    includeReasoningInContext,
+    reasoningHistoryPolicy,
     pendingContextTokens,
   ])
 

--- a/src/components/chat/chat-messages.tsx
+++ b/src/components/chat/chat-messages.tsx
@@ -3,7 +3,7 @@ import { findSelectableModel, type BaseModel } from '@/config/models'
 import { useChatPrint } from '@/hooks/use-chat-print'
 import {
   findContextStartIndex,
-  getContextTokenBudget,
+  getHistoryTokenBudget,
 } from '@/utils/token-estimation'
 import 'katex/dist/katex.min.css'
 import React, { memo, useEffect, useId, useMemo, useRef, useState } from 'react'
@@ -23,6 +23,9 @@ type ChatMessagesProps = {
   pendingRecoveries?: PendingRecoveryEnvelope[]
   recoveryDrafts?: ReadonlyArray<{ turnId: string; message: Message }>
   activeRecoveryTurnIds?: readonly string[]
+  includeReasoningInContext?: boolean
+  contextWindow?: string
+  pendingContextTokens?: number
   isDarkMode: boolean
   chatId: string
   isWaitingForResponse?: boolean
@@ -238,6 +241,9 @@ export function ChatMessages({
   pendingRecoveries = [],
   recoveryDrafts = [],
   activeRecoveryTurnIds = [],
+  includeReasoningInContext = false,
+  contextWindow,
+  pendingContextTokens = 0,
   isDarkMode,
   chatId,
   isWaitingForResponse = false,
@@ -334,13 +340,25 @@ export function ChatMessages({
 
   // Separate messages into archived and live sections - memoize this calculation
   const { archivedMessages, liveMessages } = useMemo(() => {
-    const budget = getContextTokenBudget(currentModel?.contextWindow)
-    const startIndex = findContextStartIndex(messages, budget)
+    const budget = getHistoryTokenBudget(
+      contextWindow ?? currentModel?.contextWindow,
+      pendingContextTokens,
+    )
+    const startIndex = findContextStartIndex(messages, budget, {
+      includeReasoning: includeReasoningInContext,
+      keepMostRecent: pendingContextTokens === 0,
+    })
     return {
       archivedMessages: messages.slice(0, startIndex),
       liveMessages: messages.slice(startIndex),
     }
-  }, [messages, currentModel?.contextWindow])
+  }, [
+    messages,
+    contextWindow,
+    currentModel?.contextWindow,
+    includeReasoningInContext,
+    pendingContextTokens,
+  ])
 
   useEffect(() => {
     setMounted(true)

--- a/src/components/chat/hooks/streaming/event-normalizer.ts
+++ b/src/components/chat/hooks/streaming/event-normalizer.ts
@@ -33,16 +33,7 @@ function extractReasoningContent(json: SSEJson): string | null {
   const message =
     json.choices?.[0]?.message?.reasoning_content ??
     json.choices?.[0]?.message?.reasoning
-  const hasDelta = delta !== undefined && delta !== null
-  const hasMessage = message !== undefined && message !== null
-  if (!hasDelta && !hasMessage) return null
-  return (
-    json.choices?.[0]?.message?.reasoning_content ||
-    json.choices?.[0]?.message?.reasoning ||
-    json.choices?.[0]?.delta?.reasoning_content ||
-    json.choices?.[0]?.delta?.reasoning ||
-    ''
-  )
+  return delta ?? message ?? null
 }
 
 function extractAnnotations(json: SSEJson): NormalizedEvent[] {

--- a/src/components/chat/hooks/streaming/message-assembler.ts
+++ b/src/components/chat/hooks/streaming/message-assembler.ts
@@ -99,7 +99,7 @@ export class MessageAssembler {
       role: 'assistant',
       content,
       timestamp: this.timestamp,
-      thoughts: thoughts || undefined,
+      thoughts: firstThinkingIdx >= 0 ? thoughts : undefined,
       isThinking,
       thinkingDuration,
       webSearch,

--- a/src/components/chat/hooks/streaming/timeline-builder.ts
+++ b/src/components/chat/hooks/streaming/timeline-builder.ts
@@ -69,7 +69,6 @@ export class TimelineBuilder {
     const block = this.blocks[this.currentThinkingIdx] as TimelineThinkingBlock
     this.blocks[this.currentThinkingIdx] = {
       ...block,
-      content: block.content,
       isThinking: false,
       duration,
     }
@@ -304,7 +303,6 @@ export class TimelineBuilder {
       ] as TimelineThinkingBlock
       this.blocks[this.currentThinkingIdx] = {
         ...block,
-        content: block.content,
         isThinking: false,
       }
       this.currentThinkingIdx = -1

--- a/src/components/chat/hooks/streaming/timeline-builder.ts
+++ b/src/components/chat/hooks/streaming/timeline-builder.ts
@@ -69,7 +69,7 @@ export class TimelineBuilder {
     const block = this.blocks[this.currentThinkingIdx] as TimelineThinkingBlock
     this.blocks[this.currentThinkingIdx] = {
       ...block,
-      content: block.content.trim(),
+      content: block.content,
       isThinking: false,
       duration,
     }
@@ -304,7 +304,7 @@ export class TimelineBuilder {
       ] as TimelineThinkingBlock
       this.blocks[this.currentThinkingIdx] = {
         ...block,
-        content: block.content.trim(),
+        content: block.content,
         isThinking: false,
       }
       this.currentThinkingIdx = -1

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -2,6 +2,12 @@ import { setGenUIConfig } from '@/components/chat/genui/config'
 import { API_BASE_URL, IS_DEV } from '@/config'
 import { DEV_SIMULATOR_MODEL } from '@/utils/dev-simulator'
 import { logError } from '@/utils/error-handling'
+import {
+  getStrongerReasoningHistoryPolicy,
+  normalizeReasoningHistoryPolicy,
+  REASONING_HISTORY_POLICIES,
+  type ReasoningHistoryPolicy,
+} from '@/utils/reasoning-history'
 import { getSmallestContextWindow } from '@/utils/token-estimation'
 
 const DEV_MODELS: BaseModel[] = [
@@ -72,8 +78,8 @@ export type ReasoningEndpointParams = {
  * - `supportsToggle: true` — thinking mode can be turned on or off per request
  *   via `params[endpoint].enable` / `params[endpoint].disable`.
  * - `defaultEnabled` — initial state of the toggle when `supportsToggle` is true.
- * - `requiresCompleteReasoningHistory` — prior assistant reasoning must be
- *   returned as `reasoning_content` on subsequent requests.
+ * - `reasoningHistoryPolicy` — controls whether prior assistant reasoning is
+ *   returned for every assistant message, tool-call messages only, or never.
  *
  * The presence of a `reasoningConfig` object is itself the capability flag
  * — there is no separate boolean.
@@ -91,7 +97,7 @@ export type ReasoningConfig = {
    */
   effortMap?: Record<string, string>
   params?: Record<string, ReasoningEndpointParams>
-  requiresCompleteReasoningHistory?: boolean
+  reasoningHistoryPolicy?: ReasoningHistoryPolicy
 }
 
 export type AutoTier = 'smart' | 'fast'
@@ -237,14 +243,20 @@ export type ResolvedModelSelection = {
   autoCandidates?: BaseModel[]
 }
 
-export const requiresCompleteReasoningHistory = (
+export const getReasoningHistoryPolicy = (
   selection: ResolvedModelSelection,
-): boolean => {
+): ReasoningHistoryPolicy => {
   const candidates =
     selection.autoCandidates ?? (selection.model ? [selection.model] : [])
-  return candidates.some(
-    (candidate) =>
-      candidate.reasoningConfig?.requiresCompleteReasoningHistory === true,
+  return candidates.reduce<ReasoningHistoryPolicy>(
+    (strongest, candidate) =>
+      getStrongerReasoningHistoryPolicy(
+        strongest,
+        normalizeReasoningHistoryPolicy(
+          candidate.reasoningConfig?.reasoningHistoryPolicy,
+        ),
+      ),
+    REASONING_HISTORY_POLICIES.none,
   )
 }
 

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -243,12 +243,15 @@ export type ResolvedModelSelection = {
   autoCandidates?: BaseModel[]
 }
 
+const getResolvedCandidates = (
+  selection: ResolvedModelSelection,
+): BaseModel[] =>
+  selection.autoCandidates ?? (selection.model ? [selection.model] : [])
+
 export const getReasoningHistoryPolicy = (
   selection: ResolvedModelSelection,
 ): ReasoningHistoryPolicy => {
-  const candidates =
-    selection.autoCandidates ?? (selection.model ? [selection.model] : [])
-  return candidates.reduce<ReasoningHistoryPolicy>(
+  return getResolvedCandidates(selection).reduce<ReasoningHistoryPolicy>(
     (strongest, candidate) =>
       getStrongerReasoningHistoryPolicy(
         strongest,
@@ -263,10 +266,10 @@ export const getReasoningHistoryPolicy = (
 export const getResolvedModelContextWindow = (
   selection: ResolvedModelSelection,
 ): string | undefined => {
-  const candidates =
-    selection.autoCandidates ?? (selection.model ? [selection.model] : [])
   return getSmallestContextWindow(
-    candidates.map((candidate) => candidate.contextWindow),
+    getResolvedCandidates(selection).map(
+      (candidate) => candidate.contextWindow,
+    ),
   )
 }
 

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -2,6 +2,7 @@ import { setGenUIConfig } from '@/components/chat/genui/config'
 import { API_BASE_URL, IS_DEV } from '@/config'
 import { DEV_SIMULATOR_MODEL } from '@/utils/dev-simulator'
 import { logError } from '@/utils/error-handling'
+import { getSmallestContextWindow } from '@/utils/token-estimation'
 
 const DEV_MODELS: BaseModel[] = [
   {
@@ -71,6 +72,8 @@ export type ReasoningEndpointParams = {
  * - `supportsToggle: true` — thinking mode can be turned on or off per request
  *   via `params[endpoint].enable` / `params[endpoint].disable`.
  * - `defaultEnabled` — initial state of the toggle when `supportsToggle` is true.
+ * - `requiresCompleteReasoningHistory` — prior assistant reasoning must be
+ *   returned as `reasoning_content` on subsequent requests.
  *
  * The presence of a `reasoningConfig` object is itself the capability flag
  * — there is no separate boolean.
@@ -88,6 +91,7 @@ export type ReasoningConfig = {
    */
   effortMap?: Record<string, string>
   params?: Record<string, ReasoningEndpointParams>
+  requiresCompleteReasoningHistory?: boolean
 }
 
 export type AutoTier = 'smart' | 'fast'
@@ -176,6 +180,9 @@ export const getAutoModels = (models: BaseModel[]): BaseModel[] => {
       isAuto: true,
       tier,
       multimodal: members.some((m) => m.multimodal === true),
+      contextWindow: getSmallestContextWindow(
+        members.map((member) => member.contextWindow),
+      ),
     })
   }
   add('smart', AUTO_SMART_ID, 'Auto · Smart')
@@ -228,6 +235,27 @@ export type ResolvedModelSelection = {
    * first entry is the representative model.
    */
   autoCandidates?: BaseModel[]
+}
+
+export const requiresCompleteReasoningHistory = (
+  selection: ResolvedModelSelection,
+): boolean => {
+  const candidates =
+    selection.autoCandidates ?? (selection.model ? [selection.model] : [])
+  return candidates.some(
+    (candidate) =>
+      candidate.reasoningConfig?.requiresCompleteReasoningHistory === true,
+  )
+}
+
+export const getResolvedModelContextWindow = (
+  selection: ResolvedModelSelection,
+): string | undefined => {
+  const candidates =
+    selection.autoCandidates ?? (selection.model ? [selection.model] : [])
+  return getSmallestContextWindow(
+    candidates.map((candidate) => candidate.contextWindow),
+  )
 }
 
 /**

--- a/src/services/inference/chat-query-builder.ts
+++ b/src/services/inference/chat-query-builder.ts
@@ -4,7 +4,11 @@ import {
 } from '@/components/chat/attachment-helpers'
 import { buildGenUIPromptHint } from '@/components/chat/genui/system-prompt'
 import type { Message } from '@/components/chat/types'
-import type { BaseModel } from '@/config/models'
+import {
+  getResolvedModelContextWindow,
+  requiresCompleteReasoningHistory,
+  type BaseModel,
+} from '@/config/models'
 import { formatCurrentTimeReminder } from '@/utils/time-reminder'
 import { selectMessagesWithinBudget } from '@/utils/token-estimation'
 import type {
@@ -32,6 +36,7 @@ export interface ChatQueryBuilderParams {
   systemPrompt: string
   rules?: string
   messages: Message[]
+  autoCandidates?: BaseModel[]
   /**
    * Append GenUI widget guidance to the system prompt. Defaults to `false`
    * so non-chat callers (title gen, memory) stay unaffected.
@@ -66,11 +71,20 @@ export class ChatQueryBuilder {
       systemPrompt,
       rules,
       messages: conversationMessages,
+      autoCandidates,
       includeGenUIHint,
       forcePrependSystemPrompt,
       includeTimeReminder,
     } = params
     const modelId = model.modelName
+    const includeReasoningHistory = requiresCompleteReasoningHistory({
+      model,
+      autoCandidates,
+    })
+    const contextWindow = getResolvedModelContextWindow({
+      model,
+      autoCandidates,
+    })
 
     const genUIHint = includeGenUIHint ? buildGenUIPromptHint() : null
 
@@ -107,7 +121,8 @@ export class ChatQueryBuilder {
     // Add conversation history that fits within the model's context budget
     const recentMessages = selectMessagesWithinBudget(
       conversationMessages,
-      model.contextWindow,
+      contextWindow,
+      { includeReasoning: includeReasoningHistory },
     )
     let addedSystemInstructions = useSystemRole
 
@@ -138,11 +153,16 @@ export class ChatQueryBuilder {
           role: 'user',
           content: userContent,
         } as ChatCompletionUserMessageParam)
-      } else if (msg.content || (msg.toolCalls && msg.toolCalls.length > 0)) {
+      } else if (
+        msg.content ||
+        (msg.toolCalls && msg.toolCalls.length > 0) ||
+        (includeReasoningHistory && msg.thoughts !== undefined)
+      ) {
         // Assistant messages - include annotations and searchReasoning for multi-turn context
         const assistantParam: ChatCompletionAssistantMessageParam & {
           annotations?: Message['annotations']
           search_reasoning?: string
+          reasoning_content?: string
         } = {
           role: 'assistant',
           content: msg.content || '',
@@ -152,6 +172,9 @@ export class ChatQueryBuilder {
         }
         if (msg.searchReasoning) {
           assistantParam.search_reasoning = msg.searchReasoning
+        }
+        if (includeReasoningHistory && msg.thoughts !== undefined) {
+          assistantParam.reasoning_content = msg.thoughts
         }
         if (msg.toolCalls && msg.toolCalls.length > 0) {
           assistantParam.tool_calls = msg.toolCalls.map((tc) => ({

--- a/src/services/inference/chat-query-builder.ts
+++ b/src/services/inference/chat-query-builder.ts
@@ -5,10 +5,11 @@ import {
 import { buildGenUIPromptHint } from '@/components/chat/genui/system-prompt'
 import type { Message } from '@/components/chat/types'
 import {
+  getReasoningHistoryPolicy,
   getResolvedModelContextWindow,
-  requiresCompleteReasoningHistory,
   type BaseModel,
 } from '@/config/models'
+import { shouldIncludeReasoning } from '@/utils/reasoning-history'
 import { formatCurrentTimeReminder } from '@/utils/time-reminder'
 import { selectMessagesWithinBudget } from '@/utils/token-estimation'
 import type {
@@ -77,7 +78,7 @@ export class ChatQueryBuilder {
       includeTimeReminder,
     } = params
     const modelId = model.modelName
-    const includeReasoningHistory = requiresCompleteReasoningHistory({
+    const reasoningHistoryPolicy = getReasoningHistoryPolicy({
       model,
       autoCandidates,
     })
@@ -122,12 +123,16 @@ export class ChatQueryBuilder {
     const recentMessages = selectMessagesWithinBudget(
       conversationMessages,
       contextWindow,
-      { includeReasoning: includeReasoningHistory },
+      { reasoningHistoryPolicy },
     )
     let addedSystemInstructions = useSystemRole
 
     for (let index = 0; index < recentMessages.length; index++) {
       const msg = recentMessages[index]
+      const includeReasoning = shouldIncludeReasoning(
+        reasoningHistoryPolicy,
+        Boolean(msg.toolCalls?.length),
+      )
 
       if (msg.role === 'user') {
         let userContent = this.buildUserContent(msg, model.multimodal)
@@ -156,7 +161,7 @@ export class ChatQueryBuilder {
       } else if (
         msg.content ||
         (msg.toolCalls && msg.toolCalls.length > 0) ||
-        (includeReasoningHistory && msg.thoughts !== undefined)
+        (includeReasoning && msg.thoughts !== undefined)
       ) {
         // Assistant messages - include annotations and searchReasoning for multi-turn context
         const assistantParam: ChatCompletionAssistantMessageParam & {
@@ -173,7 +178,7 @@ export class ChatQueryBuilder {
         if (msg.searchReasoning) {
           assistantParam.search_reasoning = msg.searchReasoning
         }
-        if (includeReasoningHistory && msg.thoughts !== undefined) {
+        if (includeReasoning && msg.thoughts !== undefined) {
           assistantParam.reasoning_content = msg.thoughts
         }
         if (msg.toolCalls && msg.toolCalls.length > 0) {

--- a/src/services/inference/inference-client.ts
+++ b/src/services/inference/inference-client.ts
@@ -260,6 +260,7 @@ export async function sendChatStream(
       systemPrompt,
       rules,
       messages: updatedMessages,
+      autoCandidates,
       includeGenUIHint: genUIEnabled,
       includeTimeReminder: true,
     })
@@ -378,6 +379,7 @@ export async function sendChatStream(
     systemPrompt,
     rules,
     messages: updatedMessages,
+    autoCandidates,
     includeGenUIHint: genUIEnabled,
     forcePrependSystemPrompt,
     includeTimeReminder: true,

--- a/src/utils/reasoning-history.ts
+++ b/src/utils/reasoning-history.ts
@@ -1,0 +1,42 @@
+export const REASONING_HISTORY_POLICIES = {
+  none: 'none',
+  toolCallOnly: 'tool-call-only',
+  all: 'all',
+} as const
+
+export type ReasoningHistoryPolicy =
+  (typeof REASONING_HISTORY_POLICIES)[keyof typeof REASONING_HISTORY_POLICIES]
+
+export const normalizeReasoningHistoryPolicy = (
+  value: unknown,
+): ReasoningHistoryPolicy => {
+  switch (value) {
+    case REASONING_HISTORY_POLICIES.all:
+    case REASONING_HISTORY_POLICIES.toolCallOnly:
+    case REASONING_HISTORY_POLICIES.none:
+      return value
+    default:
+      return REASONING_HISTORY_POLICIES.none
+  }
+}
+
+const REASONING_HISTORY_POLICY_RANK: Record<ReasoningHistoryPolicy, number> = {
+  [REASONING_HISTORY_POLICIES.none]: 0,
+  [REASONING_HISTORY_POLICIES.toolCallOnly]: 1,
+  [REASONING_HISTORY_POLICIES.all]: 2,
+}
+
+export const getStrongerReasoningHistoryPolicy = (
+  first: ReasoningHistoryPolicy,
+  second: ReasoningHistoryPolicy,
+): ReasoningHistoryPolicy =>
+  REASONING_HISTORY_POLICY_RANK[second] > REASONING_HISTORY_POLICY_RANK[first]
+    ? second
+    : first
+
+export const shouldIncludeReasoning = (
+  policy: ReasoningHistoryPolicy,
+  hasToolCalls: boolean,
+): boolean =>
+  policy === REASONING_HISTORY_POLICIES.all ||
+  (policy === REASONING_HISTORY_POLICIES.toolCallOnly && hasToolCalls)

--- a/src/utils/token-estimation.ts
+++ b/src/utils/token-estimation.ts
@@ -24,12 +24,38 @@ export function parseContextWindowTokens(contextWindow?: string): number {
   return tokens
 }
 
-// Estimate the tokens a message contributes to the prompt, including
-// quoted text, attachment contents that get inlined into user content,
-// and assistant tool calls. Thoughts are excluded: they are never sent
-// back in chat prompt payloads.
-export function estimateMessageTokens(msg: Message): number {
+export function getSmallestContextWindow(
+  contextWindows: Array<string | undefined>,
+): string | undefined {
+  if (contextWindows.length === 0) return undefined
+  let smallest = contextWindows[0]
+  for (let index = 1; index < contextWindows.length; index++) {
+    const candidate = contextWindows[index]
+    if (
+      parseContextWindowTokens(candidate) < parseContextWindowTokens(smallest)
+    ) {
+      smallest = candidate
+    }
+  }
+  return smallest
+}
+
+export type TokenEstimationOptions = {
+  includeReasoning?: boolean
+  keepMostRecent?: boolean
+}
+
+// Estimate the tokens a message contributes to the prompt, including quoted
+// text, attachment contents, assistant tool calls, and reasoning when the
+// selected model requires it to be returned in subsequent requests.
+export function estimateMessageTokens(
+  msg: Message,
+  options: TokenEstimationOptions = {},
+): number {
   let tokens = estimateTokenCount(msg.content)
+  if (options.includeReasoning) {
+    tokens += estimateTokenCount(msg.thoughts)
+  }
   if (msg.searchReasoning) {
     tokens += estimateTokenCount(msg.searchReasoning)
   }
@@ -60,6 +86,13 @@ export function getContextTokenBudget(contextWindow?: string): number {
   )
 }
 
+export function getHistoryTokenBudget(
+  contextWindow?: string,
+  pendingTokens = 0,
+): number {
+  return Math.max(0, getContextTokenBudget(contextWindow) - pendingTokens)
+}
+
 /**
  * Returns the index of the first message (from the end) that fits within the
  * token budget. Messages before this index are "archived" and excluded from
@@ -69,11 +102,16 @@ export function getContextTokenBudget(contextWindow?: string): number {
 export function findContextStartIndex(
   messages: Message[],
   budgetTokens: number,
+  options: TokenEstimationOptions = {},
 ): number {
   let usedTokens = 0
+  const keepMostRecent = options.keepMostRecent ?? true
   for (let i = messages.length - 1; i >= 0; i--) {
-    usedTokens += estimateMessageTokens(messages[i])
-    if (usedTokens > budgetTokens && i < messages.length - 1) {
+    usedTokens += estimateMessageTokens(messages[i], options)
+    if (
+      usedTokens > budgetTokens &&
+      (!keepMostRecent || i < messages.length - 1)
+    ) {
       return i + 1
     }
   }
@@ -87,7 +125,8 @@ export function findContextStartIndex(
 export function selectMessagesWithinBudget(
   messages: Message[],
   contextWindow?: string,
+  options: TokenEstimationOptions = {},
 ): Message[] {
   const budget = getContextTokenBudget(contextWindow)
-  return messages.slice(findContextStartIndex(messages, budget))
+  return messages.slice(findContextStartIndex(messages, budget, options))
 }

--- a/src/utils/token-estimation.ts
+++ b/src/utils/token-estimation.ts
@@ -1,4 +1,9 @@
 import type { Message } from '@/components/chat/types'
+import {
+  REASONING_HISTORY_POLICIES,
+  shouldIncludeReasoning,
+  type ReasoningHistoryPolicy,
+} from '@/utils/reasoning-history'
 
 // Fraction of the model's context window reserved for conversation history;
 // the remainder is headroom for the system prompt and the model's response.
@@ -41,7 +46,7 @@ export function getSmallestContextWindow(
 }
 
 export type TokenEstimationOptions = {
-  includeReasoning?: boolean
+  reasoningHistoryPolicy?: ReasoningHistoryPolicy
   keepMostRecent?: boolean
 }
 
@@ -53,7 +58,12 @@ export function estimateMessageTokens(
   options: TokenEstimationOptions = {},
 ): number {
   let tokens = estimateTokenCount(msg.content)
-  if (options.includeReasoning) {
+  if (
+    shouldIncludeReasoning(
+      options.reasoningHistoryPolicy ?? REASONING_HISTORY_POLICIES.none,
+      Boolean(msg.toolCalls?.length),
+    )
+  ) {
     tokens += estimateTokenCount(msg.thoughts)
   }
   if (msg.searchReasoning) {

--- a/src/utils/token-estimation.ts
+++ b/src/utils/token-estimation.ts
@@ -59,6 +59,7 @@ export function estimateMessageTokens(
 ): number {
   let tokens = estimateTokenCount(msg.content)
   if (
+    msg.role === 'assistant' &&
     shouldIncludeReasoning(
       options.reasoningHistoryPolicy ?? REASONING_HISTORY_POLICIES.none,
       Boolean(msg.toolCalls?.length),

--- a/tests/components/chat/chat-messages-recovery.test.tsx
+++ b/tests/components/chat/chat-messages-recovery.test.tsx
@@ -45,6 +45,7 @@ vi.mock('@/hooks/use-chat-print', () => ({
 vi.mock('@/utils/token-estimation', () => ({
   findContextStartIndex: () => 0,
   getContextTokenBudget: () => 1000,
+  getHistoryTokenBudget: () => 1000,
 }))
 
 vi.mock('@/components/chat/PrintableChat', () => ({

--- a/tests/components/chat/streaming/event-normalizer.test.ts
+++ b/tests/components/chat/streaming/event-normalizer.test.ts
@@ -125,7 +125,11 @@ describe('EventNormalizer', () => {
             ],
           },
         ]),
-      ).toContainEqual({ type: 'thinking_delta', content: ' delta' })
+      ).toEqual([
+        { type: 'thinking_start' },
+        { type: 'thinking_delta', content: ' delta' },
+        { type: 'thinking_end' },
+      ])
     })
 
     it('detects reasoning format from first reasoning chunk', () => {

--- a/tests/components/chat/streaming/event-normalizer.test.ts
+++ b/tests/components/chat/streaming/event-normalizer.test.ts
@@ -97,6 +97,37 @@ describe('EventNormalizer', () => {
       ])
     })
 
+    it('preserves reasoning whitespace exactly', () => {
+      expect(
+        processAll([
+          {
+            choices: [
+              { delta: {}, message: { reasoning_content: '  thinking  ' } },
+            ],
+          },
+        ]),
+      ).toEqual([
+        { type: 'thinking_start' },
+        { type: 'thinking_delta', content: '  thinking  ' },
+        { type: 'thinking_end' },
+      ])
+    })
+
+    it('prefers a streaming delta over a cumulative message value', () => {
+      expect(
+        processAll([
+          {
+            choices: [
+              {
+                delta: { reasoning_content: ' delta' },
+                message: { reasoning_content: 'cumulative delta' },
+              },
+            ],
+          },
+        ]),
+      ).toContainEqual({ type: 'thinking_delta', content: ' delta' })
+    })
+
     it('detects reasoning format from first reasoning chunk', () => {
       const events = processAll([
         reasoningChunk('thinking...'),

--- a/tests/components/chat/streaming/message-assembler.test.ts
+++ b/tests/components/chat/streaming/message-assembler.test.ts
@@ -151,6 +151,20 @@ describe('MessageAssembler', () => {
       expect(msg.searchReasoning).toBeUndefined()
     })
 
+    it('preserves an explicitly empty reasoning value', () => {
+      const asm = new MessageAssembler()
+      const msg = asm.toMessage([
+        {
+          type: 'thinking',
+          id: 'thinking-0',
+          content: '',
+          isThinking: false,
+        },
+      ])
+
+      expect(msg.thoughts).toBe('')
+    })
+
     it('passes timeline through', () => {
       const asm = new MessageAssembler()
       const timeline: TimelineBlock[] = [

--- a/tests/components/chat/streaming/rich-response-parser.test.ts
+++ b/tests/components/chat/streaming/rich-response-parser.test.ts
@@ -118,7 +118,7 @@ describe('parseRichStreamingResponse', () => {
     )
 
     expect(message.content).toBe('Final answer.')
-    expect(message.thoughts).toBe('Check sources.')
+    expect(message.thoughts).toBe('Check sources. ')
     expect(message.thinkingDuration).toBeUndefined()
     expect(message.annotations).toEqual([
       {

--- a/tests/components/chat/streaming/timeline-builder.test.ts
+++ b/tests/components/chat/streaming/timeline-builder.test.ts
@@ -25,14 +25,24 @@ describe('TimelineBuilder', () => {
       expect(block.duration).toBe(1.5)
     })
 
-    it('trims thinking content on end', () => {
+    it('preserves thinking whitespace on end', () => {
       const builder = new TimelineBuilder()
       builder.startThinking()
       builder.appendThinking('  spaced  ')
       builder.endThinking()
 
       const block = builder.snapshot()[0] as TimelineThinkingBlock
-      expect(block.content).toBe('spaced')
+      expect(block.content).toBe('  spaced  ')
+    })
+
+    it('preserves thinking whitespace at a tool boundary', () => {
+      const builder = new TimelineBuilder()
+      builder.startThinking()
+      builder.appendThinking('  spaced for tool  ')
+      builder.pushWebSearch({ status: 'searching' })
+
+      const block = builder.snapshot()[0] as TimelineThinkingBlock
+      expect(block.content).toBe('  spaced for tool  ')
     })
 
     it('tracks isThinkingOpen correctly', () => {

--- a/tests/config/models-reasoning-history.test.ts
+++ b/tests/config/models-reasoning-history.test.ts
@@ -1,0 +1,56 @@
+import {
+  getResolvedModelContextWindow,
+  requiresCompleteReasoningHistory,
+  type BaseModel,
+} from '@/config/models'
+import { describe, expect, it } from 'vitest'
+
+const model = (
+  modelName: string,
+  requiresHistory = false,
+  contextWindow?: string,
+): BaseModel => ({
+  modelName,
+  image: '',
+  name: modelName,
+  nameShort: modelName,
+  description: '',
+  type: 'chat',
+  chat: true,
+  contextWindow,
+  reasoningConfig: requiresHistory
+    ? { requiresCompleteReasoningHistory: true }
+    : undefined,
+})
+
+describe('requiresCompleteReasoningHistory', () => {
+  it('uses the direct model capability', () => {
+    expect(requiresCompleteReasoningHistory({ model: model('standard') })).toBe(
+      false,
+    )
+    expect(
+      requiresCompleteReasoningHistory({ model: model('kimi-k3', true) }),
+    ).toBe(true)
+  })
+
+  it('requires history when any Auto candidate requires it', () => {
+    expect(
+      requiresCompleteReasoningHistory({
+        model: model('standard'),
+        autoCandidates: [model('standard'), model('kimi-k3', true)],
+      }),
+    ).toBe(true)
+  })
+
+  it('uses the smallest Auto candidate context window', () => {
+    expect(
+      getResolvedModelContextWindow({
+        model: model('large', false, '256k tokens'),
+        autoCandidates: [
+          model('large', false, '256k tokens'),
+          model('small', false, '128k tokens'),
+        ],
+      }),
+    ).toBe('128k tokens')
+  })
+})

--- a/tests/config/models-reasoning-history.test.ts
+++ b/tests/config/models-reasoning-history.test.ts
@@ -1,13 +1,17 @@
 import {
+  getReasoningHistoryPolicy,
   getResolvedModelContextWindow,
-  requiresCompleteReasoningHistory,
   type BaseModel,
 } from '@/config/models'
+import {
+  REASONING_HISTORY_POLICIES,
+  type ReasoningHistoryPolicy,
+} from '@/utils/reasoning-history'
 import { describe, expect, it } from 'vitest'
 
 const model = (
   modelName: string,
-  requiresHistory = false,
+  policy?: ReasoningHistoryPolicy,
   contextWindow?: string,
 ): BaseModel => ({
   modelName,
@@ -18,37 +22,52 @@ const model = (
   type: 'chat',
   chat: true,
   contextWindow,
-  reasoningConfig: requiresHistory
-    ? { requiresCompleteReasoningHistory: true }
-    : undefined,
+  reasoningConfig: policy ? { reasoningHistoryPolicy: policy } : undefined,
 })
 
-describe('requiresCompleteReasoningHistory', () => {
-  it('uses the direct model capability', () => {
-    expect(requiresCompleteReasoningHistory({ model: model('standard') })).toBe(
-      false,
+describe('getReasoningHistoryPolicy', () => {
+  it('uses the direct model policy with a safe default', () => {
+    expect(getReasoningHistoryPolicy({ model: model('standard') })).toBe(
+      REASONING_HISTORY_POLICIES.none,
     )
     expect(
-      requiresCompleteReasoningHistory({ model: model('kimi-k3', true) }),
-    ).toBe(true)
+      getReasoningHistoryPolicy({
+        model: model('kimi-k3', REASONING_HISTORY_POLICIES.all),
+      }),
+    ).toBe(REASONING_HISTORY_POLICIES.all)
   })
 
-  it('requires history when any Auto candidate requires it', () => {
+  it('uses the strongest Auto candidate policy', () => {
     expect(
-      requiresCompleteReasoningHistory({
+      getReasoningHistoryPolicy({
         model: model('standard'),
-        autoCandidates: [model('standard'), model('kimi-k3', true)],
+        autoCandidates: [
+          model('standard'),
+          model('glm', REASONING_HISTORY_POLICIES.toolCallOnly),
+          model('kimi-k3', REASONING_HISTORY_POLICIES.all),
+        ],
       }),
-    ).toBe(true)
+    ).toBe(REASONING_HISTORY_POLICIES.all)
+  })
+
+  it('falls back safely for unknown future policies', () => {
+    const futureModel = model('future')
+    futureModel.reasoningConfig = {
+      reasoningHistoryPolicy: 'future-policy' as never,
+    }
+
+    expect(getReasoningHistoryPolicy({ model: futureModel })).toBe(
+      REASONING_HISTORY_POLICIES.none,
+    )
   })
 
   it('uses the smallest Auto candidate context window', () => {
     expect(
       getResolvedModelContextWindow({
-        model: model('large', false, '256k tokens'),
+        model: model('large', undefined, '256k tokens'),
         autoCandidates: [
-          model('large', false, '256k tokens'),
-          model('small', false, '128k tokens'),
+          model('large', undefined, '256k tokens'),
+          model('small', undefined, '128k tokens'),
         ],
       }),
     ).toBe('128k tokens')

--- a/tests/services/inference/chat-query-builder.test.ts
+++ b/tests/services/inference/chat-query-builder.test.ts
@@ -1,6 +1,7 @@
 import type { Message } from '@/components/chat/types'
 import type { BaseModel } from '@/config/models'
 import { ChatQueryBuilder } from '@/services/inference/chat-query-builder'
+import { REASONING_HISTORY_POLICIES } from '@/utils/reasoning-history'
 import { describe, expect, it, vi } from 'vitest'
 
 const model: BaseModel = {
@@ -23,7 +24,16 @@ const preservedHistoryModel: BaseModel = {
   ...model,
   modelName: 'kimi-k3',
   name: 'Kimi K3',
-  reasoningConfig: { requiresCompleteReasoningHistory: true },
+  reasoningConfig: { reasoningHistoryPolicy: REASONING_HISTORY_POLICIES.all },
+}
+
+const toolCallHistoryModel: BaseModel = {
+  ...model,
+  modelName: 'gemma4-31b',
+  name: 'Gemma 4',
+  reasoningConfig: {
+    reasoningHistoryPolicy: REASONING_HISTORY_POLICIES.toolCallOnly,
+  },
 }
 
 describe('ChatQueryBuilder', () => {
@@ -219,6 +229,39 @@ describe('ChatQueryBuilder', () => {
     })
 
     expect(messages[0]).toEqual({ role: 'assistant', content: 'answer' })
+  })
+
+  it('preserves reasoning only on tool-call messages for tool-call policy models', () => {
+    const messages = ChatQueryBuilder.buildMessages({
+      model: toolCallHistoryModel,
+      systemPrompt: '',
+      messages: [
+        {
+          role: 'assistant',
+          content: 'ordinary answer',
+          thoughts: 'omit this',
+          timestamp: new Date(),
+        },
+        {
+          role: 'assistant',
+          content: '',
+          thoughts: 'keep this',
+          toolCalls: [{ id: 'call_1', name: 'render_chart', arguments: '{}' }],
+          timestamp: new Date(),
+        },
+      ],
+      includeGenUIHint: false,
+    })
+
+    expect(messages[0]).toEqual({
+      role: 'assistant',
+      content: 'ordinary answer',
+    })
+    expect(messages[1]).toMatchObject({
+      role: 'assistant',
+      reasoning_content: 'keep this',
+      tool_calls: [{ id: 'call_1' }],
+    })
   })
 
   it('preserves reasoning when any Auto candidate requires it', () => {

--- a/tests/services/inference/chat-query-builder.test.ts
+++ b/tests/services/inference/chat-query-builder.test.ts
@@ -19,6 +19,13 @@ const userMessage: Message = {
   timestamp: new Date('2026-01-01T00:00:00Z'),
 }
 
+const preservedHistoryModel: BaseModel = {
+  ...model,
+  modelName: 'kimi-k3',
+  name: 'Kimi K3',
+  reasoningConfig: { requiresCompleteReasoningHistory: true },
+}
+
 describe('ChatQueryBuilder', () => {
   it('omits system messages when there is no prompt content', () => {
     const messages = ChatQueryBuilder.buildMessages({
@@ -139,5 +146,97 @@ describe('ChatQueryBuilder', () => {
     } finally {
       vi.useRealTimers()
     }
+  })
+
+  it('returns exact assistant reasoning alongside content and tool calls', () => {
+    const messages = ChatQueryBuilder.buildMessages({
+      model: preservedHistoryModel,
+      systemPrompt: '',
+      messages: [
+        {
+          role: 'assistant',
+          content: 'answer',
+          thoughts: '  exact reasoning  ',
+          toolCalls: [
+            { id: 'call_1', name: 'render_chart', arguments: '{"value":1}' },
+          ],
+          timestamp: new Date(),
+        },
+      ],
+      includeGenUIHint: false,
+    })
+
+    expect(messages[0]).toMatchObject({
+      role: 'assistant',
+      content: 'answer',
+      reasoning_content: '  exact reasoning  ',
+      tool_calls: [{ id: 'call_1' }],
+    })
+    expect(messages[1]).toEqual({
+      role: 'tool',
+      tool_call_id: 'call_1',
+      content: 'executed',
+    })
+  })
+
+  it('keeps reasoning-only assistant messages when history is required', () => {
+    const messages = ChatQueryBuilder.buildMessages({
+      model: preservedHistoryModel,
+      systemPrompt: '',
+      messages: [
+        {
+          role: 'assistant',
+          content: '',
+          thoughts: 'reasoning only',
+          timestamp: new Date(),
+        },
+      ],
+      includeGenUIHint: false,
+    })
+
+    expect(messages).toEqual([
+      {
+        role: 'assistant',
+        content: '',
+        reasoning_content: 'reasoning only',
+      },
+    ])
+  })
+
+  it('omits reasoning when the model does not require preserved history', () => {
+    const messages = ChatQueryBuilder.buildMessages({
+      model,
+      systemPrompt: '',
+      messages: [
+        {
+          role: 'assistant',
+          content: 'answer',
+          thoughts: 'reasoning',
+          timestamp: new Date(),
+        },
+      ],
+      includeGenUIHint: false,
+    })
+
+    expect(messages[0]).toEqual({ role: 'assistant', content: 'answer' })
+  })
+
+  it('preserves reasoning when any Auto candidate requires it', () => {
+    const messages = ChatQueryBuilder.buildMessages({
+      model,
+      autoCandidates: [model, preservedHistoryModel],
+      systemPrompt: '',
+      messages: [
+        {
+          role: 'assistant',
+          content: 'answer',
+          thoughts: 'reasoning',
+          timestamp: new Date(),
+        },
+      ],
+      includeGenUIHint: false,
+    })
+
+    expect(messages[0]).toMatchObject({ reasoning_content: 'reasoning' })
   })
 })

--- a/tests/utils/token-estimation.test.ts
+++ b/tests/utils/token-estimation.test.ts
@@ -59,7 +59,7 @@ describe('getContextTokenBudget', () => {
 })
 
 describe('estimateMessageTokens', () => {
-  it('includes quote and attachment text but excludes thoughts by default', () => {
+  it('includes quote and attachment text but excludes user thoughts', () => {
     const msg: Message = {
       role: 'user',
       content: 'a'.repeat(40),
@@ -80,7 +80,7 @@ describe('estimateMessageTokens', () => {
       estimateMessageTokens(msg, {
         reasoningHistoryPolicy: REASONING_HISTORY_POLICIES.all,
       }),
-    ).toBe(40)
+    ).toBe(30)
   })
 
   it('counts assistant tool calls and search reasoning', () => {

--- a/tests/utils/token-estimation.test.ts
+++ b/tests/utils/token-estimation.test.ts
@@ -5,6 +5,7 @@ import {
   estimateTokenCount,
   findContextStartIndex,
   getContextTokenBudget,
+  getHistoryTokenBudget,
   parseContextWindowTokens,
   selectMessagesWithinBudget,
 } from '@/utils/token-estimation'
@@ -49,10 +50,15 @@ describe('getContextTokenBudget', () => {
       Math.floor(100000 * CONTEXT_WINDOW_USAGE_RATIO),
     )
   })
+
+  it('reserves pending input tokens before budgeting persisted history', () => {
+    expect(getHistoryTokenBudget('1k tokens', 250)).toBe(650)
+    expect(getHistoryTokenBudget('1k tokens', 1000)).toBe(0)
+  })
 })
 
 describe('estimateMessageTokens', () => {
-  it('includes quote and attachment text but not thoughts', () => {
+  it('includes quote and attachment text but excludes thoughts by default', () => {
     const msg: Message = {
       role: 'user',
       content: 'a'.repeat(40),
@@ -69,6 +75,7 @@ describe('estimateMessageTokens', () => {
       timestamp: new Date(),
     }
     expect(estimateMessageTokens(msg)).toBe(30)
+    expect(estimateMessageTokens(msg, { includeReasoning: true })).toBe(40)
   })
 
   it('counts assistant tool calls and search reasoning', () => {
@@ -113,6 +120,25 @@ describe('findContextStartIndex', () => {
   it('always keeps the most recent message even when over budget', () => {
     const messages = [makeMessage('user', 400), makeMessage('user', 4000)]
     expect(findContextStartIndex(messages, 10)).toBe(1)
+  })
+
+  it('can archive every persisted message when a pending draft is newest', () => {
+    const messages = [makeMessage('user', 400)]
+
+    expect(findContextStartIndex(messages, 0, { keepMostRecent: false })).toBe(
+      1,
+    )
+  })
+
+  it('archives more history when preserved reasoning consumes the budget', () => {
+    const assistant = makeMessage('assistant', 40)
+    assistant.thoughts = 'b'.repeat(800)
+    const messages = [assistant, makeMessage('user', 40)]
+
+    expect(findContextStartIndex(messages, 100)).toBe(0)
+    expect(
+      findContextStartIndex(messages, 100, { includeReasoning: true }),
+    ).toBe(1)
   })
 })
 

--- a/tests/utils/token-estimation.test.ts
+++ b/tests/utils/token-estimation.test.ts
@@ -1,4 +1,5 @@
 import type { Message } from '@/components/chat/types'
+import { REASONING_HISTORY_POLICIES } from '@/utils/reasoning-history'
 import {
   CONTEXT_WINDOW_USAGE_RATIO,
   estimateMessageTokens,
@@ -75,7 +76,11 @@ describe('estimateMessageTokens', () => {
       timestamp: new Date(),
     }
     expect(estimateMessageTokens(msg)).toBe(30)
-    expect(estimateMessageTokens(msg, { includeReasoning: true })).toBe(40)
+    expect(
+      estimateMessageTokens(msg, {
+        reasoningHistoryPolicy: REASONING_HISTORY_POLICIES.all,
+      }),
+    ).toBe(40)
   })
 
   it('counts assistant tool calls and search reasoning', () => {
@@ -137,8 +142,24 @@ describe('findContextStartIndex', () => {
 
     expect(findContextStartIndex(messages, 100)).toBe(0)
     expect(
-      findContextStartIndex(messages, 100, { includeReasoning: true }),
+      findContextStartIndex(messages, 100, {
+        reasoningHistoryPolicy: REASONING_HISTORY_POLICIES.all,
+      }),
     ).toBe(1)
+  })
+
+  it('counts tool-call reasoning only for tool-call policy models', () => {
+    const ordinary = makeMessage('assistant', 40)
+    ordinary.thoughts = 'b'.repeat(40)
+    const toolCall = makeMessage('assistant', 40)
+    toolCall.thoughts = 'b'.repeat(40)
+    toolCall.toolCalls = [{ id: 'call_1', name: 'tool', arguments: '{}' }]
+    const options = {
+      reasoningHistoryPolicy: REASONING_HISTORY_POLICIES.toolCallOnly,
+    } as const
+
+    expect(estimateMessageTokens(ordinary, options)).toBe(10)
+    expect(estimateMessageTokens(toolCall, options)).toBe(22)
   })
 })
 


### PR DESCRIPTION
## Summary
- consume `all`, `tool-call-only`, and `none` reasoning-history policies with a safe unknown-policy fallback
- use the strongest policy across possible Auto candidates
- preserve exact assistant reasoning according to each message's policy
- align request construction, context budgeting, archive boundaries, pending drafts, and candidate context windows

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run test:unit -- --run` (119 files, 1400 tests passed; Happy DOM logs an AbortError during teardown)

## Related PRs
- tinfoilsh/controlplane#554
- tinfoilsh/confidential-model-router#454
- tinfoilsh/tinfoil-ios#246