### PR TITLE
Fix unresponsive social sign-in in Firefox

### DIFF
--- a/src/pages/signin.tsx
+++ b/src/pages/signin.tsx
@@ -243,6 +243,7 @@ export default function SignInPage() {
             : `${SSO_CALLBACK_URL}?redirect_url=${encodeURIComponent(postAuthRedirectUrl)}`
         const { error } = await signIn.sso({
           strategy,
+          popup: window,
           redirectCallbackUrl,
           redirectUrl: postAuthRedirectUrl,
         })

--- a/src/pages/signin.tsx
+++ b/src/pages/signin.tsx
@@ -24,6 +24,9 @@ const SUPPORTED_MISSING_FIELDS = new Set([
 const AUTH_ERROR_MESSAGE = 'Something went wrong. Please try again.'
 const UNSUPPORTED_REQUIREMENTS_MESSAGE =
   'Your account needs additional setup. Please contact support.'
+const SOCIAL_SIGN_IN_POPUP_FEATURES = 'popup,width=600,height=800'
+const POPUP_BLOCKED_MESSAGE =
+  'Allow pop-ups for this site to continue with Google or Apple.'
 
 type AuthStep = 'email' | 'code' | 'details'
 type VerificationKind = 'primary' | 'mfa' | 'totp'
@@ -241,14 +244,30 @@ export default function SignInPage() {
           postAuthRedirectUrl === POST_AUTH_REDIRECT_URL
             ? SSO_CALLBACK_URL
             : `${SSO_CALLBACK_URL}?redirect_url=${encodeURIComponent(postAuthRedirectUrl)}`
-        const { error } = await signIn.sso({
-          strategy,
-          popup: window,
-          redirectCallbackUrl,
-          redirectUrl: postAuthRedirectUrl,
-        })
-        if (error) {
-          setErrorMessage(getClerkErrorMessage(error, AUTH_ERROR_MESSAGE))
+        const popup = window.open(
+          'about:blank',
+          '_blank',
+          SOCIAL_SIGN_IN_POPUP_FEATURES,
+        )
+        if (!popup) {
+          setErrorMessage(POPUP_BLOCKED_MESSAGE)
+          return
+        }
+
+        try {
+          const { error } = await signIn.sso({
+            strategy,
+            popup,
+            redirectCallbackUrl,
+            redirectUrl: postAuthRedirectUrl,
+          })
+          if (error) {
+            popup.close()
+            setErrorMessage(getClerkErrorMessage(error, AUTH_ERROR_MESSAGE))
+          }
+        } catch (error) {
+          popup.close()
+          throw error
         }
       },
     )

--- a/src/pages/signin.tsx
+++ b/src/pages/signin.tsx
@@ -258,8 +258,12 @@ export default function SignInPage() {
           const { error } = await signIn.sso({
             strategy,
             popup,
-            redirectCallbackUrl,
-            redirectUrl: postAuthRedirectUrl,
+            redirectCallbackUrl: new URL(
+              redirectCallbackUrl,
+              window.location.origin,
+            ).href,
+            redirectUrl: new URL(postAuthRedirectUrl, window.location.origin)
+              .href,
           })
           if (error) {
             popup.close()

--- a/tests/pages/signin.test.tsx
+++ b/tests/pages/signin.test.tsx
@@ -278,6 +278,22 @@ describe('SignInPage', () => {
     await waitFor(() => {
       expect(auth.signIn.sso).toHaveBeenCalledWith({
         strategy: 'oauth_google',
+        popup: window,
+        redirectCallbackUrl: '/sso-callback',
+        redirectUrl: '/',
+      })
+    })
+  })
+
+  it('starts Apple sign-in in the current browser window', async () => {
+    render(<SignInPage />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Continue with Apple' }))
+
+    await waitFor(() => {
+      expect(auth.signIn.sso).toHaveBeenCalledWith({
+        strategy: 'oauth_apple',
+        popup: window,
         redirectCallbackUrl: '/sso-callback',
         redirectUrl: '/',
       })

--- a/tests/pages/signin.test.tsx
+++ b/tests/pages/signin.test.tsx
@@ -1,6 +1,8 @@
 import SignInPage from '@/pages/signin'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const socialPopup = { close: vi.fn() } as unknown as Window
 
 const auth = vi.hoisted(() => {
   const signIn = {
@@ -51,6 +53,7 @@ vi.mock('next/router', () => ({
 describe('SignInPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.spyOn(window, 'open').mockReturnValue(socialPopup)
     auth.signIn.status = 'needs_identifier'
     auth.signIn.supportedSecondFactors = []
     auth.signUp.status = 'missing_requirements'
@@ -64,6 +67,10 @@ describe('SignInPage', () => {
     auth.signIn.sso.mockResolvedValue({ error: null })
     auth.signUp.create.mockResolvedValue({ error: null })
     auth.signUp.update.mockResolvedValue({ error: null })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
   })
 
   it('uses the branded layout with social and email options', () => {
@@ -268,36 +275,46 @@ describe('SignInPage', () => {
     })
   })
 
-  it('starts social sign-in through Clerk custom flow APIs', async () => {
+  it.each([
+    ['Google', 'oauth_google'],
+    ['Apple', 'oauth_apple'],
+  ] as const)(
+    'starts %s sign-in in a dedicated popup',
+    async (provider, strategy) => {
+      render(<SignInPage />)
+
+      fireEvent.click(
+        screen.getByRole('button', { name: `Continue with ${provider}` }),
+      )
+
+      await waitFor(() => {
+        expect(window.open).toHaveBeenCalledWith(
+          'about:blank',
+          '_blank',
+          expect.any(String),
+        )
+        expect(auth.signIn.sso).toHaveBeenCalledWith({
+          strategy,
+          popup: socialPopup,
+          redirectCallbackUrl: '/sso-callback',
+          redirectUrl: '/',
+        })
+      })
+    },
+  )
+
+  it('explains how to continue when the social popup is blocked', async () => {
+    vi.mocked(window.open).mockReturnValue(null)
     render(<SignInPage />)
 
     fireEvent.click(
       screen.getByRole('button', { name: 'Continue with Google' }),
     )
 
-    await waitFor(() => {
-      expect(auth.signIn.sso).toHaveBeenCalledWith({
-        strategy: 'oauth_google',
-        popup: window,
-        redirectCallbackUrl: '/sso-callback',
-        redirectUrl: '/',
-      })
-    })
-  })
-
-  it('starts Apple sign-in in the current browser window', async () => {
-    render(<SignInPage />)
-
-    fireEvent.click(screen.getByRole('button', { name: 'Continue with Apple' }))
-
-    await waitFor(() => {
-      expect(auth.signIn.sso).toHaveBeenCalledWith({
-        strategy: 'oauth_apple',
-        popup: window,
-        redirectCallbackUrl: '/sso-callback',
-        redirectUrl: '/',
-      })
-    })
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Allow pop-ups for this site to continue with Google or Apple.',
+    )
+    expect(auth.signIn.sso).not.toHaveBeenCalled()
   })
 
   it('shows the Clerk error when social sign-in cannot start', async () => {

--- a/tests/pages/signin.test.tsx
+++ b/tests/pages/signin.test.tsx
@@ -296,8 +296,9 @@ describe('SignInPage', () => {
         expect(auth.signIn.sso).toHaveBeenCalledWith({
           strategy,
           popup: socialPopup,
-          redirectCallbackUrl: '/sso-callback',
-          redirectUrl: '/',
+          redirectCallbackUrl: new URL('/sso-callback', window.location.origin)
+            .href,
+          redirectUrl: new URL('/', window.location.origin).href,
         })
       })
     },


### PR DESCRIPTION
## Summary
- open Google and Apple authentication in a dedicated popup through Clerk's custom-flow API so Firefox receives an immediate browser navigation
- keep the branded sign-in UI and show a clear error when the browser blocks the popup
- cover both providers and blocked-popup behavior with regression tests

## Testing
- `npx vitest run tests/pages/signin.test.tsx`
- `npx vitest run` (1,427 tests passed; Happy DOM emitted an abort teardown warning)
- `npx eslint src/pages/signin.tsx tests/pages/signin.test.tsx`
- `npx tsc --noEmit`
- verified the popup reaches `accounts.google.com` with Playwright Firefox against the production Clerk instance