### PR TITLE
Restore same-tab social sign-in

### DIFF
--- a/src/pages/signin.tsx
+++ b/src/pages/signin.tsx
@@ -24,9 +24,6 @@ const SUPPORTED_MISSING_FIELDS = new Set([
 const AUTH_ERROR_MESSAGE = 'Something went wrong. Please try again.'
 const UNSUPPORTED_REQUIREMENTS_MESSAGE =
   'Your account needs additional setup. Please contact support.'
-const SOCIAL_SIGN_IN_POPUP_FEATURES = 'popup,width=600,height=800'
-const POPUP_BLOCKED_MESSAGE =
-  'Allow pop-ups for this site to continue with Google or Apple.'
 
 type AuthStep = 'email' | 'code' | 'details'
 type VerificationKind = 'primary' | 'mfa' | 'totp'
@@ -244,34 +241,13 @@ export default function SignInPage() {
           postAuthRedirectUrl === POST_AUTH_REDIRECT_URL
             ? SSO_CALLBACK_URL
             : `${SSO_CALLBACK_URL}?redirect_url=${encodeURIComponent(postAuthRedirectUrl)}`
-        const popup = window.open(
-          'about:blank',
-          '_blank',
-          SOCIAL_SIGN_IN_POPUP_FEATURES,
-        )
-        if (!popup) {
-          setErrorMessage(POPUP_BLOCKED_MESSAGE)
-          return
-        }
-
-        try {
-          const { error } = await signIn.sso({
-            strategy,
-            popup,
-            redirectCallbackUrl: new URL(
-              redirectCallbackUrl,
-              window.location.origin,
-            ).href,
-            redirectUrl: new URL(postAuthRedirectUrl, window.location.origin)
-              .href,
-          })
-          if (error) {
-            popup.close()
-            setErrorMessage(getClerkErrorMessage(error, AUTH_ERROR_MESSAGE))
-          }
-        } catch (error) {
-          popup.close()
-          throw error
+        const { error } = await signIn.sso({
+          strategy,
+          redirectCallbackUrl,
+          redirectUrl: postAuthRedirectUrl,
+        })
+        if (error) {
+          setErrorMessage(getClerkErrorMessage(error, AUTH_ERROR_MESSAGE))
         }
       },
     )

--- a/tests/pages/signin.test.tsx
+++ b/tests/pages/signin.test.tsx
@@ -2,8 +2,6 @@ import SignInPage from '@/pages/signin'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const socialPopup = { close: vi.fn() } as unknown as Window
-
 const auth = vi.hoisted(() => {
   const signIn = {
     status: 'needs_identifier',
@@ -53,7 +51,6 @@ vi.mock('next/router', () => ({
 describe('SignInPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    vi.spyOn(window, 'open').mockReturnValue(socialPopup)
     auth.signIn.status = 'needs_identifier'
     auth.signIn.supportedSecondFactors = []
     auth.signUp.status = 'missing_requirements'
@@ -279,8 +276,9 @@ describe('SignInPage', () => {
     ['Google', 'oauth_google'],
     ['Apple', 'oauth_apple'],
   ] as const)(
-    'starts %s sign-in in a dedicated popup',
+    'starts %s sign-in in the current tab',
     async (provider, strategy) => {
+      const openSpy = vi.spyOn(window, 'open')
       render(<SignInPage />)
 
       fireEvent.click(
@@ -288,35 +286,15 @@ describe('SignInPage', () => {
       )
 
       await waitFor(() => {
-        expect(window.open).toHaveBeenCalledWith(
-          'about:blank',
-          '_blank',
-          expect.any(String),
-        )
+        expect(openSpy).not.toHaveBeenCalled()
         expect(auth.signIn.sso).toHaveBeenCalledWith({
           strategy,
-          popup: socialPopup,
-          redirectCallbackUrl: new URL('/sso-callback', window.location.origin)
-            .href,
-          redirectUrl: new URL('/', window.location.origin).href,
+          redirectCallbackUrl: '/sso-callback',
+          redirectUrl: '/',
         })
       })
     },
   )
-
-  it('explains how to continue when the social popup is blocked', async () => {
-    vi.mocked(window.open).mockReturnValue(null)
-    render(<SignInPage />)
-
-    fireEvent.click(
-      screen.getByRole('button', { name: 'Continue with Google' }),
-    )
-
-    expect(await screen.findByRole('alert')).toHaveTextContent(
-      'Allow pop-ups for this site to continue with Google or Apple.',
-    )
-    expect(auth.signIn.sso).not.toHaveBeenCalled()
-  })
 
   it('shows the Clerk error when social sign-in cannot start', async () => {
     auth.signIn.sso.mockResolvedValue({


### PR DESCRIPTION
## Summary
- remove the popup OAuth flow that can leave Firefox users on a blank tab
- restore Clerk's supported same-tab redirect flow for Google and Apple
- assert both providers never call `window.open`

## Testing
- `npx vitest run tests/pages/signin.test.tsx`
- `npx vitest run` (1,445 tests passed; Happy DOM emitted an abort teardown warning)
- `npx eslint src/pages/signin.tsx tests/pages/signin.test.tsx`
- `npx tsc --noEmit`
- confirmed the restored pre-popup flow navigates to Google OAuth in Playwright Firefox

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores same-tab Google/Apple sign-in and removes the popup OAuth flow that caused a blank tab in Firefox. Uses Clerk’s redirect flow and simplifies the SSO call to avoid `window.open`.

- **Bug Fixes**
  - Removed popup logic and the blocked-popup message; providers no longer call `window.open`.
  - Simplified `signIn.sso` to use `redirectCallbackUrl` and `redirectUrl` only (no `popup`).
  - Updated tests to assert same-tab behavior and removed popup-specific tests.

<sup>Written for commit ea5a11182995ec7a8f8ce40b7c7c6a70b5168f96. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/472?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

