### PR TITLE
fix: parse M-suffix context windows and guard implausible values

### DIFF
--- a/src/utils/token-estimation.ts
+++ b/src/utils/token-estimation.ts
@@ -17,14 +17,23 @@ export function estimateTokenCount(text: string | undefined): number {
   return Math.ceil(text.length / 4)
 }
 
-// Parse values like "64k tokens" → 64000
+// Any parsed window below this is treated as an unrecognized format (e.g. a
+// suffix this parser predates) rather than a real limit; zeroing the budget
+// would silently archive the whole conversation.
+const MIN_PLAUSIBLE_CONTEXT_WINDOW_TOKENS = 1000
+
+// Parse values like "64k tokens" → 64000 or "1M tokens" → 1000000
 export function parseContextWindowTokens(contextWindow?: string): number {
   if (!contextWindow) return DEFAULT_CONTEXT_WINDOW_TOKENS
-  const match = contextWindow.match(/(\d+)(k)?/i)
+  const match = contextWindow.match(/(\d+(?:\.\d+)?)\s*([km])?/i)
   if (!match) return DEFAULT_CONTEXT_WINDOW_TOKENS
-  let tokens = parseInt(match[1], 10)
-  if (match[2]) {
-    tokens *= 1000
+  let tokens = parseFloat(match[1])
+  const suffix = match[2]?.toLowerCase()
+  if (suffix === 'k') tokens *= 1_000
+  if (suffix === 'm') tokens *= 1_000_000
+  tokens = Math.round(tokens)
+  if (tokens < MIN_PLAUSIBLE_CONTEXT_WINDOW_TOKENS) {
+    return DEFAULT_CONTEXT_WINDOW_TOKENS
   }
   return tokens
 }

--- a/tests/utils/token-estimation.test.ts
+++ b/tests/utils/token-estimation.test.ts
@@ -39,9 +39,19 @@ describe('parseContextWindowTokens', () => {
     expect(parseContextWindowTokens('32000')).toBe(32000)
   })
 
+  it('parses "1M tokens" style values', () => {
+    expect(parseContextWindowTokens('1M tokens')).toBe(1000000)
+    expect(parseContextWindowTokens('1.5m tokens')).toBe(1500000)
+  })
+
   it('falls back to a default for missing or malformed values', () => {
     expect(parseContextWindowTokens(undefined)).toBe(64000)
     expect(parseContextWindowTokens('unknown')).toBe(64000)
+  })
+
+  it('falls back to a default for implausibly small windows', () => {
+    expect(parseContextWindowTokens('1 tokens')).toBe(64000)
+    expect(parseContextWindowTokens('512')).toBe(64000)
   })
 })
 


### PR DESCRIPTION
## Problem

The new `deepseek-v4-flash` catalog entry (controlplane #558) declares `"contextWindow": "1M tokens"` — the first model to use an **M** suffix. `parseContextWindowTokens` only understood the `k` suffix, so `"1M tokens"` parsed as **1 token**, and the context budget became `floor(1 × 0.9) = 0`:

- The context ring pegs at 100% on a brand-new chat before anything is sent.
- `findContextStartIndex` archives every message except the newest one, so each request silently drops all conversation history.
- **Auto · Fast is equally affected**: the synthetic tier entry takes `getSmallestContextWindow()` across members, and 1 token is the smallest — so default-mode users hit this too, not just DeepSeek V4 Flash selections.

## Fix

- Accept `k`/`M` suffixes (case-insensitive, decimals allowed): `"1M tokens"` → 1,000,000, `"1.5m tokens"` → 1,500,000. Existing `k`-style and bare-number values parse unchanged.
- Add a plausibility floor: any parse below 1k tokens is treated as an unrecognized format and falls back to the 64k default instead of zeroing the budget, so a future unknown notation degrades gracefully rather than gutting requests.

## Testing

- New unit tests for the `M` suffix and the small-window fallback; existing pins (`'32000'` → 32000, `'1k tokens'` → 1000) unchanged.
- Full suite passes: 1479 tests / 132 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix parsing for M-suffix context windows and add a safety floor to prevent zero token budgets. This stops fresh chats from showing 100% usage and dropping history, including in Auto · Fast.

- **Bug Fixes**
  - Support `k`/`M` suffixes (case-insensitive, decimals), e.g. "1M tokens" → 1,000,000.
  - Fall back to the 64k default when parsed value is <1k or malformed.

<sup>Written for commit 19d9e15baa4f6a27bc0430723279ac3ef19fc6d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/481?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

