### PR TITLE
style: use theme accent colors instead of hardcoded greens

### DIFF
--- a/src/components/chat/chat-sidebar.tsx
+++ b/src/components/chat/chat-sidebar.tsx
@@ -1387,8 +1387,8 @@ export function ChatSidebar({
                       : 'border border-gray-400 bg-gray-200/30'
                     : isProjectMode
                       ? isDarkMode
-                        ? 'text-emerald-400'
-                        : 'text-emerald-600'
+                        ? 'text-brand-accent-light'
+                        : 'text-brand-accent-dark'
                       : 'text-content-secondary',
                 )}
               >

--- a/src/components/chat/cloud-sync-health-card.tsx
+++ b/src/components/chat/cloud-sync-health-card.tsx
@@ -127,7 +127,7 @@ export function CloudSyncHealthCard({
         <div className="flex min-w-0 items-start gap-2">
           {status.tone === 'ok' ? (
             <CheckCircleIcon
-              className="mt-0.5 h-4 w-4 shrink-0 text-emerald-500"
+              className="mt-0.5 h-4 w-4 shrink-0 text-brand-accent-dark dark:text-brand-accent-light"
               aria-hidden="true"
             />
           ) : status.tone === 'warning' ? (

--- a/src/components/chat/mfa-settings-card.tsx
+++ b/src/components/chat/mfa-settings-card.tsx
@@ -230,7 +230,7 @@ export function MfaSettingsCard({ isDarkMode }: MfaSettingsCardProps) {
                 className={cn(
                   'shrink-0 rounded-full px-2.5 py-1 text-xs font-medium',
                   totpEnabled
-                    ? 'bg-emerald-500/20 text-emerald-500'
+                    ? 'bg-brand-accent-dark/20 text-brand-accent-dark dark:bg-brand-accent-light/20 dark:text-brand-accent-light'
                     : 'bg-content-muted/20 text-content-muted',
                 )}
               >
@@ -307,7 +307,7 @@ export function MfaSettingsCard({ isDarkMode }: MfaSettingsCardProps) {
                     className="shrink-0 text-content-muted transition-colors hover:text-content-primary"
                   >
                     {copiedTarget === 'setup-key' ? (
-                      <CheckCircleIcon className="h-4 w-4 text-emerald-500" />
+                      <CheckCircleIcon className="h-4 w-4 text-brand-accent-dark dark:text-brand-accent-light" />
                     ) : (
                       <ClipboardDocumentIcon className="h-4 w-4" />
                     )}
@@ -397,7 +397,7 @@ export function MfaSettingsCard({ isDarkMode }: MfaSettingsCardProps) {
             )}
           >
             <div className="flex items-start gap-3">
-              <CheckCircleIcon className="mt-0.5 h-5 w-5 shrink-0 text-emerald-500" />
+              <CheckCircleIcon className="mt-0.5 h-5 w-5 shrink-0 text-brand-accent-dark dark:text-brand-accent-light" />
               <div>
                 <DialogPrimitive.Title className="font-aeonik text-base font-medium text-content-primary">
                   Authenticator app enabled

--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -3165,8 +3165,8 @@ ${encryptionKey.replace('key_', '')}
                                       className={cn(
                                         'font-aeonik font-medium',
                                         isDarkMode
-                                          ? 'text-emerald-400'
-                                          : 'text-emerald-600',
+                                          ? 'text-brand-accent-light'
+                                          : 'text-brand-accent-dark',
                                       )}
                                     >
                                       Tip:
@@ -3863,13 +3863,13 @@ ${encryptionKey.replace('key_', '')}
                         className={cn(
                           'rounded-lg border p-4',
                           importResult.success
-                            ? 'border-emerald-500/30 bg-emerald-500/10'
+                            ? 'border-brand-accent-dark/30 bg-brand-accent-dark/10 dark:border-brand-accent-light/30 dark:bg-brand-accent-light/10'
                             : 'border-red-500/30 bg-red-500/10',
                         )}
                       >
                         <div className="flex items-start gap-3">
                           {importResult.success ? (
-                            <CheckCircleIcon className="h-5 w-5 text-emerald-500" />
+                            <CheckCircleIcon className="h-5 w-5 text-brand-accent-dark dark:text-brand-accent-light" />
                           ) : (
                             <XMarkIcon className="h-5 w-5 text-red-500" />
                           )}
@@ -3878,7 +3878,7 @@ ${encryptionKey.replace('key_', '')}
                               className={cn(
                                 'font-aeonik text-sm font-medium',
                                 importResult.success
-                                  ? 'text-emerald-500'
+                                  ? 'text-brand-accent-dark dark:text-brand-accent-light'
                                   : 'text-red-500',
                               )}
                             >
@@ -4445,7 +4445,7 @@ ${encryptionKey.replace('key_', '')}
                               className={cn(
                                 'shrink-0 rounded-full px-3 py-1 text-xs font-medium',
                                 isPremium
-                                  ? 'bg-emerald-500/20 text-emerald-500'
+                                  ? 'bg-brand-accent-dark/20 text-brand-accent-dark dark:bg-brand-accent-light/20 dark:text-brand-accent-light'
                                   : 'bg-content-muted/20 text-content-muted',
                               )}
                             >

--- a/src/components/chat/verification-status-display.tsx
+++ b/src/components/chat/verification-status-display.tsx
@@ -104,7 +104,9 @@ export const VerificationStatusDisplay = memo(
     const getStepIcon = (status: VerificationStep['status']) => {
       switch (status) {
         case 'success':
-          return <CheckCircleIcon className="h-5 w-5 text-emerald-500" />
+          return (
+            <CheckCircleIcon className="h-5 w-5 text-brand-accent-dark dark:text-brand-accent-light" />
+          )
         case 'error':
           return (
             <div className="relative h-5 w-5 rounded-full bg-red-500">
@@ -170,7 +172,7 @@ export const VerificationStatusDisplay = memo(
               {hasError ? (
                 <div className="h-2 w-2 rounded-full bg-red-500 shadow-[0_0_4px_1px_rgba(239,68,68,0.6)]" />
               ) : isComplete ? (
-                <div className="h-2 w-2 rounded-full bg-emerald-500 shadow-[0_0_4px_1px_rgba(16,185,129,0.6)]" />
+                <div className="h-2 w-2 rounded-full bg-brand-accent-dark shadow-[0_0_4px_1px_hsl(var(--color-accent-dark)/0.6)] dark:bg-brand-accent-light dark:shadow-[0_0_4px_1px_hsl(var(--color-accent-light)/0.6)]" />
               ) : (
                 <PiSpinner className="h-5 w-5 animate-spin text-content-secondary" />
               )}
@@ -180,7 +182,7 @@ export const VerificationStatusDisplay = memo(
                 className={`font-aeonik-fono ${
                   isComplete
                     ? isDarkMode
-                      ? 'text-emerald-500'
+                      ? 'text-brand-accent-light'
                       : 'text-brand-accent-dark'
                     : hasError
                       ? 'text-red-500'
@@ -269,7 +271,7 @@ export const VerificationStatusDisplay = memo(
             {hasError ? (
               <div className="h-2 w-2 rounded-full bg-red-500 shadow-[0_0_4px_1px_rgba(239,68,68,0.6)]" />
             ) : isComplete ? (
-              <div className="h-2 w-2 rounded-full bg-emerald-500 shadow-[0_0_4px_1px_rgba(16,185,129,0.6)]" />
+              <div className="h-2 w-2 rounded-full bg-brand-accent-dark shadow-[0_0_4px_1px_hsl(var(--color-accent-dark)/0.6)] dark:bg-brand-accent-light dark:shadow-[0_0_4px_1px_hsl(var(--color-accent-light)/0.6)]" />
             ) : (
               <PiSpinner className="h-5 w-5 animate-spin text-content-secondary" />
             )}
@@ -278,7 +280,7 @@ export const VerificationStatusDisplay = memo(
               aria-live="polite"
               className={`text-xs font-medium ${
                 isComplete
-                  ? 'text-emerald-500'
+                  ? 'text-brand-accent-dark dark:text-brand-accent-light'
                   : hasError
                     ? 'text-red-500'
                     : isDarkMode
@@ -315,7 +317,7 @@ export const VerificationStatusDisplay = memo(
                   <span
                     className={`${
                       step.status === 'success'
-                        ? 'text-emerald-500'
+                        ? 'text-brand-accent-dark dark:text-brand-accent-light'
                         : step.status === 'error'
                           ? 'text-red-500'
                           : isDarkMode

--- a/src/components/modals/add-to-project-context-modal.tsx
+++ b/src/components/modals/add-to-project-context-modal.tsx
@@ -63,8 +63,8 @@ export function AddToProjectContextModal({
         )}
       >
         <div className="mb-3 flex items-center justify-center sm:mb-4">
-          <div className="rounded-full bg-emerald-500/20 p-2 sm:p-3">
-            <FolderIcon className="h-6 w-6 text-emerald-500 sm:h-8 sm:w-8" />
+          <div className="rounded-full bg-brand-accent-dark/10 p-2 dark:bg-brand-accent-light/10 sm:p-3">
+            <FolderIcon className="h-6 w-6 text-brand-accent-dark dark:text-brand-accent-light sm:h-8 sm:w-8" />
           </div>
         </div>
 
@@ -93,7 +93,7 @@ export function AddToProjectContextModal({
           </button>
           <button
             onClick={handleAddToProject}
-            className="flex-1 rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-emerald-700 sm:text-base"
+            className="flex-1 rounded-lg bg-brand-accent-dark px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-brand-accent-dark/90 sm:text-base"
           >
             Yes, add to project
           </button>

--- a/src/components/modals/cloud-sync-setup-modal.tsx
+++ b/src/components/modals/cloud-sync-setup-modal.tsx
@@ -637,7 +637,7 @@ ${generatedKey.replace('key_', '')}
               onClick={handleCopyKey}
               className={`w-full min-w-[5rem] ${
                 isCopied
-                  ? 'border-brand-accent-dark bg-brand-accent-dark text-white hover:border-brand-accent-dark-darker hover:bg-brand-accent-dark-darker'
+                  ? 'border-brand-accent-dark bg-brand-accent-dark text-white hover:border-brand-accent-dark/90 hover:bg-brand-accent-dark/90'
                   : ''
               }`}
               title="Copy to clipboard"

--- a/src/components/modals/cloud-sync-setup-modal.tsx
+++ b/src/components/modals/cloud-sync-setup-modal.tsx
@@ -637,7 +637,7 @@ ${generatedKey.replace('key_', '')}
               onClick={handleCopyKey}
               className={`w-full min-w-[5rem] ${
                 isCopied
-                  ? 'border-emerald-500 bg-emerald-500 text-white hover:border-emerald-600 hover:bg-emerald-600'
+                  ? 'border-brand-accent-dark bg-brand-accent-dark text-white hover:border-brand-accent-dark-darker hover:bg-brand-accent-dark-darker'
                   : ''
               }`}
               title="Copy to clipboard"

--- a/src/components/modals/signout-confirmation-modal.tsx
+++ b/src/components/modals/signout-confirmation-modal.tsx
@@ -68,7 +68,7 @@ ${encryptionKey.replace('key_', '')}
               disabled={hasDownloadedKey}
               className={`flex w-full items-center justify-center gap-2 rounded-lg border px-4 py-3 text-sm font-medium transition-all ${
                 hasDownloadedKey
-                  ? 'cursor-not-allowed border-emerald-500/40 bg-emerald-500/10 text-emerald-600'
+                  ? 'cursor-not-allowed border-brand-accent-dark/40 bg-brand-accent-dark/10 text-brand-accent-dark dark:border-brand-accent-light/40 dark:bg-brand-accent-light/10 dark:text-brand-accent-light'
                   : 'border-brand-accent-dark/40 bg-brand-accent-dark text-white hover:bg-brand-accent-dark/90'
               }`}
             >

--- a/src/components/project/project-document-upload.tsx
+++ b/src/components/project/project-document-upload.tsx
@@ -99,8 +99,8 @@ export function ProjectDocumentUpload({
         className={cn(
           'flex w-full items-center justify-center gap-2 rounded-md border border-dashed px-3 py-2 text-xs transition-colors',
           isDarkMode
-            ? 'border-border-strong text-content-muted hover:border-emerald-500/40 hover:text-emerald-400'
-            : 'border-border-subtle text-content-muted hover:border-emerald-500/40 hover:text-emerald-600',
+            ? 'border-border-strong text-content-muted hover:border-brand-accent-light/40 hover:text-brand-accent-light'
+            : 'border-border-subtle text-content-muted hover:border-brand-accent-dark/40 hover:text-brand-accent-dark',
           isUploading && 'cursor-not-allowed opacity-50',
         )}
       >

--- a/src/components/project/project-header.tsx
+++ b/src/components/project/project-header.tsx
@@ -26,8 +26,8 @@ export function ProjectHeader({
       className={cn(
         'flex h-12 flex-none items-center justify-between border-b px-4',
         isDarkMode
-          ? 'border-emerald-500/30 bg-emerald-950/20'
-          : 'border-emerald-500/30 bg-emerald-50/50',
+          ? 'border-brand-accent-light/30 bg-brand-accent-dark/20'
+          : 'border-brand-accent-dark/30 bg-brand-accent-light/10',
       )}
     >
       <div className="flex items-center gap-3">
@@ -51,13 +51,13 @@ export function ProjectHeader({
           <FolderIcon
             className={cn(
               'h-5 w-5',
-              isDarkMode ? 'text-emerald-400' : 'text-emerald-600',
+              isDarkMode ? 'text-brand-accent-light' : 'text-brand-accent-dark',
             )}
           />
           <span
             className={cn(
               'font-aeonik text-sm font-medium',
-              isDarkMode ? 'text-emerald-400' : 'text-emerald-700',
+              isDarkMode ? 'text-brand-accent-light' : 'text-brand-accent-dark',
             )}
           >
             {activeProject.name}

--- a/src/components/project/project-selector-modal.tsx
+++ b/src/components/project/project-selector-modal.tsx
@@ -159,7 +159,7 @@ export function ProjectSelectorModal({
                     {/* Projects list */}
                     {loadingList && projects.length === 0 ? (
                       <div className="py-8 text-center">
-                        <div className="mx-auto mb-2 h-6 w-6 animate-spin rounded-full border-2 border-emerald-500 border-t-transparent" />
+                        <div className="mx-auto mb-2 h-6 w-6 animate-spin rounded-full border-2 border-brand-accent-dark border-t-transparent dark:border-brand-accent-light dark:border-t-transparent" />
                         <p className="font-aeonik-fono text-sm text-content-muted">
                           Loading projects...
                         </p>
@@ -193,8 +193,8 @@ export function ProjectSelectorModal({
                               className={cn(
                                 'mt-0.5 h-5 w-5 flex-shrink-0',
                                 isDarkMode
-                                  ? 'text-emerald-400'
-                                  : 'text-emerald-600',
+                                  ? 'text-brand-accent-light'
+                                  : 'text-brand-accent-dark',
                               )}
                             />
                             <div className="min-w-0 flex-1">
@@ -317,9 +317,7 @@ export function ProjectSelectorModal({
                       disabled={loadingAction || !newProjectName.trim()}
                       className={cn(
                         'rounded-md px-4 py-2 font-aeonik text-sm font-medium transition-colors',
-                        isDarkMode
-                          ? 'bg-emerald-600 text-white hover:bg-emerald-700'
-                          : 'bg-emerald-600 text-white hover:bg-emerald-700',
+                        'bg-brand-accent-dark text-white hover:bg-brand-accent-dark/90',
                         (loadingAction || !newProjectName.trim()) &&
                           'cursor-not-allowed opacity-50',
                       )}

--- a/src/components/project/project-settings-content.tsx
+++ b/src/components/project/project-settings-content.tsx
@@ -271,8 +271,8 @@ export function ProjectSettingsContent({
                 isHighUsage
                   ? 'bg-amber-500'
                   : isDarkMode
-                    ? 'bg-emerald-500'
-                    : 'bg-emerald-600',
+                    ? 'bg-brand-accent-light'
+                    : 'bg-brand-accent-dark',
               )}
               style={{ width: `${usagePercent}%` }}
             />
@@ -338,8 +338,8 @@ export function ProjectSettingsContent({
                   isHighUsage
                     ? 'text-amber-500'
                     : isDarkMode
-                      ? 'text-emerald-400'
-                      : 'text-emerald-600',
+                      ? 'text-brand-accent-light'
+                      : 'text-brand-accent-dark',
                 )}
               >
                 ~{formatTokenCount(contextUsage.availableForChat)} tokens
@@ -396,7 +396,8 @@ export function ProjectSettingsContent({
             className={cn(
               'font-aeonik-fono text-xs',
               saveStatus === 'saving' && 'text-content-muted',
-              saveStatus === 'saved' && 'text-emerald-500',
+              saveStatus === 'saved' &&
+                'text-brand-accent-dark dark:text-brand-accent-light',
               saveStatus === 'error' && 'text-red-500',
             )}
           >

--- a/src/components/project/project-sidebar.tsx
+++ b/src/components/project/project-sidebar.tsx
@@ -1104,7 +1104,7 @@ export function ProjectSidebar({
                           disabled={isSaving}
                           className={cn(
                             'w-full rounded-lg px-3 py-2 font-aeonik text-sm font-medium transition-colors',
-                            'bg-emerald-600 text-white hover:bg-emerald-700',
+                            'bg-brand-accent-dark text-white hover:bg-brand-accent-dark/90',
                             isSaving && 'cursor-not-allowed opacity-50',
                           )}
                         >
@@ -1233,8 +1233,8 @@ export function ProjectSidebar({
                           ? 'mb-2 py-3'
                           : 'py-6',
                         isDarkMode
-                          ? 'border-border-strong hover:border-emerald-500/50 hover:bg-surface-chat'
-                          : 'border-border-subtle hover:border-emerald-500/50 hover:bg-surface-sidebar',
+                          ? 'border-border-strong hover:border-brand-accent-light/50 hover:bg-surface-chat'
+                          : 'border-border-subtle hover:border-brand-accent-dark/50 hover:bg-surface-sidebar',
                       )}
                     >
                       <DocumentPlusIcon
@@ -1280,8 +1280,8 @@ export function ProjectSidebar({
                               className={cn(
                                 'h-4 w-4 flex-shrink-0 animate-spin',
                                 isDarkMode
-                                  ? 'text-emerald-400'
-                                  : 'text-emerald-600',
+                                  ? 'text-brand-accent-light'
+                                  : 'text-brand-accent-dark',
                               )}
                             />
                             <div className="min-w-0 flex-1">
@@ -1310,8 +1310,8 @@ export function ProjectSidebar({
                               cn(
                                 'h-4 w-4 flex-shrink-0',
                                 isDarkMode
-                                  ? 'text-emerald-400'
-                                  : 'text-emerald-600',
+                                  ? 'text-brand-accent-light'
+                                  : 'text-brand-accent-dark',
                               ),
                             )}
                             <div className="min-w-0 flex-1">

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -59,10 +59,6 @@ export const TINFOIL_ACCENT_LIGHT = colors['tinfoil-accent-light'].DEFAULT
 export const TINFOIL_ACCENT_LIGHT_HOVER = colors['tinfoil-accent-light'].hover
 export const TINFOIL_ACCENT_LIGHT_DARKER = colors['tinfoil-accent-light'].darker
 
-// Legacy exports for backward compatibility (will be phased out)
-export const EMERALD_500 = colors['tinfoil-accent-light'].DEFAULT
-export const EMERALD_600 = colors['tinfoil-accent-light'].darker
-
 // Tailwind class names for when inline styles aren't suitable
 export const colorClasses = {
   'tinfoil-dark': {
@@ -109,14 +105,6 @@ export const colorClasses = {
     border: 'border-brand-accent-dark',
     borderHover: 'hover:border-brand-accent-dark/90',
     ring: 'ring-brand-accent-dark',
-  },
-  emerald: {
-    text500: 'text-brand-accent-light',
-    text600: 'text-brand-accent-light-darker',
-    bg500: 'bg-brand-accent-light',
-    bg600: 'bg-brand-accent-light-darker',
-    border500: 'border-brand-accent-light',
-    border600: 'border-brand-accent-light-darker',
   },
 } as const
 


### PR DESCRIPTION
## Summary
- Replace all hardcoded Tailwind `emerald-*` colors with theme tokens (`brand-accent-dark` / `brand-accent-light`) so success states, badges, buttons, and project UI follow the brand palette in both light and dark mode
- Affects the add-to-project-context modal, project header/sidebar/selector/settings/upload, chat sidebar, settings modal, MFA card, cloud sync health card, sign-out and cloud sync setup modals, and verification status display
- Remove now-unused legacy emerald aliases from the theme colors module

## Details
- Light mode uses `brand-accent-dark` (deep teal), dark mode uses `brand-accent-light` (mint), matching the existing convention in components like the share modal and subscribe prompt
- Status dot glow shadows now derive from theme CSS variables instead of hardcoded emerald rgba values
- Solid emerald buttons now match the standard primary button pattern (`bg-brand-accent-dark hover:bg-brand-accent-dark/90`)

## Testing
- `tsc --noEmit` passes
- ESLint clean on all changed files
- All 1448 unit tests pass
- Zero remaining `emerald` references in `src/`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the app to theme accent colors instead of hardcoded Tailwind greens. This aligns success states, badges, buttons, and project UI with the brand palette in both light and dark mode.

- **Refactors**
  - Replaced `emerald-*` classes with `brand-accent-dark` / `brand-accent-light` in chat sidebar, cloud sync health card, MFA settings, settings modal, verification status, add-to-project modal, cloud sync setup, signout modal, and project header/sidebar/selector/settings/upload.
  - Status dot glows now use theme CSS variables for shadows.
  - Standardized primary and copy buttons to `bg-brand-accent-dark hover:bg-brand-accent-dark/90` (with dark mode variants).
  - Removed legacy emerald aliases from `src/theme/colors.ts`.

<sup>Written for commit a91ddd5b0380ffacc4a05e5749473a54372bb9dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/475?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

