### PR TITLE
perf: settle chat UI as soon as the response finishes streaming

### DIFF
--- a/src/components/chat/hooks/use-chat-messaging.ts
+++ b/src/components/chat/hooks/use-chat-messaging.ts
@@ -902,7 +902,12 @@ export function useChatMessaging({
               },
             )
           } finally {
-            releaseActiveChatRecovery(chatId)
+            // Release only this stream's turn: the chat may already be
+            // interactive again (flags settle at stream end) with a
+            // successor stream's recovery attempt registered on it.
+            if (turnId) {
+              releaseActiveChatRecovery(chatId, turnId)
+            }
           }
         })()
         recoveryCleanupByChat.set(chatId, cleanup)

--- a/src/components/chat/hooks/use-chat-messaging.ts
+++ b/src/components/chat/hooks/use-chat-messaging.ts
@@ -30,6 +30,7 @@ import {
   cancelChatRecovery,
   completeLiveChatRecovery,
   markChatRecoveryTurnCancelled,
+  markChatRecoveryTurnSettled,
   persistChatRecoveryToken,
   releaseActiveChatRecovery,
   scanPendingChatRecoveries,
@@ -1080,6 +1081,49 @@ export function useChatMessaging({
           // navigated to a different conversation while it streamed.
           const chatId = streamChatIdRef.current
 
+          // The full response is on screen once the stream loop and its
+          // final publication settle, so settle the UI flags now instead of
+          // after title resolution and recovery finalization (which cost
+          // cloud round-trips). The streaming tracker intentionally stays
+          // active until the final save lands so storage reloads can't
+          // adopt a stale stored copy of this chat (see deferStreamCleanup).
+          if (
+            !controller.signal.aborted &&
+            ownsController(chatId, controller)
+          ) {
+            patchStatus(chatId, {
+              loadingState: 'idle',
+              retryInfo: null,
+              isWaitingForResponse: false,
+              isStreaming: false,
+              isThinking: false,
+            })
+            if (recoveryEnabled && turnId) {
+              // Strip this turn's envelope from view state so the recovery
+              // indicator can't flash for a turn that just completed on
+              // screen; the envelope itself is removed from storage by
+              // completeLiveChatRecovery below. The settled mark keeps
+              // storage reloads in that window from re-adopting it.
+              markChatRecoveryTurnSettled(chatId, turnId)
+              const stripCompletedEnvelope = (chat: Chat): Chat => ({
+                ...chat,
+                pendingRecoveries: chat.pendingRecoveries?.filter(
+                  (recovery) => recovery.turnId !== turnId,
+                ),
+              })
+              setChats((previous) =>
+                previous.map((chat) =>
+                  chat.id === chatId ? stripCompletedEnvelope(chat) : chat,
+                ),
+              )
+              setCurrentChat((previous) =>
+                previous.id === chatId
+                  ? stripCompletedEnvelope(previous)
+                  : previous,
+              )
+            }
+          }
+
           logInfo('[handleQuery] Streaming completed, processing response', {
             component: 'useChatMessaging',
             action: 'handleQuery.streamingComplete',
@@ -1208,26 +1252,33 @@ export function useChatMessaging({
                     : {}),
                 },
               })
-              const latestChat = findLiveChat(chatId)
-              const titleChangedDuringRecovery =
-                latestChat !== undefined &&
-                (latestChat.title !== titleBeforeRecovery?.title ||
-                  latestChat.titleState !== titleBeforeRecovery?.titleState)
-              const visibleChat = titleChangedDuringRecovery
-                ? {
-                    ...completedChat,
-                    title: latestChat.title,
-                    titleState: latestChat.titleState,
-                  }
-                : completedChat
-              setChats((previous) =>
-                previous.map((chat) =>
-                  chat.id === chatId ? visibleChat : chat,
-                ),
-              )
-              setCurrentChat((previous) =>
-                previous.id === chatId ? visibleChat : previous,
-              )
+              // The UI settled to idle before this finalization, so a newer
+              // stream may have started on this chat meanwhile. Its
+              // controller registration marks ownership; replacing the
+              // visible chat then would stomp the successor's optimistic
+              // messages with this stream's storage snapshot.
+              if (ownsController(chatId, controller)) {
+                const latestChat = findLiveChat(chatId)
+                const titleChangedDuringRecovery =
+                  latestChat !== undefined &&
+                  (latestChat.title !== titleBeforeRecovery?.title ||
+                    latestChat.titleState !== titleBeforeRecovery?.titleState)
+                const visibleChat = titleChangedDuringRecovery
+                  ? {
+                      ...completedChat,
+                      title: latestChat.title,
+                      titleState: latestChat.titleState,
+                    }
+                  : completedChat
+                setChats((previous) =>
+                  previous.map((chat) =>
+                    chat.id === chatId ? visibleChat : chat,
+                  ),
+                )
+                setCurrentChat((previous) =>
+                  previous.id === chatId ? visibleChat : previous,
+                )
+              }
             } catch (error) {
               if (!controller.signal.aborted) {
                 await abandonAndReleaseRecovery(chatId)
@@ -1240,7 +1291,13 @@ export function useChatMessaging({
                 action: 'handleQuery.recoveryComplete',
                 metadata: { chatId },
               })
-              persistFinalChat(true)
+              // Same ownership rule as above: a successor stream's save
+              // already persists this response (it reads the on-screen
+              // messages), so only fall back to a direct save while this
+              // stream still owns the chat.
+              if (ownsController(chatId, controller)) {
+                persistFinalChat(true)
+              }
             }
           } else {
             persistFinalChat()

--- a/src/services/inference/chat-recovery.ts
+++ b/src/services/inference/chat-recovery.ts
@@ -73,6 +73,7 @@ const activeRecoveries = new Map<string, ActiveRecovery>()
 const scannedRecoveries = new Map<string, ScannedRecovery>()
 const cancelledTurns = new Set<string>()
 const settledTurns = new Set<string>()
+const MAX_SETTLED_TURNS = 200
 const RECOVERY_SCAN_CONCURRENCY = 4
 const RECOVERY_RETRY_BASE_DELAY_MS = 100
 const RECOVERY_RETRY_MAX_DELAY_MS = 10_000
@@ -491,17 +492,31 @@ export function isChatRecoveryTurnCancelled(
  * indicator under an already-complete response. Kept separate from the
  * cancelled-turn registry: a settled turn's in-flight token persistence
  * and finalization must keep running, only envelope adoption stops.
+ *
+ * The guard is only needed until the turn's envelope removal settles, so
+ * the registry is bounded by evicting the oldest marks; every turn ever
+ * completed in a long-lived tab need not be retained.
  */
 export function markChatRecoveryTurnSettled(
   chatId: string,
   turnId: string,
 ): void {
   settledTurns.add(turnKey(chatId, turnId))
+  for (const oldest of settledTurns) {
+    if (settledTurns.size <= MAX_SETTLED_TURNS) break
+    settledTurns.delete(oldest)
+  }
 }
 
-export function releaseActiveChatRecovery(chatId: string): void {
+export function releaseActiveChatRecovery(
+  chatId: string,
+  turnId: string,
+): void {
+  // Scoped to a single turn: the chat stays interactive while a stream's
+  // finalization settles, so a chat-wide release could destroy a successor
+  // stream's just-registered recovery attempt.
   for (const recovery of activeRecoveries.values()) {
-    if (recovery.chatId === chatId) {
+    if (recovery.chatId === chatId && recovery.turnId === turnId) {
       activeRecoveries.delete(recovery.sessionId)
     }
   }
@@ -518,7 +533,8 @@ async function processEnvelope(
   const isCurrent = () =>
     generation === recoveryScanGeneration &&
     !signal.aborted &&
-    !cancelledTurns.has(key)
+    !cancelledTurns.has(key) &&
+    !settledTurns.has(key)
   if (!isCurrent()) return
   if (
     [...activeRecoveries.values()].some(

--- a/src/services/inference/chat-recovery.ts
+++ b/src/services/inference/chat-recovery.ts
@@ -72,6 +72,7 @@ type ScannedRecovery = {
 const activeRecoveries = new Map<string, ActiveRecovery>()
 const scannedRecoveries = new Map<string, ScannedRecovery>()
 const cancelledTurns = new Set<string>()
+const settledTurns = new Set<string>()
 const RECOVERY_SCAN_CONCURRENCY = 4
 const RECOVERY_RETRY_BASE_DELAY_MS = 100
 const RECOVERY_RETRY_MAX_DELAY_MS = 10_000
@@ -479,7 +480,23 @@ export function isChatRecoveryTurnCancelled(
   chatId: string,
   turnId: string,
 ): boolean {
-  return cancelledTurns.has(turnKey(chatId, turnId))
+  const key = turnKey(chatId, turnId)
+  return cancelledTurns.has(key) || settledTurns.has(key)
+}
+
+/**
+ * Mark a turn whose live stream completed on screen. The UI settles to
+ * idle before the envelope removal round-trips, so a storage reload in
+ * that window must not re-adopt the turn's envelope and flash a recovery
+ * indicator under an already-complete response. Kept separate from the
+ * cancelled-turn registry: a settled turn's in-flight token persistence
+ * and finalization must keep running, only envelope adoption stops.
+ */
+export function markChatRecoveryTurnSettled(
+  chatId: string,
+  turnId: string,
+): void {
+  settledTurns.add(turnKey(chatId, turnId))
 }
 
 export function releaseActiveChatRecovery(chatId: string): void {
@@ -970,6 +987,7 @@ export function resetChatRecoveryState(): void {
   activeRecoveries.clear()
   scannedRecoveries.clear()
   cancelledTurns.clear()
+  settledTurns.clear()
   clearChatRecoveryDrafts()
   clearActiveChatRecoveries()
   scanInFlight = null

--- a/tests/components/chat/use-chat-messaging.cancel-generation.test.tsx
+++ b/tests/components/chat/use-chat-messaging.cancel-generation.test.tsx
@@ -71,6 +71,7 @@ vi.mock('@/services/inference/chat-recovery', () => ({
   cancelChatRecovery: cancelChatRecoveryMock,
   completeLiveChatRecovery: vi.fn(),
   markChatRecoveryTurnCancelled: vi.fn(),
+  markChatRecoveryTurnSettled: vi.fn(),
   persistChatRecoveryToken: vi.fn(),
   releaseActiveChatRecovery: vi.fn(),
   scanPendingChatRecoveries: scanPendingChatRecoveriesMock,

--- a/tests/components/chat/use-chat-messaging.stop-stream.test.tsx
+++ b/tests/components/chat/use-chat-messaging.stop-stream.test.tsx
@@ -17,6 +17,7 @@ const {
   initialSaveMock,
   persistInterruptedAssistantMock,
   saveChatMock,
+  patchStatusMock,
   sendChatStreamMock,
   sessionGetAllChatsMock,
   sessionSaveMock,
@@ -53,6 +54,7 @@ const {
   persistInterruptedAssistantMock: vi.fn(
     async (..._args: unknown[]) => undefined,
   ),
+  patchStatusMock: vi.fn(),
   saveChatMock: vi.fn(async (chat: unknown) => chat),
   sendChatStreamMock: vi.fn(),
   sessionGetAllChatsMock: vi.fn(() => [] as Chat[]),
@@ -96,7 +98,7 @@ vi.mock('@/components/chat/hooks/use-chat-streams', async (importOriginal) => ({
   >()),
   useChatStreams: () => ({
     statusByChat: {},
-    patchStatus: vi.fn(),
+    patchStatus: patchStatusMock,
     resetStatus: vi.fn(),
     moveStatus: (fromId: string, toId: string) => {
       const controller = streamControllers.get(fromId)
@@ -132,6 +134,7 @@ vi.mock('@/services/inference/chat-recovery', () => ({
   completeLiveChatRecovery: (...args: unknown[]) =>
     completeLiveChatRecoveryMock(...args),
   markChatRecoveryTurnCancelled: vi.fn(),
+  markChatRecoveryTurnSettled: vi.fn(),
   persistChatRecoveryToken: vi.fn(),
   releaseActiveChatRecovery: vi.fn(),
   scanPendingChatRecoveries: vi.fn(),
@@ -779,6 +782,91 @@ describe('useChatMessaging stopped streams', () => {
       await query
     })
     expect(completeLiveChatRecoveryMock).toHaveBeenCalledOnce()
+  })
+
+  it('settles the streaming flags before recovery finalization completes', async () => {
+    authState.isSignedIn = true
+    authState.userId = 'user-1'
+    recoveryAvailableState.available = true
+    let finishRecoveryCompletion!: () => void
+    const idleWhileFinalizing: boolean[] = []
+    completeLiveChatRecoveryMock.mockImplementationOnce(
+      (...args: unknown[]) => {
+        idleWhileFinalizing.push(
+          patchStatusMock.mock.calls.some(
+            ([chatId, patch]) =>
+              chatId === 'chat-1' &&
+              (patch as { isStreaming?: boolean }).isStreaming === false &&
+              (patch as { loadingState?: string }).loadingState === 'idle',
+          ),
+        )
+        const input = args[0] as {
+          chatId: string
+          assistantMessage: Chat['messages'][number]
+        }
+        return new Promise<Chat>((resolve) => {
+          finishRecoveryCompletion = () =>
+            resolve({
+              id: input.chatId,
+              title: 'Untitled',
+              createdAt: new Date(),
+              messages: [input.assistantMessage],
+              isBlankChat: false,
+            })
+        })
+      },
+    )
+    const initialChat: Chat = {
+      id: 'chat-1',
+      title: 'Existing chat',
+      createdAt: new Date(),
+      messages: [],
+    }
+    const stream = createOpenStream()
+    sendChatStreamMock.mockResolvedValue(stream.stream)
+
+    const { result } = renderHook(() => {
+      const [currentChat, setCurrentChat] = useState(initialChat)
+      const [chats, setChats] = useState([initialChat])
+      const messaging = useChatMessaging({
+        systemPrompt: '',
+        storeHistory: true,
+        models: [{} as never],
+        selectedModel: 'test-model',
+        chats,
+        currentChat,
+        setChats,
+        setCurrentChat,
+      })
+      return { currentChat, messaging }
+    })
+
+    let query!: Promise<unknown>
+    act(() => {
+      query = result.current.messaging.handleQuery('Prompt') as Promise<unknown>
+    })
+    await vi.waitFor(() => expect(sendChatStreamMock).toHaveBeenCalled())
+    stream.send({ choices: [{ delta: { content: 'Complete answer' } }] })
+    stream.send({
+      choices: [{ index: 0, delta: {}, finish_reason: 'stop' }],
+    })
+    stream.close()
+
+    await vi.waitFor(() =>
+      expect(completeLiveChatRecoveryMock).toHaveBeenCalled(),
+    )
+    // The stop button/spinner must revert as soon as the stream ends, not
+    // after the recovery finalization round-trips settle.
+    expect(idleWhileFinalizing).toEqual([true])
+
+    await act(async () => {
+      finishRecoveryCompletion()
+      await query
+    })
+    expect(result.current.currentChat.messages.at(-1)).toMatchObject({
+      role: 'assistant',
+      content: 'Complete answer',
+    })
   })
 
   it('stops without waiting for pending recovery token persistence', async () => {


### PR DESCRIPTION
## Summary

There is a perceptible delay between the last streamed token and the UI registering the stream as ended (stop button reverting, spinner stopping). For recovery-enabled chats, the streaming flags were only cleared after the recovery finalization pipeline settled: `waitForRecoveryReady` → `completeLiveChatRecovery` (a cloud downloadChat + uploadChat pair, IndexedDB write, and a `DELETE /recovery/{id}` round-trip) plus title generation on first messages — all awaited before `patchStatus` flipped `isStreaming`/`loadingState`.

- Settle `loadingState`/`isStreaming`/`isWaitingForResponse`/`isThinking` immediately after the stream loop and final publication complete; recovery finalization, title resolution, and saves continue in the background.
- Strip the completed turn's recovery envelope from view state at the same moment (and mark the turn settled so storage reloads can't re-adopt it) so the "Recovering stream..." indicator can't flash under a response that just finished on screen.
- Guard the finalization's chat replacement and error-path fallback save with `ownsController`: since the chat is now interactive during finalization, a successor stream's optimistic messages must not be stomped by this stream's storage snapshot.
- The `streamingTracker` marker intentionally stays active until the final save lands, preserving cloud-sync gating and stale-reload protection.

A companion controlplane PR (tinfoilsh/controlplane#556) removes the server-side share of the same delay: the response body was only closed after recovery persistence database writes, and SSE consumers (the openai SDK ends on body EOF, not `[DONE]`) waited on that.

## Test plan

- New test: streaming flags settle to idle before `completeLiveChatRecovery` resolves, and the finalized message still lands.
- Full unit suite passes (128 files, 1449 tests); lint clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Settle the chat UI immediately when streaming ends to remove the lag before the stop button resets and the spinner stops. Background finalization, title generation, and saves run without blocking the UI, and a new stream’s recovery remains safe.

- **Bug Fixes**
  - Clear `loadingState`, `isStreaming`, `isWaitingForResponse`, and `isThinking` right after the final token publishes; keep the streaming tracker active until the final save for sync safety.
  - Remove the finished turn’s recovery envelope from view and mark the turn settled to prevent the "Recovering stream..." indicator from flashing.
  - Scope recovery release to the finished turn to avoid removing a successor stream’s recovery attempt during background cleanup.
  - Guard recovery finalization and fallback saves with controller ownership to avoid overwriting a newer stream’s optimistic messages.

<sup>Written for commit 57c727dbca3dc18ac449bb3ad447a713f581d3ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/476?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

