### PR TITLE
Make failed GenUI widgets independently retryable

### DIFF
--- a/src/components/chat/genui/GenUIToolCallRenderer.tsx
+++ b/src/components/chat/genui/GenUIToolCallRenderer.tsx
@@ -353,6 +353,8 @@ function ParseFailureCard({
 
   const retryFailureDescriptions: Record<ArtifactRetryErrorCode, string> = {
     request_failed: 'Could not request a replacement. Try the widget again.',
+    schema_conversion_failed:
+      'Could not prepare the component schema. Try again.',
     incomplete_replacement:
       'The replacement was incomplete or invalid JSON. Try the widget again.',
     schema_invalid_replacement:

--- a/src/components/chat/genui/GenUIToolCallRenderer.tsx
+++ b/src/components/chat/genui/GenUIToolCallRenderer.tsx
@@ -10,11 +10,12 @@
  * via `GenUIInputAreaRenderer`.
  */
 import { logError } from '@/utils/error-handling'
-import { ChevronRight, RefreshCw, Sparkles } from 'lucide-react'
+import { RefreshCw, Sparkles } from 'lucide-react'
 import React, { memo, useEffect, useState } from 'react'
 import { PiSpinner } from 'react-icons/pi'
 import { tryParsePartialJson } from './partial-json'
 import { getGenUIWidget, renderGenUIInline } from './render'
+import { ArtifactRetryError, type ArtifactRetryErrorCode } from './retry'
 import type { GenUIToolCall } from './types'
 
 /**
@@ -61,24 +62,33 @@ interface GenUIToolCallRendererProps {
   onRetry?: () => void
   /**
    * Widget-only retry: re-request just this tool call's arguments and patch
-   * the block in place, leaving the rest of the answer intact. Resolves
-   * false when the repair failed, in which case the card falls back to
-   * offering `onRetry` (full regeneration).
+   * the block in place, leaving the rest of the answer intact. Rejects with a
+   * typed failure so the card can explain it and keep retry available.
    */
   onRetryToolCall?: (toolCallId: string) => Promise<boolean>
 }
 
-function resolveInput(tc: GenUIToolCall): Record<string, unknown> | null {
-  if (!tc.arguments) return null
+function parseInput(
+  tc: GenUIToolCall,
+): { ok: true; data: unknown } | { ok: false } {
+  if (!tc.arguments) return { ok: false }
   try {
-    const parsed = JSON.parse(tc.arguments)
-    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-      return parsed as Record<string, unknown>
-    }
+    return { ok: true, data: JSON.parse(tc.arguments) }
   } catch {
-    // Arguments still streaming, JSON incomplete
+    return { ok: false }
   }
-  return null
+}
+
+function GenUIWidgetContent({
+  toolName,
+  input,
+  isDarkMode,
+}: {
+  toolName: string
+  input: unknown
+  isDarkMode?: boolean
+}) {
+  return renderGenUIInline(toolName, input, { isDarkMode })
 }
 
 export const GenUIToolCallRenderer = memo(function GenUIToolCallRenderer({
@@ -100,26 +110,8 @@ export const GenUIToolCallRenderer = memo(function GenUIToolCallRenderer({
           return null
         }
 
-        const input = resolveInput(tc)
-        if (input) {
-          const rendered = renderGenUIInline(tc.name, input, { isDarkMode })
-          if (rendered) {
-            return (
-              <GenUIWidgetErrorBoundary key={tc.id} toolName={tc.name}>
-                <div className="my-4">{rendered}</div>
-              </GenUIWidgetErrorBoundary>
-            )
-          }
-        }
-
-        if (isStreaming) {
-          return <StreamingToolCallTracer key={tc.id} toolCall={tc} />
-        }
-
-        // The widget itself isn't registered on this client (e.g. a tool
-        // call recorded before the widget was added or after it was
-        // removed). Surface a soft, non-blocking notice — there's nothing
-        // to retry because the schema is unknown here.
+        // The schema is unavailable on this client, so waiting for more
+        // argument bytes cannot make this component renderable.
         if (!widget) {
           return (
             <div
@@ -143,13 +135,53 @@ export const GenUIToolCallRenderer = memo(function GenUIToolCallRenderer({
           )
         }
 
+        const input = parseInput(tc)
+        const parsedInput = input.ok
+          ? widget.schema.safeParse(input.data)
+          : null
+        if (parsedInput?.success && widget?.render) {
+          return (
+            <GenUIWidgetErrorBoundary
+              key={tc.id}
+              toolName={tc.name}
+              argumentsValue={tc.arguments}
+              onRetry={onRetry}
+              onRetryToolCall={
+                onRetryToolCall ? () => onRetryToolCall(tc.id) : undefined
+              }
+            >
+              <div className="my-4">
+                <GenUIWidgetContent
+                  toolName={tc.name}
+                  input={parsedInput.data}
+                  isDarkMode={isDarkMode}
+                />
+              </div>
+            </GenUIWidgetErrorBoundary>
+          )
+        }
+
+        if (isStreaming && !input.ok) {
+          return <StreamingToolCallTracer key={tc.id} toolCall={tc} />
+        }
+
         // Registered widget but schema validation failed. The model
         // produced something the widget couldn't accept — offer a retry.
         return (
           <ParseFailureCard
             key={tc.id}
             toolName={tc.name}
-            hasInput={!!input}
+            failure={
+              parsedInput && !parsedInput.success
+                ? {
+                    type: 'schema_invalid',
+                    issues: parsedInput.error.issues.map((issue) => ({
+                      code: issue.code,
+                      path: issue.path,
+                    })),
+                  }
+                : { type: 'invalid_json' }
+            }
             onRetry={onRetry}
             onRetryToolCall={
               onRetryToolCall ? () => onRetryToolCall(tc.id) : undefined
@@ -163,6 +195,9 @@ export const GenUIToolCallRenderer = memo(function GenUIToolCallRenderer({
 
 interface GenUIWidgetErrorBoundaryProps {
   toolName: string
+  argumentsValue: string
+  onRetry?: () => void
+  onRetryToolCall?: () => Promise<boolean>
   children: React.ReactNode
 }
 
@@ -183,32 +218,38 @@ class GenUIWidgetErrorBoundary extends React.Component<
     return { hasError: true }
   }
 
-  componentDidCatch(error: Error): void {
-    logError('GenUI widget crashed while rendering', error, {
-      component: 'GenUIWidgetErrorBoundary',
-      action: 'render',
-      metadata: { toolName: this.props.toolName },
-    })
+  componentDidCatch(): void {
+    logError(
+      'GenUI widget crashed while rendering',
+      new Error('render_exception'),
+      {
+        component: 'GenUIWidgetErrorBoundary',
+        action: 'render',
+        metadata: { toolName: this.props.toolName },
+      },
+    )
+  }
+
+  componentDidUpdate(previousProps: GenUIWidgetErrorBoundaryProps): void {
+    if (
+      this.state.hasError &&
+      previousProps.argumentsValue !== this.props.argumentsValue
+    ) {
+      this.setState({ hasError: false })
+    }
   }
 
   render(): React.ReactNode {
     if (this.state.hasError) {
       return (
-        <div className="my-4 flex items-start gap-2.5 rounded-lg border border-orange-500/30 bg-orange-500/10 px-3 py-2.5 text-sm">
-          <Sparkles
-            className="mt-0.5 h-4 w-4 flex-shrink-0 text-orange-500"
-            aria-hidden
-          />
-          <div className="flex flex-col">
-            <span className="font-medium text-content-primary">
-              Couldn&apos;t display this widget
-            </span>
-            <span className="text-xs text-content-muted">
-              The {prettyWidgetName(this.props.toolName)} component ran into a
-              problem while rendering.
-            </span>
-          </div>
-        </div>
+        <ParseFailureCard
+          toolName={this.props.toolName}
+          failure={{ type: 'render_exception' }}
+          onRetry={this.props.onRetry}
+          onRetryToolCall={this.props.onRetryToolCall}
+          onRepairSuccess={() => this.setState({ hasError: false })}
+          logFailure={false}
+        />
       )
     }
     return this.props.children
@@ -218,20 +259,12 @@ class GenUIWidgetErrorBoundary extends React.Component<
 /**
  * Live tracer shown while the model is streaming a GenUI tool call.
  *
- * Replaces a static spinner with a card that surfaces:
- *   - The widget name being generated (e.g. "artifact preview").
- *   - A short hint pulled from the partially-streamed JSON when one is
- *     available (the tool's `title` / `description` etc.).
- *   - A live byte counter so the user can tell the stream is still
- *     making progress even when no human-readable hint has streamed.
- *   - A collapsible raw JSON view for power users who want to see
- *     exactly what the model is sending.
+ * Replaces a static spinner with the widget name and a title when one has
+ * streamed far enough to parse safely.
  */
 function StreamingToolCallTracer({ toolCall }: { toolCall: GenUIToolCall }) {
-  const [showRaw, setShowRaw] = useState(false)
   const partial = tryParsePartialJson(toolCall.arguments)
   const hint = extractPartialHint(partial)
-  const charCount = toolCall.arguments.length
   const label = prettyWidgetName(toolCall.name)
 
   return (
@@ -245,131 +278,131 @@ function StreamingToolCallTracer({ toolCall }: { toolCall: GenUIToolCall }) {
           Generating {label}
           {hint ? `: ${hint}` : null}
         </span>
-        {charCount > 0 && (
-          <span className="ml-auto text-xs tabular-nums text-content-muted">
-            {charCount.toLocaleString()} chars
-          </span>
-        )}
       </div>
-      {charCount > 0 && (
-        <div className="mt-2">
-          <button
-            type="button"
-            onClick={() => setShowRaw((prev) => !prev)}
-            className="flex items-center gap-1 text-xs text-content-muted hover:text-content-primary"
-            aria-expanded={showRaw}
-          >
-            <ChevronRight
-              className={`h-3 w-3 transition-transform ${showRaw ? 'rotate-90' : ''}`}
-              aria-hidden
-            />
-            {showRaw ? 'Hide stream' : 'Show stream'}
-          </button>
-          {showRaw && (
-            <pre className="mt-2 max-h-48 overflow-auto rounded-md bg-surface-chat-background p-2 text-xs text-content-muted">
-              <code>{toolCall.arguments}</code>
-            </pre>
-          )}
-        </div>
-      )}
     </div>
   )
 }
 
+type ParseFailure =
+  | { type: 'invalid_json' }
+  | { type: 'render_exception' }
+  | {
+      type: 'schema_invalid'
+      issues?: Array<{ code: string; path: Array<string | number> }>
+    }
+
 function ParseFailureCard({
   toolName,
-  hasInput,
+  failure,
   onRetry,
   onRetryToolCall,
+  onRepairSuccess,
+  logFailure = true,
 }: {
   toolName: string
-  hasInput: boolean
+  failure: ParseFailure
   onRetry?: () => void
   onRetryToolCall?: () => Promise<boolean>
+  onRepairSuccess?: () => void
+  logFailure?: boolean
 }) {
   const [isRetrying, setIsRetrying] = useState(false)
-  // Set when a widget-only retry failed. The card then falls back to the
-  // full-response regeneration — unless no regenerate handler was provided,
-  // in which case widget-only retry stays available rather than leaving the
-  // card with no action at all.
-  const [widgetRetryFailed, setWidgetRetryFailed] = useState(false)
+  const [retryFailure, setRetryFailure] =
+    useState<ArtifactRetryErrorCode | null>(null)
+  const primaryIssue =
+    failure.type === 'schema_invalid' ? failure.issues?.[0] : undefined
+  const issueSummary = primaryIssue
+    ? `${primaryIssue.path.join('.') || 'root'} (${primaryIssue.code})`
+    : undefined
 
   // Logging is a side effect — kept out of render so React's render-twice
   // strict mode and re-renders from parent state changes don't produce
   // duplicate log lines for the same failure.
   useEffect(() => {
-    logError(
-      'GenUI parse/render failed',
-      new Error(`Unable to produce a valid widget: ${toolName}`),
-      {
-        component: 'GenUIToolCallRenderer',
-        action: 'render',
-        metadata: { toolName, hasInput },
+    if (!logFailure) return
+    logError('GenUI arguments could not be rendered', new Error(failure.type), {
+      component: 'GenUIToolCallRenderer',
+      action: 'render',
+      metadata: {
+        toolName,
+        failure: failure.type,
+        issues: issueSummary,
       },
-    )
-  }, [toolName, hasInput])
+    })
+  }, [toolName, failure.type, issueSummary, logFailure])
 
-  const canRetryWidgetOnly =
-    !!onRetryToolCall && (!widgetRetryFailed || !onRetry)
-
-  const handleRetry = async () => {
+  const handleRetryToolCall = async () => {
     if (isRetrying) return
-    if (!canRetryWidgetOnly) {
-      onRetry?.()
-      return
-    }
+    if (!onRetryToolCall) return
     setIsRetrying(true)
     try {
-      // A thrown repair (network failure etc.) is the same outcome as a
-      // clean `false` for this card: fall back to full regeneration.
-      const repaired = await onRetryToolCall().catch(() => false)
-      if (!repaired) {
-        setWidgetRetryFailed(true)
-      }
+      const repaired = await onRetryToolCall()
+      setRetryFailure(repaired ? null : 'unavailable_target')
+      if (repaired) onRepairSuccess?.()
       // On success the patched arguments re-render the widget and this
       // card unmounts on its own.
+    } catch (error) {
+      setRetryFailure(
+        error instanceof ArtifactRetryError ? error.code : 'request_failed',
+      )
     } finally {
       setIsRetrying(false)
     }
   }
 
-  const showRetryButton = canRetryWidgetOnly || !!onRetry
-
-  let retryLabel: string
-  if (isRetrying) {
-    retryLabel = 'Fixing widget...'
-  } else if (canRetryWidgetOnly) {
-    retryLabel = 'Retry widget'
-  } else {
-    retryLabel = 'Regenerate response'
+  const retryFailureDescriptions: Record<ArtifactRetryErrorCode, string> = {
+    request_failed: 'Could not request a replacement. Try the widget again.',
+    incomplete_replacement:
+      'The replacement was incomplete or invalid JSON. Try the widget again.',
+    schema_invalid_replacement:
+      'The replacement did not match the component schema. Try again.',
+    stale_target:
+      'The component changed while retrying. Try its current version.',
+    unavailable_target: 'The component is no longer available to repair.',
   }
-
-  const description =
-    widgetRetryFailed && onRetry
-      ? 'Retrying the widget alone didn\u2019t work. Trying again will regenerate the whole response.'
-      : `The response didn't match the ${toolName} widget's expected shape.`
+  const description = retryFailure
+    ? retryFailureDescriptions[retryFailure]
+    : failure.type === 'invalid_json'
+      ? 'The component data is not valid JSON.'
+      : failure.type === 'render_exception'
+        ? `The ${prettyWidgetName(toolName)} component ran into a problem while rendering.`
+        : issueSummary
+          ? `The component data failed schema validation at ${issueSummary}.`
+          : `The response didn't match the ${toolName} widget's expected shape.`
 
   return (
     <div className="my-4 flex items-center justify-between gap-3 rounded-lg border border-border-subtle bg-surface-card px-4 py-3 text-sm">
       <div className="flex flex-col">
         <span className="font-medium text-content-primary">
-          Couldn&apos;t display this widget
+          Couldn&apos;t display {prettyWidgetName(toolName)}
         </span>
         <span className="text-xs text-content-muted">{description}</span>
       </div>
-      {showRetryButton && (
-        <button
-          type="button"
-          onClick={() => void handleRetry()}
-          disabled={isRetrying}
-          className="inline-flex flex-shrink-0 items-center gap-1.5 rounded-md border border-border-subtle bg-surface-chat-background px-3 py-1.5 text-sm font-medium text-content-primary transition-colors hover:bg-surface-card disabled:cursor-default disabled:opacity-60"
-        >
-          <RefreshCw
-            className={`h-3.5 w-3.5 ${isRetrying ? 'animate-spin' : ''}`}
-          />
-          {retryLabel}
-        </button>
-      )}
+      <div className="flex flex-shrink-0 items-center gap-2">
+        {onRetryToolCall && (
+          <button
+            type="button"
+            onClick={() => void handleRetryToolCall()}
+            disabled={isRetrying}
+            className="inline-flex flex-shrink-0 items-center gap-1.5 rounded-md border border-border-subtle bg-surface-chat-background px-3 py-1.5 text-sm font-medium text-content-primary transition-colors hover:bg-surface-card disabled:cursor-default disabled:opacity-60"
+          >
+            <RefreshCw
+              className={`h-3.5 w-3.5 ${isRetrying ? 'animate-spin' : ''}`}
+            />
+            {isRetrying ? 'Fixing widget...' : 'Retry widget'}
+          </button>
+        )}
+        {onRetry && (
+          <button
+            type="button"
+            onClick={onRetry}
+            disabled={isRetrying}
+            className="inline-flex flex-shrink-0 items-center rounded-md border border-border-subtle bg-surface-chat-background px-3 py-1.5 text-sm font-medium text-content-primary transition-colors hover:bg-surface-card disabled:cursor-default disabled:opacity-60"
+          >
+            Regenerate response
+          </button>
+        )}
+      </div>
     </div>
   )
 }

--- a/src/components/chat/genui/GenUIToolCallRenderer.tsx
+++ b/src/components/chat/genui/GenUIToolCallRenderer.tsx
@@ -88,7 +88,9 @@ function GenUIWidgetContent({
   input: unknown
   isDarkMode?: boolean
 }) {
-  return renderGenUIInline(toolName, input, { isDarkMode })
+  const rendered = renderGenUIInline(toolName, input, { isDarkMode })
+  if (rendered === null) throw new Error('Widget render returned null')
+  return rendered
 }
 
 export const GenUIToolCallRenderer = memo(function GenUIToolCallRenderer({
@@ -139,7 +141,7 @@ export const GenUIToolCallRenderer = memo(function GenUIToolCallRenderer({
         const parsedInput = input.ok
           ? widget.schema.safeParse(input.data)
           : null
-        if (parsedInput?.success && widget?.render) {
+        if (parsedInput?.success && widget.render) {
           return (
             <GenUIWidgetErrorBoundary
               key={tc.id}
@@ -218,16 +220,15 @@ class GenUIWidgetErrorBoundary extends React.Component<
     return { hasError: true }
   }
 
-  componentDidCatch(): void {
-    logError(
-      'GenUI widget crashed while rendering',
-      new Error('render_exception'),
-      {
-        component: 'GenUIWidgetErrorBoundary',
-        action: 'render',
-        metadata: { toolName: this.props.toolName },
+  componentDidCatch(error: Error): void {
+    logError('GenUI widget crashed while rendering', error, {
+      component: 'GenUIWidgetErrorBoundary',
+      action: 'render',
+      metadata: {
+        toolName: this.props.toolName,
+        failure: 'render_exception',
       },
-    )
+    })
   }
 
   componentDidUpdate(previousProps: GenUIWidgetErrorBoundaryProps): void {

--- a/src/components/chat/genui/retry.ts
+++ b/src/components/chat/genui/retry.ts
@@ -17,6 +17,7 @@ import { GENUI_WIDGETS_BY_NAME, isGenUIToolName } from './registry'
 
 export type ArtifactRetryErrorCode =
   | 'request_failed'
+  | 'schema_conversion_failed'
   | 'incomplete_replacement'
   | 'schema_invalid_replacement'
   | 'stale_target'
@@ -128,7 +129,7 @@ export async function regenerateToolCallArguments({
       $refStrategy: 'none',
     }) as Record<string, unknown>
   } catch (error) {
-    const retryError = new ArtifactRetryError('request_failed', {
+    const retryError = new ArtifactRetryError('schema_conversion_failed', {
       cause: error,
     })
     logError('Artifact schema conversion failed', retryError, {
@@ -255,7 +256,7 @@ export function patchToolCallArguments(
     block.type !== 'tool_call' ||
     block.name !== target.toolName ||
     block.arguments !== target.originalArguments ||
-    mirrors.length > 1 ||
+    (message.toolCalls !== undefined && mirrors.length !== 1) ||
     (mirrors.length === 1 &&
       (mirrors[0].name !== target.toolName ||
         mirrors[0].arguments !== target.originalArguments))

--- a/src/components/chat/genui/retry.ts
+++ b/src/components/chat/genui/retry.ts
@@ -1,30 +1,51 @@
-/**
- * Widget-only retry.
- *
- * When a GenUI tool call fails validation (the model emitted arguments the
- * widget's schema rejects), the whole assistant answer is usually fine —
- * only the one widget is broken. This helper re-asks the model for just
- * that tool call's arguments via a structured (JSON-schema constrained)
- * completion, so the failed widget can be patched in place without
- * regenerating the entire response.
- */
+import type { ReasoningEffort } from '@/components/chat/hooks/use-reasoning-effort'
+import type { Chat, Message } from '@/components/chat/types'
 import type { BaseModel } from '@/config/models'
-import { sendStructuredCompletion } from '@/services/inference/inference-client'
+import {
+  StructuredCompletionError,
+  sendStructuredCompletion,
+} from '@/services/inference/inference-client'
 import { logError } from '@/utils/error-handling'
+import {
+  estimateTokenCount,
+  findContextStartIndex,
+  getHistoryTokenBudget,
+  getSmallestContextWindow,
+} from '@/utils/token-estimation'
 import { zodToJsonSchema } from 'zod-to-json-schema'
-import type { Message } from '../types'
 import { GENUI_WIDGETS_BY_NAME, isGenUIToolName } from './registry'
 
-/** How many trailing conversation messages accompany the re-ask. */
-const RETRY_CONTEXT_MESSAGE_LIMIT = 8
+export type ArtifactRetryErrorCode =
+  | 'request_failed'
+  | 'incomplete_replacement'
+  | 'schema_invalid_replacement'
+  | 'stale_target'
+  | 'unavailable_target'
 
-/** Truncation cap for each context message sent with the re-ask. */
-const RETRY_CONTEXT_MESSAGE_MAX_CHARS = 4000
+export class ArtifactRetryError extends Error {
+  readonly code: ArtifactRetryErrorCode
+
+  constructor(code: ArtifactRetryErrorCode, options: { cause?: unknown } = {}) {
+    super(code, { cause: options.cause })
+    this.name = 'ArtifactRetryError'
+    this.code = code
+  }
+}
+
+export interface ToolCallPatchTarget {
+  messageTurnId?: string
+  messageTimestamp: number
+  timelineBlockId: string
+  toolCallId: string
+  toolName: string
+  originalArguments: string
+}
+
+export type ToolCallPatchResult =
+  { ok: true; chat: Chat } | { ok: false; error: ArtifactRetryError }
 
 function toPlainText(message: Message): string {
   if (message.content) return message.content
-  // Assistant messages built from a timeline may keep their text in
-  // content blocks rather than the top-level `content` field.
   if (message.timeline) {
     return message.timeline
       .filter((block) => block.type === 'content')
@@ -34,90 +55,214 @@ function toPlainText(message: Message): string {
   return ''
 }
 
-/**
- * Ask the model to regenerate the arguments for a single widget and
- * validate them against the widget's Zod schema.
- *
- * Returns the validated arguments serialized as a JSON string (the same
- * format tool-call blocks store), or `null` when the widget is unknown,
- * the request fails, or the regenerated arguments still don't validate.
- */
+export function selectArtifactRetryContext(
+  contextMessages: Message[],
+  contextWindow: string | undefined,
+  mandatoryPrompt: string,
+): Array<{ role: 'user' | 'assistant'; content: string }> {
+  const messages = contextMessages
+    .map((message) => ({
+      source: message,
+      role: message.role,
+      content: toPlainText(message),
+    }))
+    .filter((message) => message.content.trim().length > 0)
+  const projected = messages.map(({ source, content }) => ({
+    ...source,
+    content,
+    timeline: undefined,
+    toolCalls: undefined,
+    attachments: undefined,
+    documentContent: undefined,
+    imageData: undefined,
+  }))
+  const budget = getHistoryTokenBudget(
+    contextWindow,
+    estimateTokenCount(mandatoryPrompt),
+  )
+  const startIndex = findContextStartIndex(projected, budget, {
+    keepMostRecent: false,
+  })
+  return messages
+    .slice(startIndex)
+    .map(({ role, content }) => ({ role, content }))
+}
+
+function mapStructuredError(error: unknown): ArtifactRetryError {
+  if (
+    error instanceof StructuredCompletionError &&
+    error.code !== 'request_failed'
+  ) {
+    return new ArtifactRetryError('incomplete_replacement', { cause: error })
+  }
+  return new ArtifactRetryError('request_failed', { cause: error })
+}
+
 export async function regenerateToolCallArguments({
   toolName,
-  originalArguments,
+  originalArguments = '',
   contextMessages,
   model,
+  autoCandidates,
+  reasoningEffort,
+  thinkingEnabled,
 }: {
   toolName: string
-  /** The malformed argument JSON from the failed call, if any streamed. */
   originalArguments?: string
   contextMessages: Message[]
   model: BaseModel
-}): Promise<string | null> {
-  // Own-property check: the tool name comes from the model, and a name
-  // like "toString" would otherwise pass a plain truthiness lookup via
-  // the object prototype.
-  if (!isGenUIToolName(toolName)) return null
+  autoCandidates?: BaseModel[]
+  reasoningEffort?: ReasoningEffort
+  thinkingEnabled?: boolean
+}): Promise<string> {
+  if (!isGenUIToolName(toolName)) {
+    throw new ArtifactRetryError('unavailable_target')
+  }
   const widget = GENUI_WIDGETS_BY_NAME[toolName]
+  const jsonSchema = zodToJsonSchema(widget.schema, {
+    target: 'openApi3',
+    $refStrategy: 'none',
+  }) as Record<string, unknown>
+  const instruction =
+    `Repair only the JSON arguments for the "${toolName}" component. ` +
+    'Preserve the artifact intent and all valid data. Follow the supplied schema exactly, ' +
+    'including the matching fields for the selected variant. Do not generate or revise prose.'
+  const malformedArtifact = `Malformed arguments to repair:\n${originalArguments}`
+  const mandatoryPrompt = `${instruction}\n${JSON.stringify(jsonSchema)}\n${malformedArtifact}`
+  const contextWindow = getSmallestContextWindow(
+    (autoCandidates ?? [model]).map((candidate) => candidate.contextWindow),
+  )
+  const conversation = selectArtifactRetryContext(
+    contextMessages,
+    contextWindow,
+    mandatoryPrompt,
+  )
 
-  const conversation = contextMessages
-    .slice(-RETRY_CONTEXT_MESSAGE_LIMIT)
-    .map((message) => ({
-      role: message.role,
-      content: toPlainText(message).slice(0, RETRY_CONTEXT_MESSAGE_MAX_CHARS),
-    }))
-    .filter((message) => message.content.trim().length > 0)
-
+  let regenerated: unknown
   try {
-    const jsonSchema = zodToJsonSchema(widget.schema, {
-      target: 'openApi3',
-      $refStrategy: 'none',
-    }) as Record<string, unknown>
-
-    // The malformed arguments usually contain the intended data with a
-    // shape problem; giving them to the model preserves the widget's
-    // original content instead of asking it to reinvent the data from the
-    // conversation text alone.
-    const originalArgumentsHint = originalArguments?.trim()
-      ? ` The malformed arguments were: ${originalArguments.slice(
-          0,
-          RETRY_CONTEXT_MESSAGE_MAX_CHARS,
-        )}. Preserve their intent and data; fix only what is invalid.`
-      : ''
-
-    const regenerated = await sendStructuredCompletion<unknown>({
+    regenerated = await sendStructuredCompletion<unknown>({
       model,
+      autoCandidates,
       messages: [
-        {
-          role: 'system',
-          content:
-            `You previously tried to render a "${toolName}" UI component (${widget.description}) ` +
-            'in this conversation, but the arguments were malformed. Based on the conversation, ' +
-            'produce a valid set of arguments for that component. Respond with only the JSON arguments.' +
-            originalArgumentsHint,
-        },
+        { role: 'system', content: instruction },
         ...conversation,
+        { role: 'user', content: malformedArtifact },
       ],
       jsonSchema,
+      reasoningEffort,
+      thinkingEnabled,
     })
-
-    const parsed = widget.schema.safeParse(regenerated)
-    if (!parsed.success) {
-      logError('Regenerated widget arguments failed validation', parsed.error, {
-        component: 'genui-retry',
-        action: 'regenerateToolCallArguments',
-        metadata: { toolName },
-      })
-      return null
-    }
-
-    return JSON.stringify(parsed.data)
   } catch (error) {
-    logError('Widget argument regeneration failed', error, {
+    const retryError = mapStructuredError(error)
+    const structuredError =
+      error instanceof StructuredCompletionError ? error : undefined
+    logError('Artifact argument regeneration failed', retryError, {
       component: 'genui-retry',
       action: 'regenerateToolCallArguments',
-      metadata: { toolName },
+      metadata: {
+        toolName,
+        code: retryError.code,
+        status: structuredError?.status,
+        requestCode: structuredError?.requestCode,
+        finishReason: structuredError?.finishReason,
+      },
     })
-    return null
+    throw retryError
   }
+
+  const parsed = widget.schema.safeParse(regenerated)
+  if (!parsed.success) {
+    const retryError = new ArtifactRetryError('schema_invalid_replacement')
+    logError(
+      'Regenerated artifact arguments failed schema validation',
+      retryError,
+      {
+        component: 'genui-retry',
+        action: 'regenerateToolCallArguments',
+        metadata: {
+          toolName,
+          issues: parsed.error.issues.map(
+            (issue: { code: string; path: Array<string | number> }) => ({
+              code: issue.code,
+              path: issue.path,
+            }),
+          ),
+        },
+      },
+    )
+    throw retryError
+  }
+
+  return JSON.stringify(parsed.data)
+}
+
+export function patchToolCallArguments(
+  chat: Chat,
+  target: ToolCallPatchTarget,
+  newArguments: string,
+): ToolCallPatchResult {
+  const matchingMessageIndexes = chat.messages.flatMap((message, index) => {
+    const matchesIdentity = target.messageTurnId
+      ? message.turnId === target.messageTurnId
+      : message.timestamp.getTime() === target.messageTimestamp
+    const hasBlock = message.timeline?.some(
+      (block) =>
+        block.type === 'tool_call' &&
+        block.id === target.timelineBlockId &&
+        block.toolCallId === target.toolCallId,
+    )
+    return matchesIdentity && hasBlock ? [index] : []
+  })
+  if (matchingMessageIndexes.length !== 1) {
+    return {
+      ok: false,
+      error: new ArtifactRetryError('unavailable_target'),
+    }
+  }
+
+  const messageIndex = matchingMessageIndexes[0]
+  const message = chat.messages[messageIndex]
+  const blocks =
+    message.timeline?.filter(
+      (candidate) =>
+        candidate.type === 'tool_call' &&
+        candidate.id === target.timelineBlockId &&
+        candidate.toolCallId === target.toolCallId,
+    ) ?? []
+  const block = blocks[0]
+  const mirrors =
+    message.toolCalls?.filter(
+      (candidate) => candidate.id === target.toolCallId,
+    ) ?? []
+  if (
+    blocks.length !== 1 ||
+    !block ||
+    block.type !== 'tool_call' ||
+    block.name !== target.toolName ||
+    block.arguments !== target.originalArguments ||
+    mirrors.length !== 1 ||
+    mirrors[0].name !== target.toolName ||
+    mirrors[0].arguments !== target.originalArguments
+  ) {
+    return { ok: false, error: new ArtifactRetryError('stale_target') }
+  }
+
+  const patchedMessage: Message = {
+    ...message,
+    timeline: message.timeline?.map((candidate) =>
+      candidate.type === 'tool_call' &&
+      candidate.id === target.timelineBlockId &&
+      candidate.toolCallId === target.toolCallId
+        ? { ...candidate, arguments: newArguments }
+        : candidate,
+    ),
+    toolCalls: message.toolCalls?.map((candidate) =>
+      candidate.id === target.toolCallId
+        ? { ...candidate, arguments: newArguments }
+        : candidate,
+    ),
+  }
+  const messages = [...chat.messages]
+  messages[messageIndex] = patchedMessage
+  return { ok: true, chat: { ...chat, messages } }
 }

--- a/src/components/chat/genui/retry.ts
+++ b/src/components/chat/genui/retry.ts
@@ -75,6 +75,8 @@ export function selectArtifactRetryContext(
     attachments: undefined,
     documentContent: undefined,
     imageData: undefined,
+    quote: undefined,
+    searchReasoning: undefined,
   }))
   const budget = getHistoryTokenBudget(
     contextWindow,
@@ -119,10 +121,23 @@ export async function regenerateToolCallArguments({
     throw new ArtifactRetryError('unavailable_target')
   }
   const widget = GENUI_WIDGETS_BY_NAME[toolName]
-  const jsonSchema = zodToJsonSchema(widget.schema, {
-    target: 'openApi3',
-    $refStrategy: 'none',
-  }) as Record<string, unknown>
+  let jsonSchema: Record<string, unknown>
+  try {
+    jsonSchema = zodToJsonSchema(widget.schema, {
+      target: 'openApi3',
+      $refStrategy: 'none',
+    }) as Record<string, unknown>
+  } catch (error) {
+    const retryError = new ArtifactRetryError('request_failed', {
+      cause: error,
+    })
+    logError('Artifact schema conversion failed', retryError, {
+      component: 'genui-retry',
+      action: 'regenerateToolCallArguments',
+      metadata: { toolName, code: retryError.code },
+    })
+    throw retryError
+  }
   const instruction =
     `Repair only the JSON arguments for the "${toolName}" component. ` +
     'Preserve the artifact intent and all valid data. Follow the supplied schema exactly, ' +
@@ -240,9 +255,10 @@ export function patchToolCallArguments(
     block.type !== 'tool_call' ||
     block.name !== target.toolName ||
     block.arguments !== target.originalArguments ||
-    mirrors.length !== 1 ||
-    mirrors[0].name !== target.toolName ||
-    mirrors[0].arguments !== target.originalArguments
+    mirrors.length > 1 ||
+    (mirrors.length === 1 &&
+      (mirrors[0].name !== target.toolName ||
+        mirrors[0].arguments !== target.originalArguments))
   ) {
     return { ok: false, error: new ArtifactRetryError('stale_target') }
   }

--- a/src/components/chat/genui/widgets/ArtifactPreview.tsx
+++ b/src/components/chat/genui/widgets/ArtifactPreview.tsx
@@ -35,11 +35,19 @@ const sourceSchema = z.discriminatedUnion('type', [
   }),
   z.object({
     type: z.literal('html'),
-    html: z.string().describe('Raw HTML markup rendered in a sandboxed iframe'),
+    html: z
+      .string()
+      .describe(
+        'Raw HTML rendered in a sandboxed iframe. Use exactly {"type":"html","html":"..."}.',
+      ),
   }),
   z.object({
     type: z.literal('markdown'),
-    markdown: z.string(),
+    markdown: z
+      .string()
+      .describe(
+        'Markdown source. Use exactly {"type":"markdown","markdown":"..."}.',
+      ),
   }),
 ])
 

--- a/src/components/chat/hooks/use-chat-messaging.ts
+++ b/src/components/chat/hooks/use-chat-messaging.ts
@@ -328,6 +328,7 @@ export function useChatMessaging({
     new Map<string, ActiveLiveGeneration>(),
   )
   const cancellationPromisesRef = useRef(new Map<string, Promise<void>>())
+  const artifactRetryPersistenceRef = useRef(Promise.resolve())
 
   const dismissStreamError = useCallback(() => {
     patchStatus(viewedChatIdRef.current, { streamError: null })
@@ -1703,6 +1704,13 @@ export function useChatMessaging({
         throw patched.error
       }
 
+      chatsRef.current = chatsRef.current.map((chat) =>
+        chat.id === chatId ? patched.chat : chat,
+      )
+      if (currentChatRef.current.id === chatId) {
+        currentChatRef.current = patched.chat
+      }
+
       setChats((prevChats) =>
         prevChats.map((chat) => {
           if (chat.id !== chatId) return chat
@@ -1716,20 +1724,22 @@ export function useChatMessaging({
         return result.ok ? result.chat : prev
       })
 
-      const chatToSave = patched.chat
-      if (!chatToSave.isTemporary) {
+      const persistence = artifactRetryPersistenceRef.current.then(async () => {
+        const chatToSave = findLiveChat(chatId)
+        if (!chatToSave || chatToSave.isTemporary) return
         if (storeHistory) {
-          chatStorage.saveChatAndSync(chatToSave).catch((error) => {
-            logError('Failed to persist repaired widget', error, {
-              component: 'useChatMessaging',
-              action: 'retryToolCall',
-              metadata: { chatId, toolCallId },
-            })
-          })
+          await chatStorage.saveChatAndSync(chatToSave)
         } else {
           sessionChatStorage.saveChat(chatToSave)
         }
-      }
+      })
+      artifactRetryPersistenceRef.current = persistence.catch((error) => {
+        logError('Failed to persist repaired widget', error, {
+          component: 'useChatMessaging',
+          action: 'retryToolCall',
+          metadata: { chatId, toolCallId },
+        })
+      })
 
       return true
     },
@@ -1743,6 +1753,7 @@ export function useChatMessaging({
       storeHistory,
       setChats,
       setCurrentChat,
+      findLiveChat,
     ],
   )
 

--- a/src/components/chat/hooks/use-chat-messaging.ts
+++ b/src/components/chat/hooks/use-chat-messaging.ts
@@ -62,7 +62,12 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { getMessageAttachments, getMessageImages } from '../attachment-helpers'
 import { ChatError } from '../chat-utils'
 import { CONSTANTS } from '../constants'
-import { regenerateToolCallArguments } from '../genui/retry'
+import {
+  ArtifactRetryError,
+  patchToolCallArguments,
+  regenerateToolCallArguments,
+  type ToolCallPatchTarget,
+} from '../genui/retry'
 import type { Chat, LoadingState, Message } from '../types'
 import {
   createBlankChat,
@@ -1614,74 +1619,105 @@ export function useChatMessaging({
    * via a structured completion, validates them against the widget schema,
    * and patches the failed block (and its `toolCalls` mirror) in place.
    *
-   * Returns true when the widget was repaired; false lets the caller fall
-   * back to a full regeneration.
+   * Returns true when the widget was repaired. Typed failures are preserved so
+   * the card can explain what happened and keep retry available.
    */
   const retryToolCall = useCallback(
     async (messageIndex: number, toolCallId: string): Promise<boolean> => {
-      if (loadingState !== 'idle' || !currentChat) return false
+      if (loadingState !== 'idle' || !currentChat) {
+        throw new ArtifactRetryError('unavailable_target')
+      }
 
       const chatId = currentChat.id
       const message = currentChat.messages[messageIndex]
-      if (!message || message.role !== 'assistant') return false
+      if (!message || message.role !== 'assistant') {
+        throw new ArtifactRetryError('unavailable_target')
+      }
       const block = message.timeline?.find(
         (candidate) =>
           candidate.type === 'tool_call' && candidate.toolCallId === toolCallId,
       )
-      if (!block || block.type !== 'tool_call') return false
+      if (!block || block.type !== 'tool_call') {
+        throw new ArtifactRetryError('unavailable_target')
+      }
 
-      const { model } = resolveModelSelection(selectedModel, models, {})
-      if (!model) return false
+      const { model, autoCandidates } = resolveModelSelection(
+        selectedModel,
+        models,
+        { preferToolCalling: true },
+      )
+      if (!model) throw new ArtifactRetryError('unavailable_target')
 
-      const newArguments = await regenerateToolCallArguments({
+      const target: ToolCallPatchTarget = {
+        messageTurnId: message.turnId,
+        messageTimestamp: message.timestamp.getTime(),
+        timelineBlockId: block.id,
+        toolCallId,
         toolName: block.name,
         originalArguments: block.arguments,
-        contextMessages: currentChat.messages.slice(0, messageIndex + 1),
-        model,
-      })
-      if (newArguments === null) return false
-
-      const patchMessage = (msg: Message): Message => ({
-        ...msg,
-        timeline: msg.timeline?.map((candidate) =>
-          candidate.type === 'tool_call' && candidate.toolCallId === toolCallId
-            ? { ...candidate, arguments: newArguments }
-            : candidate,
-        ),
-        toolCalls: msg.toolCalls?.map((tc) =>
-          tc.id === toolCallId ? { ...tc, arguments: newArguments } : tc,
-        ),
-      })
+      }
+      let newArguments: string
+      try {
+        newArguments = await regenerateToolCallArguments({
+          toolName: block.name,
+          originalArguments: block.arguments,
+          contextMessages: currentChat.messages.slice(0, messageIndex + 1),
+          model,
+          autoCandidates,
+          reasoningEffort,
+          thinkingEnabled,
+        })
+      } catch (error) {
+        const retryError =
+          error instanceof ArtifactRetryError
+            ? error
+            : new ArtifactRetryError('request_failed', { cause: error })
+        logError('Failed to retry artifact arguments', retryError, {
+          component: 'useChatMessaging',
+          action: 'retryToolCall',
+          metadata: { chatId, toolCallId, code: retryError.code },
+        })
+        throw retryError
+      }
 
       // The model call above can take seconds; the chat may have gained
       // messages (or the user may have switched away) since the closure
       // captured `currentChat`. Patch the tool-call block by id against
       // the *live* state instead of writing the snapshot back, so the
       // repair can never roll back newer chat content.
-      const patchChat = (chat: Chat): Chat => ({
-        ...chat,
-        messages: chat.messages.map((msg) =>
-          msg.role === 'assistant' &&
-          msg.timeline?.some(
-            (candidate) =>
-              candidate.type === 'tool_call' &&
-              candidate.toolCallId === toolCallId,
-          )
-            ? patchMessage(msg)
-            : msg,
-        ),
-      })
+      const liveChat = chatsRef.current.find(
+        (candidate) => candidate.id === chatId,
+      )
+      if (!liveChat) throw new ArtifactRetryError('unavailable_target')
+      const patched = patchToolCallArguments(liveChat, target, newArguments)
+      if (!patched.ok) {
+        logError(
+          'Artifact retry target is stale or unavailable',
+          patched.error,
+          {
+            component: 'useChatMessaging',
+            action: 'retryToolCall',
+            metadata: { chatId, toolCallId, code: patched.error.code },
+          },
+        )
+        throw patched.error
+      }
 
       setChats((prevChats) =>
-        prevChats.map((c) => (c.id === chatId ? patchChat(c) : c)),
+        prevChats.map((chat) => {
+          if (chat.id !== chatId) return chat
+          const result = patchToolCallArguments(chat, target, newArguments)
+          return result.ok ? result.chat : chat
+        }),
       )
-      setCurrentChat((prev) => (prev.id === chatId ? patchChat(prev) : prev))
+      setCurrentChat((prev) => {
+        if (prev.id !== chatId) return prev
+        const result = patchToolCallArguments(prev, target, newArguments)
+        return result.ok ? result.chat : prev
+      })
 
-      const liveChat =
-        chatsRef.current.find((c) => c.id === chatId) ??
-        (currentChat.id === chatId ? currentChat : null)
-      const chatToSave = liveChat ? patchChat(liveChat) : null
-      if (chatToSave && !chatToSave.isTemporary) {
+      const chatToSave = patched.chat
+      if (!chatToSave.isTemporary) {
         if (storeHistory) {
           chatStorage.saveChatAndSync(chatToSave).catch((error) => {
             logError('Failed to persist repaired widget', error, {
@@ -1702,6 +1738,8 @@ export function useChatMessaging({
       currentChat,
       selectedModel,
       models,
+      reasoningEffort,
+      thinkingEnabled,
       storeHistory,
       setChats,
       setCurrentChat,

--- a/src/components/chat/renderers/types.ts
+++ b/src/components/chat/renderers/types.ts
@@ -29,9 +29,8 @@ export interface MessageRenderProps {
   onEditMessage?: (messageIndex: number, newContent: string) => void
   onRegenerateMessage?: (messageIndex: number) => void
   /**
-   * Retry a single failed GenUI tool call in place. Resolves true when the
-   * widget was repaired; false signals the caller may fall back to a full
-   * regeneration.
+   * Retry a single failed GenUI tool call in place. Resolves true when repaired
+   * and preserves typed failures for the retry card.
    */
   onRetryToolCall?: (
     messageIndex: number,

--- a/src/services/inference/inference-client.ts
+++ b/src/services/inference/inference-client.ts
@@ -17,6 +17,7 @@ import {
   APIUserAbortError,
   AuthenticationError,
 } from 'openai'
+import type { ChatCompletionCreateParamsNonStreaming } from 'openai/resources/chat/completions'
 import type { SessionRecoveryToken } from 'tinfoil'
 import { ChatQueryBuilder } from './chat-query-builder'
 import { chatChunkStreamFromSSE, type ChatChunkStream } from './chat-stream'
@@ -34,6 +35,19 @@ import {
 const CHAT_COMPLETIONS_ENDPOINT = '/v1/chat/completions'
 
 const EFFORT_PLACEHOLDER = '$EFFORT'
+const RESERVED_MODEL_BODY_PARAMS = new Set([
+  'model',
+  'messages',
+  'stream',
+  'signal',
+  'reasoning_effort',
+  'web_search_options',
+  'code_execution_options',
+  'pii_check_options',
+  'tools',
+  'tool_choice',
+  'response_format',
+])
 
 /**
  * Recursively clones an object, replacing any string equal to "$EFFORT" with
@@ -93,7 +107,12 @@ function buildModelBodyParams(
           unknown
         >
         for (const [key, value] of Object.entries(block)) {
-          out[key] = value
+          if (
+            key === 'reasoning_effort' ||
+            !RESERVED_MODEL_BODY_PARAMS.has(key)
+          ) {
+            out[key] = value
+          }
         }
       }
     }
@@ -102,20 +121,8 @@ function buildModelBodyParams(
   // Apply model-specific params, but never let them overwrite our explicit
   // or security-sensitive fields.
   if (model.requestParams) {
-    const reserved = new Set([
-      'model',
-      'messages',
-      'stream',
-      'signal',
-      'reasoning_effort',
-      'web_search_options',
-      'code_execution_options',
-      'pii_check_options',
-      'tools',
-      'tool_choice',
-    ])
     for (const [key, value] of Object.entries(model.requestParams)) {
-      if (!reserved.has(key)) {
+      if (!RESERVED_MODEL_BODY_PARAMS.has(key)) {
         out[key] = value
       }
     }
@@ -673,39 +680,126 @@ function toTerminalChatError(err: unknown, retries?: number): ChatError {
 
 export interface StructuredCompletionParams {
   model: BaseModel
+  autoCandidates?: BaseModel[]
   messages: Array<{ role: 'user' | 'assistant' | 'system'; content: string }>
   jsonSchema: Record<string, unknown>
   signal?: AbortSignal
+  reasoningEffort?: ReasoningEffort
+  thinkingEnabled?: boolean
+}
+
+export type StructuredCompletionErrorCode =
+  | 'request_failed'
+  | 'incomplete_response'
+  | 'refused_response'
+  | 'empty_response'
+  | 'invalid_json_response'
+
+export class StructuredCompletionError extends Error {
+  readonly code: StructuredCompletionErrorCode
+  readonly status?: number
+  readonly requestCode?: string
+  readonly finishReason?: string
+
+  constructor(
+    code: StructuredCompletionErrorCode,
+    options: {
+      cause?: unknown
+      status?: number
+      requestCode?: string
+      finishReason?: string
+    } = {},
+  ) {
+    super(code, { cause: options.cause })
+    this.name = 'StructuredCompletionError'
+    this.code = code
+    this.status = options.status
+    this.requestCode = options.requestCode
+    this.finishReason = options.finishReason
+  }
 }
 
 export async function sendStructuredCompletion<T>(
   params: StructuredCompletionParams,
 ): Promise<T> {
-  const { model, messages, jsonSchema, signal } = params
-
-  const client = await getTinfoilClient()
-  const response = await client.chat.completions.create(
-    {
-      model: model.modelName,
-      messages,
-      stream: false,
-      response_format: {
-        type: 'json_schema',
-        json_schema: {
-          name: 'response',
-          schema: jsonSchema,
-        },
-      },
-    },
-    {
-      signal,
-    },
+  const {
+    model,
+    autoCandidates,
+    messages,
+    jsonSchema,
+    signal,
+    reasoningEffort,
+    thinkingEnabled,
+  } = params
+  const selectedCandidates = autoCandidates ?? [model]
+  const requestMessages = selectedCandidates.some(
+    (candidate) => !ChatQueryBuilder.shouldUseSystemRole(candidate.modelName),
   )
+    ? messages.map((message) =>
+        message.role === 'system'
+          ? { ...message, role: 'user' as const }
+          : message,
+      )
+    : messages
 
-  const content = response.choices[0]?.message?.content
-  if (!content) {
-    throw new Error('No content in structured completion response')
+  const requestBody: ChatCompletionCreateParamsNonStreaming &
+    Record<string, unknown> = {
+    model: model.modelName,
+    messages: requestMessages,
+    stream: false,
+  }
+  const modelParamOpts = { thinkingEnabled, reasoningEffort }
+  if (autoCandidates && autoCandidates.length > 0) {
+    requestBody.model = AUTO_REQUEST_MODEL
+    requestBody[AUTO_MODEL_OPTIONS_FIELD] = autoCandidates.map((candidate) => ({
+      model: candidate.modelName,
+      params: buildModelBodyParams(candidate, modelParamOpts),
+    }))
+  } else {
+    Object.assign(requestBody, buildModelBodyParams(model, modelParamOpts))
+  }
+  requestBody.response_format = {
+    type: 'json_schema',
+    json_schema: {
+      name: 'response',
+      schema: jsonSchema,
+    },
   }
 
-  return JSON.parse(content) as T
+  let response
+  try {
+    const client = await getTinfoilClient()
+    response = await client.chat.completions.create(requestBody, { signal })
+  } catch (error) {
+    const status = (error as { status?: unknown })?.status
+    const requestCode = (error as { code?: unknown })?.code
+    throw new StructuredCompletionError('request_failed', {
+      cause: error,
+      status: typeof status === 'number' ? status : undefined,
+      requestCode: typeof requestCode === 'string' ? requestCode : undefined,
+    })
+  }
+
+  const choice = response.choices[0]
+  const finishReason =
+    typeof choice?.finish_reason === 'string' ? choice.finish_reason : undefined
+  if (choice?.message?.refusal) {
+    throw new StructuredCompletionError('refused_response', { finishReason })
+  }
+  if (finishReason && finishReason !== 'stop') {
+    throw new StructuredCompletionError('incomplete_response', { finishReason })
+  }
+  const content = choice?.message?.content
+  if (typeof content !== 'string' || content.trim().length === 0) {
+    throw new StructuredCompletionError('empty_response', { finishReason })
+  }
+
+  try {
+    return JSON.parse(content) as T
+  } catch (error) {
+    throw new StructuredCompletionError('invalid_json_response', {
+      cause: error,
+      finishReason,
+    })
+  }
 }

--- a/src/services/inference/inference-client.ts
+++ b/src/services/inference/inference-client.ts
@@ -771,11 +771,18 @@ export async function sendStructuredCompletion<T>(
     const client = await getTinfoilClient()
     response = await client.chat.completions.create(requestBody, { signal })
   } catch (error) {
-    const status = (error as { status?: unknown })?.status
+    if (
+      error instanceof APIUserAbortError ||
+      (typeof DOMException !== 'undefined' &&
+        error instanceof DOMException &&
+        error.name === 'AbortError')
+    ) {
+      throw error
+    }
     const requestCode = (error as { code?: unknown })?.code
     throw new StructuredCompletionError('request_failed', {
       cause: error,
-      status: typeof status === 'number' ? status : undefined,
+      status: getHttpStatus(error),
       requestCode: typeof requestCode === 'string' ? requestCode : undefined,
     })
   }

--- a/tests/components/chat/genui/registry.test.ts
+++ b/tests/components/chat/genui/registry.test.ts
@@ -31,6 +31,23 @@ describe('GenUI registry', () => {
     }
   })
 
+  it('documents exact artifact HTML and Markdown source shapes', () => {
+    const artifact = buildGenUIToolSchemas().find(
+      (entry) => entry.function.name === 'render_artifact_preview',
+    )
+    const schemaText = JSON.stringify(artifact?.function.parameters)
+
+    expect(schemaText).toContain('{\\"type\\":\\"html\\",\\"html\\":\\"...\\"}')
+    expect(schemaText).toContain(
+      '{\\"type\\":\\"markdown\\",\\"markdown\\":\\"...\\"}',
+    )
+    expect(
+      GENUI_WIDGETS_BY_NAME.render_artifact_preview.schema.safeParse({
+        source: { type: 'markdown', markdown: 123 },
+      }).success,
+    ).toBe(false)
+  })
+
   it('opts every GenUI tool into router-side auto-continuation', () => {
     const schemas = buildGenUIToolSchemas()
     for (const entry of schemas) {

--- a/tests/components/chat/genui/retry.test.ts
+++ b/tests/components/chat/genui/retry.test.ts
@@ -259,14 +259,17 @@ describe('artifact retry', () => {
         model,
       }),
     ).rejects.toMatchObject({
-      code: 'request_failed',
+      code: 'schema_conversion_failed',
       cause: conversionError,
     })
     expect(logErrorMock).toHaveBeenCalledWith(
       'Artifact schema conversion failed',
       expect.any(ArtifactRetryError),
       expect.objectContaining({
-        metadata: { toolName: 'render_chart', code: 'request_failed' },
+        metadata: {
+          toolName: 'render_chart',
+          code: 'schema_conversion_failed',
+        },
       }),
     )
   })
@@ -350,6 +353,41 @@ describe('artifact retry', () => {
       arguments: '{"fixed":true}',
     })
     expect(result.chat.messages[1].toolCalls).toBeUndefined()
+  })
+
+  it.each([
+    ['an empty mirror array', []],
+    [
+      'a mirror array missing the current tool call',
+      [
+        {
+          id: 'call-2',
+          name: 'render_chart',
+          arguments: '{"type":"bar","data":[]}',
+        },
+      ],
+    ],
+  ] as const)('rejects %s', (_description, toolCalls) => {
+    const chat = artifactChat('{}')
+    chat.messages[1].toolCalls = [...toolCalls]
+
+    expect(
+      patchToolCallArguments(
+        chat,
+        {
+          messageTurnId: 'turn-1',
+          messageTimestamp: chat.messages[1].timestamp.getTime(),
+          timelineBlockId: 'block-1',
+          toolCallId: 'call-1',
+          toolName: 'render_artifact_preview',
+          originalArguments: '{}',
+        },
+        '{"fixed":true}',
+      ),
+    ).toMatchObject({
+      ok: false,
+      error: { code: 'stale_target' },
+    })
   })
 
   it('rejects a stale or duplicate tool-call mirror', () => {

--- a/tests/components/chat/genui/retry.test.ts
+++ b/tests/components/chat/genui/retry.test.ts
@@ -1,86 +1,278 @@
-import { regenerateToolCallArguments } from '@/components/chat/genui/retry'
-import type { Message } from '@/components/chat/types'
+import {
+  ArtifactRetryError,
+  patchToolCallArguments,
+  regenerateToolCallArguments,
+  selectArtifactRetryContext,
+} from '@/components/chat/genui/retry'
+import type { Chat, Message } from '@/components/chat/types'
 import type { BaseModel } from '@/config/models'
+import { StructuredCompletionError } from '@/services/inference/inference-client'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const { sendStructuredCompletionMock } = vi.hoisted(() => ({
   sendStructuredCompletionMock: vi.fn(),
 }))
 
-vi.mock('@/services/inference/inference-client', () => ({
-  sendStructuredCompletion: sendStructuredCompletionMock,
-}))
+vi.mock('@/services/inference/inference-client', async () => {
+  const actual = await vi.importActual<
+    typeof import('@/services/inference/inference-client')
+  >('@/services/inference/inference-client')
+  return {
+    ...actual,
+    sendStructuredCompletion: sendStructuredCompletionMock,
+  }
+})
 
-const model = { modelName: 'gpt-oss-120b' } as BaseModel
+vi.mock('@/utils/error-handling', () => ({ logError: vi.fn() }))
 
-function userMessage(content: string): Message {
-  return { role: 'user', content, timestamp: new Date() }
+const model = {
+  modelName: 'gpt-oss-120b',
+  contextWindow: '64k',
+} as BaseModel
+
+function message(role: Message['role'], content: string): Message {
+  return { role, content, timestamp: new Date() }
 }
 
-describe('regenerateToolCallArguments', () => {
+function artifactChat(argumentsValue: string): Chat {
+  const timestamp = new Date('2026-08-11T12:00:00Z')
+  return {
+    id: 'chat-1',
+    title: 'Artifact',
+    createdAt: timestamp,
+    messages: [
+      message('user', 'Create an artifact'),
+      {
+        role: 'assistant',
+        content: 'Unrelated prose stays unchanged',
+        timestamp,
+        turnId: 'turn-1',
+        timeline: [
+          { type: 'content', id: 'content-1', content: 'Unrelated prose' },
+          {
+            type: 'tool_call',
+            id: 'block-1',
+            toolCallId: 'call-1',
+            name: 'render_artifact_preview',
+            arguments: argumentsValue,
+          },
+          {
+            type: 'tool_call',
+            id: 'block-2',
+            toolCallId: 'call-2',
+            name: 'render_chart',
+            arguments: '{"type":"bar","data":[]}',
+          },
+        ],
+        toolCalls: [
+          {
+            id: 'call-1',
+            name: 'render_artifact_preview',
+            arguments: argumentsValue,
+          },
+          {
+            id: 'call-2',
+            name: 'render_chart',
+            arguments: '{"type":"bar","data":[]}',
+          },
+        ],
+      },
+    ],
+  }
+}
+
+describe('artifact retry', () => {
   beforeEach(() => {
     sendStructuredCompletionMock.mockReset()
   })
 
-  it('returns validated arguments serialized for the tool-call block', async () => {
-    const regenerated = {
-      type: 'bar',
-      data: [{ label: 'A', value: 10 }],
-      title: 'Sales',
-    }
-    sendStructuredCompletionMock.mockResolvedValueOnce(regenerated)
-
-    const result = await regenerateToolCallArguments({
-      toolName: 'render_chart',
-      contextMessages: [userMessage('Chart my sales data')],
-      model,
-    })
-
-    expect(result).not.toBeNull()
-    expect(JSON.parse(result as string)).toMatchObject(regenerated)
-    // The re-ask must be constrained by the widget's JSON schema.
-    const call = sendStructuredCompletionMock.mock.calls[0][0]
-    expect(call.jsonSchema).toBeTruthy()
-    expect(call.model).toBe(model)
-  })
-
-  it('returns null when regenerated arguments still fail validation', async () => {
+  it('always sends malformed arguments larger than 4000 characters in full', async () => {
+    const malformed = `{"source":{"type":"html","html":"${'x'.repeat(5000)}`
     sendStructuredCompletionMock.mockResolvedValueOnce({
-      type: 'donut', // not a valid chart type
-      data: [],
+      source: { type: 'html', html: '<main>fixed</main>' },
     })
 
-    const result = await regenerateToolCallArguments({
-      toolName: 'render_chart',
-      contextMessages: [userMessage('Chart my sales data')],
+    await regenerateToolCallArguments({
+      toolName: 'render_artifact_preview',
+      originalArguments: malformed,
+      contextMessages: [message('user', 'Create a page')],
       model,
     })
 
-    expect(result).toBeNull()
+    const request = sendStructuredCompletionMock.mock.calls[0][0]
+    expect(request.messages.at(-1).content).toBe(
+      `Malformed arguments to repair:\n${malformed}`,
+    )
   })
 
-  it('returns null for unknown widgets without calling the model', async () => {
-    const result = await regenerateToolCallArguments({
-      toolName: 'render_nonexistent',
-      contextMessages: [userMessage('Hello')],
-      model,
-    })
-
-    expect(result).toBeNull()
-    expect(sendStructuredCompletionMock).not.toHaveBeenCalled()
-  })
-
-  it('returns null when the structured completion fails', async () => {
-    sendStructuredCompletionMock.mockRejectedValueOnce(
-      new Error('network down'),
+  it('selects only whole ancillary messages within the remaining budget', () => {
+    const older = 'a'.repeat(300)
+    const recent = 'b'.repeat(200)
+    const selected = selectArtifactRetryContext(
+      [message('user', older), message('assistant', recent)],
+      '1k',
+      'm'.repeat(3200),
     )
 
-    const result = await regenerateToolCallArguments({
+    expect(selected).toEqual([{ role: 'assistant', content: recent }])
+  })
+
+  it('preserves Auto candidates and current reasoning options', async () => {
+    const candidate = {
+      ...model,
+      modelName: 'candidate-a',
+      requestParams: { temperature: 0.2 },
+    }
+    sendStructuredCompletionMock.mockResolvedValueOnce({
+      type: 'bar',
+      data: [{ label: 'A', value: 1 }],
+    })
+
+    await regenerateToolCallArguments({
       toolName: 'render_chart',
-      contextMessages: [userMessage('Chart my sales data')],
+      originalArguments: '{}',
+      contextMessages: [],
+      model: candidate,
+      autoCandidates: [candidate],
+      reasoningEffort: 'high',
+      thinkingEnabled: true,
+    })
+
+    expect(sendStructuredCompletionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: candidate,
+        autoCandidates: [candidate],
+        reasoningEffort: 'high',
+        thinkingEnabled: true,
+      }),
+    )
+  })
+
+  it('allows schema-valid arguments to be replaced after a render exception', async () => {
+    const originalArguments = JSON.stringify({
+      type: 'bar',
+      data: [{ label: 'Before', value: 1 }],
+    })
+    sendStructuredCompletionMock.mockResolvedValueOnce({
+      type: 'bar',
+      data: [{ label: 'Recovered', value: 2 }],
+    })
+
+    const replacement = await regenerateToolCallArguments({
+      toolName: 'render_chart',
+      originalArguments,
+      contextMessages: [message('user', 'Fix the chart')],
       model,
     })
 
-    expect(result).toBeNull()
+    expect(JSON.parse(replacement).data[0]).toEqual({
+      label: 'Recovered',
+      value: 2,
+    })
+    expect(sendStructuredCompletionMock).toHaveBeenCalledOnce()
+  })
+
+  it('classifies incomplete and schema-invalid replacements', async () => {
+    sendStructuredCompletionMock.mockRejectedValueOnce(
+      new StructuredCompletionError('incomplete_response', {
+        finishReason: 'length',
+      }),
+    )
+    await expect(
+      regenerateToolCallArguments({
+        toolName: 'render_chart',
+        contextMessages: [],
+        model,
+      }),
+    ).rejects.toMatchObject({ code: 'incomplete_replacement' })
+
+    sendStructuredCompletionMock.mockResolvedValueOnce({
+      type: 'donut',
+      data: [],
+    })
+    await expect(
+      regenerateToolCallArguments({
+        toolName: 'render_chart',
+        contextMessages: [],
+        model,
+      }),
+    ).rejects.toMatchObject({ code: 'schema_invalid_replacement' })
+  })
+
+  it('distinguishes request failures and unavailable widgets', async () => {
+    sendStructuredCompletionMock.mockRejectedValueOnce(
+      new StructuredCompletionError('request_failed', { status: 503 }),
+    )
+    await expect(
+      regenerateToolCallArguments({
+        toolName: 'render_chart',
+        contextMessages: [],
+        model,
+      }),
+    ).rejects.toMatchObject({ code: 'request_failed' })
+
+    await expect(
+      regenerateToolCallArguments({
+        toolName: 'render_unknown',
+        contextMessages: [],
+        model,
+      }),
+    ).rejects.toMatchObject({ code: 'unavailable_target' })
+  })
+
+  it('patches only the originating block and mirror while preserving changes', () => {
+    const original = '{"source":{"type":"html"}'
+    const chat = artifactChat(original)
+    chat.messages.push(message('user', 'Concurrent message'))
+    const result = patchToolCallArguments(
+      chat,
+      {
+        messageTurnId: 'turn-1',
+        messageTimestamp: chat.messages[1].timestamp.getTime(),
+        timelineBlockId: 'block-1',
+        toolCallId: 'call-1',
+        toolName: 'render_artifact_preview',
+        originalArguments: original,
+      },
+      '{"source":{"type":"html","html":"fixed"}}',
+    )
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.chat.messages.at(-1)?.content).toBe('Concurrent message')
+    expect(result.chat.messages[1].content).toBe(
+      'Unrelated prose stays unchanged',
+    )
+    expect(result.chat.messages[1].toolCalls?.[0].arguments).toContain('fixed')
+    expect(result.chat.messages[1].toolCalls?.[1].arguments).toBe(
+      '{"type":"bar","data":[]}',
+    )
+  })
+
+  it('refuses a stale originating block or mirror', () => {
+    const original = '{}'
+    const chat = artifactChat(original)
+    chat.messages[1].timeline![1] = {
+      ...chat.messages[1].timeline![1],
+      arguments: '{"newer":true}',
+    } as NonNullable<Message['timeline']>[number]
+    const result = patchToolCallArguments(
+      chat,
+      {
+        messageTurnId: 'turn-1',
+        messageTimestamp: chat.messages[1].timestamp.getTime(),
+        timelineBlockId: 'block-1',
+        toolCallId: 'call-1',
+        toolName: 'render_artifact_preview',
+        originalArguments: original,
+      },
+      '{"fixed":true}',
+    )
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: expect.any(ArtifactRetryError),
+    })
+    if (!result.ok) expect(result.error.code).toBe('stale_target')
   })
 })

--- a/tests/components/chat/genui/retry.test.ts
+++ b/tests/components/chat/genui/retry.test.ts
@@ -9,9 +9,21 @@ import type { BaseModel } from '@/config/models'
 import { StructuredCompletionError } from '@/services/inference/inference-client'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { sendStructuredCompletionMock } = vi.hoisted(() => ({
-  sendStructuredCompletionMock: vi.fn(),
-}))
+const { logErrorMock, sendStructuredCompletionMock, zodToJsonSchemaMock } =
+  vi.hoisted(() => ({
+    logErrorMock: vi.fn(),
+    sendStructuredCompletionMock: vi.fn(),
+    zodToJsonSchemaMock: vi.fn(),
+  }))
+
+vi.mock('zod-to-json-schema', async () => {
+  const actual =
+    await vi.importActual<typeof import('zod-to-json-schema')>(
+      'zod-to-json-schema',
+    )
+  zodToJsonSchemaMock.mockImplementation(actual.zodToJsonSchema)
+  return { ...actual, zodToJsonSchema: zodToJsonSchemaMock }
+})
 
 vi.mock('@/services/inference/inference-client', async () => {
   const actual = await vi.importActual<
@@ -23,7 +35,7 @@ vi.mock('@/services/inference/inference-client', async () => {
   }
 })
 
-vi.mock('@/utils/error-handling', () => ({ logError: vi.fn() }))
+vi.mock('@/utils/error-handling', () => ({ logError: logErrorMock }))
 
 const model = {
   modelName: 'gpt-oss-120b',
@@ -84,6 +96,8 @@ function artifactChat(argumentsValue: string): Chat {
 describe('artifact retry', () => {
   beforeEach(() => {
     sendStructuredCompletionMock.mockReset()
+    zodToJsonSchemaMock.mockClear()
+    logErrorMock.mockReset()
   })
 
   it('always sends malformed arguments larger than 4000 characters in full', async () => {
@@ -115,6 +129,18 @@ describe('artifact retry', () => {
     )
 
     expect(selected).toEqual([{ role: 'assistant', content: recent }])
+  })
+
+  it('budgets only the role and content serialized for retry context', () => {
+    const contextualMessage = {
+      ...message('assistant', 'visible'),
+      quote: 'q'.repeat(2000),
+      searchReasoning: 'r'.repeat(2000),
+    }
+
+    expect(
+      selectArtifactRetryContext([contextualMessage], '1k', 'm'.repeat(3200)),
+    ).toEqual([{ role: 'assistant', content: 'visible' }])
   })
 
   it('preserves Auto candidates and current reasoning options', async () => {
@@ -220,6 +246,31 @@ describe('artifact retry', () => {
     ).rejects.toMatchObject({ code: 'unavailable_target' })
   })
 
+  it('classifies and safely logs schema conversion failures', async () => {
+    const conversionError = new Error('conversion failed')
+    zodToJsonSchemaMock.mockImplementationOnce(() => {
+      throw conversionError
+    })
+
+    await expect(
+      regenerateToolCallArguments({
+        toolName: 'render_chart',
+        contextMessages: [],
+        model,
+      }),
+    ).rejects.toMatchObject({
+      code: 'request_failed',
+      cause: conversionError,
+    })
+    expect(logErrorMock).toHaveBeenCalledWith(
+      'Artifact schema conversion failed',
+      expect.any(ArtifactRetryError),
+      expect.objectContaining({
+        metadata: { toolName: 'render_chart', code: 'request_failed' },
+      }),
+    )
+  })
+
   it('patches only the originating block and mirror while preserving changes', () => {
     const original = '{"source":{"type":"html"}'
     const chat = artifactChat(original)
@@ -274,5 +325,60 @@ describe('artifact retry', () => {
       error: expect.any(ArtifactRetryError),
     })
     if (!result.ok) expect(result.error.code).toBe('stale_target')
+  })
+
+  it('patches a timeline-only legacy message without adding a mirror', () => {
+    const chat = artifactChat('{}')
+    chat.messages[1].toolCalls = undefined
+
+    const result = patchToolCallArguments(
+      chat,
+      {
+        messageTurnId: 'turn-1',
+        messageTimestamp: chat.messages[1].timestamp.getTime(),
+        timelineBlockId: 'block-1',
+        toolCallId: 'call-1',
+        toolName: 'render_artifact_preview',
+        originalArguments: '{}',
+      },
+      '{"fixed":true}',
+    )
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.chat.messages[1].timeline?.[1]).toMatchObject({
+      arguments: '{"fixed":true}',
+    })
+    expect(result.chat.messages[1].toolCalls).toBeUndefined()
+  })
+
+  it('rejects a stale or duplicate tool-call mirror', () => {
+    const target = {
+      messageTurnId: 'turn-1',
+      messageTimestamp: artifactChat('{}').messages[1].timestamp.getTime(),
+      timelineBlockId: 'block-1',
+      toolCallId: 'call-1',
+      toolName: 'render_artifact_preview',
+      originalArguments: '{}',
+    }
+    const staleMirrorChat = artifactChat('{}')
+    staleMirrorChat.messages[1].toolCalls![0].arguments = '{"stale":true}'
+    const duplicateMirrorChat = artifactChat('{}')
+    duplicateMirrorChat.messages[1].toolCalls!.push({
+      ...duplicateMirrorChat.messages[1].toolCalls![0],
+    })
+
+    expect(
+      patchToolCallArguments(staleMirrorChat, target, '{"fixed":true}'),
+    ).toMatchObject({
+      ok: false,
+      error: { code: 'stale_target' },
+    })
+    expect(
+      patchToolCallArguments(duplicateMirrorChat, target, '{"fixed":true}'),
+    ).toMatchObject({
+      ok: false,
+      error: { code: 'stale_target' },
+    })
   })
 })

--- a/tests/components/chat/genui/tool-call-renderer.test.tsx
+++ b/tests/components/chat/genui/tool-call-renderer.test.tsx
@@ -1,8 +1,26 @@
 import { GenUIToolCallRenderer } from '@/components/chat/genui/GenUIToolCallRenderer'
-import { render, screen } from '@testing-library/react'
-import { describe, expect, it } from 'vitest'
+import { GENUI_WIDGETS_BY_NAME } from '@/components/chat/genui/registry'
+import { ArtifactRetryError } from '@/components/chat/genui/retry'
+import type { GenUIRenderContext } from '@/components/chat/genui/types'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { useState } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { logErrorMock } = vi.hoisted(() => ({ logErrorMock: vi.fn() }))
+
+vi.mock('@/utils/error-handling', () => ({ logError: logErrorMock }))
+
+const validMessageCompose = JSON.stringify({
+  channel: 'message',
+  title: 'Reply draft',
+  variants: [{ label: 'Concise', body: 'Thanks, I will confirm.' }],
+})
 
 describe('GenUIToolCallRenderer', () => {
+  beforeEach(() => {
+    logErrorMock.mockReset()
+  })
+
   it('renders completed widget arguments while the assistant stream continues', () => {
     render(
       <GenUIToolCallRenderer
@@ -11,16 +29,7 @@ describe('GenUIToolCallRenderer', () => {
           {
             id: 'tool-call-1',
             name: 'render_message_compose',
-            arguments: JSON.stringify({
-              channel: 'message',
-              title: 'Reply draft',
-              variants: [
-                {
-                  label: 'Concise',
-                  body: 'Thanks, I will confirm the details.',
-                },
-              ],
-            }),
+            arguments: validMessageCompose,
           },
         ]}
       />,
@@ -32,20 +41,243 @@ describe('GenUIToolCallRenderer', () => {
     ).not.toBeInTheDocument()
   })
 
-  it('keeps the streaming tracer while widget arguments are incomplete', () => {
+  it('shows a simple generating state without raw data or a character count', () => {
+    const rawArguments = '{"source":{"type":"html","html":"private-markup"'
     render(
       <GenUIToolCallRenderer
         isStreaming
         toolCalls={[
           {
             id: 'tool-call-1',
-            name: 'render_message_compose',
-            arguments: '{"title":"Reply draft"',
+            name: 'render_artifact_preview',
+            arguments: rawArguments,
           },
         ]}
       />,
     )
 
-    expect(screen.getByText(/Generating message compose/)).toBeInTheDocument()
+    expect(screen.getByText(/Generating artifact preview/)).toBeInTheDocument()
+    expect(screen.queryByText(/chars/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/private-markup/)).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: /show stream/i }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('distinguishes invalid JSON, schema validation, and unknown widgets', () => {
+    const { rerender } = render(
+      <GenUIToolCallRenderer
+        isStreaming={false}
+        toolCalls={[
+          { id: 'one', name: 'render_chart', arguments: '{"type":"bar"' },
+        ]}
+      />,
+    )
+    expect(
+      screen.getByText('The component data is not valid JSON.'),
+    ).toBeInTheDocument()
+
+    rerender(
+      <GenUIToolCallRenderer
+        isStreaming={false}
+        toolCalls={[
+          {
+            id: 'two',
+            name: 'render_chart',
+            arguments: '{"type":"invalid","data":[]}',
+          },
+        ]}
+      />,
+    )
+    expect(screen.getByText(/failed schema validation/)).toBeInTheDocument()
+
+    rerender(
+      <GenUIToolCallRenderer
+        isStreaming={false}
+        toolCalls={[{ id: 'three', name: 'render_unknown', arguments: '{}' }]}
+      />,
+    )
+    expect(screen.getByText('Component unavailable')).toBeInTheDocument()
+  })
+
+  it('shows schema-invalid complete JSON while continuation is streaming', () => {
+    render(
+      <GenUIToolCallRenderer
+        isStreaming
+        toolCalls={[
+          {
+            id: 'one',
+            name: 'render_chart',
+            arguments: '{"type":"invalid","data":[]}',
+          },
+        ]}
+      />,
+    )
+
+    expect(screen.getByText(/failed schema validation/)).toBeInTheDocument()
+    expect(screen.queryByText(/Generating chart/)).not.toBeInTheDocument()
+  })
+
+  it('keeps widget retry repeatable and exposes full regeneration separately', async () => {
+    const retryWidget = vi
+      .fn()
+      .mockRejectedValue(new ArtifactRetryError('incomplete_replacement'))
+    const regenerate = vi.fn()
+    render(
+      <GenUIToolCallRenderer
+        isStreaming={false}
+        toolCalls={[
+          { id: 'one', name: 'render_chart', arguments: '{"type":"bar"' },
+        ]}
+        onRetryToolCall={retryWidget}
+        onRetry={regenerate}
+      />,
+    )
+
+    const retryButton = screen.getByRole('button', { name: 'Retry widget' })
+    expect(
+      screen.getByRole('button', { name: 'Regenerate response' }),
+    ).toBeInTheDocument()
+    fireEvent.click(retryButton)
+    await waitFor(() => expect(retryWidget).toHaveBeenCalledTimes(1))
+    expect(
+      screen.getByText(/replacement was incomplete or invalid JSON/),
+    ).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Retry widget' }))
+    await waitFor(() => expect(retryWidget).toHaveBeenCalledTimes(2))
+    expect(regenerate).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    ['request_failed', /Could not request a replacement/],
+    [
+      'schema_invalid_replacement',
+      /replacement did not match the component schema/,
+    ],
+    ['stale_target', /component changed while retrying/],
+    ['unavailable_target', /component is no longer available to repair/],
+  ] as const)('shows the %s retry category', async (code, description) => {
+    render(
+      <GenUIToolCallRenderer
+        isStreaming={false}
+        toolCalls={[
+          { id: 'one', name: 'render_chart', arguments: '{"type":"bar"' },
+        ]}
+        onRetryToolCall={vi
+          .fn()
+          .mockRejectedValue(new ArtifactRetryError(code))}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry widget' }))
+    expect(await screen.findByText(description)).toBeInTheDocument()
+  })
+
+  it('retries render exceptions and resets after arguments change', async () => {
+    const widget = GENUI_WIDGETS_BY_NAME.render_message_compose
+    const originalRender = widget.render
+    const retryWidget = vi.fn()
+    const regenerate = vi.fn()
+    widget.render = (args: { title?: string }, context: GenUIRenderContext) => {
+      if (args.title === 'Reply draft') throw new Error('render failed')
+      return originalRender?.(args, context) ?? null
+    }
+
+    function RenderExceptionHarness() {
+      const [argumentsValue, setArgumentsValue] = useState(validMessageCompose)
+      return (
+        <GenUIToolCallRenderer
+          isStreaming={false}
+          toolCalls={[
+            {
+              id: 'tool-call-1',
+              name: 'render_message_compose',
+              arguments: argumentsValue,
+            },
+          ]}
+          onRetry={regenerate}
+          onRetryToolCall={async () => {
+            retryWidget()
+            if (retryWidget.mock.calls.length === 1) {
+              throw new ArtifactRetryError('request_failed')
+            }
+            setArgumentsValue(
+              JSON.stringify({
+                channel: 'message',
+                title: 'Recovered draft',
+                variants: [{ label: 'Concise', body: 'Recovered.' }],
+              }),
+            )
+            return true
+          }}
+        />
+      )
+    }
+
+    try {
+      render(<RenderExceptionHarness />)
+      expect(
+        screen.getByText(/component ran into a problem while rendering/),
+      ).toBeInTheDocument()
+      expect(
+        screen.getByRole('button', { name: 'Regenerate response' }),
+      ).toBeInTheDocument()
+      expect(logErrorMock).toHaveBeenCalledTimes(1)
+      expect(logErrorMock.mock.calls[0][1]).toMatchObject({
+        message: 'render_exception',
+      })
+
+      fireEvent.click(screen.getByRole('button', { name: 'Retry widget' }))
+      expect(
+        await screen.findByText(/Could not request a replacement/),
+      ).toBeInTheDocument()
+      fireEvent.click(screen.getByRole('button', { name: 'Retry widget' }))
+
+      expect(await screen.findByText('Recovered draft')).toBeInTheDocument()
+      expect(retryWidget).toHaveBeenCalledTimes(2)
+      expect(regenerate).not.toHaveBeenCalled()
+      expect(logErrorMock).toHaveBeenCalledTimes(1)
+      await waitFor(() =>
+        expect(
+          screen.queryByText(/component ran into a problem while rendering/),
+        ).not.toBeInTheDocument(),
+      )
+    } finally {
+      widget.render = originalRender
+    }
+  })
+
+  it('retries rendering when repaired arguments are unchanged', async () => {
+    const widget = GENUI_WIDGETS_BY_NAME.render_message_compose
+    const originalRender = widget.render
+    let shouldThrow = true
+    widget.render = (args: { title?: string }, context: GenUIRenderContext) => {
+      if (shouldThrow) throw new Error('render failed')
+      return originalRender?.(args, context) ?? null
+    }
+
+    try {
+      render(
+        <GenUIToolCallRenderer
+          isStreaming={false}
+          toolCalls={[
+            {
+              id: 'tool-call-1',
+              name: 'render_message_compose',
+              arguments: validMessageCompose,
+            },
+          ]}
+          onRetryToolCall={async () => {
+            shouldThrow = false
+            return true
+          }}
+        />,
+      )
+
+      fireEvent.click(screen.getByRole('button', { name: 'Retry widget' }))
+      expect(await screen.findByText('Reply draft')).toBeInTheDocument()
+    } finally {
+      widget.render = originalRender
+    }
   })
 })

--- a/tests/components/chat/genui/tool-call-renderer.test.tsx
+++ b/tests/components/chat/genui/tool-call-renderer.test.tsx
@@ -154,6 +154,7 @@ describe('GenUIToolCallRenderer', () => {
 
   it.each([
     ['request_failed', /Could not request a replacement/],
+    ['schema_conversion_failed', /Could not prepare the component schema/],
     [
       'schema_invalid_replacement',
       /replacement did not match the component schema/,

--- a/tests/components/chat/genui/tool-call-renderer.test.tsx
+++ b/tests/components/chat/genui/tool-call-renderer.test.tsx
@@ -4,7 +4,7 @@ import { ArtifactRetryError } from '@/components/chat/genui/retry'
 import type { GenUIRenderContext } from '@/components/chat/genui/types'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { useState } from 'react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const { logErrorMock } = vi.hoisted(() => ({ logErrorMock: vi.fn() }))
 
@@ -19,6 +19,10 @@ const validMessageCompose = JSON.stringify({
 describe('GenUIToolCallRenderer', () => {
   beforeEach(() => {
     logErrorMock.mockReset()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
   })
 
   it('renders completed widget arguments while the assistant stream continues', () => {
@@ -178,10 +182,12 @@ describe('GenUIToolCallRenderer', () => {
     const originalRender = widget.render
     const retryWidget = vi.fn()
     const regenerate = vi.fn()
-    widget.render = (args: { title?: string }, context: GenUIRenderContext) => {
-      if (args.title === 'Reply draft') throw new Error('render failed')
-      return originalRender?.(args, context) ?? null
-    }
+    vi.spyOn(widget, 'render').mockImplementation(
+      (args: { title?: string }, context: GenUIRenderContext) => {
+        if (args.title === 'Reply draft') throw new Error('render failed')
+        return originalRender!(args, context)
+      },
+    )
 
     function RenderExceptionHarness() {
       const [argumentsValue, setArgumentsValue] = useState(validMessageCompose)
@@ -214,70 +220,96 @@ describe('GenUIToolCallRenderer', () => {
       )
     }
 
-    try {
-      render(<RenderExceptionHarness />)
-      expect(
-        screen.getByText(/component ran into a problem while rendering/),
-      ).toBeInTheDocument()
-      expect(
-        screen.getByRole('button', { name: 'Regenerate response' }),
-      ).toBeInTheDocument()
-      expect(logErrorMock).toHaveBeenCalledTimes(1)
-      expect(logErrorMock.mock.calls[0][1]).toMatchObject({
-        message: 'render_exception',
-      })
+    render(<RenderExceptionHarness />)
+    expect(
+      screen.getByText(/component ran into a problem while rendering/),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Regenerate response' }),
+    ).toBeInTheDocument()
+    expect(logErrorMock).toHaveBeenCalledTimes(1)
+    expect(logErrorMock.mock.calls[0][1]).toMatchObject({
+      message: 'render failed',
+    })
 
-      fireEvent.click(screen.getByRole('button', { name: 'Retry widget' }))
-      expect(
-        await screen.findByText(/Could not request a replacement/),
-      ).toBeInTheDocument()
-      fireEvent.click(screen.getByRole('button', { name: 'Retry widget' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Retry widget' }))
+    expect(
+      await screen.findByText(/Could not request a replacement/),
+    ).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Retry widget' }))
 
-      expect(await screen.findByText('Recovered draft')).toBeInTheDocument()
-      expect(retryWidget).toHaveBeenCalledTimes(2)
-      expect(regenerate).not.toHaveBeenCalled()
-      expect(logErrorMock).toHaveBeenCalledTimes(1)
-      await waitFor(() =>
-        expect(
-          screen.queryByText(/component ran into a problem while rendering/),
-        ).not.toBeInTheDocument(),
-      )
-    } finally {
-      widget.render = originalRender
-    }
+    expect(await screen.findByText('Recovered draft')).toBeInTheDocument()
+    expect(retryWidget).toHaveBeenCalledTimes(2)
+    expect(regenerate).not.toHaveBeenCalled()
+    expect(logErrorMock).toHaveBeenCalledTimes(1)
+    await waitFor(() =>
+      expect(
+        screen.queryByText(/component ran into a problem while rendering/),
+      ).not.toBeInTheDocument(),
+    )
   })
 
   it('retries rendering when repaired arguments are unchanged', async () => {
     const widget = GENUI_WIDGETS_BY_NAME.render_message_compose
     const originalRender = widget.render
     let shouldThrow = true
-    widget.render = (args: { title?: string }, context: GenUIRenderContext) => {
-      if (shouldThrow) throw new Error('render failed')
-      return originalRender?.(args, context) ?? null
-    }
+    vi.spyOn(widget, 'render').mockImplementation(
+      (args: { title?: string }, context: GenUIRenderContext) => {
+        if (shouldThrow) throw new Error('render failed')
+        return originalRender!(args, context)
+      },
+    )
 
-    try {
-      render(
-        <GenUIToolCallRenderer
-          isStreaming={false}
-          toolCalls={[
-            {
-              id: 'tool-call-1',
-              name: 'render_message_compose',
-              arguments: validMessageCompose,
-            },
-          ]}
-          onRetryToolCall={async () => {
-            shouldThrow = false
-            return true
-          }}
-        />,
-      )
+    render(
+      <GenUIToolCallRenderer
+        isStreaming={false}
+        toolCalls={[
+          {
+            id: 'tool-call-1',
+            name: 'render_message_compose',
+            arguments: validMessageCompose,
+          },
+        ]}
+        onRetryToolCall={async () => {
+          shouldThrow = false
+          return true
+        }}
+      />,
+    )
 
-      fireEvent.click(screen.getByRole('button', { name: 'Retry widget' }))
-      expect(await screen.findByText('Reply draft')).toBeInTheDocument()
-    } finally {
-      widget.render = originalRender
-    }
+    fireEvent.click(screen.getByRole('button', { name: 'Retry widget' }))
+    expect(await screen.findByText('Reply draft')).toBeInTheDocument()
+  })
+
+  it('classifies a null widget render as a retryable render failure', () => {
+    const widget = GENUI_WIDGETS_BY_NAME.render_message_compose
+    vi.spyOn(widget, 'render').mockReturnValue(null)
+
+    render(
+      <GenUIToolCallRenderer
+        isStreaming={false}
+        toolCalls={[
+          {
+            id: 'tool-call-1',
+            name: 'render_message_compose',
+            arguments: validMessageCompose,
+          },
+        ]}
+        onRetryToolCall={vi.fn()}
+      />,
+    )
+
+    expect(
+      screen.getByText(/component ran into a problem while rendering/),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Retry widget' }),
+    ).toBeInTheDocument()
+    expect(logErrorMock.mock.calls[0][1]).toMatchObject({
+      message: 'Widget render returned null',
+    })
+    expect(logErrorMock.mock.calls[0][2]).toMatchObject({
+      metadata: { failure: 'render_exception' },
+    })
   })
 })

--- a/tests/components/chat/use-chat-messaging.retry.test.tsx
+++ b/tests/components/chat/use-chat-messaging.retry.test.tsx
@@ -2,8 +2,9 @@ import { ArtifactRetryError } from '@/components/chat/genui/retry'
 import { useChatMessaging } from '@/components/chat/hooks/use-chat-messaging'
 import type { Chat, Message } from '@/components/chat/types'
 import type { BaseModel } from '@/config/models'
-import { act, renderHook } from '@testing-library/react'
-import { type Dispatch, type SetStateAction } from 'react'
+import { chatStorage } from '@/services/storage/chat-storage'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { type Dispatch, type SetStateAction, useState } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const abortMock = vi.fn()
@@ -227,5 +228,103 @@ describe('useChatMessaging retryLastMessage', () => {
         retryError,
       )
     })
+  })
+
+  it('persists concurrent widget repairs from the latest composed chat', async () => {
+    const chat = createChatWithUserMessage('chat-a')
+    chat.messages.push({
+      role: 'assistant',
+      content: '',
+      timestamp: new Date(),
+      turnId: 'turn-1',
+      timeline: [
+        {
+          type: 'tool_call',
+          id: 'block-1',
+          toolCallId: 'call-1',
+          name: 'render_chart',
+          arguments: '{"type":"bar"',
+        },
+        {
+          type: 'tool_call',
+          id: 'block-2',
+          toolCallId: 'call-2',
+          name: 'render_stat_cards',
+          arguments: '{"stats":',
+        },
+      ],
+      toolCalls: [
+        {
+          id: 'call-1',
+          name: 'render_chart',
+          arguments: '{"type":"bar"',
+        },
+        {
+          id: 'call-2',
+          name: 'render_stat_cards',
+          arguments: '{"stats":',
+        },
+      ],
+    })
+    regenerateToolCallArgumentsMock.mockImplementation(
+      ({ toolName }: { toolName: string }) =>
+        Promise.resolve(
+          toolName === 'render_chart'
+            ? '{"type":"bar","data":[]}'
+            : '{"stats":[]}',
+        ),
+    )
+    let releaseFirstSave: (() => void) | undefined
+    vi.mocked(chatStorage.saveChatAndSync)
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            releaseFirstSave = resolve
+          }),
+      )
+      .mockResolvedValue(undefined)
+    const model = { modelName: 'gpt-oss-120b' } as BaseModel
+
+    const { result } = renderHook(() => {
+      const [chats, setChats] = useState([chat])
+      const [currentChat, setCurrentChat] = useState(chat)
+      return useChatMessaging({
+        systemPrompt: '',
+        storeHistory: true,
+        models: [model],
+        selectedModel: model.modelName,
+        chats,
+        currentChat,
+        setChats,
+        setCurrentChat,
+      })
+    })
+
+    let firstRetry!: Promise<boolean>
+    act(() => {
+      firstRetry = result.current.retryToolCall(1, 'call-1')
+    })
+    await waitFor(() =>
+      expect(chatStorage.saveChatAndSync).toHaveBeenCalledTimes(1),
+    )
+
+    let secondRetry!: Promise<boolean>
+    act(() => {
+      secondRetry = result.current.retryToolCall(1, 'call-2')
+    })
+    releaseFirstSave?.()
+    await act(async () => {
+      await Promise.all([firstRetry, secondRetry])
+    })
+
+    await waitFor(() =>
+      expect(chatStorage.saveChatAndSync).toHaveBeenCalledTimes(2),
+    )
+    const latestSavedChat = vi.mocked(chatStorage.saveChatAndSync).mock
+      .calls[1][0]
+    expect(latestSavedChat.messages[1].toolCalls).toEqual([
+      expect.objectContaining({ arguments: '{"type":"bar","data":[]}' }),
+      expect.objectContaining({ arguments: '{"stats":[]}' }),
+    ])
   })
 })

--- a/tests/components/chat/use-chat-messaging.retry.test.tsx
+++ b/tests/components/chat/use-chat-messaging.retry.test.tsx
@@ -1,5 +1,7 @@
+import { ArtifactRetryError } from '@/components/chat/genui/retry'
 import { useChatMessaging } from '@/components/chat/hooks/use-chat-messaging'
 import type { Chat, Message } from '@/components/chat/types'
+import type { BaseModel } from '@/config/models'
 import { act, renderHook } from '@testing-library/react'
 import { type Dispatch, type SetStateAction } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -10,6 +12,19 @@ const resetStatusMock = vi.fn()
 const moveStatusMock = vi.fn()
 const registerControllerMock = vi.fn()
 const clearControllerMock = vi.fn()
+const { regenerateToolCallArgumentsMock } = vi.hoisted(() => ({
+  regenerateToolCallArgumentsMock: vi.fn(),
+}))
+
+vi.mock('@/components/chat/genui/retry', async () => {
+  const actual = await vi.importActual<
+    typeof import('@/components/chat/genui/retry')
+  >('@/components/chat/genui/retry')
+  return {
+    ...actual,
+    regenerateToolCallArguments: regenerateToolCallArgumentsMock,
+  }
+})
 
 vi.mock('@clerk/nextjs', () => ({
   useAuth: () => ({
@@ -163,6 +178,54 @@ describe('useChatMessaging retryLastMessage', () => {
       loadingState: 'loading',
       isWaitingForResponse: true,
       isStreaming: true,
+    })
+  })
+
+  it('preserves typed artifact retry failures for the renderer', async () => {
+    const chat = createChatWithUserMessage('chat-a')
+    const timestamp = new Date()
+    chat.messages.push({
+      role: 'assistant',
+      content: '',
+      timestamp,
+      timeline: [
+        {
+          type: 'tool_call',
+          id: 'block-1',
+          toolCallId: 'call-1',
+          name: 'render_chart',
+          arguments: '{"type":"bar"',
+        },
+      ],
+      toolCalls: [
+        {
+          id: 'call-1',
+          name: 'render_chart',
+          arguments: '{"type":"bar"',
+        },
+      ],
+    })
+    const retryError = new ArtifactRetryError('incomplete_replacement')
+    regenerateToolCallArgumentsMock.mockRejectedValueOnce(retryError)
+    const model = { modelName: 'gpt-oss-120b' } as BaseModel
+
+    const { result } = renderHook(() =>
+      useChatMessaging({
+        systemPrompt: '',
+        storeHistory: false,
+        models: [model],
+        selectedModel: model.modelName,
+        chats: [chat],
+        currentChat: chat,
+        setChats: noopSetChats,
+        setCurrentChat: noopSetCurrentChat,
+      }),
+    )
+
+    await act(async () => {
+      await expect(result.current.retryToolCall(1, 'call-1')).rejects.toBe(
+        retryError,
+      )
     })
   })
 })

--- a/tests/services/inference/inference-client-structured.test.ts
+++ b/tests/services/inference/inference-client-structured.test.ts
@@ -1,0 +1,135 @@
+import type { BaseModel } from '@/config/models'
+import {
+  sendStructuredCompletion,
+  StructuredCompletionError,
+} from '@/services/inference/inference-client'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { createMock } = vi.hoisted(() => ({ createMock: vi.fn() }))
+
+vi.mock('@/services/inference/tinfoil-client', () => ({
+  getTinfoilClient: vi.fn(async () => ({
+    chat: { completions: { create: createMock } },
+  })),
+  createRecoverableTinfoilClient: vi.fn(),
+  createRecoverableTinfoilTransport: vi.fn(),
+  discardRateLimitSnapshot: vi.fn(),
+  getRateLimitInfo: vi.fn(),
+  refreshRateLimit: vi.fn(),
+  resetTinfoilClient: vi.fn(),
+}))
+
+vi.mock('@/utils/error-handling', () => ({
+  logError: vi.fn(),
+  logInfo: vi.fn(),
+}))
+
+const schema = {
+  type: 'object',
+  properties: { value: { type: 'string' } },
+  required: ['value'],
+}
+
+function response(
+  content: string | null,
+  finishReason: string | null = 'stop',
+  refusal: string | null = null,
+) {
+  return {
+    choices: [
+      {
+        finish_reason: finishReason,
+        message: { content, refusal },
+      },
+    ],
+  }
+}
+
+describe('sendStructuredCompletion', () => {
+  beforeEach(() => {
+    createMock.mockReset()
+  })
+
+  it('preserves Auto candidate params and protects response_format', async () => {
+    const candidate = {
+      modelName: 'candidate-a',
+      requestParams: {
+        temperature: 0.25,
+        response_format: { type: 'text' },
+      },
+      reasoningConfig: {
+        supportsEffort: true,
+        params: {
+          '/v1/chat/completions': {
+            enable: { reasoning_effort: '$EFFORT' },
+          },
+        },
+      },
+    } as BaseModel
+    createMock.mockResolvedValueOnce(response('{"value":"ok"}'))
+
+    await sendStructuredCompletion({
+      model: candidate,
+      autoCandidates: [candidate],
+      messages: [{ role: 'user', content: 'repair' }],
+      jsonSchema: schema,
+      reasoningEffort: 'high',
+      thinkingEnabled: true,
+    })
+
+    const body = createMock.mock.calls[0][0]
+    expect(body.model).toBe('auto')
+    expect(body.auto_model_options).toEqual([
+      {
+        model: 'candidate-a',
+        params: { temperature: 0.25, reasoning_effort: 'high' },
+      },
+    ])
+    expect(body.response_format).toEqual({
+      type: 'json_schema',
+      json_schema: { name: 'response', schema },
+    })
+    expect(createMock.mock.calls[0][1]).not.toHaveProperty('maxRetries')
+  })
+
+  it.each([
+    [response('{"value":', 'length'), 'incomplete_response'],
+    [response(null, 'stop', 'cannot comply'), 'refused_response'],
+    [response('', 'stop'), 'empty_response'],
+    [response('{not-json}', 'stop'), 'invalid_json_response'],
+  ])(
+    'classifies malformed structured responses',
+    async (apiResponse: ReturnType<typeof response>, code: string) => {
+      createMock.mockResolvedValueOnce(apiResponse)
+      await expect(
+        sendStructuredCompletion({
+          model: { modelName: 'gpt-oss-120b' } as BaseModel,
+          messages: [{ role: 'user', content: 'repair' }],
+          jsonSchema: schema,
+        }),
+      ).rejects.toMatchObject({ code })
+    },
+  )
+
+  it('preserves request status and code without message matching', async () => {
+    createMock.mockRejectedValueOnce({
+      status: 503,
+      code: 'service_unavailable',
+      message: 'localized message',
+    })
+
+    await expect(
+      sendStructuredCompletion({
+        model: { modelName: 'gpt-oss-120b' } as BaseModel,
+        messages: [{ role: 'user', content: 'repair' }],
+        jsonSchema: schema,
+      }),
+    ).rejects.toEqual(
+      expect.objectContaining<Partial<StructuredCompletionError>>({
+        code: 'request_failed',
+        status: 503,
+        requestCode: 'service_unavailable',
+      }),
+    )
+  })
+})

--- a/tests/services/inference/inference-client-structured.test.ts
+++ b/tests/services/inference/inference-client-structured.test.ts
@@ -3,6 +3,7 @@ import {
   sendStructuredCompletion,
   StructuredCompletionError,
 } from '@/services/inference/inference-client'
+import { APIUserAbortError } from 'openai'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const { createMock } = vi.hoisted(() => ({ createMock: vi.fn() }))
@@ -131,5 +132,20 @@ describe('sendStructuredCompletion', () => {
         requestCode: 'service_unavailable',
       }),
     )
+  })
+
+  it.each([
+    new APIUserAbortError(),
+    new DOMException('cancelled', 'AbortError'),
+  ])('preserves abort errors without wrapping', async (abortError) => {
+    createMock.mockRejectedValueOnce(abortError)
+
+    await expect(
+      sendStructuredCompletion({
+        model: { modelName: 'gpt-oss-120b' } as BaseModel,
+        messages: [{ role: 'user', content: 'repair' }],
+        jsonSchema: schema,
+      }),
+    ).rejects.toBe(abortError)
   })
 })


### PR DESCRIPTION
## Summary
- regenerate and patch only the failed widget arguments while preserving full artifact data, Auto routing, and concurrent chat updates
- classify malformed JSON, schema failures, render exceptions, and retry failures with repeatable widget-only recovery
- remove misleading stream counters/raw payloads and add exact artifact schema guidance

## Tests
- `npx vitest run` (130 files, 1481 tests)
- `npx tsc --noEmit`
- targeted ESLint

## Related
- https://github.com/tinfoilsh/confidential-model-router/pull/457

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes failed GenUI widgets independently retryable by regenerating only the broken widget’s arguments and safely patching them in place. Adds clearer, typed retry outcomes and a simpler UI that avoids regenerating the whole response.

- New Features
  - Widget-only retry with schema validation and safe patching of the timeline block and `toolCalls` mirror, with identity checks and support for legacy timeline-only messages.
  - Expanded typed retry errors and clearer messages: `request_failed`, `schema_conversion_failed`, `incomplete_replacement`, `schema_invalid_replacement`, `stale_target`, `unavailable_target`. Render-time failures classified as `invalid_json`, `schema_invalid` (with path/code), or `render_exception`. Both “Retry widget” and “Regenerate response” buttons are shown.
  - Hardened structured completions via `StructuredCompletionError` (refused/length/empty/invalid JSON), preserves Auto candidates and reasoning options, protects `response_format`, and adapts system-role usage per model.
  - Token-aware retry context picks the smallest candidate context window, includes the full malformed arguments, and only budgets role/content. Streaming tracer shows a simple “Generating …” state (no raw payload or counters).

- Bug Fixes
  - Widget error boundary resets after arguments change; null renders are treated as retryable render exceptions.
  - Prevents stale/duplicate patches and persists repairs reliably with a queued save to handle concurrent retries.
  - Tightens `render_artifact_preview` schema with exact HTML/Markdown shapes and adds tests.

<sup>Written for commit b7fd13a1460cf6760692c3015d2e0c3109e3bbe8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/479?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

