### PR TITLE
Keep project documents available after reload

### DIFF
--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -230,11 +230,7 @@ function buildAttachment(opts: {
   // images mode and md_content is missing, so consumers that filter on
   // textContent (share, preview) still see the document.
   const textContent =
-    opts.textContent ||
-    opts.pages
-      ?.map((p) => p.text)
-      .filter(Boolean)
-      .join('\n\n---\n\n')
+    getDocumentTextContent(opts.textContent ?? '', opts.pages) ?? undefined
   if (textContent || opts.pages?.length) {
     return {
       id: opts.id,

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -112,6 +112,7 @@ import { ChatMessages } from './chat-messages'
 import { ChatSidebar } from './chat-sidebar'
 import { PromptPresetSuggestions } from './components/prompt-preset-suggestions'
 import { CONSTANTS } from './constants'
+import { getDocumentTextContent } from './document-content'
 import { useDocumentUploader } from './document-uploader'
 import { DragProvider } from './drag-context'
 import { GenUIInputAreaRenderer } from './genui/GenUIInputAreaRenderer'
@@ -2252,13 +2253,20 @@ export function ChatInterface({
 
       await handleDocumentUpload(
         file,
-        async (content) => {
+        async (content, _documentId, _imageData, _hasDescription, pages) => {
           try {
-            await uploadProjectDocument(file, content)
-          } catch {
+            const projectContent = getDocumentTextContent(content, pages)
+            if (!projectContent) {
+              throw new Error('No readable content was found in this document.')
+            }
+            await uploadProjectDocument(file, projectContent)
+          } catch (error) {
             toast({
               title: 'Upload failed',
-              description: 'Failed to add document to project context.',
+              description:
+                error instanceof Error
+                  ? error.message
+                  : 'Failed to add document to project context.',
               variant: 'destructive',
               position: 'top-right',
             })
@@ -2275,6 +2283,8 @@ export function ChatInterface({
           })
           removeUploadingFile(uploadId)
         },
+        undefined,
+        { requireTextContent: true },
       )
     },
     [

--- a/src/components/chat/document-content.ts
+++ b/src/components/chat/document-content.ts
@@ -1,0 +1,15 @@
+import type { DocumentPage } from './types'
+
+export function getDocumentTextContent(
+  content: string,
+  pages?: DocumentPage[],
+): string | null {
+  if (content.trim()) return content
+
+  const pageContent = pages
+    ?.map((page) => page.text)
+    .filter((text) => text.trim())
+    .join('\n\n---\n\n')
+
+  return pageContent?.trim() ? pageContent : null
+}

--- a/src/components/chat/document-uploader.tsx
+++ b/src/components/chat/document-uploader.tsx
@@ -150,7 +150,7 @@ export const useDocumentUploader = (isCurrentModelMultimodal?: boolean) => {
       },
       hasDescription?: boolean,
       pages?: DocumentPage[],
-    ) => void,
+    ) => void | Promise<void>,
     onError: (error: Error, documentId: string) => void,
     onGeneratingDescription?: (
       documentId: string,
@@ -160,6 +160,7 @@ export const useDocumentUploader = (isCurrentModelMultimodal?: boolean) => {
         thumbnailBase64?: string
       },
     ) => void,
+    options?: { requireTextContent?: boolean },
   ) => {
     const documentId = getDocumentId()
 
@@ -187,7 +188,7 @@ export const useDocumentUploader = (isCurrentModelMultimodal?: boolean) => {
           return
         }
         const formattedContent = await handleTextFile(file)
-        onSuccess(formattedContent, documentId)
+        await onSuccess(formattedContent, documentId)
         return
       }
 
@@ -222,10 +223,10 @@ export const useDocumentUploader = (isCurrentModelMultimodal?: boolean) => {
 
           const imageData = { ...scaled, thumbnailBase64 }
 
-          // If current model is multimodal, skip description generation
-          // The image will be sent directly to the model
-          if (isCurrentModelMultimodal) {
-            onSuccess('', documentId, imageData, false)
+          // Chat attachments can be sent directly to multimodal models, but
+          // persistent project documents require reusable text content.
+          if (isCurrentModelMultimodal && !options?.requireTextContent) {
+            await onSuccess('', documentId, imageData, false)
             return
           }
 
@@ -237,7 +238,7 @@ export const useDocumentUploader = (isCurrentModelMultimodal?: boolean) => {
             imageData.base64,
             imageData.mimeType,
           )
-          onSuccess(description, documentId, imageData, true)
+          await onSuccess(description, documentId, imageData, true)
           return
         } catch (error) {
           logError('Image description failed', error, {
@@ -284,7 +285,7 @@ export const useDocumentUploader = (isCurrentModelMultimodal?: boolean) => {
           return
         }
 
-        onSuccess(text.trim(), documentId)
+        await onSuccess(text.trim(), documentId)
         return
       }
 
@@ -296,12 +297,14 @@ export const useDocumentUploader = (isCurrentModelMultimodal?: boolean) => {
 
       const { endpoint } = await getDocUploadModel()
       // Decided at upload time based on the current model: vision-capable
-      // models get per-page images, text-only models skip the bandwidth.
+      // chat attachments get per-page images, while persistent project
+      // documents always request reusable text.
       // If the user later switches to a vision model they'll need to
       // re-upload to get image rendering for an existing attachment.
-      const fetchEndpoint = isCurrentModelMultimodal
-        ? `${endpoint}?mode=images`
-        : endpoint
+      const fetchEndpoint =
+        isCurrentModelMultimodal && !options?.requireTextContent
+          ? `${endpoint}?mode=images`
+          : endpoint
 
       const apiKey = await getSessionToken()
       const secureFetch = await getSecureFetch()
@@ -322,7 +325,7 @@ export const useDocumentUploader = (isCurrentModelMultimodal?: boolean) => {
 
       // Handle 204 No Content response
       if (response.status === 204) {
-        onSuccess('', documentId)
+        await onSuccess('', documentId)
         return
       }
 
@@ -350,7 +353,7 @@ export const useDocumentUploader = (isCurrentModelMultimodal?: boolean) => {
 
       const doc = processingResult.document
       if (doc?.md_content || doc?.pages?.length) {
-        onSuccess(
+        await onSuccess(
           doc.md_content ?? '',
           documentId,
           undefined,
@@ -358,7 +361,7 @@ export const useDocumentUploader = (isCurrentModelMultimodal?: boolean) => {
           doc.pages,
         )
       } else {
-        onSuccess('', documentId)
+        await onSuccess('', documentId)
       }
     } catch (error) {
       logError('Document processing failed', error, {

--- a/src/components/project/project-document-hydration.ts
+++ b/src/components/project/project-document-hydration.ts
@@ -1,0 +1,44 @@
+import type {
+  ProjectDocument,
+  ProjectDocumentListResponse,
+} from '@/types/project'
+
+export function hydrateProjectDocuments(
+  listedDocuments: ProjectDocumentListResponse['documents'],
+  fullDocuments: Map<string, ProjectDocument>,
+  previousDocuments: ProjectDocument[] = [],
+): ProjectDocument[] {
+  const previousById = new Map(previousDocuments.map((doc) => [doc.id, doc]))
+
+  return listedDocuments.map((listed) => {
+    const full = fullDocuments.get(listed.id)
+    const previous = previousById.get(listed.id)
+
+    if (!full || full.decryptionFailed) {
+      if (previous?.content !== undefined && !previous.decryptionFailed) {
+        return {
+          ...previous,
+          syncVersion: listed.syncVersion,
+          createdAt: listed.createdAt,
+          updatedAt: listed.updatedAt,
+        }
+      }
+
+      return {
+        ...listed,
+        filename: full?.filename || '',
+        contentType: full?.contentType || '',
+        decryptionFailed: true,
+      }
+    }
+
+    return {
+      ...listed,
+      content: full.content,
+      filename: full.filename,
+      contentType: full.contentType,
+      sizeBytes: full.sizeBytes,
+      decryptionFailed: false,
+    }
+  })
+}

--- a/src/components/project/project-document-upload.tsx
+++ b/src/components/project/project-document-upload.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { getDocumentTextContent } from '@/components/chat/document-content'
 import { useDocumentUploader } from '@/components/chat/document-uploader'
 import { cn } from '@/components/ui/utils'
 import { ArrowUpTrayIcon } from '@heroicons/react/24/outline'
@@ -42,10 +43,14 @@ export function ProjectDocumentUpload({
 
       handleDocumentUpload(
         file,
-        async (content, _documentId, _imageData) => {
+        async (content, _documentId, _imageData, _hasDescription, pages) => {
           try {
+            const projectContent = getDocumentTextContent(content, pages)
+            if (!projectContent) {
+              throw new Error('No readable content was found in this document.')
+            }
             setUploadStatus('Uploading...')
-            await uploadDocument(file, content)
+            await uploadDocument(file, projectContent)
             setUploadStatus(null)
           } catch (err) {
             setError(
@@ -58,6 +63,8 @@ export function ProjectDocumentUpload({
           setError(err.message)
           setUploadStatus(null)
         },
+        undefined,
+        { requireTextContent: true },
       )
 
       if (fileInputRef.current) {

--- a/src/components/project/project-provider.tsx
+++ b/src/components/project/project-provider.tsx
@@ -47,7 +47,8 @@ export function ProjectProvider({
   const [uploadingFiles, setUploadingFiles] = useState<UploadingFile[]>([])
   const initializingRef = useRef(false)
   const initialProjectLoadedRef = useRef(false)
-  const activeProjectIdRef = useRef<string | null>(null)
+  const pendingProjectIdRef = useRef<string | null>(null)
+  const committedProjectIdRef = useRef<string | null>(null)
   const projectLoadGenerationRef = useRef(0)
   const documentRefreshGenerationRef = useRef(0)
   const documentMutationGenerationRef = useRef(0)
@@ -61,7 +62,8 @@ export function ProjectProvider({
       projectLoadGenerationRef.current += 1
       documentRefreshGenerationRef.current += 1
       documentMutationGenerationRef.current += 1
-      activeProjectIdRef.current = null
+      pendingProjectIdRef.current = null
+      committedProjectIdRef.current = null
       initializingRef.current = false
       initialProjectLoadedRef.current = false
       // Clear all user-specific state on logout to prevent data leaking across sessions
@@ -138,11 +140,10 @@ export function ProjectProvider({
 
   const enterProjectMode = useCallback(
     async (projectId: string, projectName?: string): Promise<boolean> => {
-      const previousProjectId = activeProjectIdRef.current
       const generation = projectLoadGenerationRef.current + 1
       projectLoadGenerationRef.current = generation
       documentRefreshGenerationRef.current += 1
-      activeProjectIdRef.current = projectId
+      pendingProjectIdRef.current = projectId
       setLoading(true)
       setError(null)
       setUploadingFiles([])
@@ -168,11 +169,12 @@ export function ProjectProvider({
 
         if (
           projectLoadGenerationRef.current !== generation ||
-          activeProjectIdRef.current !== projectId
+          pendingProjectIdRef.current !== projectId
         ) {
           return false
         }
 
+        committedProjectIdRef.current = projectId
         setActiveProject(project)
         setProjectDocuments(documents)
 
@@ -184,7 +186,7 @@ export function ProjectProvider({
         return true
       } catch (err) {
         if (projectLoadGenerationRef.current !== generation) return false
-        activeProjectIdRef.current = previousProjectId
+        pendingProjectIdRef.current = committedProjectIdRef.current
         const message =
           err instanceof Error ? err.message : 'Failed to load project'
         setError(message)
@@ -225,7 +227,8 @@ export function ProjectProvider({
     projectLoadGenerationRef.current += 1
     documentRefreshGenerationRef.current += 1
     documentMutationGenerationRef.current += 1
-    activeProjectIdRef.current = null
+    pendingProjectIdRef.current = null
+    committedProjectIdRef.current = null
     setActiveProject(null)
     setProjectDocuments([])
     setUploadingFiles([])
@@ -350,7 +353,7 @@ export function ProjectProvider({
         )
 
         documentMutationGenerationRef.current += 1
-        if (activeProjectIdRef.current === projectId) {
+        if (committedProjectIdRef.current === projectId) {
           setProjectDocuments((prev) => [
             ...prev.filter((existing) => existing.id !== document.id),
             document,
@@ -395,7 +398,7 @@ export function ProjectProvider({
       try {
         await projectStorage.deleteDocument(projectId, docId)
         documentMutationGenerationRef.current += 1
-        if (activeProjectIdRef.current === projectId) {
+        if (committedProjectIdRef.current === projectId) {
           setProjectDocuments((prev) =>
             prev.filter((document) => document.id !== docId),
           )
@@ -408,7 +411,7 @@ export function ProjectProvider({
         })
       } catch (err) {
         documentMutationGenerationRef.current += 1
-        if (removedDoc && activeProjectIdRef.current === projectId) {
+        if (removedDoc && committedProjectIdRef.current === projectId) {
           setProjectDocuments((prev) =>
             prev.some((document) => document.id === removedDoc.id)
               ? prev
@@ -443,7 +446,7 @@ export function ProjectProvider({
       if (
         documentRefreshGenerationRef.current !== generation ||
         documentMutationGenerationRef.current !== mutationGeneration ||
-        activeProjectIdRef.current !== projectId
+        committedProjectIdRef.current !== projectId
       ) {
         return
       }

--- a/src/components/project/project-provider.tsx
+++ b/src/components/project/project-provider.tsx
@@ -55,25 +55,30 @@ export function ProjectProvider({
 
   const isProjectMode = activeProject !== null
 
+  const resetProjectSessionState = useCallback(() => {
+    projectLoadGenerationRef.current += 1
+    documentRefreshGenerationRef.current += 1
+    documentMutationGenerationRef.current += 1
+    pendingProjectIdRef.current = null
+    committedProjectIdRef.current = null
+    setActiveProject(null)
+    setProjectDocuments([])
+    setUploadingFiles([])
+    setError(null)
+    setLoading(false)
+    setLoadingProject(null)
+  }, [])
+
   useEffect(() => {
     if (isSignedIn && !initializingRef.current) {
       initializingRef.current = true
     } else if (!isSignedIn) {
-      projectLoadGenerationRef.current += 1
-      documentRefreshGenerationRef.current += 1
-      documentMutationGenerationRef.current += 1
-      pendingProjectIdRef.current = null
-      committedProjectIdRef.current = null
       initializingRef.current = false
       initialProjectLoadedRef.current = false
       // Clear all user-specific state on logout to prevent data leaking across sessions
-      setActiveProject(null)
-      setProjectDocuments([])
-      setError(null)
-      setLoading(false)
-      setLoadingProject(null)
+      resetProjectSessionState()
     }
-  }, [isSignedIn])
+  }, [isSignedIn, resetProjectSessionState])
 
   // Memory callbacks for useMemory hook
   const memoryCallbacks = useMemo(
@@ -224,15 +229,7 @@ export function ProjectProvider({
   }, [initialProjectId, isSignedIn, activeProject, enterProjectMode])
 
   const exitProjectMode = useCallback(() => {
-    projectLoadGenerationRef.current += 1
-    documentRefreshGenerationRef.current += 1
-    documentMutationGenerationRef.current += 1
-    pendingProjectIdRef.current = null
-    committedProjectIdRef.current = null
-    setActiveProject(null)
-    setProjectDocuments([])
-    setUploadingFiles([])
-    setError(null)
+    resetProjectSessionState()
 
     // Signal to ChatSidebar that projects should be expanded
     sessionStorage.setItem(UI_EXPAND_PROJECTS_ON_MOUNT, 'true')
@@ -241,7 +238,7 @@ export function ProjectProvider({
       component: 'ProjectProvider',
       action: 'exitProjectMode',
     })
-  }, [])
+  }, [resetProjectSessionState])
 
   const createProject = useCallback(
     async (data: CreateProjectData): Promise<Project> => {

--- a/src/components/project/project-provider.tsx
+++ b/src/components/project/project-provider.tsx
@@ -23,6 +23,7 @@ import {
   type ProjectContextValue,
   type UploadingFile,
 } from './project-context'
+import { hydrateProjectDocuments } from './project-document-hydration'
 
 interface ProjectProviderProps {
   children: React.ReactNode
@@ -46,6 +47,10 @@ export function ProjectProvider({
   const [uploadingFiles, setUploadingFiles] = useState<UploadingFile[]>([])
   const initializingRef = useRef(false)
   const initialProjectLoadedRef = useRef(false)
+  const activeProjectIdRef = useRef<string | null>(null)
+  const projectLoadGenerationRef = useRef(0)
+  const documentRefreshGenerationRef = useRef(0)
+  const documentMutationGenerationRef = useRef(0)
 
   const isProjectMode = activeProject !== null
 
@@ -53,6 +58,10 @@ export function ProjectProvider({
     if (isSignedIn && !initializingRef.current) {
       initializingRef.current = true
     } else if (!isSignedIn) {
+      projectLoadGenerationRef.current += 1
+      documentRefreshGenerationRef.current += 1
+      documentMutationGenerationRef.current += 1
+      activeProjectIdRef.current = null
       initializingRef.current = false
       initialProjectLoadedRef.current = false
       // Clear all user-specific state on logout to prevent data leaking across sessions
@@ -129,6 +138,11 @@ export function ProjectProvider({
 
   const enterProjectMode = useCallback(
     async (projectId: string, projectName?: string): Promise<boolean> => {
+      const previousProjectId = activeProjectIdRef.current
+      const generation = projectLoadGenerationRef.current + 1
+      projectLoadGenerationRef.current = generation
+      documentRefreshGenerationRef.current += 1
+      activeProjectIdRef.current = projectId
       setLoading(true)
       setError(null)
       setUploadingFiles([])
@@ -147,24 +161,17 @@ export function ProjectProvider({
           documentsResponse.documents.map((doc) => doc.id),
         )
 
-        const documents: ProjectDocument[] = documentsResponse.documents.map(
-          (doc) => {
-            const full = fullById.get(doc.id)
-            if (!full) {
-              return { ...doc, filename: '', contentType: '' }
-            }
-            return {
-              ...doc,
-              content: full.content,
-              filename: full.filename,
-              contentType: full.contentType,
-              // The list surface only carries metadata and stamps
-              // sizeBytes as 0; the real size comes from the decoded
-              // document content.
-              sizeBytes: full.sizeBytes,
-            }
-          },
+        const documents = hydrateProjectDocuments(
+          documentsResponse.documents,
+          fullById,
         )
+
+        if (
+          projectLoadGenerationRef.current !== generation ||
+          activeProjectIdRef.current !== projectId
+        ) {
+          return false
+        }
 
         setActiveProject(project)
         setProjectDocuments(documents)
@@ -176,6 +183,8 @@ export function ProjectProvider({
         })
         return true
       } catch (err) {
+        if (projectLoadGenerationRef.current !== generation) return false
+        activeProjectIdRef.current = previousProjectId
         const message =
           err instanceof Error ? err.message : 'Failed to load project'
         setError(message)
@@ -186,8 +195,10 @@ export function ProjectProvider({
         })
         return false
       } finally {
-        setLoading(false)
-        setLoadingProject(null)
+        if (projectLoadGenerationRef.current === generation) {
+          setLoading(false)
+          setLoadingProject(null)
+        }
       }
     },
     [],
@@ -211,6 +222,10 @@ export function ProjectProvider({
   }, [initialProjectId, isSignedIn, activeProject, enterProjectMode])
 
   const exitProjectMode = useCallback(() => {
+    projectLoadGenerationRef.current += 1
+    documentRefreshGenerationRef.current += 1
+    documentMutationGenerationRef.current += 1
+    activeProjectIdRef.current = null
     setActiveProject(null)
     setProjectDocuments([])
     setUploadingFiles([])
@@ -321,23 +336,32 @@ export function ProjectProvider({
         throw new Error('No active project')
       }
 
+      const projectId = activeProject.id
+      documentRefreshGenerationRef.current += 1
       setError(null)
 
       try {
         const document = await projectStorage.uploadDocument(
-          activeProject.id,
+          projectId,
           file.name,
           file.type || 'text/plain',
           content,
+          file.size,
         )
 
-        setProjectDocuments((prev) => [...prev, document])
+        documentMutationGenerationRef.current += 1
+        if (activeProjectIdRef.current === projectId) {
+          setProjectDocuments((prev) => [
+            ...prev.filter((existing) => existing.id !== document.id),
+            document,
+          ])
+        }
 
         logInfo('Uploaded document', {
           component: 'ProjectProvider',
           action: 'uploadDocument',
           metadata: {
-            projectId: activeProject.id,
+            projectId,
             documentId: document.id,
             filename: file.name,
           },
@@ -360,6 +384,8 @@ export function ProjectProvider({
         throw new Error('No active project')
       }
 
+      const projectId = activeProject.id
+      documentRefreshGenerationRef.current += 1
       setError(null)
 
       const removedDoc = projectDocuments.find((doc) => doc.id === docId)
@@ -367,16 +393,27 @@ export function ProjectProvider({
       setProjectDocuments((prev) => prev.filter((doc) => doc.id !== docId))
 
       try {
-        await projectStorage.deleteDocument(activeProject.id, docId)
+        await projectStorage.deleteDocument(projectId, docId)
+        documentMutationGenerationRef.current += 1
+        if (activeProjectIdRef.current === projectId) {
+          setProjectDocuments((prev) =>
+            prev.filter((document) => document.id !== docId),
+          )
+        }
 
         logInfo('Removed document', {
           component: 'ProjectProvider',
           action: 'removeDocument',
-          metadata: { projectId: activeProject.id, documentId: docId },
+          metadata: { projectId, documentId: docId },
         })
       } catch (err) {
-        if (removedDoc) {
-          setProjectDocuments((prev) => [...prev, removedDoc])
+        documentMutationGenerationRef.current += 1
+        if (removedDoc && activeProjectIdRef.current === projectId) {
+          setProjectDocuments((prev) =>
+            prev.some((document) => document.id === removedDoc.id)
+              ? prev
+              : [...prev, removedDoc],
+          )
         }
 
         const message =
@@ -390,38 +427,40 @@ export function ProjectProvider({
 
   const refreshDocuments = useCallback(async () => {
     if (!activeProject) return
+    const projectId = activeProject.id
+    const generation = documentRefreshGenerationRef.current + 1
+    documentRefreshGenerationRef.current = generation
+    const mutationGeneration = documentMutationGenerationRef.current
 
     try {
-      const documentsResponse = await projectStorage.listDocuments(
-        activeProject.id,
-      )
+      const documentsResponse = await projectStorage.listDocuments(projectId)
 
       const fullById = await projectStorage.getDocuments(
-        activeProject.id,
+        projectId,
         documentsResponse.documents.map((doc) => doc.id),
       )
 
-      const documents: ProjectDocument[] = documentsResponse.documents.map(
-        (doc) => {
-          const full = fullById.get(doc.id)
-          if (!full) {
-            return { ...doc, filename: '', contentType: '' }
-          }
-          return {
-            ...doc,
-            content: full.content,
-            filename: full.filename,
-            contentType: full.contentType,
-          }
-        },
-      )
+      if (
+        documentRefreshGenerationRef.current !== generation ||
+        documentMutationGenerationRef.current !== mutationGeneration ||
+        activeProjectIdRef.current !== projectId
+      ) {
+        return
+      }
 
-      setProjectDocuments(documents)
+      setProjectDocuments((previous) =>
+        hydrateProjectDocuments(
+          documentsResponse.documents,
+          fullById,
+          previous,
+        ),
+      )
     } catch (err) {
+      if (documentRefreshGenerationRef.current !== generation) return
       logError('Failed to refresh documents', err, {
         component: 'ProjectProvider',
         action: 'refreshDocuments',
-        metadata: { projectId: activeProject.id },
+        metadata: { projectId },
       })
     }
   }, [activeProject])

--- a/src/components/project/project-sidebar.tsx
+++ b/src/components/project/project-sidebar.tsx
@@ -2,6 +2,7 @@
 
 import { ChatList, type ChatItemData } from '@/components/chat/chat-list'
 import { formatRelativeTime } from '@/components/chat/chat-list-utils'
+import { getDocumentTextContent } from '@/components/chat/document-content'
 import { useDocumentUploader } from '@/components/chat/document-uploader'
 import { useDrag } from '@/components/chat/drag-context'
 import { TypingAnimation } from '@/components/chat/typing-animation'
@@ -561,14 +562,28 @@ export function ProjectSidebar({
           return new Promise<void>((resolve) => {
             processDocument(
               file,
-              async (content) => {
+              async (
+                content,
+                _documentId,
+                _imageData,
+                _hasDescription,
+                pages,
+              ) => {
                 try {
-                  await uploadDocument(file, content)
-                } catch {
+                  const projectContent = getDocumentTextContent(content, pages)
+                  if (!projectContent) {
+                    throw new Error(
+                      'No readable content was found in this document.',
+                    )
+                  }
+                  await uploadDocument(file, projectContent)
+                } catch (error) {
                   toast({
                     title: 'Upload failed',
                     description:
-                      'Failed to upload the document. Please try again.',
+                      error instanceof Error
+                        ? error.message
+                        : 'Failed to upload the document. Please try again.',
                     variant: 'destructive',
                   })
                 } finally {
@@ -585,6 +600,8 @@ export function ProjectSidebar({
                 removeUploadingFile(uploadIds[i])
                 resolve()
               },
+              undefined,
+              { requireTextContent: true },
             )
           })
         }),
@@ -1299,17 +1316,23 @@ export function ProjectSidebar({
                             )}
                             <div className="min-w-0 flex-1">
                               <div className="truncate font-aeonik-fono text-xs text-content-primary">
-                                {doc.filename}
+                                {doc.decryptionFailed
+                                  ? 'Unable to load document'
+                                  : doc.filename}
                               </div>
                               <div className="font-aeonik-fono text-[10px] text-content-muted">
-                                {formatFileSize(doc.sizeBytes)}
+                                {doc.decryptionFailed
+                                  ? 'Unavailable'
+                                  : !doc.content?.trim()
+                                    ? 'No readable content'
+                                    : formatFileSize(doc.sizeBytes)}
                               </div>
                             </div>
                             <button
                               type="button"
                               onClick={() => handleRemoveDocument(doc.id)}
                               disabled={contextLoading}
-                              aria-label={`Remove ${doc.filename}`}
+                              aria-label={`Remove ${doc.filename || 'unavailable document'}`}
                               className={cn(
                                 'rounded p-0.5 transition-colors',
                                 isDarkMode

--- a/src/services/cloud/project-storage.ts
+++ b/src/services/cloud/project-storage.ts
@@ -56,6 +56,13 @@ function unavailableProjectDocument(
   }
 }
 
+function resolveDocumentSizeBytes(
+  content: string,
+  persistedSizeBytes?: number,
+): number {
+  return persistedSizeBytes ?? new TextEncoder().encode(content).length
+}
+
 // The legacy controlplane row exposed a numeric `syncVersion` to the
 // client. The enclave protocol carries the same monotonic counter as a
 // string ETag (§7 of the sync spec). The Project type still requires a
@@ -527,8 +534,7 @@ export class ProjectStorageService {
 
     const { documentId } = await this.generateDocumentId(projectId)
 
-    const persistedSizeBytes =
-      sizeBytes ?? new TextEncoder().encode(content).length
+    const persistedSizeBytes = resolveDocumentSizeBytes(content, sizeBytes)
     const docPayload = {
       content,
       filename,
@@ -603,8 +609,7 @@ export class ProjectStorageService {
         projectId,
         filename: decoded.filename || '',
         contentType: decoded.contentType || '',
-        sizeBytes:
-          decoded.sizeBytes ?? new TextEncoder().encode(decoded.content).length,
+        sizeBytes: resolveDocumentSizeBytes(decoded.content, decoded.sizeBytes),
         syncVersion: etagToSyncVersion(item.etag),
         createdAt: now,
         updatedAt: now,
@@ -702,9 +707,10 @@ export class ProjectStorageService {
             projectId,
             filename: decoded.filename || '',
             contentType: decoded.contentType || '',
-            sizeBytes:
-              decoded.sizeBytes ??
-              new TextEncoder().encode(decoded.content).length,
+            sizeBytes: resolveDocumentSizeBytes(
+              decoded.content,
+              decoded.sizeBytes,
+            ),
             syncVersion: etagToSyncVersion(item.etag),
             createdAt: now,
             updatedAt: now,

--- a/src/services/cloud/project-storage.ts
+++ b/src/services/cloud/project-storage.ts
@@ -38,6 +38,24 @@ function projectDocumentId(projectId: string, documentId: string): string {
   return `${projectId}/${documentId}`
 }
 
+function unavailableProjectDocument(
+  projectId: string,
+  documentId: string,
+): ProjectDocument {
+  const now = new Date().toISOString()
+  return {
+    id: documentId,
+    projectId,
+    filename: '',
+    contentType: '',
+    sizeBytes: 0,
+    syncVersion: 1,
+    createdAt: now,
+    updatedAt: now,
+    decryptionFailed: true,
+  }
+}
+
 // The legacy controlplane row exposed a numeric `syncVersion` to the
 // client. The enclave protocol carries the same monotonic counter as a
 // string ETag (§7 of the sync spec). The Project type still requires a
@@ -499,6 +517,7 @@ export class ProjectStorageService {
     filename: string,
     contentType: string,
     content: string,
+    sizeBytes?: number,
   ): Promise<ProjectDocument> {
     if (!(await canWriteToCloud())) {
       throw new Error(
@@ -508,7 +527,14 @@ export class ProjectStorageService {
 
     const { documentId } = await this.generateDocumentId(projectId)
 
-    const docPayload = { content, filename, contentType }
+    const persistedSizeBytes =
+      sizeBytes ?? new TextEncoder().encode(content).length
+    const docPayload = {
+      content,
+      filename,
+      contentType,
+      sizeBytes: persistedSizeBytes,
+    }
     const plaintext = new TextEncoder().encode(JSON.stringify(docPayload))
 
     const pushResp = await enclavePush({
@@ -527,7 +553,7 @@ export class ProjectStorageService {
       projectId,
       filename,
       contentType,
-      sizeBytes: new TextEncoder().encode(content).length,
+      sizeBytes: persistedSizeBytes,
       syncVersion: etagToSyncVersion(pushResp.etag),
       createdAt: now,
       updatedAt: now,
@@ -577,7 +603,8 @@ export class ProjectStorageService {
         projectId,
         filename: decoded.filename || '',
         contentType: decoded.contentType || '',
-        sizeBytes: new TextEncoder().encode(decoded.content).length,
+        sizeBytes:
+          decoded.sizeBytes ?? new TextEncoder().encode(decoded.content).length,
         syncVersion: etagToSyncVersion(item.etag),
         createdAt: now,
         updatedAt: now,
@@ -595,8 +622,8 @@ export class ProjectStorageService {
 
   // Batch variant of getDocument: pulls every requested document for a
   // project in a single enclave round-trip and returns the decoded
-  // ProjectDocument objects keyed by id. Missing ids are simply absent
-  // from the result Map.
+  // ProjectDocument objects keyed by id. Unavailable rows are represented
+  // explicitly so callers never mistake a pull failure for an empty file.
   async getDocuments(
     projectId: string,
     documentIds: string[],
@@ -623,11 +650,32 @@ export class ProjectStorageService {
       })
 
       for (const item of resp.items) {
-        if (!item.ok) continue
         const originalId = compositeToOriginal.get(item.id)
         if (!originalId) continue
+        if (!item.ok) {
+          result.set(
+            originalId,
+            unavailableProjectDocument(projectId, originalId),
+          )
+          logError('Failed to pull project document', undefined, {
+            component: 'ProjectStorage',
+            action: 'getDocuments',
+            metadata: {
+              projectId,
+              documentId: originalId,
+              code: item.code,
+            },
+          })
+          continue
+        }
         const plaintextBytes = pullItemPlaintext(item)
-        if (!plaintextBytes) continue
+        if (!plaintextBytes) {
+          result.set(
+            originalId,
+            unavailableProjectDocument(projectId, originalId),
+          )
+          continue
+        }
         try {
           const documentValidation = ProjectDocumentPlaintextSchema.safeParse(
             JSON.parse(new TextDecoder().decode(plaintextBytes)),
@@ -641,6 +689,10 @@ export class ProjectStorageService {
                 issues: documentValidation.error.message,
               },
             })
+            result.set(
+              originalId,
+              unavailableProjectDocument(projectId, originalId),
+            )
             continue
           }
           const decoded = documentValidation.data
@@ -650,7 +702,9 @@ export class ProjectStorageService {
             projectId,
             filename: decoded.filename || '',
             contentType: decoded.contentType || '',
-            sizeBytes: new TextEncoder().encode(decoded.content).length,
+            sizeBytes:
+              decoded.sizeBytes ??
+              new TextEncoder().encode(decoded.content).length,
             syncVersion: etagToSyncVersion(item.etag),
             createdAt: now,
             updatedAt: now,
@@ -662,6 +716,18 @@ export class ProjectStorageService {
             action: 'getDocuments',
             metadata: { projectId, documentId: originalId },
           })
+          result.set(
+            originalId,
+            unavailableProjectDocument(projectId, originalId),
+          )
+        }
+      }
+      for (const documentId of documentIds) {
+        if (!result.has(documentId)) {
+          result.set(
+            documentId,
+            unavailableProjectDocument(projectId, documentId),
+          )
         }
       }
       return result

--- a/src/services/cloud/schemas.ts
+++ b/src/services/cloud/schemas.ts
@@ -183,5 +183,6 @@ export const ProjectDocumentPlaintextSchema = z
     content: z.string(),
     filename: z.string().optional(),
     contentType: z.string().optional(),
+    sizeBytes: z.number().nonnegative().optional(),
   })
   .passthrough()

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -28,6 +28,7 @@ export interface ProjectDocument {
   createdAt: string
   updatedAt: string
   content?: string
+  decryptionFailed?: boolean
 }
 
 export interface ProjectChat {

--- a/tests/components/chat/document-content.test.ts
+++ b/tests/components/chat/document-content.test.ts
@@ -1,0 +1,21 @@
+import { getDocumentTextContent } from '@/components/chat/document-content'
+import { describe, expect, it } from 'vitest'
+
+describe('getDocumentTextContent', () => {
+  it('uses extracted markdown when available', () => {
+    expect(getDocumentTextContent('# Notes')).toBe('# Notes')
+  })
+
+  it('recovers text from processed pages', () => {
+    expect(
+      getDocumentTextContent('', [
+        { page: 1, text: 'First page', image: '', is_scanned: false },
+        { page: 2, text: 'Second page', image: '', is_scanned: true },
+      ]),
+    ).toBe('First page\n\n---\n\nSecond page')
+  })
+
+  it('rejects processing results without readable content', () => {
+    expect(getDocumentTextContent('   ', [])).toBeNull()
+  })
+})

--- a/tests/components/chat/document-uploader.test.tsx
+++ b/tests/components/chat/document-uploader.test.tsx
@@ -1,0 +1,39 @@
+import { useDocumentUploader } from '@/components/chat/document-uploader'
+import { act, renderHook } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+describe('useDocumentUploader', () => {
+  it('waits for asynchronous persistence callbacks to finish', async () => {
+    const { result } = renderHook(() => useDocumentUploader())
+    let resolvePersistence!: () => void
+    const onSuccess = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolvePersistence = resolve
+        }),
+    )
+    let completed = false
+
+    let uploadPromise!: Promise<void>
+    act(() => {
+      uploadPromise = result.current
+        .handleDocumentUpload(
+          new File(['Project context'], 'notes.txt', { type: 'text/plain' }),
+          onSuccess,
+          vi.fn(),
+        )
+        .then(() => {
+          completed = true
+        })
+    })
+
+    await vi.waitFor(() => expect(onSuccess).toHaveBeenCalledOnce())
+    expect(completed).toBe(false)
+
+    await act(async () => {
+      resolvePersistence()
+      await uploadPromise
+    })
+    expect(completed).toBe(true)
+  })
+})

--- a/tests/components/project/project-document-hydration.test.ts
+++ b/tests/components/project/project-document-hydration.test.ts
@@ -1,0 +1,88 @@
+import { hydrateProjectDocuments } from '@/components/project/project-document-hydration'
+import type { ProjectDocument } from '@/types/project'
+import { describe, expect, it } from 'vitest'
+
+const listedDocument = {
+  id: 'doc-1',
+  projectId: 'project-1',
+  sizeBytes: 0,
+  syncVersion: 2,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-02T00:00:00.000Z',
+}
+
+function fullDocument(
+  overrides: Partial<ProjectDocument> = {},
+): ProjectDocument {
+  return {
+    ...listedDocument,
+    filename: 'notes.pdf',
+    contentType: 'application/pdf',
+    sizeBytes: 4096,
+    content: 'Persisted project context',
+    ...overrides,
+  }
+}
+
+describe('hydrateProjectDocuments', () => {
+  it('uses the persisted document size instead of list metadata', () => {
+    const hydrated = hydrateProjectDocuments(
+      [listedDocument],
+      new Map([['doc-1', fullDocument()]]),
+    )
+
+    expect(hydrated[0]).toMatchObject({
+      filename: 'notes.pdf',
+      sizeBytes: 4096,
+      content: 'Persisted project context',
+    })
+  })
+
+  it('preserves loaded content when a refresh cannot decrypt the document', () => {
+    const previous = fullDocument()
+    const unavailable = fullDocument({
+      filename: '',
+      contentType: '',
+      sizeBytes: 0,
+      content: undefined,
+      decryptionFailed: true,
+    })
+
+    const hydrated = hydrateProjectDocuments(
+      [listedDocument],
+      new Map([['doc-1', unavailable]]),
+      [previous],
+    )
+
+    expect(hydrated[0]).toMatchObject({
+      filename: 'notes.pdf',
+      sizeBytes: 4096,
+      content: 'Persisted project context',
+    })
+    expect(hydrated[0].decryptionFailed).toBeFalsy()
+  })
+
+  it('preserves valid empty legacy documents during a failed refresh', () => {
+    const previous = fullDocument({ content: '', sizeBytes: 128 })
+
+    const hydrated = hydrateProjectDocuments([listedDocument], new Map(), [
+      previous,
+    ])
+
+    expect(hydrated[0]).toMatchObject({
+      filename: 'notes.pdf',
+      sizeBytes: 128,
+      content: '',
+    })
+  })
+
+  it('marks an unavailable document instead of presenting it as empty', () => {
+    const hydrated = hydrateProjectDocuments([listedDocument], new Map())
+
+    expect(hydrated[0]).toMatchObject({
+      filename: '',
+      sizeBytes: 0,
+      decryptionFailed: true,
+    })
+  })
+})

--- a/tests/components/project/project-provider-documents.test.tsx
+++ b/tests/components/project/project-provider-documents.test.tsx
@@ -1,0 +1,272 @@
+import { useProject } from '@/components/project/project-context'
+import { ProjectProvider } from '@/components/project/project-provider'
+import type { Project, ProjectDocument } from '@/types/project'
+import { act, renderHook } from '@testing-library/react'
+import type { PropsWithChildren } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  getProject: vi.fn(),
+  listDocuments: vi.fn(),
+  getDocuments: vi.fn(),
+  uploadDocument: vi.fn(),
+  deleteDocument: vi.fn(),
+  loadMemory: vi.fn(),
+  processMessages: vi.fn(),
+}))
+
+vi.mock('@clerk/nextjs', () => ({
+  useAuth: () => ({ isSignedIn: true }),
+}))
+
+vi.mock('@/hooks/use-memory', () => ({
+  useMemory: () => ({
+    loadMemory: mocks.loadMemory,
+    processMessages: mocks.processMessages,
+  }),
+}))
+
+vi.mock('@/services/project/project-events', () => ({
+  projectEvents: { on: vi.fn(() => vi.fn()) },
+}))
+
+vi.mock('@/services/cloud/project-storage', () => ({
+  projectStorage: {
+    getProject: mocks.getProject,
+    listDocuments: mocks.listDocuments,
+    getDocuments: mocks.getDocuments,
+    uploadDocument: mocks.uploadDocument,
+    deleteDocument: mocks.deleteDocument,
+  },
+}))
+
+vi.mock('@/utils/error-handling', () => ({
+  logError: vi.fn(),
+  logInfo: vi.fn(),
+}))
+
+const project: Project = {
+  id: 'project-1',
+  name: 'Research',
+  description: '',
+  systemInstructions: '',
+  memory: [],
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  syncVersion: 1,
+}
+
+const listedDocument = {
+  id: 'doc-1',
+  projectId: project.id,
+  sizeBytes: 0,
+  syncVersion: 1,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+}
+
+const persistedDocument: ProjectDocument = {
+  ...listedDocument,
+  filename: 'notes.pdf',
+  contentType: 'application/pdf',
+  sizeBytes: 2048,
+  content: 'Project notes',
+}
+
+function wrapper({ children }: PropsWithChildren) {
+  return <ProjectProvider>{children}</ProjectProvider>
+}
+
+describe('ProjectProvider documents', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.getProject.mockResolvedValue(project)
+    mocks.listDocuments.mockResolvedValue({ documents: [listedDocument] })
+    mocks.getDocuments.mockResolvedValue(
+      new Map([['doc-1', persistedDocument]]),
+    )
+  })
+
+  it('keeps decoded document sizes after a refresh', async () => {
+    const { result } = renderHook(() => useProject(), { wrapper })
+
+    await act(async () => {
+      await result.current.enterProjectMode(project.id)
+    })
+    await act(async () => {
+      await result.current.refreshDocuments()
+    })
+
+    expect(result.current.projectDocuments[0].sizeBytes).toBe(2048)
+  })
+
+  it('does not let a stale refresh remove a completed upload', async () => {
+    mocks.listDocuments.mockResolvedValueOnce({ documents: [] })
+    mocks.getDocuments.mockResolvedValueOnce(new Map())
+    const { result } = renderHook(() => useProject(), { wrapper })
+
+    await act(async () => {
+      await result.current.enterProjectMode(project.id)
+    })
+
+    let resolveRefresh!: (documents: Map<string, ProjectDocument>) => void
+    mocks.listDocuments.mockResolvedValueOnce({ documents: [] })
+    mocks.getDocuments.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveRefresh = resolve
+      }),
+    )
+
+    let refreshPromise!: Promise<void>
+    act(() => {
+      refreshPromise = result.current.refreshDocuments()
+    })
+    await vi.waitFor(() => expect(mocks.getDocuments).toHaveBeenCalledTimes(2))
+
+    const uploadedDocument = {
+      ...persistedDocument,
+      id: 'doc-uploaded',
+    }
+    mocks.uploadDocument.mockResolvedValue(uploadedDocument)
+    await act(async () => {
+      await result.current.uploadDocument(
+        new File(['Project notes'], 'notes.pdf', {
+          type: 'application/pdf',
+        }),
+        'Project notes',
+      )
+    })
+
+    await act(async () => {
+      resolveRefresh(new Map())
+      await refreshPromise
+    })
+
+    expect(result.current.projectDocuments).toContainEqual(uploadedDocument)
+  })
+
+  it('discards a refresh that snapshots while an upload is pending', async () => {
+    mocks.listDocuments.mockResolvedValueOnce({ documents: [] })
+    mocks.getDocuments.mockResolvedValueOnce(new Map())
+    const { result } = renderHook(() => useProject(), { wrapper })
+
+    await act(async () => {
+      await result.current.enterProjectMode(project.id)
+    })
+
+    let resolveUpload!: (document: ProjectDocument) => void
+    mocks.uploadDocument.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveUpload = resolve
+      }),
+    )
+    let uploadPromise!: Promise<ProjectDocument>
+    act(() => {
+      uploadPromise = result.current.uploadDocument(
+        new File(['Project notes'], 'notes.pdf', {
+          type: 'application/pdf',
+        }),
+        'Project notes',
+      )
+    })
+
+    let resolveRefresh!: (documents: Map<string, ProjectDocument>) => void
+    mocks.listDocuments.mockResolvedValueOnce({ documents: [] })
+    mocks.getDocuments.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveRefresh = resolve
+      }),
+    )
+    let refreshPromise!: Promise<void>
+    act(() => {
+      refreshPromise = result.current.refreshDocuments()
+    })
+    await vi.waitFor(() => expect(mocks.getDocuments).toHaveBeenCalledTimes(2))
+
+    const uploadedDocument = {
+      ...persistedDocument,
+      id: 'doc-uploaded',
+    }
+    await act(async () => {
+      resolveUpload(uploadedDocument)
+      await uploadPromise
+    })
+    await act(async () => {
+      resolveRefresh(new Map())
+      await refreshPromise
+    })
+
+    expect(result.current.projectDocuments).toContainEqual(uploadedDocument)
+  })
+
+  it('does not let a stale refresh restore a deleted document', async () => {
+    const { result } = renderHook(() => useProject(), { wrapper })
+    await act(async () => {
+      await result.current.enterProjectMode(project.id)
+    })
+
+    let resolveDelete!: () => void
+    mocks.deleteDocument.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        resolveDelete = resolve
+      }),
+    )
+    let deletePromise!: Promise<void>
+    act(() => {
+      deletePromise = result.current.removeDocument(persistedDocument.id)
+    })
+
+    let resolveRefresh!: (documents: Map<string, ProjectDocument>) => void
+    mocks.listDocuments.mockResolvedValueOnce({ documents: [listedDocument] })
+    mocks.getDocuments.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveRefresh = resolve
+      }),
+    )
+    let refreshPromise!: Promise<void>
+    act(() => {
+      refreshPromise = result.current.refreshDocuments()
+    })
+    await vi.waitFor(() => expect(mocks.getDocuments).toHaveBeenCalledTimes(2))
+
+    await act(async () => {
+      resolveDelete()
+      await deletePromise
+    })
+    await act(async () => {
+      resolveRefresh(new Map([['doc-1', persistedDocument]]))
+      await refreshPromise
+    })
+
+    expect(result.current.projectDocuments).toEqual([])
+  })
+
+  it('does not duplicate a document when deletion rollback follows a refresh', async () => {
+    const { result } = renderHook(() => useProject(), { wrapper })
+    await act(async () => {
+      await result.current.enterProjectMode(project.id)
+    })
+
+    let rejectDelete!: (error: Error) => void
+    mocks.deleteDocument.mockReturnValueOnce(
+      new Promise<void>((_resolve, reject) => {
+        rejectDelete = reject
+      }),
+    )
+    let deletePromise!: Promise<void>
+    act(() => {
+      deletePromise = result.current.removeDocument(persistedDocument.id)
+    })
+
+    await act(async () => {
+      await result.current.refreshDocuments()
+    })
+    await act(async () => {
+      rejectDelete(new Error('Delete failed'))
+      await expect(deletePromise).rejects.toThrow('Delete failed')
+    })
+
+    expect(result.current.projectDocuments).toHaveLength(1)
+    expect(result.current.projectDocuments[0]).toMatchObject(persistedDocument)
+  })
+})

--- a/tests/components/project/project-provider-documents.test.tsx
+++ b/tests/components/project/project-provider-documents.test.tsx
@@ -73,8 +73,20 @@ const persistedDocument: ProjectDocument = {
   content: 'Project notes',
 }
 
+const testFile = new File(['Project notes'], 'notes.pdf', {
+  type: 'application/pdf',
+})
+
 function wrapper({ children }: PropsWithChildren) {
   return <ProjectProvider>{children}</ProjectProvider>
+}
+
+async function renderInProject() {
+  const rendered = renderHook(() => useProject(), { wrapper })
+  await act(async () => {
+    await rendered.result.current.enterProjectMode(project.id)
+  })
+  return rendered
 }
 
 describe('ProjectProvider documents', () => {
@@ -88,11 +100,7 @@ describe('ProjectProvider documents', () => {
   })
 
   it('keeps decoded document sizes after a refresh', async () => {
-    const { result } = renderHook(() => useProject(), { wrapper })
-
-    await act(async () => {
-      await result.current.enterProjectMode(project.id)
-    })
+    const { result } = await renderInProject()
     await act(async () => {
       await result.current.refreshDocuments()
     })
@@ -103,11 +111,7 @@ describe('ProjectProvider documents', () => {
   it('does not let a stale refresh remove a completed upload', async () => {
     mocks.listDocuments.mockResolvedValueOnce({ documents: [] })
     mocks.getDocuments.mockResolvedValueOnce(new Map())
-    const { result } = renderHook(() => useProject(), { wrapper })
-
-    await act(async () => {
-      await result.current.enterProjectMode(project.id)
-    })
+    const { result } = await renderInProject()
 
     let resolveRefresh!: (documents: Map<string, ProjectDocument>) => void
     mocks.listDocuments.mockResolvedValueOnce({ documents: [] })
@@ -129,12 +133,7 @@ describe('ProjectProvider documents', () => {
     }
     mocks.uploadDocument.mockResolvedValue(uploadedDocument)
     await act(async () => {
-      await result.current.uploadDocument(
-        new File(['Project notes'], 'notes.pdf', {
-          type: 'application/pdf',
-        }),
-        'Project notes',
-      )
+      await result.current.uploadDocument(testFile, 'Project notes')
     })
 
     await act(async () => {
@@ -148,11 +147,7 @@ describe('ProjectProvider documents', () => {
   it('discards a refresh that snapshots while an upload is pending', async () => {
     mocks.listDocuments.mockResolvedValueOnce({ documents: [] })
     mocks.getDocuments.mockResolvedValueOnce(new Map())
-    const { result } = renderHook(() => useProject(), { wrapper })
-
-    await act(async () => {
-      await result.current.enterProjectMode(project.id)
-    })
+    const { result } = await renderInProject()
 
     let resolveUpload!: (document: ProjectDocument) => void
     mocks.uploadDocument.mockReturnValueOnce(
@@ -162,12 +157,7 @@ describe('ProjectProvider documents', () => {
     )
     let uploadPromise!: Promise<ProjectDocument>
     act(() => {
-      uploadPromise = result.current.uploadDocument(
-        new File(['Project notes'], 'notes.pdf', {
-          type: 'application/pdf',
-        }),
-        'Project notes',
-      )
+      uploadPromise = result.current.uploadDocument(testFile, 'Project notes')
     })
 
     let resolveRefresh!: (documents: Map<string, ProjectDocument>) => void
@@ -200,10 +190,7 @@ describe('ProjectProvider documents', () => {
   })
 
   it('does not let a stale refresh restore a deleted document', async () => {
-    const { result } = renderHook(() => useProject(), { wrapper })
-    await act(async () => {
-      await result.current.enterProjectMode(project.id)
-    })
+    const { result } = await renderInProject()
 
     let resolveDelete!: () => void
     mocks.deleteDocument.mockReturnValueOnce(
@@ -242,10 +229,7 @@ describe('ProjectProvider documents', () => {
   })
 
   it('does not duplicate a document when deletion rollback follows a refresh', async () => {
-    const { result } = renderHook(() => useProject(), { wrapper })
-    await act(async () => {
-      await result.current.enterProjectMode(project.id)
-    })
+    const { result } = await renderInProject()
 
     let rejectDelete!: (error: Error) => void
     mocks.deleteDocument.mockReturnValueOnce(
@@ -268,5 +252,44 @@ describe('ProjectProvider documents', () => {
 
     expect(result.current.projectDocuments).toHaveLength(1)
     expect(result.current.projectDocuments[0]).toMatchObject(persistedDocument)
+  })
+
+  it('restores the committed project after a superseding switch fails', async () => {
+    const { result } = await renderInProject()
+    let resolvePendingSwitch!: (project: Project) => void
+    mocks.getProject
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolvePendingSwitch = resolve
+        }),
+      )
+      .mockResolvedValueOnce(null)
+
+    let pendingSwitch!: Promise<boolean>
+    act(() => {
+      pendingSwitch = result.current.enterProjectMode('project-b')
+    })
+    await act(async () => {
+      await expect(result.current.enterProjectMode('project-d')).resolves.toBe(
+        false,
+      )
+    })
+
+    const uploadedDocument = {
+      ...persistedDocument,
+      id: 'doc-after-failed-switch',
+    }
+    mocks.uploadDocument.mockResolvedValue(uploadedDocument)
+    await act(async () => {
+      await result.current.uploadDocument(testFile, 'Project notes')
+    })
+
+    await act(async () => {
+      resolvePendingSwitch({ ...project, id: 'project-b' })
+      await expect(pendingSwitch).resolves.toBe(false)
+    })
+
+    expect(result.current.activeProject?.id).toBe(project.id)
+    expect(result.current.projectDocuments).toContainEqual(uploadedDocument)
   })
 })

--- a/tests/services/cloud/project-storage.documents.test.ts
+++ b/tests/services/cloud/project-storage.documents.test.ts
@@ -1,0 +1,114 @@
+import { ProjectStorageService } from '@/services/cloud/project-storage'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  enclavePull: vi.fn(),
+  enclavePush: vi.fn(),
+  pullItemPlaintext: vi.fn(),
+}))
+
+vi.mock('@/services/auth', () => ({
+  authTokenManager: { getToken: vi.fn() },
+}))
+
+vi.mock('@/services/cloud/cloud-key-authorization', () => ({
+  canWriteToCloud: vi.fn().mockResolvedValue(true),
+}))
+
+vi.mock('@/services/cloud/cek-encoding', () => ({
+  pullKey: () => [{ key: 'primary-key' }],
+  requirePrimaryKeyB64: () => 'primary-key',
+}))
+
+vi.mock('@/services/sync-enclave/sync-api', () => ({
+  deleteRow: vi.fn(),
+  listStatus: vi.fn(),
+  pull: mocks.enclavePull,
+  push: mocks.enclavePush,
+  newIdempotencyKey: () => 'idempotency-key',
+  pullItemPlaintext: mocks.pullItemPlaintext,
+}))
+
+vi.mock('@/utils/error-handling', () => ({
+  logError: vi.fn(),
+}))
+
+describe('ProjectStorageService documents', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('persists and restores the original file size', async () => {
+    const storage = new ProjectStorageService()
+    vi.spyOn(storage, 'generateDocumentId').mockResolvedValue({
+      documentId: 'doc-1',
+      timestamp: '2026-01-01T00:00:00.000Z',
+      reverseTimestamp: 1,
+    })
+    mocks.enclavePush.mockResolvedValue({ etag: '1' })
+
+    const document = await storage.uploadDocument(
+      'project-1',
+      'notes.pdf',
+      'application/pdf',
+      'Extracted text',
+      8192,
+    )
+
+    const pushRequest = mocks.enclavePush.mock.calls[0][0]
+    const payload = JSON.parse(new TextDecoder().decode(pushRequest.plaintext))
+    expect(payload.sizeBytes).toBe(8192)
+    expect(document.sizeBytes).toBe(8192)
+
+    mocks.enclavePull.mockResolvedValue({
+      items: [{ id: 'project-1/doc-1', ok: true, etag: '1' }],
+    })
+    mocks.pullItemPlaintext.mockReturnValue(pushRequest.plaintext)
+    const restored = await storage.getDocuments('project-1', ['doc-1'])
+    expect(restored.get('doc-1')?.sizeBytes).toBe(8192)
+  })
+
+  it('derives a size when reading legacy document payloads', async () => {
+    const storage = new ProjectStorageService()
+    const content = 'R\u00e9sum\u00e9'
+    mocks.enclavePull.mockResolvedValue({
+      items: [{ id: 'project-1/doc-1', ok: true, etag: '1' }],
+    })
+    mocks.pullItemPlaintext.mockReturnValue(
+      new TextEncoder().encode(
+        JSON.stringify({
+          content,
+          filename: 'notes.txt',
+          contentType: 'text/plain',
+        }),
+      ),
+    )
+
+    const documents = await storage.getDocuments('project-1', ['doc-1'])
+
+    expect(documents.get('doc-1')?.sizeBytes).toBe(
+      new TextEncoder().encode(content).length,
+    )
+  })
+
+  it('marks failed pulls as unavailable documents', async () => {
+    const storage = new ProjectStorageService()
+    mocks.enclavePull.mockResolvedValue({
+      items: [
+        {
+          id: 'project-1/doc-1',
+          ok: false,
+          code: 'UNKNOWN_KEY',
+        },
+      ],
+    })
+
+    const documents = await storage.getDocuments('project-1', ['doc-1'])
+
+    expect(documents.get('doc-1')).toMatchObject({
+      id: 'doc-1',
+      projectId: 'project-1',
+      decryptionFailed: true,
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- preserve hydrated project document content and file sizes across sidebar refreshes
- prevent stale refreshes from removing uploads or restoring deleted documents
- persist original file sizes while retaining compatibility with legacy document payloads
- surface unavailable and unreadable documents instead of presenting them as empty files
- require reusable text content for persistent project uploads and await storage completion

## Verification
- `npm run test:unit -- --run` (124 files, 1417 tests passed)
- focused project document suite (16 tests passed)
- `npx eslint` on changed source and tests
- `npx tsc --noEmit`
- `npm run build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps project documents intact across reloads by preserving content and sizes, prevents stale refreshes from overwriting recent uploads or deletions, and keeps the active project when a later switch fails; also unifies project session cleanup to avoid cross-session leaks. Unreadable documents are clearly marked and uploads require real text to avoid empty files.

- **Bug Fixes**
  - Preserve hydrated content and accurate `sizeBytes` across sidebar refreshes; derive size from legacy payloads when needed.
  - Guard against stale refreshes during upload/delete with generation checks; avoid restoring deleted docs or duplicating on rollback.
  - Keep the committed project active if a superseding project switch fails; prevent cross-project state leaks.
  - Mark unavailable pulls as `decryptionFailed` and show clear UI states (“Unable to load” / “Unavailable”) instead of empty files.
  - Unify project session cleanup for logout/exit to reliably clear user state and loading flags.

- **New Features**
  - Require reusable text for project document uploads; recover text from per-page results; block uploads without readable content.
  - Await storage completion for uploads; uploader success callbacks can be async; storage persists `sizeBytes` and batch pulls return explicit unavailable rows.

<sup>Written for commit ff95e4f73f4a04befd9a6577204130237b548399. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/470?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

