### PR TITLE
Fix local data cleanup and project file routing

### DIFF
--- a/src/components/auth-cleanup-handler.tsx
+++ b/src/components/auth-cleanup-handler.tsx
@@ -1,5 +1,9 @@
 import { SignoutConfirmationModal } from '@/components/modals/signout-confirmation-modal'
-import { AUTH_ACTIVE_USER_ID } from '@/constants/storage-keys'
+import { ACCOUNT_RESET_FAILED_EVENT } from '@/constants/auth-events'
+import {
+  AUTH_ACCOUNT_RESET_FAILED,
+  AUTH_ACTIVE_USER_ID,
+} from '@/constants/storage-keys'
 import { logError, logInfo } from '@/utils/error-handling'
 import {
   deleteEncryptionKey,
@@ -7,6 +11,7 @@ import {
   hasPasskeyBackup,
   performSignoutCleanup,
   performUserSwitchCleanup,
+  retryFailedStorageCleanup,
 } from '@/utils/signout-cleanup'
 import {
   completeSignoutStep,
@@ -24,8 +29,13 @@ export function AuthCleanupHandler() {
   const { user } = useUser()
   const [showModal, setShowModal] = useState(false)
   const [isDarkMode, setIsDarkMode] = useState(false)
+  const [cleanupError, setCleanupError] = useState<{
+    message: string
+    retryStorage: boolean
+  } | null>(null)
   const hasCheckedRef = useRef(false)
   const pendingSignoutCleanupRef = useRef<number | null>(null)
+  const pendingUserSwitchCleanupRef = useRef<Promise<void> | null>(null)
   const latestAuthStateRef = useRef({
     isLoaded,
     isSignedIn,
@@ -39,6 +49,28 @@ export function AuthCleanupHandler() {
       userId: user?.id,
     }
   }, [isLoaded, isSignedIn, user?.id])
+
+  useEffect(() => {
+    const handleCrossTabResetFailure = () => {
+      setCleanupError({
+        message:
+          'Local data could not be cleared after another tab changed accounts.',
+        retryStorage: true,
+      })
+    }
+    if (sessionStorage.getItem(AUTH_ACCOUNT_RESET_FAILED) === 'true') {
+      handleCrossTabResetFailure()
+    }
+    window.addEventListener(
+      ACCOUNT_RESET_FAILED_EVENT,
+      handleCrossTabResetFailure,
+    )
+    return () =>
+      window.removeEventListener(
+        ACCOUNT_RESET_FAILED_EVENT,
+        handleCrossTabResetFailure,
+      )
+  }, [])
 
   const clearPendingSignoutCleanup = useCallback(() => {
     if (pendingSignoutCleanupRef.current !== null) {
@@ -59,19 +91,21 @@ export function AuthCleanupHandler() {
         component: 'AuthCleanupHandler',
         action,
       })
-      // Remove the active user ID first so that if cleanup throws before
-      // localStorage.clear(), the reload won't re-enter this branch and loop.
-      localStorage.removeItem(AUTH_ACTIVE_USER_ID)
       performSignoutCleanup()
+        .then(() => {
+          reportSignoutStep(SIGNOUT_STEPS.RELOAD)
+          window.location.reload()
+        })
         .catch((error) => {
           logError('Failed to cleanup on signout', error, {
             component: 'AuthCleanupHandler',
             action,
           })
-        })
-        .finally(() => {
-          reportSignoutStep(SIGNOUT_STEPS.RELOAD)
-          window.location.reload()
+          hideSignoutProgress()
+          setCleanupError({
+            message: 'Local data could not be cleared after signing out.',
+            retryStorage: false,
+          })
         })
       return
     }
@@ -81,18 +115,23 @@ export function AuthCleanupHandler() {
       action: 'signoutWithoutPasskey',
     })
     performSignoutCleanup({ preserveEncryptionKey: true })
-      .catch((error) => {
-        logError('Failed to cleanup on signout (preserving key)', error, {
-          component: 'AuthCleanupHandler',
-          action: 'signoutWithoutPasskey',
-        })
-      })
-      .finally(() => {
+      .then(() => {
         hideSignoutProgress()
         // Check theme from data-theme attribute (source of truth)
         const dataTheme = document.documentElement.getAttribute('data-theme')
         setIsDarkMode(dataTheme === 'dark')
         setShowModal(true)
+      })
+      .catch((error) => {
+        logError('Failed to cleanup on signout (preserving key)', error, {
+          component: 'AuthCleanupHandler',
+          action: 'signoutWithoutPasskey',
+        })
+        hideSignoutProgress()
+        setCleanupError({
+          message: 'Local data could not be cleared after signing out.',
+          retryStorage: false,
+        })
       })
   }, [])
 
@@ -105,7 +144,26 @@ export function AuthCleanupHandler() {
 
       if (storedUserId && storedUserId !== user.id) {
         // Different user signed in — clear all previous user data + reload
-        performUserSwitchCleanup(user.id)
+        if (!pendingUserSwitchCleanupRef.current && !cleanupError) {
+          const cleanup = performUserSwitchCleanup(user.id)
+          pendingUserSwitchCleanupRef.current = cleanup
+          void cleanup
+            .then(() => {
+              window.location.reload()
+            })
+            .catch(() => {
+              setCleanupError({
+                message:
+                  'Local data from the previous account could not be cleared.',
+                retryStorage: false,
+              })
+            })
+            .finally(() => {
+              if (pendingUserSwitchCleanupRef.current === cleanup) {
+                pendingUserSwitchCleanupRef.current = null
+              }
+            })
+        }
         return
       }
 
@@ -152,6 +210,7 @@ export function AuthCleanupHandler() {
     isLoaded,
     user?.id,
     clearPendingSignoutCleanup,
+    cleanupError,
     runSignoutCleanup,
   ])
 
@@ -161,6 +220,53 @@ export function AuthCleanupHandler() {
     deleteEncryptionKey()
     setShowModal(false)
     window.location.reload()
+  }
+
+  if (cleanupError) {
+    return (
+      <div
+        className="fixed inset-0 z-[110] flex items-center justify-center bg-surface-chat-background px-4"
+        role="alertdialog"
+        aria-modal="true"
+        aria-labelledby="cleanup-error-title"
+      >
+        <div className="w-full max-w-md rounded-site-lg border border-border-subtle bg-surface-card p-6 text-center shadow-xl">
+          <h2
+            id="cleanup-error-title"
+            className="text-lg font-semibold text-content-primary"
+          >
+            Unable to clear local data
+          </h2>
+          <p className="mt-3 text-sm text-content-secondary">
+            {cleanupError.message} Close any other Tinfoil tabs, then retry
+            before continuing.
+          </p>
+          <button
+            type="button"
+            onClick={() => {
+              if (!cleanupError.retryStorage) {
+                window.location.reload()
+                return
+              }
+
+              setCleanupError(null)
+              void retryFailedStorageCleanup()
+                .then(() => window.location.reload())
+                .catch(() => {
+                  setCleanupError({
+                    message:
+                      'Local data still could not be cleared after another tab changed accounts.',
+                    retryStorage: true,
+                  })
+                })
+            }}
+            className="mt-6 rounded-lg bg-brand-accent-dark px-5 py-2.5 text-sm font-medium text-white hover:bg-brand-accent-dark/90"
+          >
+            Retry cleanup
+          </button>
+        </div>
+      </div>
+    )
   }
 
   if (!showModal) {

--- a/src/components/auth-cleanup-handler.tsx
+++ b/src/components/auth-cleanup-handler.tsx
@@ -33,6 +33,7 @@ export function AuthCleanupHandler() {
     message: string
     retryStorage: boolean
   } | null>(null)
+  const [cleanupRetrying, setCleanupRetrying] = useState(false)
   const hasCheckedRef = useRef(false)
   const pendingSignoutCleanupRef = useRef<number | null>(null)
   const pendingUserSwitchCleanupRef = useRef<Promise<void> | null>(null)
@@ -137,6 +138,10 @@ export function AuthCleanupHandler() {
 
   useEffect(() => {
     if (!isLoaded) return
+    if (cleanupError) {
+      clearPendingSignoutCleanup()
+      return
+    }
 
     if (isSignedIn && user?.id) {
       clearPendingSignoutCleanup()
@@ -249,10 +254,11 @@ export function AuthCleanupHandler() {
                 return
               }
 
-              setCleanupError(null)
+              setCleanupRetrying(true)
               void retryFailedStorageCleanup()
                 .then(() => window.location.reload())
                 .catch(() => {
+                  setCleanupRetrying(false)
                   setCleanupError({
                     message:
                       'Local data still could not be cleared after another tab changed accounts.',
@@ -260,9 +266,10 @@ export function AuthCleanupHandler() {
                   })
                 })
             }}
+            disabled={cleanupRetrying}
             className="mt-6 rounded-lg bg-brand-accent-dark px-5 py-2.5 text-sm font-medium text-white hover:bg-brand-accent-dark/90"
           >
-            Retry cleanup
+            {cleanupRetrying ? 'Retrying cleanup...' : 'Retry cleanup'}
           </button>
         </div>
       </div>

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -116,7 +116,10 @@ import { CONSTANTS } from './constants'
 import { getDocumentTextContent } from './document-content'
 import { useDocumentUploader } from './document-uploader'
 import { DragProvider } from './drag-context'
-import { routeChatFileUpload } from './file-upload-routing'
+import {
+  resolveProjectUploadTarget,
+  routeChatFileUpload,
+} from './file-upload-routing'
 import { GenUIInputAreaRenderer } from './genui/GenUIInputAreaRenderer'
 import { selectPendingInputToolCallFromChat } from './genui/pending-input-tool-call'
 import {
@@ -542,7 +545,10 @@ export function ChatInterface({
 
   // State for add-to-project-context modal
   const [showAddToProjectModal, setShowAddToProjectModal] = useState(false)
-  const [pendingUploadFiles, setPendingUploadFiles] = useState<File[]>([])
+  const [pendingProjectUpload, setPendingProjectUpload] = useState<{
+    projectId: string
+    files: File[]
+  } | null>(null)
 
   // Quote state for highlighted text from messages
   const [quote, setQuote] = useState<string | null>(null)
@@ -665,10 +671,63 @@ export function ChatInterface({
     exitProjectMode,
     createProject,
     loadingProject,
+    error: projectError,
     uploadDocument: uploadProjectDocument,
     addUploadingFile,
     removeUploadingFile,
   } = useProject()
+
+  useEffect(() => {
+    if (!pendingProjectUpload) return
+
+    if (loadingProject) {
+      if (loadingProject.id === pendingProjectUpload.projectId) return
+      setPendingProjectUpload(null)
+      setShowAddToProjectModal(false)
+      toast({
+        title: 'Upload canceled',
+        description: 'The file was not attached because the project changed.',
+        variant: 'destructive',
+        position: 'top-right',
+      })
+      return
+    }
+
+    if (activeProject?.id === pendingProjectUpload.projectId) {
+      setShowAddToProjectModal(true)
+      return
+    }
+
+    if (projectError) {
+      setPendingProjectUpload(null)
+      setShowAddToProjectModal(false)
+      toast({
+        title: 'Project unavailable',
+        description:
+          'The file was not attached because the project failed to load.',
+        variant: 'destructive',
+        position: 'top-right',
+      })
+      return
+    }
+
+    if (activeProject?.id) {
+      setPendingProjectUpload(null)
+      setShowAddToProjectModal(false)
+      toast({
+        title: 'Upload canceled',
+        description: 'The file was not attached because the project changed.',
+        variant: 'destructive',
+        position: 'top-right',
+      })
+    }
+  }, [
+    activeProject?.id,
+    loadingProject,
+    pendingProjectUpload,
+    projectError,
+    toast,
+  ])
   const { effectiveSystemPrompt: finalSystemPrompt } = useProjectSystemPrompt({
     baseSystemPrompt: effectiveSystemPrompt,
     baseRules: processedRules,
@@ -1920,6 +1979,8 @@ export function ChatInterface({
 
   // Handler for exiting project mode - creates a new chat and exits
   const handleExitProject = useCallback(() => {
+    setPendingProjectUpload(null)
+    setShowAddToProjectModal(false)
     createNewChat(false, true)
     exitProjectMode()
   }, [createNewChat, exitProjectMode])
@@ -2043,6 +2104,8 @@ export function ChatInterface({
   // Handler for exiting project mode while dragging - does NOT create a new chat
   // so the drag operation can continue and drop into cloud/local tabs
   const handleExitProjectWhileDragging = useCallback(() => {
+    setPendingProjectUpload(null)
+    setShowAddToProjectModal(false)
     exitProjectMode()
   }, [exitProjectMode])
 
@@ -2396,9 +2459,24 @@ export function ChatInterface({
   // Handler for modal confirmation
   const handleAddToProjectConfirm = useCallback(
     async (addToProject: boolean) => {
+      if (
+        !pendingProjectUpload ||
+        activeProject?.id !== pendingProjectUpload.projectId
+      ) {
+        setPendingProjectUpload(null)
+        setShowAddToProjectModal(false)
+        toast({
+          title: 'Upload canceled',
+          description: 'The file was not attached because the project changed.',
+          variant: 'destructive',
+          position: 'top-right',
+        })
+        return
+      }
+
       // Capture files and close modal immediately
-      const filesToUpload = pendingUploadFiles
-      setPendingUploadFiles([])
+      const filesToUpload = pendingProjectUpload.files
+      setPendingProjectUpload(null)
       setShowAddToProjectModal(false)
 
       // Then process uploads (UI will show upload progress)
@@ -2410,23 +2488,58 @@ export function ChatInterface({
         }
       }
     },
-    [pendingUploadFiles, addFileToProjectContext, processFileForChat],
+    [
+      activeProject?.id,
+      pendingProjectUpload,
+      addFileToProjectContext,
+      processFileForChat,
+      toast,
+    ],
   )
 
   // Document upload handler wrapper
   const handleFileUpload = useCallback(
     async (file: File) => {
+      const projectTarget = resolveProjectUploadTarget({
+        activeProjectId: activeProject?.id,
+        loadingProjectId: loadingProject?.id,
+      })
+
       await routeChatFileUpload(file, {
-        isProjectMode,
-        hasActiveProject: !!activeProject,
-        requestDestination: (pendingFile) => {
-          setPendingUploadFiles((prev) => [...prev, pendingFile])
-          setShowAddToProjectModal(true)
+        projectTarget,
+        requestDestination: (pendingFile, target) => {
+          if (
+            pendingProjectUpload &&
+            pendingProjectUpload.projectId !== target.projectId
+          ) {
+            toast({
+              title: 'Previous upload canceled',
+              description: 'The project changed before the file was attached.',
+              variant: 'destructive',
+              position: 'top-right',
+            })
+          }
+          setPendingProjectUpload((previous) => ({
+            projectId: target.projectId,
+            files:
+              previous?.projectId === target.projectId
+                ? [...previous.files, pendingFile]
+                : [pendingFile],
+          }))
+          if (target.isReady) {
+            setShowAddToProjectModal(true)
+          }
         },
         processFileForChat,
       })
     },
-    [isProjectMode, activeProject, processFileForChat],
+    [
+      activeProject,
+      loadingProject,
+      pendingProjectUpload,
+      processFileForChat,
+      toast,
+    ],
   )
 
   // Global drag and drop handlers
@@ -3943,14 +4056,14 @@ export function ChatInterface({
       <AddToProjectContextModal
         isOpen={showAddToProjectModal}
         onClose={() => {
-          setPendingUploadFiles([])
+          setPendingProjectUpload(null)
           setShowAddToProjectModal(false)
         }}
         onConfirm={handleAddToProjectConfirm}
         fileName={
-          pendingUploadFiles.length === 1
-            ? pendingUploadFiles[0].name
-            : `${pendingUploadFiles.length} files`
+          pendingProjectUpload?.files.length === 1
+            ? pendingProjectUpload.files[0].name
+            : `${pendingProjectUpload?.files.length ?? 0} files`
         }
         projectName={activeProject?.name ?? ''}
         isDarkMode={isDarkMode}

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -711,16 +711,16 @@ export function ChatInterface({
       return
     }
 
-    if (activeProject?.id) {
-      setPendingProjectUpload(null)
-      setShowAddToProjectModal(false)
-      toast({
-        title: 'Upload canceled',
-        description: 'The file was not attached because the project changed.',
-        variant: 'destructive',
-        position: 'top-right',
-      })
-    }
+    setPendingProjectUpload(null)
+    setShowAddToProjectModal(false)
+    toast({
+      title: 'Upload canceled',
+      description: activeProject?.id
+        ? 'The file was not attached because the project changed.'
+        : 'The file was not attached because project mode ended.',
+      variant: 'destructive',
+      position: 'top-right',
+    })
   }, [
     activeProject?.id,
     loadingProject,

--- a/src/components/chat/file-upload-routing.ts
+++ b/src/components/chat/file-upload-routing.ts
@@ -1,21 +1,40 @@
+export interface ProjectUploadTarget {
+  projectId: string
+  isReady: boolean
+}
+
 type FileUploadRoutingOptions = {
-  isProjectMode: boolean
-  hasActiveProject: boolean
-  requestDestination: (file: File) => void
+  projectTarget: ProjectUploadTarget | null
+  requestDestination: (file: File, target: ProjectUploadTarget) => void
   processFileForChat: (file: File) => Promise<void>
+}
+
+export function resolveProjectUploadTarget({
+  activeProjectId,
+  loadingProjectId,
+}: {
+  activeProjectId?: string
+  loadingProjectId?: string
+}): ProjectUploadTarget | null {
+  if (loadingProjectId) {
+    return { projectId: loadingProjectId, isReady: false }
+  }
+  if (activeProjectId) {
+    return { projectId: activeProjectId, isReady: true }
+  }
+  return null
 }
 
 export async function routeChatFileUpload(
   file: File,
   {
-    isProjectMode,
-    hasActiveProject,
+    projectTarget,
     requestDestination,
     processFileForChat,
   }: FileUploadRoutingOptions,
 ): Promise<void> {
-  if (isProjectMode && hasActiveProject) {
-    requestDestination(file)
+  if (projectTarget) {
+    requestDestination(file, projectTarget)
     return
   }
 

--- a/src/components/project/project-provider.tsx
+++ b/src/components/project/project-provider.tsx
@@ -35,14 +35,14 @@ export function ProjectProvider({
   children,
   initialProjectId,
 }: ProjectProviderProps) {
-  const { isSignedIn, userId } = useAuth()
+  const { isSignedIn, isLoaded, userId } = useAuth()
   const [activeProject, setActiveProject] = useState<Project | null>(null)
   const [projectDocuments, setProjectDocuments] = useState<ProjectDocument[]>(
     [],
   )
-  const [loading, setLoading] = useState(false)
+  const [loading, setLoading] = useState(Boolean(initialProjectId))
   const [loadingProject, setLoadingProject] = useState<LoadingProject | null>(
-    null,
+    initialProjectId ? { id: initialProjectId, name: 'Loading...' } : null,
   )
   const [error, setError] = useState<string | null>(null)
   const [uploadingFiles, setUploadingFiles] = useState<UploadingFile[]>([])
@@ -73,13 +73,13 @@ export function ProjectProvider({
   useEffect(() => {
     if (isSignedIn && !initializingRef.current) {
       initializingRef.current = true
-    } else if (!isSignedIn) {
+    } else if (isLoaded && !isSignedIn) {
       initializingRef.current = false
       initialProjectLoadedRef.current = false
       // Clear all user-specific state on logout to prevent data leaking across sessions
       resetProjectSessionState()
     }
-  }, [isSignedIn, resetProjectSessionState])
+  }, [isLoaded, isSignedIn, resetProjectSessionState])
 
   // Memory callbacks for useMemory hook
   const memoryCallbacks = useMemo(

--- a/src/constants/auth-events.ts
+++ b/src/constants/auth-events.ts
@@ -1,0 +1,1 @@
+export const ACCOUNT_RESET_FAILED_EVENT = 'tinfoil:account-reset-failed'

--- a/src/constants/storage-keys.ts
+++ b/src/constants/storage-keys.ts
@@ -25,7 +25,6 @@ export const SECRET_CLOUD_KEY_AUTHORIZATION_PREFIX =
 // --- localStorage: Auth ----------------------------------------------------
 export const AUTH_ACTIVE_USER_ID = 'tinfoil-auth-active-user-id'
 export const AUTH_ACCOUNT_RESET_SIGNAL = 'tinfoil-auth-account-reset-signal'
-export const AUTH_ACCOUNT_RESET_FAILED = 'tinfoil-auth-account-reset-failed'
 
 // --- localStorage: App settings --------------------------------------------
 export const SETTINGS_CLOUD_SYNC_ENABLED = 'tinfoil-settings-cloud-sync-enabled'
@@ -89,6 +88,9 @@ export const SETTINGS_MANUAL_RECOVERY_DISMISSED =
 // for genuinely new warning conditions later.
 export const SETTINGS_BACKUP_WARNING_DISMISSED =
   'tinfoil-settings-backup-warning-dismissed'
+
+// --- sessionStorage: Auth ---------------------------------------------------
+export const AUTH_ACCOUNT_RESET_FAILED = 'tinfoil-auth-account-reset-failed'
 
 // --- sessionStorage: Passkey setup failure ---------------------------------
 // Tracks whether the user has dismissed the "passkey backup failed" warning

--- a/src/constants/storage-keys.ts
+++ b/src/constants/storage-keys.ts
@@ -24,6 +24,8 @@ export const SECRET_CLOUD_KEY_AUTHORIZATION_PREFIX =
 
 // --- localStorage: Auth ----------------------------------------------------
 export const AUTH_ACTIVE_USER_ID = 'tinfoil-auth-active-user-id'
+export const AUTH_ACCOUNT_RESET_SIGNAL = 'tinfoil-auth-account-reset-signal'
+export const AUTH_ACCOUNT_RESET_FAILED = 'tinfoil-auth-account-reset-failed'
 
 // --- localStorage: App settings --------------------------------------------
 export const SETTINGS_CLOUD_SYNC_ENABLED = 'tinfoil-settings-cloud-sync-enabled'

--- a/src/services/storage/indexed-db.ts
+++ b/src/services/storage/indexed-db.ts
@@ -183,8 +183,19 @@ export class IndexedDBStorage {
   private initializationPromise: Promise<void> | null = null
   private saveQueue: Promise<unknown> = Promise.resolve()
   private saveGeneration = 0
+  // Account cleanup always reloads; keep this instance fail-closed until then.
   private accountResetStarted = false
   private accountResetPromise: Promise<void> | null = null
+  private activeSaveGeneration: number | null = null
+  private readonly accountResetSignal: Promise<never>
+  private rejectAccountReads!: (reason: Error) => void
+
+  constructor() {
+    this.accountResetSignal = new Promise((_, reject) => {
+      this.rejectAccountReads = reject
+    })
+    void this.accountResetSignal.catch(() => {})
+  }
 
   async initialize(): Promise<void> {
     if (this.db) return
@@ -308,6 +319,29 @@ export class IndexedDBStorage {
     return this.db
   }
 
+  private async waitForSaveQueue(): Promise<void> {
+    if (this.accountResetStarted) {
+      throw new Error('IndexedDB read superseded by account change')
+    }
+    await this.saveQueue.catch(() => {})
+    if (this.accountResetStarted) {
+      throw new Error('IndexedDB read superseded by account change')
+    }
+  }
+
+  private protectRead<T>(read: Promise<T>): Promise<T> {
+    return Promise.race([read, this.accountResetSignal])
+  }
+
+  private assertActiveSaveGeneration(): void {
+    if (
+      this.accountResetStarted ||
+      this.activeSaveGeneration !== this.saveGeneration
+    ) {
+      throw new Error('IndexedDB write superseded by account change')
+    }
+  }
+
   /**
    * Serialize a write behind every previously queued one. The
    * returned promise is the caller's view of the operation (typed
@@ -333,11 +367,18 @@ export class IndexedDBStorage {
           action: `${action}.queueRecovery`,
         })
       })
-      .then(() => {
+      .then(async () => {
         if (saveGeneration !== this.saveGeneration) {
           throw new Error('IndexedDB write superseded by account change')
         }
-        return operation()
+        this.activeSaveGeneration = saveGeneration
+        try {
+          return await operation()
+        } finally {
+          if (this.activeSaveGeneration === saveGeneration) {
+            this.activeSaveGeneration = null
+          }
+        }
       })
     this.saveQueue = result
     return result
@@ -356,6 +397,9 @@ export class IndexedDBStorage {
     }
 
     this.accountResetStarted = true
+    this.rejectAccountReads(
+      new Error('IndexedDB read superseded by account change'),
+    )
     this.saveGeneration += 1
     this.saveQueue = Promise.resolve()
     this.initializationPromise = null
@@ -506,7 +550,9 @@ export class IndexedDBStorage {
       markContentChangesAsLocal?: boolean
     } = {},
   ): Promise<void> {
+    this.assertActiveSaveGeneration()
     const db = await this.ensureDB()
+    this.assertActiveSaveGeneration()
 
     // Don't save blank chats to IndexedDB
     if ((chat as StoredChat).isBlankChat === true) {
@@ -675,17 +721,20 @@ export class IndexedDBStorage {
   }
 
   async getChat(id: string): Promise<StoredChat | null> {
-    await this.saveQueue.catch(() => {})
-    const chat = await this.getChatInternal(id)
-    if (chat) {
-      this.updateLastAccessed(id).catch((error) =>
-        logError('Failed to update last accessed time', error, {
-          component: 'IndexedDBStorage',
-          metadata: { chatId: id },
-        }),
-      )
-    }
-    return chat
+    await this.waitForSaveQueue()
+    return this.protectRead(
+      this.getChatInternal(id).then((chat) => {
+        if (chat) {
+          this.updateLastAccessed(id).catch((error) =>
+            logError('Failed to update last accessed time', error, {
+              component: 'IndexedDBStorage',
+              metadata: { chatId: id },
+            }),
+          )
+        }
+        return chat
+      }),
+    )
   }
 
   async deleteChat(id: string): Promise<void> {
@@ -737,30 +786,31 @@ export class IndexedDBStorage {
   }
 
   async deleteAllNonLocalChats(): Promise<number> {
-    const db = await this.ensureDB()
+    return this.enqueueSave('deleteAllNonLocalChats', async () => {
+      const db = await this.ensureDB()
+      return new Promise((resolve, reject) => {
+        const transaction = db.transaction([CHATS_STORE], 'readwrite')
+        const store = transaction.objectStore(CHATS_STORE)
+        const request = store.openCursor()
+        let deletedCount = 0
 
-    return new Promise((resolve, reject) => {
-      const transaction = db.transaction([CHATS_STORE], 'readwrite')
-      const store = transaction.objectStore(CHATS_STORE)
-      const request = store.openCursor()
-      let deletedCount = 0
-
-      request.onsuccess = (event) => {
-        const cursor = (event.target as IDBRequest<IDBCursorWithValue>).result
-        if (cursor) {
-          const chat = cursor.value as StoredChat
-          if (!chat.isLocalOnly) {
-            cursor.delete()
-            deletedCount++
+        request.onsuccess = (event) => {
+          const cursor = (event.target as IDBRequest<IDBCursorWithValue>).result
+          if (cursor) {
+            const chat = cursor.value as StoredChat
+            if (!chat.isLocalOnly) {
+              cursor.delete()
+              deletedCount++
+            }
+            cursor.continue()
+          } else {
+            resolve(deletedCount)
           }
-          cursor.continue()
-        } else {
-          resolve(deletedCount)
         }
-      }
 
-      request.onerror = () =>
-        reject(new Error('Failed to delete non-local chats'))
+        request.onerror = () =>
+          reject(new Error('Failed to delete non-local chats'))
+      })
     })
   }
 
@@ -797,33 +847,37 @@ export class IndexedDBStorage {
   }
 
   async getAllChatIds(): Promise<string[]> {
-    await this.saveQueue.catch(() => {})
+    await this.waitForSaveQueue()
     const db = await this.ensureDB()
 
-    return new Promise((resolve, reject) => {
-      const transaction = db.transaction([CHATS_STORE], 'readonly')
-      const store = transaction.objectStore(CHATS_STORE)
-      const request = store.getAllKeys()
+    return this.protectRead(
+      new Promise((resolve, reject) => {
+        const transaction = db.transaction([CHATS_STORE], 'readonly')
+        const store = transaction.objectStore(CHATS_STORE)
+        const request = store.getAllKeys()
 
-      request.onsuccess = () => {
-        resolve((request.result as IDBValidKey[]).map((k) => String(k)))
-      }
-      request.onerror = () => reject(new Error('Failed to list chat IDs'))
-    })
+        request.onsuccess = () => {
+          resolve((request.result as IDBValidKey[]).map((k) => String(k)))
+        }
+        request.onerror = () => reject(new Error('Failed to list chat IDs'))
+      }),
+    )
   }
 
   async getChatCount(): Promise<number> {
-    await this.saveQueue.catch(() => {})
+    await this.waitForSaveQueue()
     const db = await this.ensureDB()
 
-    return new Promise((resolve, reject) => {
-      const transaction = db.transaction([CHATS_STORE], 'readonly')
-      const store = transaction.objectStore(CHATS_STORE)
-      const request = store.count()
+    return this.protectRead(
+      new Promise((resolve, reject) => {
+        const transaction = db.transaction([CHATS_STORE], 'readonly')
+        const store = transaction.objectStore(CHATS_STORE)
+        const request = store.count()
 
-      request.onsuccess = () => resolve(request.result)
-      request.onerror = () => reject(new Error('Failed to count chats'))
-    })
+        request.onsuccess = () => resolve(request.result)
+        request.onerror = () => reject(new Error('Failed to count chats'))
+      }),
+    )
   }
 
   async deleteAllChats(): Promise<number> {
@@ -853,181 +907,195 @@ export class IndexedDBStorage {
   // local-only rows). Cheaper than getAllChats when the caller only
   // needs the total — avoids deserializing every stored message.
   async getCloudChatCount(): Promise<number> {
-    await this.saveQueue.catch(() => {})
+    await this.waitForSaveQueue()
     const db = await this.ensureDB()
 
-    return new Promise((resolve, reject) => {
-      const transaction = db.transaction([CHATS_STORE], 'readonly')
-      const store = transaction.objectStore(CHATS_STORE)
-      const request = store.openCursor()
-      let count = 0
+    return this.protectRead(
+      new Promise((resolve, reject) => {
+        const transaction = db.transaction([CHATS_STORE], 'readonly')
+        const store = transaction.objectStore(CHATS_STORE)
+        const request = store.openCursor()
+        let count = 0
 
-      request.onsuccess = (event) => {
-        const cursor = (event.target as IDBRequest).result
-        if (cursor) {
-          const chat = cursor.value
-          if (!chat.isLocalOnly) {
-            count++
+        request.onsuccess = (event) => {
+          const cursor = (event.target as IDBRequest).result
+          if (cursor) {
+            const chat = cursor.value
+            if (!chat.isLocalOnly) {
+              count++
+            }
+            cursor.continue()
+          } else {
+            resolve(count)
           }
-          cursor.continue()
-        } else {
-          resolve(count)
         }
-      }
 
-      request.onerror = () => reject(new Error('Failed to count chats'))
-    })
+        request.onerror = () => reject(new Error('Failed to count chats'))
+      }),
+    )
   }
 
   async getProjectChatCount(projectId: string): Promise<number> {
-    await this.saveQueue.catch(() => {})
+    await this.waitForSaveQueue()
     const db = await this.ensureDB()
 
-    return new Promise((resolve, reject) => {
-      const transaction = db.transaction([CHATS_STORE], 'readonly')
-      const store = transaction.objectStore(CHATS_STORE)
-      const request = store
-        .index(CHATS_PROJECT_INDEX)
-        .openCursor(IDBKeyRange.only(projectId))
-      let count = 0
+    return this.protectRead(
+      new Promise((resolve, reject) => {
+        const transaction = db.transaction([CHATS_STORE], 'readonly')
+        const store = transaction.objectStore(CHATS_STORE)
+        const request = store
+          .index(CHATS_PROJECT_INDEX)
+          .openCursor(IDBKeyRange.only(projectId))
+        let count = 0
 
-      request.onsuccess = () => {
-        const cursor = request.result
-        if (!cursor) {
-          resolve(count)
-          return
+        request.onsuccess = () => {
+          const cursor = request.result
+          if (!cursor) {
+            resolve(count)
+            return
+          }
+          const chat = cursor.value as StoredChat
+          if (!chat.isLocalOnly) {
+            count += 1
+          }
+          cursor.continue()
         }
-        const chat = cursor.value as StoredChat
-        if (!chat.isLocalOnly) {
-          count += 1
-        }
-        cursor.continue()
-      }
-      request.onerror = () =>
-        reject(new Error('Failed to count cached project chats'))
-    })
+        request.onerror = () =>
+          reject(new Error('Failed to count cached project chats'))
+      }),
+    )
   }
 
   async hasPendingChatRecoveries(): Promise<boolean> {
-    await this.saveQueue.catch(() => {})
+    await this.waitForSaveQueue()
     const db = await this.ensureDB()
 
-    return new Promise((resolve, reject) => {
-      const transaction = db.transaction([CHATS_STORE], 'readonly')
-      const store = transaction.objectStore(CHATS_STORE)
-      const request = store.openCursor()
+    return this.protectRead(
+      new Promise((resolve, reject) => {
+        const transaction = db.transaction([CHATS_STORE], 'readonly')
+        const store = transaction.objectStore(CHATS_STORE)
+        const request = store.openCursor()
 
-      request.onsuccess = (event) => {
-        const cursor = (event.target as IDBRequest<IDBCursorWithValue | null>)
-          .result
-        if (!cursor) {
-          resolve(false)
-          return
+        request.onsuccess = (event) => {
+          const cursor = (event.target as IDBRequest<IDBCursorWithValue | null>)
+            .result
+          if (!cursor) {
+            resolve(false)
+            return
+          }
+          const chat = cursor.value as StoredChat
+          if ((chat.pendingRecoveries?.length ?? 0) > 0) {
+            resolve(true)
+            return
+          }
+          cursor.continue()
         }
-        const chat = cursor.value as StoredChat
-        if ((chat.pendingRecoveries?.length ?? 0) > 0) {
-          resolve(true)
-          return
-        }
-        cursor.continue()
-      }
 
-      request.onerror = () =>
-        reject(new Error('Failed to inspect pending chat recoveries'))
-    })
+        request.onerror = () =>
+          reject(new Error('Failed to inspect pending chat recoveries'))
+      }),
+    )
   }
 
   async isChatHistoryAuthoritative(
     expectedCloudVersions: ReadonlyMap<string, number>,
   ): Promise<boolean> {
-    await this.saveQueue.catch(() => {})
+    await this.waitForSaveQueue()
     const db = await this.ensureDB()
 
-    return new Promise((resolve, reject) => {
-      const transaction = db.transaction([CHATS_STORE], 'readonly')
-      const store = transaction.objectStore(CHATS_STORE)
-      const request = store.openCursor()
-      const missingCloudVersions = new Map(expectedCloudVersions)
+    return this.protectRead(
+      new Promise((resolve, reject) => {
+        const transaction = db.transaction([CHATS_STORE], 'readonly')
+        const store = transaction.objectStore(CHATS_STORE)
+        const request = store.openCursor()
+        const missingCloudVersions = new Map(expectedCloudVersions)
 
-      request.onsuccess = (event) => {
-        const cursor = (event.target as IDBRequest<IDBCursorWithValue | null>)
-          .result
-        if (!cursor) {
-          resolve(missingCloudVersions.size === 0)
-          return
-        }
-        const chat = cursor.value as StoredChat
-        if (!chat.isLocalOnly) {
-          const expectedVersion = missingCloudVersions.get(chat.id)
-          if (
-            chat.locallyModified ||
-            chat.decryptionFailed ||
-            expectedVersion === undefined ||
-            chat.syncVersion !== expectedVersion
-          ) {
-            resolve(false)
+        request.onsuccess = (event) => {
+          const cursor = (event.target as IDBRequest<IDBCursorWithValue | null>)
+            .result
+          if (!cursor) {
+            resolve(missingCloudVersions.size === 0)
             return
           }
-          missingCloudVersions.delete(chat.id)
+          const chat = cursor.value as StoredChat
+          if (!chat.isLocalOnly) {
+            const expectedVersion = missingCloudVersions.get(chat.id)
+            if (
+              chat.locallyModified ||
+              chat.decryptionFailed ||
+              expectedVersion === undefined ||
+              chat.syncVersion !== expectedVersion
+            ) {
+              resolve(false)
+              return
+            }
+            missingCloudVersions.delete(chat.id)
+          }
+          cursor.continue()
         }
-        cursor.continue()
-      }
 
-      request.onerror = () =>
-        reject(new Error('Failed to verify local chat history'))
-    })
+        request.onerror = () =>
+          reject(new Error('Failed to verify local chat history'))
+      }),
+    )
   }
 
   async getAllChats(): Promise<StoredChat[]> {
-    await this.saveQueue.catch(() => {})
+    await this.waitForSaveQueue()
     const db = await this.ensureDB()
 
-    return new Promise((resolve, reject) => {
-      const transaction = db.transaction([CHATS_STORE], 'readonly')
-      const store = transaction.objectStore(CHATS_STORE)
-      // Sort by ID (primary key) which contains reverse timestamp
-      const request = store.openCursor(null, 'next') // Ascending order on reverse timestamp = most recent first
+    return this.protectRead(
+      new Promise((resolve, reject) => {
+        const transaction = db.transaction([CHATS_STORE], 'readonly')
+        const store = transaction.objectStore(CHATS_STORE)
+        // Sort by ID (primary key) which contains reverse timestamp
+        const request = store.openCursor(null, 'next') // Ascending order on reverse timestamp = most recent first
 
-      const chats: StoredChat[] = []
+        const chats: StoredChat[] = []
 
-      request.onsuccess = (event) => {
-        const cursor = (event.target as IDBRequest).result
-        if (cursor) {
-          try {
-            chats.push(deserializeStoredChat(cursor.value as StoredChat))
-            cursor.continue()
-          } catch (error) {
-            reject(error)
+        request.onsuccess = (event) => {
+          const cursor = (event.target as IDBRequest).result
+          if (cursor) {
+            try {
+              chats.push(deserializeStoredChat(cursor.value as StoredChat))
+              cursor.continue()
+            } catch (error) {
+              reject(error)
+            }
+          } else {
+            resolve(chats)
           }
-        } else {
-          resolve(chats)
         }
-      }
 
-      request.onerror = () => reject(new Error('Failed to get all chats'))
-    })
+        request.onerror = () => reject(new Error('Failed to get all chats'))
+      }),
+    )
   }
 
   async getProjectsForUser(userId: string): Promise<Project[]> {
-    await this.saveQueue.catch(() => {})
+    await this.waitForSaveQueue()
     const db = await this.ensureDB()
 
-    return new Promise((resolve, reject) => {
-      const transaction = db.transaction([PROJECTS_STORE], 'readonly')
-      const store = transaction.objectStore(PROJECTS_STORE)
-      const request = store.index(PROJECTS_USER_INDEX).getAll(userId)
+    return this.protectRead(
+      new Promise((resolve, reject) => {
+        const transaction = db.transaction([PROJECTS_STORE], 'readonly')
+        const store = transaction.objectStore(PROJECTS_STORE)
+        const request = store.index(PROJECTS_USER_INDEX).getAll(userId)
 
-      request.onsuccess = () => {
-        const projects = (request.result as StoredProject[])
-          .map((record) => record.project)
-          .sort(
-            (a, b) =>
-              new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
-          )
-        resolve(projects)
-      }
-      request.onerror = () => reject(new Error('Failed to get cached projects'))
-    })
+        request.onsuccess = () => {
+          const projects = (request.result as StoredProject[])
+            .map((record) => record.project)
+            .sort(
+              (a, b) =>
+                new Date(b.updatedAt).getTime() -
+                new Date(a.updatedAt).getTime(),
+            )
+          resolve(projects)
+        }
+        request.onerror = () =>
+          reject(new Error('Failed to get cached projects'))
+      }),
+    )
   }
 
   async replaceProjectsForUser(

--- a/src/services/storage/indexed-db.ts
+++ b/src/services/storage/indexed-db.ts
@@ -1,4 +1,9 @@
 import type { Chat as ChatType } from '@/components/chat/types'
+import { ACCOUNT_RESET_FAILED_EVENT } from '@/constants/auth-events'
+import {
+  AUTH_ACCOUNT_RESET_FAILED,
+  AUTH_ACCOUNT_RESET_SIGNAL,
+} from '@/constants/storage-keys'
 import { nextClock } from '@/services/cloud/edit-clock'
 import type { Project } from '@/types/project'
 import { logError, logWarning } from '@/utils/error-handling'
@@ -57,6 +62,7 @@ const CHATS_STORE = 'chats'
 const CHATS_PROJECT_INDEX = 'projectId'
 const PROJECTS_STORE = 'projects'
 const PROJECTS_USER_INDEX = 'userId'
+const ACCOUNT_CHANGE_RESET_TIMEOUT_MS = 10_000
 let isUpgradeBlocked = false
 
 export function isIndexedDBUpgradeBlocked(): boolean {
@@ -71,6 +77,20 @@ function hashString(input: string): string {
   }
   // Unsigned hex string
   return (hash >>> 0).toString(16)
+}
+
+function deserializeStoredChat(chat: StoredChat): StoredChat {
+  if (!Array.isArray(chat.messages)) {
+    throw new Error('Stored chat has invalid messages')
+  }
+
+  return {
+    ...chat,
+    messages: chat.messages.map((message) => ({
+      ...message,
+      timestamp: message.timestamp ? new Date(message.timestamp) : new Date(),
+    })),
+  } as StoredChat
 }
 
 /**
@@ -162,6 +182,9 @@ export class IndexedDBStorage {
   private db: IDBDatabase | null = null
   private initializationPromise: Promise<void> | null = null
   private saveQueue: Promise<unknown> = Promise.resolve()
+  private saveGeneration = 0
+  private accountResetStarted = false
+  private accountResetPromise: Promise<void> | null = null
 
   async initialize(): Promise<void> {
     if (this.db) return
@@ -172,7 +195,8 @@ export class IndexedDBStorage {
       throw new Error('IndexedDB not available')
     }
 
-    this.initializationPromise = new Promise((resolve, reject) => {
+    const saveGeneration = this.saveGeneration
+    const initializationPromise = new Promise<void>((resolve, reject) => {
       const request = indexedDB.open(DB_NAME, DB_VERSION)
       let abandoned = false
 
@@ -194,11 +218,21 @@ export class IndexedDBStorage {
           return
         }
         isUpgradeBlocked = false
-        this.db = request.result
-        this.db.onversionchange = () => {
-          this.db?.close()
-          this.db = null
+        const db = request.result
+        db.onversionchange = () => {
+          db.close()
+          if (this.db === db) {
+            this.db = null
+          }
         }
+
+        if (saveGeneration !== this.saveGeneration) {
+          db.close()
+          reject(new Error('Database open superseded by account change'))
+          return
+        }
+
+        this.db = db
         resolve()
       }
 
@@ -253,10 +287,14 @@ export class IndexedDBStorage {
       }
     })
 
+    this.initializationPromise = initializationPromise
+
     try {
-      await this.initializationPromise
+      await initializationPromise
     } finally {
-      this.initializationPromise = null
+      if (this.initializationPromise === initializationPromise) {
+        this.initializationPromise = null
+      }
     }
   }
 
@@ -281,6 +319,13 @@ export class IndexedDBStorage {
     action: string,
     operation: () => Promise<T>,
   ): Promise<T> {
+    if (this.accountResetStarted) {
+      return Promise.reject(
+        new Error('IndexedDB write superseded by account change'),
+      )
+    }
+
+    const saveGeneration = this.saveGeneration
     const result = this.saveQueue
       .catch((error) => {
         logError('Previous save operation failed, recovering queue', error, {
@@ -288,9 +333,98 @@ export class IndexedDBStorage {
           action: `${action}.queueRecovery`,
         })
       })
-      .then(operation)
+      .then(() => {
+        if (saveGeneration !== this.saveGeneration) {
+          throw new Error('IndexedDB write superseded by account change')
+        }
+        return operation()
+      })
     this.saveQueue = result
     return result
+  }
+
+  async resetForAccountChange(notifyOtherTabs = true): Promise<void> {
+    if (this.accountResetPromise) return this.accountResetPromise
+
+    if (notifyOtherTabs && typeof window !== 'undefined') {
+      try {
+        localStorage.setItem(AUTH_ACCOUNT_RESET_SIGNAL, crypto.randomUUID())
+        localStorage.removeItem(AUTH_ACCOUNT_RESET_SIGNAL)
+      } catch {
+        // best-effort — this tab still clears and blocks its own storage
+      }
+    }
+
+    this.accountResetStarted = true
+    this.saveGeneration += 1
+    this.saveQueue = Promise.resolve()
+    this.initializationPromise = null
+
+    const db = this.db
+    this.db = null
+    db?.close()
+
+    const reset = this.ensureDB().then(
+      (resetDb) =>
+        new Promise<void>((resolve, reject) => {
+          const transaction = resetDb.transaction(
+            [CHATS_STORE, PROJECTS_STORE],
+            'readwrite',
+          )
+          const timeout = window.setTimeout(() => {
+            try {
+              transaction.abort()
+            } finally {
+              reject(
+                new Error('Timed out resetting IndexedDB for account change'),
+              )
+            }
+          }, ACCOUNT_CHANGE_RESET_TIMEOUT_MS)
+
+          transaction.oncomplete = () => {
+            clearTimeout(timeout)
+            resolve()
+          }
+          transaction.onerror = () => {
+            clearTimeout(timeout)
+            reject(new Error('Failed to reset IndexedDB for account change'))
+          }
+          transaction.onabort = () => {
+            clearTimeout(timeout)
+            reject(new Error('IndexedDB account reset was aborted'))
+          }
+
+          const chatsRequest = transaction.objectStore(CHATS_STORE).clear()
+          chatsRequest.onerror = () => {
+            clearTimeout(timeout)
+            reject(new Error('Failed to clear chats for account change'))
+          }
+          const projectsRequest = transaction
+            .objectStore(PROJECTS_STORE)
+            .clear()
+          projectsRequest.onerror = () => {
+            clearTimeout(timeout)
+            reject(new Error('Failed to clear projects for account change'))
+          }
+        }),
+    )
+
+    const trackedReset = reset
+    this.accountResetPromise = trackedReset
+    this.saveQueue = trackedReset
+    void trackedReset.then(
+      () => {
+        if (this.accountResetPromise === trackedReset) {
+          this.accountResetPromise = null
+        }
+      },
+      () => {
+        if (this.accountResetPromise === trackedReset) {
+          this.accountResetPromise = null
+        }
+      },
+    )
+    return trackedReset
   }
 
   async saveChat(chat: Chat): Promise<void> {
@@ -529,15 +663,12 @@ export class IndexedDBStorage {
       const request = store.get(id)
 
       request.onsuccess = () => {
-        const chat = request.result
-        if (chat) {
-          // Convert string timestamps back to Date objects
-          chat.messages = chat.messages.map((msg: any) => ({
-            ...msg,
-            timestamp: msg.timestamp ? new Date(msg.timestamp) : new Date(),
-          }))
+        try {
+          const chat = request.result as StoredChat | undefined
+          resolve(chat ? deserializeStoredChat(chat) : null)
+        } catch (error) {
+          reject(error)
         }
-        resolve(chat || null)
       }
       request.onerror = () => reject(new Error('Failed to get chat'))
     })
@@ -862,14 +993,12 @@ export class IndexedDBStorage {
       request.onsuccess = (event) => {
         const cursor = (event.target as IDBRequest).result
         if (cursor) {
-          const chat = cursor.value
-          // Convert string timestamps back to Date objects
-          chat.messages = chat.messages.map((msg: any) => ({
-            ...msg,
-            timestamp: msg.timestamp ? new Date(msg.timestamp) : new Date(),
-          }))
-          chats.push(chat)
-          cursor.continue()
+          try {
+            chats.push(deserializeStoredChat(cursor.value as StoredChat))
+            cursor.continue()
+          } catch (error) {
+            reject(error)
+          }
         } else {
           resolve(chats)
         }
@@ -1358,3 +1487,34 @@ export class IndexedDBStorage {
 }
 
 export const indexedDBStorage = new IndexedDBStorage()
+
+export function handleIndexedDBAccountResetStorageEvent(
+  storage: IndexedDBStorage,
+  event: StorageEvent,
+): void {
+  if (event.key !== AUTH_ACCOUNT_RESET_SIGNAL || !event.newValue) return
+  void storage
+    .resetForAccountChange(false)
+    .then(() => {
+      sessionStorage.removeItem(AUTH_ACCOUNT_RESET_FAILED)
+      window.location.reload()
+    })
+    .catch((error) => {
+      logError(
+        'Failed to reset IndexedDB after cross-tab account change',
+        error,
+        {
+          component: 'IndexedDBStorage',
+          action: 'crossTabAccountReset',
+        },
+      )
+      sessionStorage.setItem(AUTH_ACCOUNT_RESET_FAILED, 'true')
+      window.dispatchEvent(new CustomEvent(ACCOUNT_RESET_FAILED_EVENT))
+    })
+}
+
+if (typeof window !== 'undefined') {
+  window.addEventListener('storage', (event) => {
+    handleIndexedDBAccountResetStorageEvent(indexedDBStorage, event)
+  })
+}

--- a/src/services/storage/indexed-db.ts
+++ b/src/services/storage/indexed-db.ts
@@ -63,6 +63,9 @@ const CHATS_PROJECT_INDEX = 'projectId'
 const PROJECTS_STORE = 'projects'
 const PROJECTS_USER_INDEX = 'userId'
 const ACCOUNT_CHANGE_RESET_TIMEOUT_MS = 10_000
+const ACCOUNT_CHANGE_READ_ERROR = 'IndexedDB read superseded by account change'
+const ACCOUNT_CHANGE_WRITE_ERROR =
+  'IndexedDB write superseded by account change'
 let isUpgradeBlocked = false
 
 export function isIndexedDBUpgradeBlocked(): boolean {
@@ -321,11 +324,14 @@ export class IndexedDBStorage {
 
   private async waitForSaveQueue(): Promise<void> {
     if (this.accountResetStarted) {
-      throw new Error('IndexedDB read superseded by account change')
+      throw new Error(ACCOUNT_CHANGE_READ_ERROR)
     }
-    await this.saveQueue.catch(() => {})
+    await Promise.race([
+      this.saveQueue.catch(() => {}),
+      this.accountResetSignal,
+    ])
     if (this.accountResetStarted) {
-      throw new Error('IndexedDB read superseded by account change')
+      throw new Error(ACCOUNT_CHANGE_READ_ERROR)
     }
   }
 
@@ -338,7 +344,7 @@ export class IndexedDBStorage {
       this.accountResetStarted ||
       this.activeSaveGeneration !== this.saveGeneration
     ) {
-      throw new Error('IndexedDB write superseded by account change')
+      throw new Error(ACCOUNT_CHANGE_WRITE_ERROR)
     }
   }
 
@@ -354,9 +360,7 @@ export class IndexedDBStorage {
     operation: () => Promise<T>,
   ): Promise<T> {
     if (this.accountResetStarted) {
-      return Promise.reject(
-        new Error('IndexedDB write superseded by account change'),
-      )
+      return Promise.reject(new Error(ACCOUNT_CHANGE_WRITE_ERROR))
     }
 
     const saveGeneration = this.saveGeneration
@@ -369,7 +373,7 @@ export class IndexedDBStorage {
       })
       .then(async () => {
         if (saveGeneration !== this.saveGeneration) {
-          throw new Error('IndexedDB write superseded by account change')
+          throw new Error(ACCOUNT_CHANGE_WRITE_ERROR)
         }
         this.activeSaveGeneration = saveGeneration
         try {
@@ -397,9 +401,7 @@ export class IndexedDBStorage {
     }
 
     this.accountResetStarted = true
-    this.rejectAccountReads(
-      new Error('IndexedDB read superseded by account change'),
-    )
+    this.rejectAccountReads(new Error(ACCOUNT_CHANGE_READ_ERROR))
     this.saveGeneration += 1
     this.saveQueue = Promise.resolve()
     this.initializationPromise = null

--- a/src/utils/signout-cleanup.ts
+++ b/src/utils/signout-cleanup.ts
@@ -240,6 +240,6 @@ export function hasPasskeyBackup(): boolean {
 }
 
 export async function retryFailedStorageCleanup(): Promise<void> {
-  await indexedDBStorage.resetForAccountChange(false)
+  await indexedDBStorage.resetForAccountChange(/* notifyOtherTabs */ false)
   sessionStorage.removeItem(AUTH_ACCOUNT_RESET_FAILED)
 }

--- a/src/utils/signout-cleanup.ts
+++ b/src/utils/signout-cleanup.ts
@@ -1,5 +1,6 @@
 import { resetRendererRegistry } from '@/components/chat/renderers'
 import {
+  AUTH_ACCOUNT_RESET_FAILED,
   AUTH_ACTIVE_USER_ID,
   SECRET_PASSKEY_BACKED_UP,
   SETTINGS_HAS_SEEN_ONBOARDING,
@@ -102,19 +103,18 @@ async function clearAllUserData(options: ClearUserDataOptions): Promise<void> {
   // Clear localStorage, preserving only non-user-specific keys
   reportStep(SIGNOUT_STEPS.CLEAR_STORAGE)
   try {
-    const encryptionKey = preserveEncryptionKey
-      ? localStorage.getItem(USER_ENCRYPTION_KEY)
-      : null
-    const hasSeenOnboarding = localStorage.getItem(SETTINGS_HAS_SEEN_ONBOARDING)
-    localStorage.clear()
-    if (hasSeenOnboarding !== null) {
-      localStorage.setItem(SETTINGS_HAS_SEEN_ONBOARDING, hasSeenOnboarding)
-    }
-    if (preserveUserId) {
-      localStorage.setItem(AUTH_ACTIVE_USER_ID, preserveUserId)
-    }
-    if (encryptionKey) {
-      localStorage.setItem(USER_ENCRYPTION_KEY, encryptionKey)
+    const preservedKeys = new Set([
+      AUTH_ACTIVE_USER_ID,
+      SETTINGS_HAS_SEEN_ONBOARDING,
+      ...(preserveEncryptionKey ? [USER_ENCRYPTION_KEY] : []),
+    ])
+    const keys = Array.from({ length: localStorage.length }, (_, index) =>
+      localStorage.key(index),
+    )
+    for (const key of keys) {
+      if (key && !preservedKeys.has(key)) {
+        localStorage.removeItem(key)
+      }
     }
   } catch {
     // best-effort — don't let localStorage failures skip remaining cleanup
@@ -130,17 +130,15 @@ async function clearAllUserData(options: ClearUserDataOptions): Promise<void> {
 
   // Clear IndexedDB
   reportStep(SIGNOUT_STEPS.CLEAR_BROWSING_DATA)
-  const indexedDBCleanupResults = await Promise.allSettled([
-    indexedDBStorage.deleteAllChats(),
-    projectCache.clear(),
-  ])
-  for (const result of indexedDBCleanupResults) {
-    if (result.status === 'rejected') {
-      logError('Failed to clear IndexedDB', result.reason, {
-        component: context,
-        action: 'clearAllUserData',
-      })
-    }
+  projectCache.invalidate()
+  try {
+    await indexedDBStorage.resetForAccountChange()
+  } catch (error) {
+    logError('Failed to clear IndexedDB', error, {
+      component: context,
+      action: 'clearAllUserData',
+    })
+    throw error
   }
 
   // Clear service worker caches
@@ -153,6 +151,12 @@ async function clearAllUserData(options: ClearUserDataOptions): Promise<void> {
     }
   }
   completeStep(SIGNOUT_STEPS.CLEAR_BROWSING_DATA)
+
+  if (preserveUserId) {
+    localStorage.setItem(AUTH_ACTIVE_USER_ID, preserveUserId)
+  } else {
+    localStorage.removeItem(AUTH_ACTIVE_USER_ID)
+  }
 }
 
 export async function performSignoutCleanup(opts?: {
@@ -201,27 +205,28 @@ export function deleteEncryptionKey(): void {
   encryptionService.clearKey({ persist: true })
 }
 
-export function performUserSwitchCleanup(newUserId: string): void {
+export async function performUserSwitchCleanup(
+  newUserId: string,
+): Promise<void> {
   logInfo('User switch detected, clearing all data', {
     component: 'AuthCleanupHandler',
     action: 'performUserSwitchCleanup',
     metadata: { newUserId },
   })
 
-  clearAllUserData({
-    context: 'AuthCleanupHandler',
-    preserveUserId: newUserId,
-    skipProgressReporting: true,
-  })
-    .catch((error) => {
-      logError('Failed to clear user data during switch', error, {
-        component: 'AuthCleanupHandler',
-        action: 'performUserSwitchCleanup',
-      })
+  try {
+    await clearAllUserData({
+      context: 'AuthCleanupHandler',
+      preserveUserId: newUserId,
+      skipProgressReporting: true,
     })
-    .finally(() => {
-      window.location.reload()
+  } catch (error) {
+    logError('Failed to clear user data during switch', error, {
+      component: 'AuthCleanupHandler',
+      action: 'performUserSwitchCleanup',
     })
+    throw error
+  }
 }
 
 export function getEncryptionKey(): string | null {
@@ -232,4 +237,9 @@ export function getEncryptionKey(): string | null {
 export function hasPasskeyBackup(): boolean {
   if (typeof window === 'undefined') return false
   return localStorage.getItem(SECRET_PASSKEY_BACKED_UP) === 'true'
+}
+
+export async function retryFailedStorageCleanup(): Promise<void> {
+  await indexedDBStorage.resetForAccountChange(false)
+  sessionStorage.removeItem(AUTH_ACCOUNT_RESET_FAILED)
 }

--- a/src/utils/storage-migration.ts
+++ b/src/utils/storage-migration.ts
@@ -4,6 +4,10 @@
 // ---------------------------------------------------------------------------
 
 const MIGRATION_FLAG = 'tinfoil-storage-migrated'
+const RETIRED_LOCAL_STORAGE_KEYS = [
+  'projectUploadPreference',
+  'tinfoil-user-prefs-project-upload',
+]
 
 const LOCAL_STORAGE_KEY_MAP: Record<string, string> = {
   // Sensitive
@@ -110,6 +114,10 @@ export function migrateStorageKeys(): void {
   if (typeof window === 'undefined') return
 
   try {
+    for (const key of RETIRED_LOCAL_STORAGE_KEYS) {
+      localStorage.removeItem(key)
+    }
+
     if (localStorage.getItem(MIGRATION_FLAG) === 'true') return
 
     migrateStorage(localStorage, LOCAL_STORAGE_KEY_MAP)

--- a/tests/components/auth-cleanup-handler.test.tsx
+++ b/tests/components/auth-cleanup-handler.test.tsx
@@ -1,6 +1,10 @@
 import { AuthCleanupHandler } from '@/components/auth-cleanup-handler'
-import { AUTH_ACTIVE_USER_ID } from '@/constants/storage-keys'
-import { act, render } from '@testing-library/react'
+import { ACCOUNT_RESET_FAILED_EVENT } from '@/constants/auth-events'
+import {
+  AUTH_ACCOUNT_RESET_FAILED,
+  AUTH_ACTIVE_USER_ID,
+} from '@/constants/storage-keys'
+import { act, fireEvent, render, screen } from '@testing-library/react'
 import { createElement } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -8,6 +12,7 @@ const mockPerformSignoutCleanup = vi.fn()
 const mockPerformUserSwitchCleanup = vi.fn()
 const mockGetEncryptionKey = vi.fn()
 const mockHasPasskeyBackup = vi.fn()
+const mockRetryFailedStorageCleanup = vi.fn()
 
 let authState: { isSignedIn: boolean; isLoaded: boolean } = {
   isSignedIn: false,
@@ -38,6 +43,8 @@ vi.mock('@/utils/signout-cleanup', () => ({
   performSignoutCleanup: (...args: any[]) => mockPerformSignoutCleanup(...args),
   performUserSwitchCleanup: (...args: any[]) =>
     mockPerformUserSwitchCleanup(...args),
+  retryFailedStorageCleanup: (...args: any[]) =>
+    mockRetryFailedStorageCleanup(...args),
 }))
 
 describe('AuthCleanupHandler', () => {
@@ -45,6 +52,7 @@ describe('AuthCleanupHandler', () => {
     vi.clearAllMocks()
     vi.useFakeTimers()
     localStorage.clear()
+    sessionStorage.clear()
 
     authState = {
       isSignedIn: false,
@@ -55,7 +63,8 @@ describe('AuthCleanupHandler', () => {
     }
 
     mockPerformSignoutCleanup.mockResolvedValue(undefined)
-    mockPerformUserSwitchCleanup.mockImplementation(() => {})
+    mockPerformUserSwitchCleanup.mockResolvedValue(undefined)
+    mockRetryFailedStorageCleanup.mockResolvedValue(undefined)
     mockGetEncryptionKey.mockReturnValue(null)
     mockHasPasskeyBackup.mockReturnValue(true)
     vi.spyOn(window.location, 'reload').mockImplementation(() => {})
@@ -109,6 +118,38 @@ describe('AuthCleanupHandler', () => {
     expect(window.location.reload).toHaveBeenCalledTimes(1)
   })
 
+  it('keeps cleanup retryable while browser data is still being cleared', async () => {
+    localStorage.setItem(AUTH_ACTIVE_USER_ID, 'user_123')
+    mockPerformSignoutCleanup.mockReturnValueOnce(new Promise(() => {}))
+
+    render(createElement(AuthCleanupHandler))
+
+    await act(async () => {
+      vi.advanceTimersByTime(2000)
+      await Promise.resolve()
+    })
+
+    expect(mockPerformSignoutCleanup).toHaveBeenCalledTimes(1)
+    expect(localStorage.getItem(AUTH_ACTIVE_USER_ID)).toBe('user_123')
+    expect(window.location.reload).not.toHaveBeenCalled()
+  })
+
+  it('does not reload-loop when browser data cleanup fails', async () => {
+    localStorage.setItem(AUTH_ACTIVE_USER_ID, 'user_123')
+    mockPerformSignoutCleanup.mockRejectedValueOnce(new Error('reset failed'))
+
+    render(createElement(AuthCleanupHandler))
+
+    await act(async () => {
+      vi.advanceTimersByTime(2000)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(localStorage.getItem(AUTH_ACTIVE_USER_ID)).toBe('user_123')
+    expect(window.location.reload).not.toHaveBeenCalled()
+  })
+
   it('still clears data immediately on user switch', () => {
     localStorage.setItem(AUTH_ACTIVE_USER_ID, 'user_old')
     authState = {
@@ -123,5 +164,65 @@ describe('AuthCleanupHandler', () => {
 
     expect(mockPerformUserSwitchCleanup).toHaveBeenCalledWith('user_new')
     expect(mockPerformSignoutCleanup).not.toHaveBeenCalled()
+  })
+
+  it('blocks the new account without reload-looping when cleanup fails', async () => {
+    localStorage.setItem(AUTH_ACTIVE_USER_ID, 'user_old')
+    mockPerformUserSwitchCleanup.mockRejectedValueOnce(
+      new Error('reset failed'),
+    )
+    authState = {
+      isSignedIn: true,
+      isLoaded: true,
+    }
+    userState = {
+      user: { id: 'user_new' },
+    }
+
+    render(createElement(AuthCleanupHandler))
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(
+      screen.getByRole('alertdialog', {
+        name: 'Unable to clear local data',
+      }),
+    ).toBeTruthy()
+    expect(mockPerformUserSwitchCleanup).toHaveBeenCalledTimes(1)
+    expect(window.location.reload).not.toHaveBeenCalled()
+    expect(localStorage.getItem(AUTH_ACTIVE_USER_ID)).toBe('user_old')
+  })
+
+  it('retries a failed reset signaled by another tab', async () => {
+    render(createElement(AuthCleanupHandler))
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent(ACCOUNT_RESET_FAILED_EVENT))
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Retry cleanup' }))
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(mockRetryFailedStorageCleanup).toHaveBeenCalledTimes(1)
+    expect(window.location.reload).toHaveBeenCalledTimes(1)
+  })
+
+  it('restores a cross-tab reset failure reported before mount', async () => {
+    sessionStorage.setItem(AUTH_ACCOUNT_RESET_FAILED, 'true')
+
+    render(createElement(AuthCleanupHandler))
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(
+      screen.getByRole('alertdialog', {
+        name: 'Unable to clear local data',
+      }),
+    ).toBeTruthy()
   })
 })

--- a/tests/components/auth-cleanup-handler.test.tsx
+++ b/tests/components/auth-cleanup-handler.test.tsx
@@ -196,19 +196,55 @@ describe('AuthCleanupHandler', () => {
   })
 
   it('retries a failed reset signaled by another tab', async () => {
+    let finishRetry!: () => void
+    mockRetryFailedStorageCleanup.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        finishRetry = resolve
+      }),
+    )
     render(createElement(AuthCleanupHandler))
 
     act(() => {
       window.dispatchEvent(new CustomEvent(ACCOUNT_RESET_FAILED_EVENT))
     })
     fireEvent.click(screen.getByRole('button', { name: 'Retry cleanup' }))
+
+    expect(
+      screen.getByRole('alertdialog', {
+        name: 'Unable to clear local data',
+      }),
+    ).toBeTruthy()
+    expect(
+      screen.getByRole('button', { name: 'Retrying cleanup...' }),
+    ).toBeTruthy()
+    expect(window.location.reload).not.toHaveBeenCalled()
+
     await act(async () => {
+      finishRetry()
       await Promise.resolve()
       await Promise.resolve()
     })
 
     expect(mockRetryFailedStorageCleanup).toHaveBeenCalledTimes(1)
     expect(window.location.reload).toHaveBeenCalledTimes(1)
+  })
+
+  it('cancels scheduled sign-out cleanup when reset failure is reported', async () => {
+    localStorage.setItem(AUTH_ACTIVE_USER_ID, 'user_123')
+    render(createElement(AuthCleanupHandler))
+
+    await act(async () => {
+      vi.advanceTimersByTime(1000)
+    })
+    act(() => {
+      window.dispatchEvent(new CustomEvent(ACCOUNT_RESET_FAILED_EVENT))
+    })
+    await act(async () => {
+      vi.advanceTimersByTime(2000)
+      await Promise.resolve()
+    })
+
+    expect(mockPerformSignoutCleanup).not.toHaveBeenCalled()
   })
 
   it('restores a cross-tab reset failure reported before mount', async () => {

--- a/tests/components/chat/file-upload-routing.test.ts
+++ b/tests/components/chat/file-upload-routing.test.ts
@@ -1,21 +1,46 @@
-import { routeChatFileUpload } from '@/components/chat/file-upload-routing'
-import { describe, expect, it, vi } from 'vitest'
+import {
+  resolveProjectUploadTarget,
+  routeChatFileUpload,
+} from '@/components/chat/file-upload-routing'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 describe('routeChatFileUpload', () => {
   const file = new File(['content'], 'notes.txt', { type: 'text/plain' })
 
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
   it('asks for a destination when a project is active', async () => {
     const requestDestination = vi.fn()
     const processFileForChat = vi.fn().mockResolvedValue(undefined)
+    const projectTarget = { projectId: 'project_123', isReady: true }
+
+    localStorage.setItem('projectUploadPreference', 'project')
+    localStorage.setItem('tinfoil-user-prefs-project-upload', 'project')
 
     await routeChatFileUpload(file, {
-      isProjectMode: true,
-      hasActiveProject: true,
+      projectTarget,
       requestDestination,
       processFileForChat,
     })
 
-    expect(requestDestination).toHaveBeenCalledWith(file)
+    expect(requestDestination).toHaveBeenCalledWith(file, projectTarget)
+    expect(processFileForChat).not.toHaveBeenCalled()
+  })
+
+  it('queues the destination request while a project is loading', async () => {
+    const requestDestination = vi.fn()
+    const processFileForChat = vi.fn().mockResolvedValue(undefined)
+    const projectTarget = { projectId: 'project_123', isReady: false }
+
+    await routeChatFileUpload(file, {
+      projectTarget,
+      requestDestination,
+      processFileForChat,
+    })
+
+    expect(requestDestination).toHaveBeenCalledWith(file, projectTarget)
     expect(processFileForChat).not.toHaveBeenCalled()
   })
 
@@ -24,13 +49,35 @@ describe('routeChatFileUpload', () => {
     const processFileForChat = vi.fn().mockResolvedValue(undefined)
 
     await routeChatFileUpload(file, {
-      isProjectMode: false,
-      hasActiveProject: false,
+      projectTarget: null,
       requestDestination,
       processFileForChat,
     })
 
     expect(processFileForChat).toHaveBeenCalledWith(file)
     expect(requestDestination).not.toHaveBeenCalled()
+  })
+})
+
+describe('resolveProjectUploadTarget', () => {
+  it('queues files for the project being loaded instead of the old active project', () => {
+    expect(
+      resolveProjectUploadTarget({
+        activeProjectId: 'project_old',
+        loadingProjectId: 'project_new',
+      }),
+    ).toEqual({ projectId: 'project_new', isReady: false })
+  })
+
+  it('queues files until the loading project becomes active', () => {
+    expect(
+      resolveProjectUploadTarget({
+        loadingProjectId: 'project_123',
+      }),
+    ).toEqual({ projectId: 'project_123', isReady: false })
+  })
+
+  it('does not target a project after project mode exits', () => {
+    expect(resolveProjectUploadTarget({})).toBeNull()
   })
 })

--- a/tests/services/storage/indexed-db-account-reset.test.ts
+++ b/tests/services/storage/indexed-db-account-reset.test.ts
@@ -210,6 +210,21 @@ describe('IndexedDBStorage account reset', () => {
     await reset
   })
 
+  it('rejects reads waiting behind a stalled save queue when reset starts', async () => {
+    const storage = new IndexedDBStorage()
+    Object.assign(storage as any, { saveQueue: new Promise(() => {}) })
+    const read = storage.getAllChats()
+    const { transaction } = prepareReset(storage)
+
+    const reset = storage.resetForAccountChange()
+
+    await expect(read).rejects.toThrow(
+      'IndexedDB read superseded by account change',
+    )
+    await completeReset(transaction)
+    await reset
+  })
+
   it('rejects reads that were already in flight when reset started', async () => {
     const storage = new IndexedDBStorage()
     let finishRead!: (value: string) => void

--- a/tests/services/storage/indexed-db-account-reset.test.ts
+++ b/tests/services/storage/indexed-db-account-reset.test.ts
@@ -194,6 +194,72 @@ describe('IndexedDBStorage account reset', () => {
     expect(saveInternal).not.toHaveBeenCalled()
   })
 
+  it('rejects reads after an account reset starts', async () => {
+    const storage = new IndexedDBStorage()
+    const { transaction } = prepareReset(storage)
+    const reset = storage.resetForAccountChange()
+
+    await expect(storage.getAllChats()).rejects.toThrow(
+      'IndexedDB read superseded by account change',
+    )
+    await expect(storage.getProjectsForUser('user_123')).rejects.toThrow(
+      'IndexedDB read superseded by account change',
+    )
+
+    await completeReset(transaction)
+    await reset
+  })
+
+  it('rejects reads that were already in flight when reset started', async () => {
+    const storage = new IndexedDBStorage()
+    let finishRead!: (value: string) => void
+    const protectedRead = (storage as any).protectRead(
+      new Promise<string>((resolve) => {
+        finishRead = resolve
+      }),
+    )
+    const { transaction } = prepareReset(storage)
+
+    const reset = storage.resetForAccountChange()
+    finishRead('stale data')
+
+    await expect(protectedRead).rejects.toThrow(
+      'IndexedDB read superseded by account change',
+    )
+    await completeReset(transaction)
+    await reset
+  })
+
+  it('rejects a final write after reset interrupts a multi-stage mutation', async () => {
+    const storage = new IndexedDBStorage()
+    let finishRead!: (chat: any) => void
+    const getChat = vi.spyOn(storage as any, 'getChatInternal').mockReturnValue(
+      new Promise((resolve) => {
+        finishRead = resolve
+      }),
+    )
+
+    const update = storage.updateChatProject('chat_123', 'project_123')
+    await vi.waitFor(() => expect(getChat).toHaveBeenCalledTimes(1))
+    const { transaction } = prepareReset(storage)
+    const reset = storage.resetForAccountChange()
+
+    finishRead({
+      id: 'chat_123',
+      title: 'Old account chat',
+      messages: [],
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      lastAccessedAt: Date.now(),
+    })
+
+    await expect(update).rejects.toThrow(
+      'IndexedDB write superseded by account change',
+    )
+    await completeReset(transaction)
+    await reset
+  })
+
   it('aborts a stalled reset transaction before rejecting', async () => {
     vi.useFakeTimers()
     const storage = new IndexedDBStorage()

--- a/tests/services/storage/indexed-db-account-reset.test.ts
+++ b/tests/services/storage/indexed-db-account-reset.test.ts
@@ -1,0 +1,243 @@
+import { ACCOUNT_RESET_FAILED_EVENT } from '@/constants/auth-events'
+import {
+  AUTH_ACCOUNT_RESET_FAILED,
+  AUTH_ACCOUNT_RESET_SIGNAL,
+} from '@/constants/storage-keys'
+import {
+  handleIndexedDBAccountResetStorageEvent,
+  IndexedDBStorage,
+} from '@/services/storage/indexed-db'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+interface FakeResetTransaction {
+  oncomplete: (() => void) | null
+  onerror: (() => void) | null
+  onabort: (() => void) | null
+  abort: ReturnType<typeof vi.fn>
+  objectStore: (storeName: string) => {
+    clear: ReturnType<typeof vi.fn>
+  }
+}
+
+describe('IndexedDBStorage account reset', () => {
+  function prepareReset(storage: IndexedDBStorage) {
+    const clear = vi.fn(() => ({ onerror: null }))
+    const clearProjects = vi.fn(() => ({ onerror: null }))
+    const transaction: FakeResetTransaction = {
+      oncomplete: null,
+      onerror: null,
+      onabort: null,
+      abort: vi.fn(),
+      objectStore: (storeName) => ({
+        clear: storeName === 'chats' ? clear : clearProjects,
+      }),
+    }
+    const resetDb = {
+      transaction: vi.fn(() => transaction),
+    }
+    vi.spyOn(storage as any, 'ensureDB').mockResolvedValue(resetDb)
+    return { clear, clearProjects, transaction }
+  }
+
+  async function completeReset(transaction: FakeResetTransaction) {
+    await vi.waitFor(() => expect(transaction.oncomplete).not.toBeNull())
+    transaction.oncomplete?.()
+  }
+
+  beforeEach(() => {
+    sessionStorage.clear()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('bypasses a stalled write queue and closes the old connection', async () => {
+    const storage = new IndexedDBStorage()
+    const { clear, clearProjects, transaction } = prepareReset(storage)
+    const close = vi.fn()
+    Object.assign(storage as any, {
+      db: { close },
+      saveQueue: new Promise(() => {}),
+    })
+
+    const reset = storage.resetForAccountChange()
+
+    expect(close).toHaveBeenCalledTimes(1)
+    await vi.waitFor(() => expect(clear).toHaveBeenCalledTimes(1))
+    expect(clearProjects).toHaveBeenCalledTimes(1)
+    await completeReset(transaction)
+    await reset
+  })
+
+  it('coalesces concurrent account reset requests', async () => {
+    const storage = new IndexedDBStorage()
+    const { clear, transaction } = prepareReset(storage)
+
+    const firstReset = storage.resetForAccountChange()
+    const secondReset = storage.resetForAccountChange()
+
+    await vi.waitFor(() => expect(clear).toHaveBeenCalledTimes(1))
+    await completeReset(transaction)
+    await Promise.all([firstReset, secondReset])
+
+    expect(clear).toHaveBeenCalledTimes(1)
+  })
+
+  it('resets storage when another tab signals an account change', async () => {
+    const storage = new IndexedDBStorage()
+    const reset = vi
+      .spyOn(storage, 'resetForAccountChange')
+      .mockResolvedValue(undefined)
+    const reload = vi
+      .spyOn(window.location, 'reload')
+      .mockImplementation(() => {})
+    sessionStorage.setItem(AUTH_ACCOUNT_RESET_FAILED, 'true')
+
+    handleIndexedDBAccountResetStorageEvent(
+      storage,
+      new StorageEvent('storage', {
+        key: AUTH_ACCOUNT_RESET_SIGNAL,
+        newValue: 'reset_123',
+      }),
+    )
+
+    expect(reset).toHaveBeenCalledWith(false)
+    await vi.waitFor(() => expect(reload).toHaveBeenCalledTimes(1))
+    expect(sessionStorage.getItem(AUTH_ACCOUNT_RESET_FAILED)).toBeNull()
+  })
+
+  it('reports cross-tab reset failures without re-enabling writes', async () => {
+    const storage = new IndexedDBStorage()
+    vi.spyOn(storage, 'resetForAccountChange').mockRejectedValue(
+      new Error('reset failed'),
+    )
+    const handleFailure = vi.fn()
+    window.addEventListener(ACCOUNT_RESET_FAILED_EVENT, handleFailure)
+
+    handleIndexedDBAccountResetStorageEvent(
+      storage,
+      new StorageEvent('storage', {
+        key: AUTH_ACCOUNT_RESET_SIGNAL,
+        newValue: 'reset_123',
+      }),
+    )
+
+    await vi.waitFor(() => expect(handleFailure).toHaveBeenCalledTimes(1))
+    expect(sessionStorage.getItem(AUTH_ACCOUNT_RESET_FAILED)).toBe('true')
+    window.removeEventListener(ACCOUNT_RESET_FAILED_EVENT, handleFailure)
+  })
+
+  it('cancels writes that were queued before the account reset', async () => {
+    const storage = new IndexedDBStorage()
+    const { transaction } = prepareReset(storage)
+    let releaseQueue!: () => void
+    const stalledQueue = new Promise<void>((resolve) => {
+      releaseQueue = resolve
+    })
+    Object.assign(storage as any, { saveQueue: stalledQueue })
+    const saveInternal = vi
+      .spyOn(storage as any, 'saveChatInternal')
+      .mockResolvedValue(undefined)
+
+    const save = storage.saveChat({
+      id: 'chat_123',
+      title: 'Old account chat',
+      messages: [],
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    } as any)
+    const reset = storage.resetForAccountChange()
+    await completeReset(transaction)
+    await reset
+
+    releaseQueue()
+
+    await expect(save).rejects.toThrow(
+      'IndexedDB write superseded by account change',
+    )
+    expect(saveInternal).not.toHaveBeenCalled()
+  })
+
+  it('rejects writes submitted after the account reset starts', async () => {
+    const storage = new IndexedDBStorage()
+    const { transaction } = prepareReset(storage)
+    const saveInternal = vi
+      .spyOn(storage as any, 'saveChatInternal')
+      .mockResolvedValue(undefined)
+    const reset = storage.resetForAccountChange()
+
+    const save = storage.saveChat({
+      id: 'chat_123',
+      title: 'Old account chat',
+      messages: [],
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    } as any)
+
+    await expect(save).rejects.toThrow(
+      'IndexedDB write superseded by account change',
+    )
+    await completeReset(transaction)
+    await reset
+
+    await expect(
+      storage.saveChat({
+        id: 'chat_456',
+        title: 'Late old account chat',
+        messages: [],
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      } as any),
+    ).rejects.toThrow('IndexedDB write superseded by account change')
+    expect(saveInternal).not.toHaveBeenCalled()
+  })
+
+  it('aborts a stalled reset transaction before rejecting', async () => {
+    vi.useFakeTimers()
+    const storage = new IndexedDBStorage()
+    const { transaction } = prepareReset(storage)
+
+    const reset = storage.resetForAccountChange()
+    const rejection = expect(reset).rejects.toThrow(
+      'Timed out resetting IndexedDB for account change',
+    )
+
+    await vi.runAllTimersAsync()
+
+    await rejection
+    expect(transaction.abort).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects malformed stored chats instead of leaving reads pending', async () => {
+    const storage = new IndexedDBStorage()
+    const cursorRequest = {
+      onsuccess: null,
+      onerror: null,
+    } as {
+      onsuccess: ((event: unknown) => void) | null
+      onerror: (() => void) | null
+    }
+    const openCursor = vi.fn(() => cursorRequest)
+    vi.spyOn(storage as any, 'ensureDB').mockResolvedValue({
+      transaction: () => ({
+        objectStore: () => ({ openCursor }),
+      }),
+    })
+
+    const chats = storage.getAllChats()
+    await vi.waitFor(() => expect(cursorRequest.onsuccess).not.toBeNull())
+
+    cursorRequest.onsuccess?.({
+      target: {
+        result: {
+          value: { id: 'broken_chat', messages: null },
+          continue: vi.fn(),
+        },
+      },
+    })
+
+    await expect(chats).rejects.toThrow('Stored chat has invalid messages')
+  })
+})

--- a/tests/utils/signout-cleanup.test.ts
+++ b/tests/utils/signout-cleanup.test.ts
@@ -1,5 +1,9 @@
 import { resetRendererRegistry } from '@/components/chat/renderers'
-import { SETTINGS_HAS_SEEN_ONBOARDING } from '@/constants/storage-keys'
+import {
+  AUTH_ACCOUNT_RESET_FAILED,
+  AUTH_ACTIVE_USER_ID,
+  SETTINGS_HAS_SEEN_ONBOARDING,
+} from '@/constants/storage-keys'
 import { cloudSync } from '@/services/cloud/cloud-sync'
 import { resetEditClockCache } from '@/services/cloud/edit-clock'
 import { profileSync } from '@/services/cloud/profile-sync'
@@ -11,7 +15,11 @@ import { projectEvents } from '@/services/project/project-events'
 import { deletedChatsTracker } from '@/services/storage/deleted-chats-tracker'
 import { indexedDBStorage } from '@/services/storage/indexed-db'
 import { resetSyncEnclaveClient } from '@/services/sync-enclave'
-import { performSignoutCleanup } from '@/utils/signout-cleanup'
+import {
+  performSignoutCleanup,
+  performUserSwitchCleanup,
+  retryFailedStorageCleanup,
+} from '@/utils/signout-cleanup'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('@/components/chat/renderers', () => ({
@@ -56,8 +64,7 @@ vi.mock('@/services/storage/deleted-chats-tracker', () => ({
 
 vi.mock('@/services/storage/indexed-db', () => ({
   indexedDBStorage: {
-    deleteAllChats: vi.fn().mockResolvedValue(0),
-    deleteAllProjects: vi.fn().mockResolvedValue(undefined),
+    resetForAccountChange: vi.fn().mockResolvedValue(undefined),
   },
 }))
 
@@ -109,14 +116,68 @@ describe('performSignoutCleanup', () => {
     expect(resetSyncHealth).toHaveBeenCalled()
     expect(resetEditClockCache).toHaveBeenCalled()
     expect(projectEvents.clear).toHaveBeenCalled()
-    expect(indexedDBStorage.deleteAllChats).toHaveBeenCalled()
-    expect(indexedDBStorage.deleteAllProjects).toHaveBeenCalled()
+    expect(indexedDBStorage.resetForAccountChange).toHaveBeenCalled()
   })
 
   it('keeps the encryption key when preserveEncryptionKey is set', async () => {
     await performSignoutCleanup({ preserveEncryptionKey: true })
 
     expect(encryptionService.clearKey).not.toHaveBeenCalled()
-    expect(indexedDBStorage.deleteAllChats).toHaveBeenCalled()
+    expect(indexedDBStorage.resetForAccountChange).toHaveBeenCalled()
+  })
+
+  it('keeps the active-user marker until browser data is cleared', async () => {
+    let finishReset!: () => void
+    vi.mocked(indexedDBStorage.resetForAccountChange).mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        finishReset = resolve
+      }),
+    )
+    localStorage.setItem(AUTH_ACTIVE_USER_ID, 'user_123')
+    const clearLocalStorage = vi.spyOn(localStorage, 'clear')
+
+    const cleanup = performSignoutCleanup()
+    await Promise.resolve()
+
+    expect(localStorage.getItem(AUTH_ACTIVE_USER_ID)).toBe('user_123')
+    expect(clearLocalStorage).not.toHaveBeenCalled()
+
+    finishReset()
+    await cleanup
+
+    expect(localStorage.getItem(AUTH_ACTIVE_USER_ID)).toBeNull()
+  })
+
+  it('keeps the active-user marker when browser data cannot be cleared', async () => {
+    vi.mocked(indexedDBStorage.resetForAccountChange).mockRejectedValueOnce(
+      new Error('reset failed'),
+    )
+    localStorage.setItem(AUTH_ACTIVE_USER_ID, 'user_123')
+
+    await expect(performSignoutCleanup()).rejects.toThrow('reset failed')
+
+    expect(localStorage.getItem(AUTH_ACTIVE_USER_ID)).toBe('user_123')
+  })
+
+  it('surfaces user-switch cleanup failures without replacing the marker', async () => {
+    vi.mocked(indexedDBStorage.resetForAccountChange).mockRejectedValueOnce(
+      new Error('reset failed'),
+    )
+    localStorage.setItem(AUTH_ACTIVE_USER_ID, 'user_old')
+
+    await expect(performUserSwitchCleanup('user_new')).rejects.toThrow(
+      'reset failed',
+    )
+
+    expect(localStorage.getItem(AUTH_ACTIVE_USER_ID)).toBe('user_old')
+  })
+
+  it('retries a failed cross-tab reset without notifying other tabs', async () => {
+    sessionStorage.setItem(AUTH_ACCOUNT_RESET_FAILED, 'true')
+
+    await retryFailedStorageCleanup()
+
+    expect(indexedDBStorage.resetForAccountChange).toHaveBeenCalledWith(false)
+    expect(sessionStorage.getItem(AUTH_ACCOUNT_RESET_FAILED)).toBeNull()
   })
 })

--- a/tests/utils/storage-migration.test.ts
+++ b/tests/utils/storage-migration.test.ts
@@ -1,0 +1,22 @@
+import { migrateStorageKeys } from '@/utils/storage-migration'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+describe('migrateStorageKeys', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    sessionStorage.clear()
+  })
+
+  it('removes retired project upload preferences for migrated users', () => {
+    localStorage.setItem('tinfoil-storage-migrated', 'true')
+    localStorage.setItem('projectUploadPreference', 'project')
+    localStorage.setItem('tinfoil-user-prefs-project-upload', 'project')
+    localStorage.setItem('unrelated-preference', 'keep')
+
+    migrateStorageKeys()
+
+    expect(localStorage.getItem('projectUploadPreference')).toBeNull()
+    expect(localStorage.getItem('tinfoil-user-prefs-project-upload')).toBeNull()
+    expect(localStorage.getItem('unrelated-preference')).toBe('keep')
+  })
+})


### PR DESCRIPTION
## Summary
- make sign-out and account-switch cleanup bypass stalled IndexedDB writes, clear chat and project caches across tabs, and fail closed with a retry path
- reject malformed stored chats instead of leaving cloud-sync reads pending after passkey recovery
- remove retired project-upload preferences and queue attachments until the intended project is ready so the destination modal always appears

## Testing
- `npx vitest run` (135 files, 1533 tests)
- `npx tsc --noEmit`
- `npm run lint`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes local data cleanup fail-closed and recoverable across sign‑out, account switches, and tabs, preventing reload loops and blocking stale writes while canceling queued reads. Also fixes project file routing so uploads target the correct project, queue while loading, and the destination modal appears at the right time.

- **Bug Fixes**
  - Replace IndexedDB wipes with a transactional account reset that cancels queued reads and writes, rejects in‑flight reads, blocks new writes until reload, and times out stalled clears.
  - Cross‑tab cleanup: broadcast via `AUTH_ACCOUNT_RESET_SIGNAL`; auto‑reset and reload on success; on failure, set a session flag and fire `ACCOUNT_RESET_FAILED_EVENT` to show a retryable “Unable to clear local data” dialog.
  - Keep `AUTH_ACTIVE_USER_ID` until cleanup completes or surfaces an error; add “Retry cleanup” to reattempt the storage reset without notifying other tabs.
  - On user switch, block the new account until local data is cleared; surface errors instead of reload‑looping.
  - Project uploads: resolve the intended target with `resolveProjectUploadTarget`; queue files for the project being loaded, open the destination modal when ready, and cancel with a toast if the project changes or fails; clear pending state on exit.
  - Reject malformed stored chats to avoid hanging reads.
  - Remove retired project upload preference keys during storage migration.

<sup>Written for commit d957eb9a1bd4808a4cef59e29029f20f73120d37. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/482?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

