### PR TITLE
fix: don't send or retry requests when the free quota is exhausted

### DIFF
--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -8,6 +8,7 @@ import {
   type BaseModel,
 } from '@/config/models'
 import { DEFAULT_CHAT_TITLE, TEMPORARY_CHAT_TITLE } from '@/constants/chat'
+import { REQUEST_UPGRADE_EVENT } from '@/constants/chat-events'
 import { PIXELATE_SIDEBAR_CHAT_TITLES_CHANGED_EVENT } from '@/constants/settings-events'
 import {
   SETTINGS_CODE_EXECUTION_ENABLED,
@@ -33,7 +34,6 @@ import {
   getRateLimitInfo,
   getSessionToken,
   invalidateSessionCache,
-  snapshotAndDecrementRemaining,
   type RateLimitInfo,
 } from '@/services/inference/tinfoil-client'
 import { generateTitle, getTitleContent } from '@/services/inference/title'
@@ -907,10 +907,6 @@ export function ChatInterface({
     [rateLimit],
   )
 
-  const handleQueueDispatch = useCallback(() => {
-    if (rateLimit) snapshotAndDecrementRemaining()
-  }, [rateLimit])
-
   const handleQueueRateLimited = useCallback(() => {
     setIsSubscribePromptOpen(true)
   }, [])
@@ -933,7 +929,6 @@ export function ChatInterface({
       hasPendingRecoveryRef.current ||
       (currentChatId ? isChatRecoveryActive(currentChatId) : false),
     dispatchBlocked: hasPendingRecovery || activeRecoveryTurnIds.length > 0,
-    onBeforeDispatch: handleQueueDispatch,
     onRateLimited: handleQueueRateLimited,
     cancelGeneration,
   })
@@ -1131,14 +1126,14 @@ export function ChatInterface({
     })
   }, [isSignedIn, cloudSyncInitialized, chat_subscription_active])
 
-  // Handle upgrade requests from error CTA buttons
+  // Handle upgrade requests from error CTA buttons and quota-gated sends
   useEffect(() => {
     const handleRequestUpgrade = () => {
       setIsSubscribePromptOpen(true)
     }
-    window.addEventListener('requestUpgrade', handleRequestUpgrade)
+    window.addEventListener(REQUEST_UPGRADE_EVENT, handleRequestUpgrade)
     return () => {
-      window.removeEventListener('requestUpgrade', handleRequestUpgrade)
+      window.removeEventListener(REQUEST_UPGRADE_EVENT, handleRequestUpgrade)
     }
   }, [])
 

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -899,13 +899,17 @@ export function ChatInterface({
   // per-account hourly cap (subscribers) reuses the same indicator channel but
   // must not block the queue or prompt subscribing; those sends fail fast with
   // an in-chat rate-limit message and recover once the hourly window resets.
-  const isRateLimited = useCallback(
-    () =>
-      Boolean(
-        rateLimit && rateLimit.remaining <= 0 && rateLimit.kind !== 'hourly',
-      ),
-    [rateLimit],
-  )
+  //
+  // Reads the live cache rather than the mirrored `rateLimit` state so the
+  // queue pump's pre-dequeue check can never lag behind handleQuery's own
+  // quota gate (which reads the same cache): a stale mirror would let the
+  // pump dequeue a message the gate then drops. `rateLimit` stays a
+  // dependency so the queue-resume effect re-fires when the limit clears.
+  const isRateLimited = useCallback(() => {
+    void rateLimit
+    const limit = getRateLimitInfo()
+    return Boolean(limit && limit.remaining <= 0 && limit.kind !== 'hourly')
+  }, [rateLimit])
 
   const handleQueueRateLimited = useCallback(() => {
     setIsSubscribePromptOpen(true)

--- a/src/components/chat/hooks/use-chat-messaging.ts
+++ b/src/components/chat/hooks/use-chat-messaging.ts
@@ -20,6 +20,7 @@
 import { useProject } from '@/components/project'
 import { resolveModelSelection, type BaseModel } from '@/config/models'
 import { DEFAULT_CHAT_TITLE, TEMPORARY_CHAT_TITLE } from '@/constants/chat'
+import { REQUEST_UPGRADE_EVENT } from '@/constants/chat-events'
 import { useChatRecoveryActive } from '@/hooks/use-chat-recovery-drafts'
 import { streamingTracker } from '@/services/cloud/streaming-tracker'
 import { ENCRYPTION_KEY_CHANGED_EVENT } from '@/services/encryption/encryption-service'
@@ -46,6 +47,7 @@ import {
   getRateLimitInfo,
   isChatRecoveryAvailable,
   refreshRateLimit,
+  snapshotAndDecrementRemaining,
 } from '@/services/inference/tinfoil-client'
 import { generateTitle, getTitleContent } from '@/services/inference/title'
 import { chatEvents } from '@/services/storage/chat-events'
@@ -551,6 +553,20 @@ export function useChatMessaging({
         })
         return
       }
+
+      // Free-tier daily quota gate. Every send path funnels through here
+      // (queue dispatches, regenerate/edit, URL-hash sends), so an exhausted
+      // quota never fires a request the server is guaranteed to reject. The
+      // hourly cap intentionally passes: those sends fail fast with an
+      // in-chat message instead of the subscribe prompt.
+      const quota = getRateLimitInfo()
+      if (quota && quota.remaining <= 0 && quota.kind !== 'hourly') {
+        window.dispatchEvent(new CustomEvent(REQUEST_UPGRADE_EVENT))
+        return
+      }
+      // Optimistically consume one request so the banner updates immediately
+      // and refreshRateLimit can detect stale server counts.
+      snapshotAndDecrementRemaining()
 
       // Clear input immediately when send button is pressed
       setInput('')

--- a/src/components/chat/hooks/use-chat-messaging.ts
+++ b/src/components/chat/hooks/use-chat-messaging.ts
@@ -564,9 +564,6 @@ export function useChatMessaging({
         window.dispatchEvent(new CustomEvent(REQUEST_UPGRADE_EVENT))
         return
       }
-      // Optimistically consume one request so the banner updates immediately
-      // and refreshRateLimit can detect stale server counts.
-      snapshotAndDecrementRemaining()
 
       // Clear input immediately when send button is pressed
       setInput('')
@@ -1039,6 +1036,12 @@ export function useChatMessaging({
         // the whole request, including the wait for the first token. The
         // stream processor's own startStreaming call is idempotent.
         streamingTracker.startStreaming(streamChatIdRef.current)
+
+        // Optimistically consume one request so the banner updates
+        // immediately and refreshRateLimit can detect stale server counts.
+        // Done here, past all preflight steps, so an aborted or failed
+        // preflight never eats a request locally.
+        snapshotAndDecrementRemaining()
 
         response = await sendChatStream({
           model,

--- a/src/components/chat/hooks/use-message-queue.ts
+++ b/src/components/chat/hooks/use-message-queue.ts
@@ -23,7 +23,6 @@ type UseMessageQueueArgs = {
   isRateLimited: () => boolean
   isDispatchBlocked?: () => boolean
   dispatchBlocked?: boolean
-  onBeforeDispatch?: () => void
   onRateLimited?: () => void
   cancelGeneration?: (chatId?: string) => void | Promise<void>
 }
@@ -120,7 +119,6 @@ export function useMessageQueue({
   isRateLimited,
   isDispatchBlocked,
   dispatchBlocked = false,
-  onBeforeDispatch,
   onRateLimited,
   cancelGeneration,
 }: UseMessageQueueArgs): UseMessageQueueReturn {
@@ -165,13 +163,11 @@ export function useMessageQueue({
   const handleQueryRef = useRef(handleQuery)
   const isRateLimitedRef = useRef(isRateLimited)
   const isDispatchBlockedRef = useRef(isDispatchBlocked)
-  const onBeforeDispatchRef = useRef(onBeforeDispatch)
   const onRateLimitedRef = useRef(onRateLimited)
   const cancelGenerationRef = useRef(cancelGeneration)
   handleQueryRef.current = handleQuery
   isRateLimitedRef.current = isRateLimited
   isDispatchBlockedRef.current = isDispatchBlocked
-  onBeforeDispatchRef.current = onBeforeDispatch
   onRateLimitedRef.current = onRateLimited
   cancelGenerationRef.current = cancelGeneration
 
@@ -277,7 +273,6 @@ export function useMessageQueue({
           const [next, ...rest] = getQueue(pump.id)
           if (!next) break
           setQueueFor(pump.id, rest)
-          onBeforeDispatchRef.current?.()
 
           try {
             const result = handleQueryRef.current(

--- a/src/components/chat/renderers/default/DefaultMessageRenderer.tsx
+++ b/src/components/chat/renderers/default/DefaultMessageRenderer.tsx
@@ -1,6 +1,7 @@
 import { GenUIToolCallRenderer } from '@/components/chat/genui/GenUIToolCallRenderer'
 import { renderGenUIResolved } from '@/components/chat/genui/render'
 import { cn } from '@/components/ui/utils'
+import { REQUEST_UPGRADE_EVENT } from '@/constants/chat-events'
 import {
   ArrowPathIcon,
   ArrowUturnLeftIcon,
@@ -476,7 +477,7 @@ const DefaultMessageComponent = ({
                         className="w-fit rounded-md bg-brand-accent-dark px-4 py-1.5 text-sm font-medium text-white transition-colors hover:bg-brand-accent-dark/90"
                         onClick={() => {
                           window.dispatchEvent(
-                            new CustomEvent('requestUpgrade'),
+                            new CustomEvent(REQUEST_UPGRADE_EVENT),
                           )
                         }}
                       >

--- a/src/constants/chat-events.ts
+++ b/src/constants/chat-events.ts
@@ -1,0 +1,3 @@
+// Window event dispatched when the user should be shown the upgrade /
+// subscribe prompt (e.g. free-tier quota exhausted).
+export const REQUEST_UPGRADE_EVENT = 'requestUpgrade'

--- a/src/services/inference/inference-client.ts
+++ b/src/services/inference/inference-client.ts
@@ -23,6 +23,7 @@ import { chatChunkStreamFromSSE, type ChatChunkStream } from './chat-stream'
 import {
   createRecoverableTinfoilClient,
   createRecoverableTinfoilTransport,
+  discardRateLimitSnapshot,
   getRateLimitInfo,
   getTinfoilClient,
   refreshRateLimit,
@@ -169,6 +170,12 @@ function getHttpStatus(error: unknown): number | undefined {
 async function classifyQuotaExhausted429(
   error: unknown,
 ): Promise<ChatError | null> {
+  // The 429 means the server rejected the request without consuming quota,
+  // so its refreshed count is authoritative. Drop the optimistic-decrement
+  // snapshot first: reconciling against it would force `remaining` to 0 for
+  // a user whose last request was merely throttled, misclassifying a
+  // transient 429 as exhaustion.
+  discardRateLimitSnapshot()
   await refreshRateLimit()
   const limit = getRateLimitInfo()
   if (!limit || limit.remaining > 0) {
@@ -521,9 +528,12 @@ export async function sendChatStream(
         client = await getTinfoilClient()
       }
 
+      // This loop owns retry policy with typed error classification; the
+      // SDK's internal retries would stack under it and delay terminal
+      // errors such as quota-exhausted 429s.
       const stream = await (client.chat.completions.create as Function)(
         requestBody,
-        { signal },
+        { signal, maxRetries: 0 },
       )
       if (!waitForTokenCapture || !recoverySessionCleanup) {
         return stream as ChatChunkStream

--- a/src/services/inference/inference-client.ts
+++ b/src/services/inference/inference-client.ts
@@ -23,7 +23,9 @@ import { chatChunkStreamFromSSE, type ChatChunkStream } from './chat-stream'
 import {
   createRecoverableTinfoilClient,
   createRecoverableTinfoilTransport,
+  getRateLimitInfo,
   getTinfoilClient,
+  refreshRateLimit,
   resetTinfoilClient,
   type RecoverableTinfoilTransport,
 } from './tinfoil-client'
@@ -150,6 +152,35 @@ export interface ChatRecoveryCallbacks {
     token: SessionRecoveryToken,
   ) => Promise<void>
   onAttemptAbandoned: (sessionId: string) => Promise<void>
+}
+
+function getHttpStatus(error: unknown): number | undefined {
+  const status = (error as { status?: unknown })?.status
+  return typeof status === 'number' ? status : undefined
+}
+
+/**
+ * A 429 can mean transient per-request throttling (worth retrying) or an
+ * exhausted usage quota (which cannot succeed until the window resets).
+ * Distinguishes the two by refreshing the quota from the server: returns a
+ * terminal ChatError when the quota is exhausted, or null when the 429 looks
+ * transient and the caller may retry.
+ */
+async function classifyQuotaExhausted429(
+  error: unknown,
+): Promise<ChatError | null> {
+  await refreshRateLimit()
+  const limit = getRateLimitInfo()
+  if (!limit || limit.remaining > 0) {
+    return null
+  }
+  const message =
+    (error as { message?: string })?.message ?? 'Rate limit reached'
+  return new ChatError(
+    message,
+    limit.kind === 'hourly' ? 'HOURLY_LIMIT' : 'RATE_LIMIT',
+    { status: 429 },
+  )
 }
 
 // Typed classification only — never inspect error message strings, which
@@ -551,6 +582,16 @@ export async function sendChatStream(
       if (refreshAuthentication) {
         resetTinfoilClient()
       }
+
+      // A 429 caused by an exhausted quota cannot succeed on retry; surface
+      // it immediately so the paywall/limit UI shows instead of a retry loop.
+      if (getHttpStatus(err) === 429) {
+        const quotaError = await classifyQuotaExhausted429(err)
+        if (quotaError) {
+          throw quotaError
+        }
+      }
+
       if (
         attempt < maxRetries &&
         (refreshAuthentication || isRetryableError(err))

--- a/src/services/inference/tinfoil-client.ts
+++ b/src/services/inference/tinfoil-client.ts
@@ -318,6 +318,16 @@ export function snapshotAndDecrementRemaining(): void {
 }
 
 /**
+ * Drops the pending optimistic-decrement snapshot so the next
+ * refreshRateLimit treats the server's count as authoritative. Called when
+ * a request was rejected outright (e.g. a 429): the server never consumed
+ * it, so reconciling against the snapshot would undercount by one.
+ */
+export function discardRateLimitSnapshot(): void {
+  remainingBeforeRequest = null
+}
+
+/**
  * Forces a fresh fetch of the session token (and rate limit info) from
  * the server, bypassing the local cache.  Called after each stream
  * completes so the UI reflects the server's actual remaining count.
@@ -401,10 +411,6 @@ async function initClient(sessionToken: string): Promise<OpenAI> {
         apiKey: sessionToken,
         baseURL: `${window.location.origin}/api/local-router/v1`,
         dangerouslyAllowBrowser: true,
-        // The app runs its own retry loop (sendChatStream) with typed error
-        // classification; the SDK's internal retries would stack under it
-        // and delay terminal errors such as quota-exhausted 429s.
-        maxRetries: 0,
         defaultHeaders: {
           [TINFOIL_EVENTS_HEADER]: `${TINFOIL_EVENTS_VALUE_WEB_SEARCH},${TINFOIL_EVENTS_VALUE_CODE_EXECUTION}`,
         },
@@ -417,8 +423,6 @@ async function initClient(sessionToken: string): Promise<OpenAI> {
         apiKey: sessionToken,
         baseURL: secureClient.getBaseURL(),
         dangerouslyAllowBrowser: true,
-        // See the dev client above: app-level retries own this concern.
-        maxRetries: 0,
         // Opt into the router's inline progress-marker stream.
         defaultHeaders: {
           [TINFOIL_EVENTS_HEADER]: `${TINFOIL_EVENTS_VALUE_WEB_SEARCH},${TINFOIL_EVENTS_VALUE_CODE_EXECUTION}`,

--- a/src/services/inference/tinfoil-client.ts
+++ b/src/services/inference/tinfoil-client.ts
@@ -533,6 +533,13 @@ export async function createRecoverableTinfoilClient(
       apiKey: sessionToken,
       baseURL: transport.baseURL,
       dangerouslyAllowBrowser: true,
+      // Suppressed at the factory level (unlike initClient's shared client,
+      // where callers scope it per-request): this client is single-use for
+      // one recovery attempt. recoverableFetch captures a recovery token
+      // bound to this client's X-Session-Id, so an SDK-internal silent
+      // retry would reuse the session id and fire onTokenCaptured twice
+      // for the same attempt. Retries happen in sendChatStream's loop,
+      // which builds a fresh client (and session id) per attempt.
       maxRetries: 0,
       defaultHeaders: {
         [TINFOIL_EVENTS_HEADER]: `${TINFOIL_EVENTS_VALUE_WEB_SEARCH},${TINFOIL_EVENTS_VALUE_CODE_EXECUTION}`,

--- a/src/services/inference/tinfoil-client.ts
+++ b/src/services/inference/tinfoil-client.ts
@@ -401,6 +401,10 @@ async function initClient(sessionToken: string): Promise<OpenAI> {
         apiKey: sessionToken,
         baseURL: `${window.location.origin}/api/local-router/v1`,
         dangerouslyAllowBrowser: true,
+        // The app runs its own retry loop (sendChatStream) with typed error
+        // classification; the SDK's internal retries would stack under it
+        // and delay terminal errors such as quota-exhausted 429s.
+        maxRetries: 0,
         defaultHeaders: {
           [TINFOIL_EVENTS_HEADER]: `${TINFOIL_EVENTS_VALUE_WEB_SEARCH},${TINFOIL_EVENTS_VALUE_CODE_EXECUTION}`,
         },
@@ -413,6 +417,8 @@ async function initClient(sessionToken: string): Promise<OpenAI> {
         apiKey: sessionToken,
         baseURL: secureClient.getBaseURL(),
         dangerouslyAllowBrowser: true,
+        // See the dev client above: app-level retries own this concern.
+        maxRetries: 0,
         // Opt into the router's inline progress-marker stream.
         defaultHeaders: {
           [TINFOIL_EVENTS_HEADER]: `${TINFOIL_EVENTS_VALUE_WEB_SEARCH},${TINFOIL_EVENTS_VALUE_CODE_EXECUTION}`,

--- a/tests/components/chat/use-chat-messaging.retry.test.tsx
+++ b/tests/components/chat/use-chat-messaging.retry.test.tsx
@@ -70,6 +70,7 @@ vi.mock('@/services/inference/title', () => ({
 vi.mock('@/services/inference/tinfoil-client', () => ({
   getRateLimitInfo: vi.fn(() => null),
   refreshRateLimit: vi.fn(),
+  snapshotAndDecrementRemaining: vi.fn(),
 }))
 
 vi.mock('@/services/storage/chat-storage', () => ({

--- a/tests/components/chat/use-chat-messaging.stop-stream.test.tsx
+++ b/tests/components/chat/use-chat-messaging.stop-stream.test.tsx
@@ -153,6 +153,7 @@ vi.mock('@/services/inference/tinfoil-client', () => ({
   getRateLimitInfo: () => null,
   isChatRecoveryAvailable: () => recoveryAvailableState.available,
   refreshRateLimit: vi.fn(),
+  snapshotAndDecrementRemaining: vi.fn(),
 }))
 
 vi.mock('@/services/inference/title', () => ({

--- a/tests/services/inference/inference-client-quota.test.ts
+++ b/tests/services/inference/inference-client-quota.test.ts
@@ -1,0 +1,144 @@
+import type { BaseModel } from '@/config/models'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const createCompletion = vi.fn()
+const getRateLimitInfo = vi.fn()
+const refreshRateLimit = vi.fn(async () => undefined)
+
+vi.mock('@/components/chat/constants', async () => {
+  const actual = await vi.importActual<
+    typeof import('@/components/chat/constants')
+  >('@/components/chat/constants')
+  return {
+    ...actual,
+    CONSTANTS: {
+      ...actual.CONSTANTS,
+      MESSAGE_SEND_MAX_RETRIES: 2,
+      MESSAGE_SEND_RETRY_DELAY_MS: 0,
+    },
+  }
+})
+
+vi.mock('@/services/inference/tinfoil-client', () => ({
+  createRecoverableTinfoilTransport: vi.fn(),
+  createRecoverableTinfoilClient: vi.fn(),
+  getRateLimitInfo: () => getRateLimitInfo(),
+  getTinfoilClient: vi.fn(async () => ({
+    chat: {
+      completions: {
+        create: (...args: unknown[]) => createCompletion(...args),
+      },
+    },
+  })),
+  refreshRateLimit: () => refreshRateLimit(),
+  resetTinfoilClient: vi.fn(),
+}))
+
+import { ChatError } from '@/components/chat/chat-utils'
+import { sendChatStream } from '@/services/inference/inference-client'
+
+const model: BaseModel = {
+  modelName: 'gpt-oss-120b',
+  image: '',
+  name: 'Test',
+  nameShort: 'Test',
+  description: 'Test model',
+  type: 'chat',
+}
+
+function status429Error() {
+  return Object.assign(new Error('Rate limit reached'), { status: 429 })
+}
+
+function successfulStream() {
+  return {
+    async *[Symbol.asyncIterator]() {
+      yield { choices: [{ delta: { content: 'answer' } }] }
+    },
+  }
+}
+
+function send(onRetry?: (attempt: number, maxRetries: number) => void) {
+  return sendChatStream({
+    model,
+    systemPrompt: '',
+    updatedMessages: [
+      { role: 'user', content: 'question', timestamp: new Date() },
+    ],
+    signal: new AbortController().signal,
+    genUIEnabled: false,
+    onRetry,
+  })
+}
+
+describe('sendChatStream 429 quota classification', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('fails immediately with RATE_LIMIT when the daily quota is exhausted', async () => {
+    createCompletion.mockRejectedValue(status429Error())
+    getRateLimitInfo.mockReturnValue({
+      maxRequests: 10,
+      remaining: 0,
+      resetsAt: '',
+      kind: 'free_daily',
+    })
+    const onRetry = vi.fn()
+
+    const error = await send(onRetry).catch((e: unknown) => e)
+
+    expect(error).toBeInstanceOf(ChatError)
+    expect((error as ChatError).code).toBe('RATE_LIMIT')
+    expect(refreshRateLimit).toHaveBeenCalled()
+    expect(onRetry).not.toHaveBeenCalled()
+    expect(createCompletion).toHaveBeenCalledTimes(1)
+  })
+
+  it('fails immediately with HOURLY_LIMIT when the hourly cap is exhausted', async () => {
+    createCompletion.mockRejectedValue(status429Error())
+    getRateLimitInfo.mockReturnValue({
+      maxRequests: 0,
+      remaining: 0,
+      resetsAt: '',
+      kind: 'hourly',
+    })
+
+    const error = await send().catch((e: unknown) => e)
+
+    expect(error).toBeInstanceOf(ChatError)
+    expect((error as ChatError).code).toBe('HOURLY_LIMIT')
+    expect(createCompletion).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries a 429 when the refreshed quota still has requests remaining', async () => {
+    createCompletion
+      .mockRejectedValueOnce(status429Error())
+      .mockResolvedValueOnce(successfulStream())
+    getRateLimitInfo.mockReturnValue({
+      maxRequests: 10,
+      remaining: 5,
+      resetsAt: '',
+      kind: 'free_daily',
+    })
+    const onRetry = vi.fn()
+
+    const stream = await send(onRetry)
+
+    expect(typeof stream[Symbol.asyncIterator]).toBe('function')
+    expect(onRetry).toHaveBeenCalledTimes(1)
+    expect(createCompletion).toHaveBeenCalledTimes(2)
+  })
+
+  it('retries a 429 when no quota is tracked (paid tier)', async () => {
+    createCompletion
+      .mockRejectedValueOnce(status429Error())
+      .mockResolvedValueOnce(successfulStream())
+    getRateLimitInfo.mockReturnValue(null)
+
+    const stream = await send()
+
+    expect(typeof stream[Symbol.asyncIterator]).toBe('function')
+    expect(createCompletion).toHaveBeenCalledTimes(2)
+  })
+})

--- a/tests/services/inference/inference-client-quota.test.ts
+++ b/tests/services/inference/inference-client-quota.test.ts
@@ -2,6 +2,7 @@ import type { BaseModel } from '@/config/models'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const createCompletion = vi.fn()
+const discardRateLimitSnapshot = vi.fn()
 const getRateLimitInfo = vi.fn()
 const refreshRateLimit = vi.fn(async () => undefined)
 
@@ -22,6 +23,7 @@ vi.mock('@/components/chat/constants', async () => {
 vi.mock('@/services/inference/tinfoil-client', () => ({
   createRecoverableTinfoilTransport: vi.fn(),
   createRecoverableTinfoilClient: vi.fn(),
+  discardRateLimitSnapshot: () => discardRateLimitSnapshot(),
   getRateLimitInfo: () => getRateLimitInfo(),
   getTinfoilClient: vi.fn(async () => ({
     chat: {
@@ -90,6 +92,9 @@ describe('sendChatStream 429 quota classification', () => {
 
     expect(error).toBeInstanceOf(ChatError)
     expect((error as ChatError).code).toBe('RATE_LIMIT')
+    // The rejected request never consumed quota server-side, so the
+    // optimistic snapshot must be dropped before trusting the refresh.
+    expect(discardRateLimitSnapshot).toHaveBeenCalled()
     expect(refreshRateLimit).toHaveBeenCalled()
     expect(onRetry).not.toHaveBeenCalled()
     expect(createCompletion).toHaveBeenCalledTimes(1)

--- a/tests/services/inference/inference-client-recovery.test.ts
+++ b/tests/services/inference/inference-client-recovery.test.ts
@@ -25,6 +25,7 @@ vi.mock('@/services/inference/tinfoil-client', () => ({
   createRecoverableTinfoilTransport: () => createRecoverableTransport(),
   createRecoverableTinfoilClient: (...args: unknown[]) =>
     createRecoverableClient(...args),
+  discardRateLimitSnapshot: vi.fn(),
   getRateLimitInfo: vi.fn(() => null),
   getTinfoilClient: vi.fn(),
   refreshRateLimit: vi.fn(async () => undefined),

--- a/tests/services/inference/inference-client-recovery.test.ts
+++ b/tests/services/inference/inference-client-recovery.test.ts
@@ -25,7 +25,9 @@ vi.mock('@/services/inference/tinfoil-client', () => ({
   createRecoverableTinfoilTransport: () => createRecoverableTransport(),
   createRecoverableTinfoilClient: (...args: unknown[]) =>
     createRecoverableClient(...args),
+  getRateLimitInfo: vi.fn(() => null),
   getTinfoilClient: vi.fn(),
+  refreshRateLimit: vi.fn(async () => undefined),
   resetTinfoilClient: () => resetTinfoilClient(),
 }))
 


### PR DESCRIPTION
## Summary

Fixes the state shown in the bug report screenshot: an out-of-quota free user sends a message, the "You've used your free requests" modal opens, **and** the chat simultaneously shows "Connection issue. Attempting retry (2 of 6)..." because the request was still fired and its 429 rejection was being retried.

### Root causes

1. **429s were unconditionally classified as retryable** (`RETRYABLE_HTTP_STATUSES` in `inference-client.ts`), so a quota-exhaustion 429 — which cannot succeed until the window resets — was retried up to 6 times with backoff, driving the misleading "Connection issue" retry UI.
2. **The pre-send quota check only lived in the UI layer** (`handleSubmit` / queue pump) and consulted a client-side cache. Direct `handleQuery` paths (regenerate, edit, URL-hash sends) had no quota check at all, and a stale cache let sends through.

### Changes

- **Retry loop**: on a 429, refresh the quota from the server and classify. If the quota is exhausted, throw a terminal `ChatError` (`RATE_LIMIT` / `HOURLY_LIMIT`) immediately — no retries, the paywall/limit UI shows right away. Transient 429s (per-request throttling, paid tier) still retry as before.
- **Pre-send gate in `handleQuery`**: every send path (queue dispatch, regenerate, edit, URL-hash, retry-last) now funnels through a single free-tier quota gate that opens the subscribe prompt instead of firing a doomed request. The optimistic remaining-count decrement moved here too, so it covers all paths (previously only queue dispatches decremented).
- **SDK retries disabled** (`maxRetries: 0`) on the main OpenAI client: the app's own retry loop owns retry policy; the SDK's internal retries were stacking underneath it and delaying terminal errors.
- Extracted the `requestUpgrade` window event name into a shared constant.

### Tests

- New `inference-client-quota.test.ts` covering: terminal RATE_LIMIT on exhausted daily quota (no retries), terminal HOURLY_LIMIT, retrying transient 429s with remaining quota, and retrying 429s when no quota is tracked (paid tier).
- Full vitest suite passes (1459 tests), tsc and eslint clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop sending or retrying chat requests when a free user's quota is exhausted. The app now shows the upgrade/limit UI immediately instead of the misleading “Connection issue… retrying” state.

- **Bug Fixes**
  - Classify 429s: refresh server quota on 429 and, if exhausted, throw a terminal `ChatError` (`RATE_LIMIT`/`HOURLY_LIMIT`) with no retries; transient 429s still retry. Drop the optimistic snapshot before refresh to avoid misclassifying throttled/non‑chat 429s, and disable SDK retries (`maxRetries: 0`) on both the main and recovery clients to prevent stacked retries or duplicate token capture.
  - Pre-send gate in `handleQuery`: all send paths are blocked when free daily quota is 0 and the subscribe prompt opens via `REQUEST_UPGRADE_EVENT`. The queue’s rate‑limit check now reads the live cache to avoid stale sends.
  - Count requests only when actually sent: the optimistic decrement happens right before streaming starts, so aborted preflights or rejected dispatches don’t consume local quota.
  - Added tests for exhausted daily/hourly limits, transient 429 retry behavior, and paid-tier no-quota cases.

<sup>Written for commit 7076232b6e790c19cab83ba75ec76112f339dc3f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/477?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

