### PR TITLE
perf: start recoverable chats before cloud sync

### DIFF
--- a/src/components/chat/hooks/use-chat-messaging.ts
+++ b/src/components/chat/hooks/use-chat-messaging.ts
@@ -566,6 +566,7 @@ export function useChatMessaging({
       const streamChatIdRef = { current: currentChat.id }
       let earlyTitlePromise: Promise<string> | null = null
       let initialSavePromise: Promise<void> | undefined
+      let recoveryLocalSavePromise: Promise<Chat> | undefined
 
       const setLoadingStateFor = (s: LoadingState) =>
         patchStatus(streamChatIdRef.current, { loadingState: s })
@@ -609,6 +610,17 @@ export function useChatMessaging({
         (attachments && attachments.length > 0) ||
         Boolean(quote)
       const turnId = hasUserContent ? crypto.randomUUID() : null
+      const recoveryUserId = typeof userId === 'string' ? userId : null
+      const canRecoverTurn = (chat: Chat) =>
+        recoveryUserId !== null &&
+        turnId !== null &&
+        canUseChatRecovery({
+          isSignedIn,
+          userId: recoveryUserId,
+          storeHistory,
+          chat,
+        })
+      let recoveryEligible = false
 
       const userMessage: Message | null = hasUserContent
         ? {
@@ -688,6 +700,7 @@ export function useChatMessaging({
           projectId:
             isProjectMode && activeProject ? activeProject.id : undefined,
         }
+        recoveryEligible = canRecoverTurn(updatedChat)
 
         // Update state immediately for instant UI feedback
         moveStatus(streamChatIdRef.current, chatId)
@@ -720,9 +733,15 @@ export function useChatMessaging({
           setTimeout(() => scrollToBottom(), 50)
         }
 
-        // Save immediately (and sync if applicable). ID is already server-valid.
-        initialSavePromise = chatStorage
-          .saveChatAndSync(updatedChat)
+        // Save immediately. Recoverable turns stay local until their envelope
+        // mutation; other chats retain the ordinary background sync path.
+        const initialSave = recoveryEligible
+          ? chatStorage.saveChat(updatedChat, true)
+          : chatStorage.saveChatAndSync(updatedChat)
+        if (recoveryEligible) {
+          recoveryLocalSavePromise = initialSave
+        }
+        initialSavePromise = initialSave
           .then(() => {
             setChats((prevChats) =>
               prevChats.map((c) =>
@@ -812,6 +831,7 @@ export function useChatMessaging({
             updatedChat.codeExecutionAccessToken ??
             generateCodeExecutionAccessToken(),
         }
+        recoveryEligible = canRecoverTurn(updatedChat)
 
         setCurrentChat(updatedChat)
         setChats((prevChats) =>
@@ -829,7 +849,25 @@ export function useChatMessaging({
         if (updatedChat.isTemporary) {
           // Temporary chats are never persisted
         } else if (storeHistory) {
-          await chatStorage.saveChatAndSync(updatedChat)
+          if (recoveryEligible) {
+            recoveryLocalSavePromise = chatStorage.saveChat(updatedChat, true)
+            try {
+              updatedChat = await recoveryLocalSavePromise
+            } catch (error) {
+              recoveryEligible = false
+              logError(
+                'Chat persistence for recovery failed; streaming without recovery',
+                error,
+                {
+                  component: 'useChatMessaging',
+                  action: 'handleQuery.recoveryPreUpload',
+                  metadata: { chatId: updatedChat.id },
+                },
+              )
+            }
+          } else {
+            updatedChat = await chatStorage.saveChatAndSync(updatedChat)
+          }
         } else {
           sessionChatStorage.saveChat(updatedChat)
         }
@@ -953,26 +991,18 @@ export function useChatMessaging({
             )) ?? undefined)
           : undefined
 
-        const recoveryUserId = typeof userId === 'string' ? userId : null
-        const recoveryEligible =
-          recoveryUserId !== null &&
-          turnId !== null &&
-          canUseChatRecovery({
-            isSignedIn,
-            userId: recoveryUserId,
-            storeHistory,
-            chat: updatedChat,
-          })
-        // Recovery is best-effort: the user turn must be durable before the
-        // recovery token is captured, locally or across devices.
+        // Recovery is best-effort: the user turn must be durable locally
+        // before the recoverable inference request starts. This required wait
+        // has no cloud network work; ordinary backup remains non-blocking, and
+        // the recovery mutation can publish the turn with its envelope later.
         let recoveryEnabled = recoveryEligible
 
         if (recoveryEnabled) {
           try {
-            updatedChat =
-              updatedChat.isLocalOnly || !isCloudSyncEnabled()
-                ? await chatStorage.saveChat(updatedChat, true)
-                : await chatStorage.saveChatAndWaitForSync(updatedChat)
+            if (!recoveryLocalSavePromise) {
+              throw new Error('Chat recovery local save did not start')
+            }
+            updatedChat = await recoveryLocalSavePromise
           } catch (error) {
             recoveryEnabled = false
             logError(
@@ -1018,7 +1048,10 @@ export function useChatMessaging({
           codeExecutionEncryptionKey: codeExecutionEncryptionKey ?? undefined,
           codeExecutionContainerAuthToken,
           recovery:
-            recoveryEligible && recoveryEnabled
+            recoveryEligible &&
+            recoveryEnabled &&
+            recoveryUserId !== null &&
+            turnId !== null
               ? {
                   onAttemptStarted: (sessionId) => {
                     startChatRecoveryAttempt(
@@ -1029,7 +1062,7 @@ export function useChatMessaging({
                   },
                   onTokenCaptured: (sessionId, token) =>
                     persistChatRecoveryToken({
-                      userId: recoveryUserId as string,
+                      userId: recoveryUserId,
                       chatId: streamChatIdRef.current,
                       turnId,
                       sessionId,

--- a/src/components/chat/hooks/use-chat-messaging.ts
+++ b/src/components/chat/hooks/use-chat-messaging.ts
@@ -999,10 +999,7 @@ export function useChatMessaging({
 
         if (recoveryEnabled) {
           try {
-            if (!recoveryLocalSavePromise) {
-              throw new Error('Chat recovery local save did not start')
-            }
-            updatedChat = await recoveryLocalSavePromise
+            updatedChat = await recoveryLocalSavePromise!
           } catch (error) {
             recoveryEnabled = false
             logError(

--- a/src/services/inference/chat-recovery-sync.ts
+++ b/src/services/inference/chat-recovery-sync.ts
@@ -21,6 +21,12 @@ import { isCloudSyncEnabled } from '@/utils/cloud-sync-settings'
 
 const RECOVERY_MUTATION_MAX_ATTEMPTS = 3
 
+function messageTimestampMs(timestamp: Date | string): number | null {
+  const milliseconds =
+    timestamp instanceof Date ? timestamp.getTime() : Date.parse(timestamp)
+  return Number.isFinite(milliseconds) ? milliseconds : null
+}
+
 type ChatMutation = (
   chat: StoredChat,
   local?: StoredChat | null,
@@ -264,12 +270,35 @@ export function addPendingRecovery(
       : (local?.messages.filter(
           (message) => message.turnId === envelope.turnId,
         ) ?? [])
+    const localTurnTimestamp = localTurn[0]
+      ? messageTimestampMs(localTurn[0].timestamp)
+      : null
+    const remoteMessageTimestamps = chat.messages.map((message) =>
+      messageTimestampMs(message.timestamp),
+    )
+    const hasInvalidRemoteTimestamp = remoteMessageTimestamps.some(
+      (timestamp) => timestamp === null,
+    )
+    const firstNewerMessageIndex =
+      localTurnTimestamp !== null && !hasInvalidRemoteTimestamp
+        ? remoteMessageTimestamps.findIndex(
+            (timestamp) => timestamp !== null && timestamp > localTurnTimestamp,
+          )
+        : -1
+    const insertAt =
+      firstNewerMessageIndex >= 0
+        ? firstNewerMessageIndex
+        : chat.messages.length
     return {
       chat: {
         ...chat,
         messages:
           localTurn.length > 0
-            ? [...chat.messages, ...localTurn]
+            ? [
+                ...chat.messages.slice(0, insertAt),
+                ...localTurn,
+                ...chat.messages.slice(insertAt),
+              ]
             : chat.messages,
         pendingRecoveries: pending,
       },

--- a/src/services/inference/chat-recovery-sync.ts
+++ b/src/services/inference/chat-recovery-sync.ts
@@ -21,7 +21,10 @@ import { isCloudSyncEnabled } from '@/utils/cloud-sync-settings'
 
 const RECOVERY_MUTATION_MAX_ATTEMPTS = 3
 
-type ChatMutation = (chat: StoredChat) => { chat: StoredChat; changed: boolean }
+type ChatMutation = (
+  chat: StoredChat,
+  local?: StoredChat | null,
+) => { chat: StoredChat; changed: boolean }
 
 const mutationTails = new Map<string, Promise<void>>()
 let mutationGeneration = 0
@@ -110,7 +113,7 @@ async function mutateSyncedChat(
         if (!mutationIsCurrent()) {
           throw new DOMException('Aborted', 'AbortError')
         }
-        const result = mutation(chat)
+        const result = mutation(chat, chat)
         changed = result.changed
         return result.changed
           ? {
@@ -165,7 +168,7 @@ async function mutateSyncedChat(
         }
       }
 
-      const result = mutation(base)
+      const result = mutation(base, local)
       if (!result.changed) {
         if (remote && base === remote && local !== remote) {
           const syncVersion = remote.syncVersion ?? 0
@@ -244,7 +247,7 @@ export function addPendingRecovery(
   chatId: string,
   envelope: PendingRecoveryEnvelope,
 ): Promise<StoredChat> {
-  return mutateSyncedChat(chatId, (chat) => {
+  return mutateSyncedChat(chatId, (chat, local) => {
     const existing = chat.pendingRecoveries ?? []
     const pending = existing.filter(
       (candidate) => candidate.turnId !== envelope.turnId,
@@ -253,8 +256,23 @@ export function addPendingRecovery(
       throw new Error('Chat has too many pending recovery sessions')
     }
     pending.push(envelope)
+    const baseHasTurn = chat.messages.some(
+      (message) => message.turnId === envelope.turnId,
+    )
+    const localTurn = baseHasTurn
+      ? []
+      : (local?.messages.filter(
+          (message) => message.turnId === envelope.turnId,
+        ) ?? [])
     return {
-      chat: { ...chat, pendingRecoveries: pending },
+      chat: {
+        ...chat,
+        messages:
+          localTurn.length > 0
+            ? [...chat.messages, ...localTurn]
+            : chat.messages,
+        pendingRecoveries: pending,
+      },
       changed: true,
     }
   })

--- a/src/services/storage/chat-storage.ts
+++ b/src/services/storage/chat-storage.ts
@@ -120,15 +120,6 @@ export class ChatStorageService {
     return await this.saveChat(chat, false)
   }
 
-  async saveChatAndWaitForSync(chat: Chat): Promise<Chat> {
-    const saved = await this.saveChat(chat, true)
-    if (saved.isBlankChat) {
-      return saved
-    }
-    await cloudSync.backupChatAndWait(saved.id)
-    return (await this.getChat(saved.id)) ?? saved
-  }
-
   async getChat(id: string): Promise<Chat | null> {
     await this.initialize()
 

--- a/tests/components/chat/use-chat-messaging.stop-stream.test.tsx
+++ b/tests/components/chat/use-chat-messaging.stop-stream.test.tsx
@@ -24,6 +24,7 @@ const {
   streamControllers,
   streamingChats,
   recoveryAvailableState,
+  cloudSyncState,
 } = vi.hoisted(() => ({
   authState: {
     isSignedIn: false,
@@ -61,6 +62,7 @@ const {
   streamControllers: new Map<string, AbortController>(),
   streamingChats: new Set<string>(),
   recoveryAvailableState: { available: false },
+  cloudSyncState: { enabled: false },
 }))
 
 vi.mock('@clerk/nextjs', () => ({
@@ -162,7 +164,6 @@ vi.mock('@/services/storage/chat-storage', () => ({
   chatStorage: {
     saveChat: saveChatMock,
     saveChatAndSync: initialSaveMock,
-    saveChatAndWaitForSync: vi.fn(async (chat) => chat),
   },
 }))
 
@@ -183,7 +184,7 @@ vi.mock('@/services/exec-snapshot/use-exec-snapshot', () => ({
 }))
 
 vi.mock('@/utils/cloud-sync-settings', () => ({
-  isCloudSyncEnabled: () => false,
+  isCloudSyncEnabled: () => cloudSyncState.enabled,
 }))
 
 vi.mock('@/utils/error-handling', () => ({
@@ -232,6 +233,8 @@ describe('useChatMessaging stopped streams', () => {
     authState.isSignedIn = false
     authState.userId = undefined
     recoveryAvailableState.available = false
+    cloudSyncState.enabled = false
+    saveChatMock.mockImplementation(async (chat: unknown) => chat)
     streamControllers.clear()
     streamingChats.clear()
     pendingStreams.clear()
@@ -715,6 +718,307 @@ describe('useChatMessaging stopped streams', () => {
     expect(result.current.currentChat.messages[0]).toEqual(
       remotelyMergedMessage,
     )
+  })
+
+  it('uses only local saves before recoverable inference for an existing cloud chat', async () => {
+    authState.isSignedIn = true
+    authState.userId = 'user-1'
+    recoveryAvailableState.available = true
+    cloudSyncState.enabled = true
+    const initialChat: Chat = {
+      id: 'chat-1',
+      title: 'Existing chat',
+      createdAt: new Date(),
+      messages: [],
+    }
+    const stream = createOpenStream()
+    let finishLocalSave!: () => void
+    saveChatMock.mockImplementationOnce(
+      (chat: unknown) =>
+        new Promise((resolve) => {
+          finishLocalSave = () => resolve(chat)
+        }),
+    )
+    sendChatStreamMock.mockResolvedValue(stream.stream)
+
+    const { result } = renderHook(() => {
+      const [currentChat, setCurrentChat] = useState(initialChat)
+      const [chats, setChats] = useState([initialChat])
+      const messaging = useChatMessaging({
+        systemPrompt: '',
+        storeHistory: true,
+        models: [{} as never],
+        selectedModel: 'test-model',
+        chats,
+        currentChat,
+        setChats,
+        setCurrentChat,
+      })
+      return { messaging }
+    })
+
+    let query!: Promise<unknown>
+    act(() => {
+      query = result.current.messaging.handleQuery('Prompt') as Promise<unknown>
+    })
+    await vi.waitFor(() => expect(saveChatMock).toHaveBeenCalled())
+
+    expect(initialSaveMock).not.toHaveBeenCalled()
+    expect(saveChatMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messages: [
+          expect.objectContaining({ role: 'user', content: 'Prompt' }),
+        ],
+      }),
+      true,
+    )
+    expect(sendChatStreamMock).not.toHaveBeenCalled()
+
+    await act(async () => {
+      finishLocalSave()
+    })
+    await vi.waitFor(() => expect(sendChatStreamMock).toHaveBeenCalled())
+    expect(initialSaveMock).not.toHaveBeenCalled()
+    expect(saveChatMock).toHaveBeenCalledOnce()
+    expect(saveChatMock.mock.calls.every((call) => call[1] === true)).toBe(true)
+    expect(sendChatStreamMock).toHaveBeenCalledWith(
+      expect.objectContaining({ recovery: expect.any(Object) }),
+    )
+
+    stream.send({ choices: [{ index: 0, delta: {}, finish_reason: 'stop' }] })
+    stream.close()
+    await act(async () => {
+      await query
+    })
+  })
+
+  it('uses only local saves before recoverable inference for a new cloud chat', async () => {
+    authState.isSignedIn = true
+    authState.userId = 'user-1'
+    recoveryAvailableState.available = true
+    cloudSyncState.enabled = true
+    const initialChat: Chat = {
+      id: '',
+      title: 'Untitled',
+      titleState: 'placeholder',
+      createdAt: new Date(),
+      messages: [],
+      isBlankChat: true,
+    }
+    const stream = createOpenStream()
+    let finishLocalSave!: () => void
+    saveChatMock.mockImplementationOnce(
+      (chat: unknown) =>
+        new Promise((resolve) => {
+          finishLocalSave = () => resolve(chat)
+        }),
+    )
+    sendChatStreamMock.mockResolvedValue(stream.stream)
+
+    const { result } = renderHook(() => {
+      const [currentChat, setCurrentChat] = useState(initialChat)
+      const [chats, setChats] = useState([initialChat])
+      const messaging = useChatMessaging({
+        systemPrompt: '',
+        storeHistory: true,
+        models: [{} as never],
+        selectedModel: 'test-model',
+        chats,
+        currentChat,
+        setChats,
+        setCurrentChat,
+      })
+      return { messaging }
+    })
+
+    let query!: Promise<unknown>
+    act(() => {
+      query = result.current.messaging.handleQuery(
+        'First prompt',
+      ) as Promise<unknown>
+    })
+    await vi.waitFor(() => expect(saveChatMock).toHaveBeenCalled())
+
+    expect(initialSaveMock).not.toHaveBeenCalled()
+    expect(sendChatStreamMock).not.toHaveBeenCalled()
+
+    await act(async () => {
+      finishLocalSave()
+    })
+    await vi.waitFor(() => expect(sendChatStreamMock).toHaveBeenCalled())
+
+    expect(initialSaveMock).not.toHaveBeenCalled()
+    expect(saveChatMock).toHaveBeenCalledOnce()
+    expect(saveChatMock.mock.calls.every((call) => call[1] === true)).toBe(true)
+    expect(saveChatMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: expect.stringMatching(/\S/),
+        isBlankChat: false,
+        messages: [
+          expect.objectContaining({ role: 'user', content: 'First prompt' }),
+        ],
+      }),
+      true,
+    )
+
+    stream.send({ choices: [{ index: 0, delta: {}, finish_reason: 'stop' }] })
+    stream.close()
+    await act(async () => {
+      await query
+    })
+  })
+
+  it('disables recovery when a new chat local save fails', async () => {
+    authState.isSignedIn = true
+    authState.userId = 'user-1'
+    recoveryAvailableState.available = true
+    cloudSyncState.enabled = true
+    const initialChat: Chat = {
+      id: '',
+      title: 'Untitled',
+      titleState: 'placeholder',
+      createdAt: new Date(),
+      messages: [],
+      isBlankChat: true,
+    }
+    const stream = createOpenStream()
+    saveChatMock.mockRejectedValueOnce(new Error('IndexedDB unavailable'))
+    sendChatStreamMock.mockResolvedValue(stream.stream)
+
+    const { result } = renderHook(() => {
+      const [currentChat, setCurrentChat] = useState(initialChat)
+      const [chats, setChats] = useState([initialChat])
+      const messaging = useChatMessaging({
+        systemPrompt: '',
+        storeHistory: true,
+        models: [{} as never],
+        selectedModel: 'test-model',
+        chats,
+        currentChat,
+        setChats,
+        setCurrentChat,
+      })
+      return { messaging }
+    })
+
+    let query!: Promise<unknown>
+    act(() => {
+      query = result.current.messaging.handleQuery(
+        'First prompt',
+      ) as Promise<unknown>
+    })
+    await vi.waitFor(() => expect(sendChatStreamMock).toHaveBeenCalled())
+
+    expect(initialSaveMock).not.toHaveBeenCalled()
+    expect(saveChatMock).toHaveBeenCalledOnce()
+    expect(saveChatMock).toHaveBeenCalledWith(expect.any(Object), true)
+    expect(sendChatStreamMock).toHaveBeenCalledWith(
+      expect.objectContaining({ recovery: undefined }),
+    )
+
+    stream.send({ choices: [{ index: 0, delta: {}, finish_reason: 'stop' }] })
+    stream.close()
+    await act(async () => {
+      await query
+    })
+  })
+
+  it('retains ordinary cloud persistence for non-recoverable sends', async () => {
+    cloudSyncState.enabled = true
+    const initialChat: Chat = {
+      id: 'chat-1',
+      title: 'Existing chat',
+      createdAt: new Date(),
+      messages: [],
+    }
+    const stream = createOpenStream()
+    sendChatStreamMock.mockResolvedValue(stream.stream)
+
+    const { result } = renderHook(() => {
+      const [currentChat, setCurrentChat] = useState(initialChat)
+      const [chats, setChats] = useState([initialChat])
+      const messaging = useChatMessaging({
+        systemPrompt: '',
+        storeHistory: true,
+        models: [{} as never],
+        selectedModel: 'test-model',
+        chats,
+        currentChat,
+        setChats,
+        setCurrentChat,
+      })
+      return { messaging }
+    })
+
+    let query!: Promise<unknown>
+    act(() => {
+      query = result.current.messaging.handleQuery('Prompt') as Promise<unknown>
+    })
+    await vi.waitFor(() => expect(sendChatStreamMock).toHaveBeenCalled())
+
+    expect(initialSaveMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messages: [
+          expect.objectContaining({ role: 'user', content: 'Prompt' }),
+        ],
+      }),
+    )
+    expect(saveChatMock).not.toHaveBeenCalled()
+
+    stream.send({ choices: [{ index: 0, delta: {}, finish_reason: 'stop' }] })
+    stream.close()
+    await act(async () => {
+      await query
+    })
+  })
+
+  it('streams without recovery when the required local save fails', async () => {
+    authState.isSignedIn = true
+    authState.userId = 'user-1'
+    recoveryAvailableState.available = true
+    cloudSyncState.enabled = true
+    const initialChat: Chat = {
+      id: 'chat-1',
+      title: 'Existing chat',
+      createdAt: new Date(),
+      messages: [],
+    }
+    const stream = createOpenStream()
+    saveChatMock.mockRejectedValueOnce(new Error('IndexedDB unavailable'))
+    sendChatStreamMock.mockResolvedValue(stream.stream)
+
+    const { result } = renderHook(() => {
+      const [currentChat, setCurrentChat] = useState(initialChat)
+      const [chats, setChats] = useState([initialChat])
+      const messaging = useChatMessaging({
+        systemPrompt: '',
+        storeHistory: true,
+        models: [{} as never],
+        selectedModel: 'test-model',
+        chats,
+        currentChat,
+        setChats,
+        setCurrentChat,
+      })
+      return { messaging }
+    })
+
+    let query!: Promise<unknown>
+    act(() => {
+      query = result.current.messaging.handleQuery('Prompt') as Promise<unknown>
+    })
+    await vi.waitFor(() => expect(sendChatStreamMock).toHaveBeenCalled())
+
+    expect(saveChatMock).toHaveBeenCalledWith(expect.any(Object), true)
+    expect(sendChatStreamMock).toHaveBeenCalledWith(
+      expect.objectContaining({ recovery: undefined }),
+    )
+
+    stream.send({ choices: [{ index: 0, delta: {}, finish_reason: 'stop' }] })
+    stream.close()
+    await act(async () => {
+      await query
+    })
   })
 
   it('renders response chunks while recovery token persistence is pending', async () => {

--- a/tests/services/inference/chat-recovery-sync.test.ts
+++ b/tests/services/inference/chat-recovery-sync.test.ts
@@ -249,6 +249,66 @@ describe('chat recovery sync mutations', () => {
     expect(remoteChat.pendingRecoveries).toHaveLength(1)
   })
 
+  it('uploads a dirty local user turn with its recovery envelope', async () => {
+    remoteChat.updatedAt = '2026-01-01T00:00:00.000Z'
+    localChat = {
+      ...structuredClone(remoteChat),
+      messages: [
+        ...remoteChat.messages,
+        message('user', 'Unsynced question', 'turn-2'),
+      ],
+      updatedAt: '2026-01-01T00:01:00.000Z',
+      locallyModified: true,
+    }
+
+    await addPendingRecovery(remoteChat.id, envelope('turn-2'))
+
+    expect(uploadChat).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messages: expect.arrayContaining([
+          expect.objectContaining({
+            role: 'user',
+            content: 'Unsynced question',
+            turnId: 'turn-2',
+          }),
+        ]),
+        pendingRecoveries: [expect.objectContaining({ turnId: 'turn-2' })],
+      }),
+    )
+  })
+
+  it('preserves only the recovery turn when a newer remote chat wins', async () => {
+    remoteChat = {
+      ...remoteChat,
+      title: 'Newer remote title',
+      updatedAt: '2026-01-01T00:02:00.000Z',
+    }
+    localChat = {
+      ...structuredClone(remoteChat),
+      title: 'Stale local title',
+      messages: [
+        ...remoteChat.messages,
+        message('user', 'Unrelated stale edit', 'stale-turn'),
+        message('user', 'Unsynced question', 'turn-2'),
+      ],
+      updatedAt: '2026-01-01T00:01:00.000Z',
+      locallyModified: true,
+    }
+
+    await addPendingRecovery(remoteChat.id, envelope('turn-2'))
+
+    expect(uploadChat).toHaveBeenCalledOnce()
+    const uploaded = uploadChat.mock.calls[0][0]
+    expect(uploaded.title).toBe('Newer remote title')
+    expect(uploaded.messages.map((item) => item.content)).toEqual([
+      'Question',
+      'Unsynced question',
+    ])
+    expect(uploaded.pendingRecoveries).toEqual([
+      expect.objectContaining({ turnId: 'turn-2' }),
+    ])
+  })
+
   it('merges a recovered response once after its user turn', async () => {
     remoteChat.messages.push(message('user', 'Later question', 'turn-2'))
     remoteChat.pendingRecoveries = [envelope('turn-1')]

--- a/tests/services/inference/chat-recovery-sync.test.ts
+++ b/tests/services/inference/chat-recovery-sync.test.ts
@@ -103,8 +103,9 @@ function message(
   role: Message['role'],
   content: string,
   turnId?: string,
+  timestamp: Date | string = new Date(),
 ): Message {
-  return { role, content, turnId, timestamp: new Date().toISOString() }
+  return { role, content, turnId, timestamp: timestamp as Date }
 }
 
 function envelope(turnId: string): PendingRecoveryEnvelope {
@@ -306,6 +307,102 @@ describe('chat recovery sync mutations', () => {
     ])
     expect(uploaded.pendingRecoveries).toEqual([
       expect.objectContaining({ turnId: 'turn-2' }),
+    ])
+  })
+
+  it('completes a local recovery turn before a newer remote turn', async () => {
+    const originalQuestion = message(
+      'user',
+      'Question',
+      'turn-1',
+      '2026-01-01T00:00:00.000Z',
+    )
+    const recoveryQuestion = message(
+      'user',
+      'Recovery question',
+      'turn-2',
+      new Date('2026-01-01T00:01:00.000Z'),
+    )
+    remoteChat = {
+      ...remoteChat,
+      messages: [
+        originalQuestion,
+        message('user', 'Newer question', 'turn-3', '2026-01-01T00:02:00.000Z'),
+        message(
+          'assistant',
+          'Newer answer',
+          'turn-3',
+          '2026-01-01T00:03:00.000Z',
+        ),
+      ],
+      updatedAt: '2026-01-01T00:04:00.000Z',
+    }
+    localChat = {
+      ...structuredClone(remoteChat),
+      messages: [originalQuestion, recoveryQuestion],
+      updatedAt: '2026-01-01T00:01:00.000Z',
+      locallyModified: true,
+    }
+
+    await addPendingRecovery(remoteChat.id, envelope('turn-2'))
+    await completePendingRecovery(
+      remoteChat.id,
+      currentEnvelope('turn-2'),
+      message(
+        'assistant',
+        'Recovered answer',
+        'turn-2',
+        new Date('2026-01-01T00:01:30.000Z'),
+      ),
+    )
+
+    expect(remoteChat.messages.map((item) => item.content)).toEqual([
+      'Question',
+      'Recovery question',
+      'Recovered answer',
+      'Newer question',
+      'Newer answer',
+    ])
+  })
+
+  it('appends a local recovery turn when a remote timestamp is invalid', async () => {
+    const originalQuestion = message(
+      'user',
+      'Question',
+      'turn-1',
+      '2026-01-01T00:00:00.000Z',
+    )
+    remoteChat = {
+      ...remoteChat,
+      messages: [
+        originalQuestion,
+        message('assistant', 'Invalid timestamp', 'turn-1', 'invalid'),
+        message('user', 'Newer question', 'turn-3', '2026-01-01T00:02:00.000Z'),
+      ],
+      updatedAt: '2026-01-01T00:03:00.000Z',
+    }
+    localChat = {
+      ...structuredClone(remoteChat),
+      messages: [
+        originalQuestion,
+        message(
+          'user',
+          'Recovery question',
+          'turn-2',
+          new Date('2026-01-01T00:01:00.000Z'),
+        ),
+      ],
+      updatedAt: '2026-01-01T00:01:00.000Z',
+      locallyModified: true,
+    }
+
+    await addPendingRecovery(remoteChat.id, envelope('turn-2'))
+
+    expect(remoteChat.messages.map((item) => item.content)).toEqual([
+      'Question',
+      'Invalid timestamp',
+      'Newer question',
+      'Recovery question',
     ])
   })
 

--- a/tests/services/inference/inference-client-recovery.test.ts
+++ b/tests/services/inference/inference-client-recovery.test.ts
@@ -131,13 +131,13 @@ describe('recoverable inference retries', () => {
     expect(createRecoverableClient).toHaveBeenCalledTimes(2)
   })
 
-  it('returns the stream before recovery token persistence completes', async () => {
-    let finishTokenCapture!: () => void
-    const tokenCapture = new Promise<void>((resolve) => {
-      finishTokenCapture = resolve
+  it('returns the stream before the pending recovery cloud upload completes', async () => {
+    let finishCloudUpload!: () => void
+    const pendingCloudUpload = new Promise<void>((resolve) => {
+      finishCloudUpload = resolve
     })
     createRecoverableClient.mockResolvedValueOnce({
-      waitForTokenCapture: () => tokenCapture,
+      waitForTokenCapture: () => pendingCloudUpload,
       client: {
         chat: {
           completions: {
@@ -155,9 +155,14 @@ describe('recoverable inference retries', () => {
     })
 
     expect(recoveryReady).toBe(false)
-    expect(typeof stream[Symbol.asyncIterator]).toBe('function')
+    const chunks = []
+    for await (const chunk of stream) {
+      chunks.push(chunk)
+    }
+    expect(chunks).toEqual([{ choices: [{ delta: { content: 'answer' } }] }])
+    expect(recoveryReady).toBe(false)
 
-    finishTokenCapture()
+    finishCloudUpload()
     await stream.recoveryReady
     expect(recoveryReady).toBe(true)
   })

--- a/tests/services/storage/chat-storage-pending-save.test.ts
+++ b/tests/services/storage/chat-storage-pending-save.test.ts
@@ -5,7 +5,6 @@ const saveChatSpy = vi.fn(async (chat: unknown) => chat)
 const getChatSpy = vi.fn(async () => null as unknown)
 const getAllChatsSpy = vi.fn(async () => [] as unknown[])
 const backupChatSpy = vi.fn(async () => {})
-const backupChatAndWaitSpy = vi.fn(async () => {})
 
 vi.mock('@/services/storage/indexed-db', () => ({
   indexedDBStorage: {
@@ -18,7 +17,6 @@ vi.mock('@/services/storage/indexed-db', () => ({
 vi.mock('@/services/cloud/cloud-sync', () => ({
   cloudSync: {
     backupChat: (...args: unknown[]) => backupChatSpy(...args),
-    backupChatAndWait: (...args: unknown[]) => backupChatAndWaitSpy(...args),
   },
 }))
 vi.mock('@/services/cloud/cloud-storage', () => ({ cloudStorage: {} }))
@@ -102,20 +100,5 @@ describe('chatStorage pendingSave is not persisted', () => {
     const chats = await chatStorage.getAllChatsWithSyncStatus()
 
     expect('pendingSave' in chats[0]).toBe(false)
-  })
-
-  it('propagates a required cloud upload failure', async () => {
-    backupChatAndWaitSpy.mockRejectedValueOnce(new Error('upload failed'))
-
-    await expect(
-      chatStorage.saveChatAndWaitForSync(makeChat()),
-    ).rejects.toThrow('upload failed')
-  })
-
-  it('does not require a cloud upload for a blank chat', async () => {
-    const blank = makeChat({ isBlankChat: true })
-
-    await expect(chatStorage.saveChatAndWaitForSync(blank)).resolves.toBe(blank)
-    expect(backupChatAndWaitSpy).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Summary
- persist recovery-eligible turns locally before inference without awaiting cloud synchronization
- publish the turn and recovery envelope together while streaming, preserving local turns across conflicts
- add sequencing, fallback, and conflict tests for asynchronous recovery persistence

## Testing
- `npm run test:unit -- --run` (1,453 passed)
- `npm run lint`
- `npx tsc --noEmit`
- `npm run test:ui` (3 passed, 10 failed because the app UI was unavailable to the smoke-test server)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Start recoverable chat streaming sooner by saving recovery-eligible user turns locally before any cloud sync. This lowers first-token latency and keeps recovery robust across sync conflicts and remote message ordering.

- **New Features**
  - In `useChatMessaging`, persist recovery-eligible turns with a local-only `chatStorage.saveChat(..., true)` before starting the stream; publish the recovery envelope later while streaming.
  - Non-recoverable sends keep the existing `saveChatAndSync` path.
  - `addPendingRecovery` uploads the local user turn with its recovery envelope if the remote chat doesn’t have that turn, preserving it across conflicts; removed `saveChatAndWaitForSync`.

- **Bug Fixes**
  - Preserve recovery turn ordering by inserting the local turn by timestamp when publishing, and appending when remote timestamps are invalid.

<sup>Written for commit 3c73f5d6e2ba0ee66cf228502c25d61da18f2d0a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/474?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

