### PR TITLE
Recover abandoned social sign-in attempts

### DIFF
--- a/src/pages/signin.tsx
+++ b/src/pages/signin.tsx
@@ -5,7 +5,7 @@ import { Button } from '@/components/ui/button'
 import { getClerkErrorMessage } from '@/utils/clerk-errors'
 import { logError } from '@/utils/error-handling'
 import { sanitizeRelativeRedirect } from '@/utils/redirect-url'
-import { useSignIn, useSignUp } from '@clerk/nextjs'
+import { useClerk, useSignIn, useSignUp } from '@clerk/nextjs'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { useEffect, useRef, useState } from 'react'
@@ -57,6 +57,7 @@ function clerkErrorCode(error: unknown): string | undefined {
 
 export default function SignInPage() {
   const router = useRouter()
+  const clerk = useClerk()
   const { signIn, errors: signInErrors } = useSignIn()
   const { signUp } = useSignUp()
   const [isDarkMode, setIsDarkMode] = useState(false)
@@ -380,6 +381,18 @@ export default function SignInPage() {
       },
     )
   }
+
+  const landingAttemptCheckedRef = useRef(false)
+  useEffect(() => {
+    if (!router.isReady || !clerk.loaded || landingAttemptCheckedRef.current) {
+      return
+    }
+
+    landingAttemptCheckedRef.current = true
+    if (router.query.resume === '1' || !signIn.id) return
+
+    void signIn.reset()
+  }, [clerk.loaded, router.isReady, router.query.resume, signIn, signIn.id])
 
   // Social sign-ins that still need MFA, client trust, or sign-up details
   // come back from the SSO callback with ?resume=1 — pick the flow back up

--- a/tests/pages/signin.test.tsx
+++ b/tests/pages/signin.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const auth = vi.hoisted(() => {
   const signIn = {
+    id: undefined as string | undefined,
     status: 'needs_identifier',
     supportedSecondFactors: [] as Array<{ strategy: string }>,
     create: vi.fn(),
@@ -28,10 +29,16 @@ const auth = vi.hoisted(() => {
     finalize: vi.fn(),
   }
 
-  return { signIn, signUp, routerPush: vi.fn() }
+  const router = {
+    isReady: true,
+    query: {} as Record<string, string | undefined>,
+  }
+
+  return { clerkLoaded: true, signIn, signUp, router, routerPush: vi.fn() }
 })
 
 vi.mock('@clerk/nextjs', () => ({
+  useClerk: () => ({ loaded: auth.clerkLoaded }),
   useSignIn: () => ({
     signIn: auth.signIn,
     errors: { fields: {} },
@@ -45,12 +52,16 @@ vi.mock('@clerk/nextjs', () => ({
 }))
 
 vi.mock('next/router', () => ({
-  useRouter: () => ({ push: auth.routerPush, query: {}, isReady: true }),
+  useRouter: () => ({ push: auth.routerPush, ...auth.router }),
 }))
 
 describe('SignInPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    auth.clerkLoaded = true
+    auth.router.isReady = true
+    auth.router.query = {}
+    auth.signIn.id = undefined
     auth.signIn.status = 'needs_identifier'
     auth.signIn.supportedSecondFactors = []
     auth.signUp.status = 'missing_requirements'
@@ -62,6 +73,7 @@ describe('SignInPage', () => {
     auth.signIn.mfa.verifyEmailCode.mockResolvedValue({ error: null })
     auth.signIn.mfa.verifyTOTP.mockResolvedValue({ error: null })
     auth.signIn.sso.mockResolvedValue({ error: null })
+    auth.signIn.reset.mockResolvedValue({ error: null })
     auth.signUp.create.mockResolvedValue({ error: null })
     auth.signUp.update.mockResolvedValue({ error: null })
   })
@@ -95,6 +107,34 @@ describe('SignInPage', () => {
       'text-balance',
       'text-center',
     )
+  })
+
+  it('clears an abandoned sign-in attempt on a fresh landing', async () => {
+    auth.signIn.id = 'stale_sign_in'
+
+    render(<SignInPage />)
+
+    await waitFor(() => {
+      expect(auth.signIn.reset).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('preserves a sign-in attempt resumed from the OAuth callback', () => {
+    auth.router.query = { resume: '1' }
+    auth.signIn.id = 'resumed_sign_in'
+
+    render(<SignInPage />)
+
+    expect(auth.signIn.reset).not.toHaveBeenCalled()
+  })
+
+  it('does not reset a sign-in attempt started after landing', () => {
+    const { rerender } = render(<SignInPage />)
+
+    auth.signIn.id = 'new_sign_in'
+    rerender(<SignInPage />)
+
+    expect(auth.signIn.reset).not.toHaveBeenCalled()
   })
 
   it('sends a privacy-preserving email code for sign-in or sign-up', async () => {


### PR DESCRIPTION
## Summary
- clear a persisted Clerk sign-in attempt when opening a fresh sign-in page
- preserve attempts returning through the OAuth callback for MFA or account setup
- leave Tinfoil local storage, sessions, and resumed authentication untouched

## Testing
- `npx vitest run tests/pages/signin.test.tsx`
- `npx vitest run` (1,448 tests passed; Happy DOM emitted an abort teardown warning)
- `npx eslint src/pages/signin.tsx tests/pages/signin.test.tsx`
- `npx tsc --noEmit`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clears stale Clerk social sign-in attempts on a fresh sign-in page and preserves attempts resumed from the OAuth callback, improving reliability and preventing users from getting stuck.

- **Bug Fixes**
  - On initial load, if `@clerk/nextjs` is loaded and no `?resume=1`, reset any existing `signIn.id` to drop abandoned attempts.
  - Preserve attempts resumed via `?resume=1` (MFA, trust checks, or sign-up completion).
  - Do not reset attempts created after landing.
  - Added tests for fresh landing, resumed flow, and post-landing starts.

<sup>Written for commit 03900f03ae4156780972a62ca819026160ab0939. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/473?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

