### PR TITLE
Open generated artifact previews automatically on desktop

### DIFF
--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -123,7 +123,7 @@ import {
 import { GenUIInputAreaRenderer } from './genui/GenUIInputAreaRenderer'
 import { selectPendingInputToolCallFromChat } from './genui/pending-input-tool-call'
 import {
-  artifactDetailsEqual,
+  artifactPreviewTargetsEqual,
   OPEN_ARTIFACT_PREVIEW_EVENT,
   type ArtifactPreviewSidebarDetail,
   type ArtifactPreviewSidebarEventDetail,
@@ -576,6 +576,9 @@ export function ChatInterface({
   )
   const [artifactPreview, setArtifactPreview] =
     useState<ArtifactPreviewSidebarDetail | null>(null)
+  const [activeArtifactToolCallId, setActiveArtifactToolCallId] = useState<
+    string | null
+  >(null)
 
   const [webSearchAvailable, setWebSearchAvailable] = useState(() => {
     if (typeof window === 'undefined') return true
@@ -1445,18 +1448,24 @@ export function ChatInterface({
       event: CustomEvent<ArtifactPreviewSidebarEventDetail>,
     ) => {
       if (!event.detail) return
-      const { action, artifact } = event.detail
+      const { action, artifact, toolCallId } = event.detail
       // Toggle: clicking the inline card while its artifact is already open
       // closes the sidebar instead of re-opening it.
       setArtifactPreview((prev) => {
         const sameArtifact =
           prev !== null &&
           isArtifactSidebarOpen &&
-          artifactDetailsEqual(prev, artifact)
+          artifactPreviewTargetsEqual(
+            prev,
+            activeArtifactToolCallId,
+            artifact,
+            toolCallId,
+          )
         if (action === 'toggle' && sameArtifact) {
           setIsArtifactSidebarOpen(false)
           return prev
         }
+        setActiveArtifactToolCallId(toolCallId ?? null)
         setIsArtifactSidebarOpen(true)
         setIsVerifierSidebarOpen(false)
         setIsSettingsModalOpen(false)
@@ -1477,7 +1486,12 @@ export function ChatInterface({
         handleOpenArtifactPreview as EventListener,
       )
     }
-  }, [windowWidth, setIsSidebarOpen, isArtifactSidebarOpen])
+  }, [
+    windowWidth,
+    setIsSidebarOpen,
+    isArtifactSidebarOpen,
+    activeArtifactToolCallId,
+  ])
 
   // Auto-focus input when component mounts and is ready (no autoscroll)
   // Keyed on the chat id, not the chat object: the object's identity changes
@@ -3726,6 +3740,9 @@ export function ChatInterface({
                     chatId={currentChat.id}
                     isWaitingForResponse={isWaitingForResponse}
                     isStreamingResponse={isStreaming}
+                    activeArtifactToolCallId={
+                      isArtifactSidebarOpen ? activeArtifactToolCallId : null
+                    }
                     isPremium={isPremium}
                     models={models}
                     onSubmit={handleSubmit}

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -126,6 +126,7 @@ import {
   artifactDetailsEqual,
   OPEN_ARTIFACT_PREVIEW_EVENT,
   type ArtifactPreviewSidebarDetail,
+  type ArtifactPreviewSidebarEventDetail,
 } from './genui/widgets/ArtifactPreview'
 import {
   canToggleTemporaryChat,
@@ -1441,17 +1442,18 @@ export function ChatInterface({
   // slide-over and closes any other right-side panel so only one is visible.
   useEffect(() => {
     const handleOpenArtifactPreview = (
-      event: CustomEvent<ArtifactPreviewSidebarDetail>,
+      event: CustomEvent<ArtifactPreviewSidebarEventDetail>,
     ) => {
       if (!event.detail) return
+      const { action, artifact } = event.detail
       // Toggle: clicking the inline card while its artifact is already open
       // closes the sidebar instead of re-opening it.
       setArtifactPreview((prev) => {
         const sameArtifact =
           prev !== null &&
           isArtifactSidebarOpen &&
-          artifactDetailsEqual(prev, event.detail)
-        if (sameArtifact) {
+          artifactDetailsEqual(prev, artifact)
+        if (action === 'toggle' && sameArtifact) {
           setIsArtifactSidebarOpen(false)
           return prev
         }
@@ -1462,7 +1464,7 @@ export function ChatInterface({
         if (windowWidth < CONSTANTS.SINGLE_SIDEBAR_BREAKPOINT) {
           setIsSidebarOpen(false)
         }
-        return event.detail
+        return artifact
       })
     }
     window.addEventListener(

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -1451,30 +1451,28 @@ export function ChatInterface({
       const { action, artifact, toolCallId } = event.detail
       // Toggle: clicking the inline card while its artifact is already open
       // closes the sidebar instead of re-opening it.
-      setArtifactPreview((prev) => {
-        const sameArtifact =
-          prev !== null &&
-          isArtifactSidebarOpen &&
-          artifactPreviewTargetsEqual(
-            prev,
-            activeArtifactToolCallId,
-            artifact,
-            toolCallId,
-          )
-        if (action === 'toggle' && sameArtifact) {
-          setIsArtifactSidebarOpen(false)
-          return prev
-        }
-        setActiveArtifactToolCallId(toolCallId ?? null)
-        setIsArtifactSidebarOpen(true)
-        setIsVerifierSidebarOpen(false)
-        setIsSettingsModalOpen(false)
-        setIsAskSidebarOpen(false)
-        if (windowWidth < CONSTANTS.SINGLE_SIDEBAR_BREAKPOINT) {
-          setIsSidebarOpen(false)
-        }
-        return artifact
-      })
+      const sameArtifact =
+        artifactPreview !== null &&
+        isArtifactSidebarOpen &&
+        artifactPreviewTargetsEqual(
+          artifactPreview,
+          activeArtifactToolCallId,
+          artifact,
+          toolCallId,
+        )
+      if (action === 'toggle' && sameArtifact) {
+        setIsArtifactSidebarOpen(false)
+        return
+      }
+      setArtifactPreview(artifact)
+      setActiveArtifactToolCallId(toolCallId ?? null)
+      setIsArtifactSidebarOpen(true)
+      setIsVerifierSidebarOpen(false)
+      setIsSettingsModalOpen(false)
+      setIsAskSidebarOpen(false)
+      if (windowWidth < CONSTANTS.SINGLE_SIDEBAR_BREAKPOINT) {
+        setIsSidebarOpen(false)
+      }
     }
     window.addEventListener(
       OPEN_ARTIFACT_PREVIEW_EVENT,
@@ -1490,6 +1488,7 @@ export function ChatInterface({
     windowWidth,
     setIsSidebarOpen,
     isArtifactSidebarOpen,
+    artifactPreview,
     activeArtifactToolCallId,
   ])
 

--- a/src/components/chat/chat-messages.tsx
+++ b/src/components/chat/chat-messages.tsx
@@ -34,6 +34,7 @@ type ChatMessagesProps = {
   chatId: string
   isWaitingForResponse?: boolean
   isStreamingResponse?: boolean
+  activeArtifactToolCallId?: string | null
   isPremium?: boolean
   models?: BaseModel[]
   onSubmit?: (e: React.FormEvent) => void
@@ -75,6 +76,23 @@ type ChatMessagesProps = {
   onSelectPromptPreset?: (presetId: string | null) => void
 }
 
+function getMessageActiveArtifactToolCallId(
+  message: Message,
+  activeArtifactToolCallId?: string | null,
+): string | null {
+  if (!activeArtifactToolCallId) return null
+  const isActive =
+    message.toolCalls?.some(
+      (toolCall) => toolCall.id === activeArtifactToolCallId,
+    ) ||
+    message.timeline?.some(
+      (block) =>
+        block.type === 'tool_call' &&
+        block.toolCallId === activeArtifactToolCallId,
+    )
+  return isActive ? activeArtifactToolCallId : null
+}
+
 // Optimized wrapper component that receives expanded state from parent
 const ChatMessage = memo(
   function ChatMessage({
@@ -84,6 +102,7 @@ const ChatMessage = memo(
     isDarkMode,
     isLastMessage = false,
     isStreaming = false,
+    activeArtifactToolCallId,
     hideActions = false,
     onEditMessage,
     onRegenerateMessage,
@@ -95,6 +114,7 @@ const ChatMessage = memo(
     isDarkMode: boolean
     isLastMessage?: boolean
     isStreaming?: boolean
+    activeArtifactToolCallId?: string | null
     hideActions?: boolean
     onEditMessage?: (messageIndex: number, newContent: string) => void
     onRegenerateMessage?: (messageIndex: number) => void
@@ -115,6 +135,7 @@ const ChatMessage = memo(
         isDarkMode={isDarkMode}
         isLastMessage={isLastMessage}
         isStreaming={isStreaming}
+        activeArtifactToolCallId={activeArtifactToolCallId}
         hideActions={hideActions}
         onEditMessage={onEditMessage}
         onRegenerateMessage={onRegenerateMessage}
@@ -133,6 +154,8 @@ const ChatMessage = memo(
       prevProps.isDarkMode === nextProps.isDarkMode &&
       prevProps.isLastMessage === nextProps.isLastMessage &&
       prevProps.isStreaming === nextProps.isStreaming &&
+      prevProps.activeArtifactToolCallId ===
+        nextProps.activeArtifactToolCallId &&
       prevProps.hideActions === nextProps.hideActions &&
       prevProps.onEditMessage === nextProps.onEditMessage &&
       prevProps.onRegenerateMessage === nextProps.onRegenerateMessage &&
@@ -252,6 +275,7 @@ export function ChatMessages({
   chatId,
   isWaitingForResponse = false,
   isStreamingResponse = false,
+  activeArtifactToolCallId,
   isPremium,
   models,
   onSubmit,
@@ -492,6 +516,10 @@ export function ChatMessages({
             isDarkMode={isDarkMode}
             isLastMessage
             isStreaming
+            activeArtifactToolCallId={getMessageActiveArtifactToolCallId(
+              draft,
+              activeArtifactToolCallId,
+            )}
           />
         )}
         {!draft && <RecoveryMessage />}
@@ -524,6 +552,10 @@ export function ChatMessages({
                       isDarkMode={isDarkMode}
                       isLastMessage={Boolean(recoveryDraft)}
                       isStreaming={Boolean(recoveryDraft)}
+                      activeArtifactToolCallId={getMessageActiveArtifactToolCallId(
+                        recoveryDraft ?? message,
+                        activeArtifactToolCallId,
+                      )}
                       onEditMessage={recoveryDraft ? undefined : onEditMessage}
                       onRegenerateMessage={
                         recoveryDraft ? undefined : onRegenerateMessage
@@ -562,6 +594,10 @@ export function ChatMessages({
                   Boolean(recoveryDraft) ||
                   (i === liveMessages.length - 1 && isStreamingResponse)
                 }
+                activeArtifactToolCallId={getMessageActiveArtifactToolCallId(
+                  recoveryDraft ?? message,
+                  activeArtifactToolCallId,
+                )}
                 onEditMessage={recoveryDraft ? undefined : onEditMessage}
                 onRegenerateMessage={
                   recoveryDraft ? undefined : onRegenerateMessage

--- a/src/components/chat/genui/GenUIToolCallRenderer.tsx
+++ b/src/components/chat/genui/GenUIToolCallRenderer.tsx
@@ -54,6 +54,7 @@ interface GenUIToolCallRendererProps {
   toolCalls: GenUIToolCall[]
   isStreaming: boolean
   isDarkMode?: boolean
+  activeArtifactToolCallId?: string | null
   /**
    * If provided, a "Try again" button is shown on parse-failure cards and
    * will regenerate the assistant message that produced the failed tool
@@ -80,19 +81,25 @@ function parseInput(
 }
 
 function GenUIWidgetContent({
+  toolCallId,
   toolName,
   input,
+  isActive,
   isDarkMode,
   isStreaming,
 }: {
+  toolCallId: string
   toolName: string
   input: unknown
+  isActive: boolean
   isDarkMode?: boolean
   isStreaming: boolean
 }) {
   const rendered = renderGenUIInline(toolName, input, {
+    isActive,
     isDarkMode,
     isStreaming,
+    toolCallId,
   })
   if (rendered === null) throw new Error('Widget render returned null')
   return rendered
@@ -102,6 +109,7 @@ export const GenUIToolCallRenderer = memo(function GenUIToolCallRenderer({
   toolCalls,
   isStreaming,
   isDarkMode,
+  activeArtifactToolCallId,
   onRetry,
   onRetryToolCall,
 }: GenUIToolCallRendererProps) {
@@ -159,8 +167,10 @@ export const GenUIToolCallRenderer = memo(function GenUIToolCallRenderer({
             >
               <div className="my-4">
                 <GenUIWidgetContent
+                  toolCallId={tc.id}
                   toolName={tc.name}
                   input={parsedInput.data}
+                  isActive={activeArtifactToolCallId === tc.id}
                   isDarkMode={isDarkMode}
                   isStreaming={isStreaming}
                 />

--- a/src/components/chat/genui/GenUIToolCallRenderer.tsx
+++ b/src/components/chat/genui/GenUIToolCallRenderer.tsx
@@ -83,12 +83,17 @@ function GenUIWidgetContent({
   toolName,
   input,
   isDarkMode,
+  isStreaming,
 }: {
   toolName: string
   input: unknown
   isDarkMode?: boolean
+  isStreaming: boolean
 }) {
-  const rendered = renderGenUIInline(toolName, input, { isDarkMode })
+  const rendered = renderGenUIInline(toolName, input, {
+    isDarkMode,
+    isStreaming,
+  })
   if (rendered === null) throw new Error('Widget render returned null')
   return rendered
 }
@@ -157,6 +162,7 @@ export const GenUIToolCallRenderer = memo(function GenUIToolCallRenderer({
                   toolName={tc.name}
                   input={parsedInput.data}
                   isDarkMode={isDarkMode}
+                  isStreaming={isStreaming}
                 />
               </div>
             </GenUIWidgetErrorBoundary>

--- a/src/components/chat/genui/types.ts
+++ b/src/components/chat/genui/types.ts
@@ -38,8 +38,10 @@ export function defineGenUIWidget<Schema extends ZodTypeAny>(
  * Context passed to all widgets when rendering.
  */
 export interface GenUIRenderContext {
+  isActive?: boolean
   isDarkMode?: boolean
   isStreaming?: boolean
+  toolCallId?: string
 }
 
 /**

--- a/src/components/chat/genui/types.ts
+++ b/src/components/chat/genui/types.ts
@@ -39,6 +39,7 @@ export function defineGenUIWidget<Schema extends ZodTypeAny>(
  */
 export interface GenUIRenderContext {
   isDarkMode?: boolean
+  isStreaming?: boolean
 }
 
 /**

--- a/src/components/chat/genui/widgets/ArtifactPreview.tsx
+++ b/src/components/chat/genui/widgets/ArtifactPreview.tsx
@@ -9,6 +9,7 @@
  *
  * Supported source types: `url`, `html`, `markdown`, `svg`, `mermaid`.
  */
+import { CONSTANTS } from '@/components/chat/constants'
 import CopyButton from '@/components/copy-button'
 import {
   Card,
@@ -20,7 +21,7 @@ import {
 import { cn } from '@/components/ui/utils'
 import { sanitizeUrl } from '@braintree/sanitize-url'
 import { Code2, Download, ExternalLink, Eye, FileText } from 'lucide-react'
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import ReactMarkdown from 'react-markdown'
 import { z } from 'zod'
 import { defineGenUIWidget } from '../types'
@@ -74,14 +75,23 @@ export interface ArtifactPreviewSidebarDetail {
   footer?: string
 }
 
+export interface ArtifactPreviewSidebarEventDetail {
+  artifact: ArtifactPreviewSidebarDetail
+  action: 'open' | 'toggle'
+}
+
 export function openArtifactPreviewSidebar(
   detail: ArtifactPreviewSidebarDetail,
+  action: ArtifactPreviewSidebarEventDetail['action'] = 'toggle',
 ): void {
   if (typeof window === 'undefined') return
   window.dispatchEvent(
-    new CustomEvent<ArtifactPreviewSidebarDetail>(OPEN_ARTIFACT_PREVIEW_EVENT, {
-      detail,
-    }),
+    new CustomEvent<ArtifactPreviewSidebarEventDetail>(
+      OPEN_ARTIFACT_PREVIEW_EVENT,
+      {
+        detail: { artifact: detail, action },
+      },
+    ),
   )
 }
 
@@ -405,15 +415,28 @@ function ArtifactPreviewInlineCard({
   description,
   source,
   footer,
-}: z.infer<typeof schema>) {
-  const detail: ArtifactPreviewSidebarDetail = {
-    title,
-    description,
-    source,
-    footer,
-  }
+  shouldAutoOpen,
+}: z.infer<typeof schema> & { shouldAutoOpen?: boolean }) {
+  const hasAutoOpenedRef = useRef(false)
+  const detail = useMemo<ArtifactPreviewSidebarDetail>(
+    () => ({ title, description, source, footer }),
+    [description, footer, source, title],
+  )
   const displayTitle = title ?? getSourceLabel(source)
   const subtitle = description ?? getSourceLabel(source)
+
+  useEffect(() => {
+    if (
+      !shouldAutoOpen ||
+      hasAutoOpenedRef.current ||
+      window.innerWidth < CONSTANTS.MOBILE_BREAKPOINT
+    ) {
+      return
+    }
+    hasAutoOpenedRef.current = true
+    openArtifactPreviewSidebar(detail, 'open')
+  }, [detail, shouldAutoOpen])
+
   return (
     <div className="my-3 flex w-full items-center rounded-lg border border-border-subtle bg-surface-card text-left transition-colors hover:bg-surface-chat-background">
       <button
@@ -453,5 +476,7 @@ export const widget = defineGenUIWidget({
     'Display a visual artifact in a side panel: a hosted URL, a self-contained HTML snippet, or Markdown. Use for content worth inspecting at full size — interactive demos, long-form documents, or rich HTML mockups. For SVG illustrations and Mermaid diagrams, emit a fenced `svg` or `mermaid` code block in the regular assistant message instead. The chat shows a compact summary card; clicking it opens the full artifact in the right sidebar.',
   schema,
   promptHint: 'large artifacts (markdown/html/url) opened in a side panel',
-  render: (args) => <ArtifactPreviewInlineCard {...args} />,
+  render: (args, { isStreaming }) => (
+    <ArtifactPreviewInlineCard {...args} shouldAutoOpen={isStreaming} />
+  ),
 })

--- a/src/components/chat/genui/widgets/ArtifactPreview.tsx
+++ b/src/components/chat/genui/widgets/ArtifactPreview.tsx
@@ -78,18 +78,20 @@ export interface ArtifactPreviewSidebarDetail {
 export interface ArtifactPreviewSidebarEventDetail {
   artifact: ArtifactPreviewSidebarDetail
   action: 'open' | 'toggle'
+  toolCallId?: string
 }
 
 export function openArtifactPreviewSidebar(
   detail: ArtifactPreviewSidebarDetail,
   action: ArtifactPreviewSidebarEventDetail['action'] = 'toggle',
+  toolCallId?: string,
 ): void {
   if (typeof window === 'undefined') return
   window.dispatchEvent(
     new CustomEvent<ArtifactPreviewSidebarEventDetail>(
       OPEN_ARTIFACT_PREVIEW_EVENT,
       {
-        detail: { artifact: detail, action },
+        detail: { artifact: detail, action, toolCallId },
       },
     ),
   )
@@ -109,6 +111,18 @@ export function artifactDetailsEqual(
   if (a.footer !== b.footer) return false
   if (a.source.type !== b.source.type) return false
   return sourceToCopyString(a.source) === sourceToCopyString(b.source)
+}
+
+export function artifactPreviewTargetsEqual(
+  currentArtifact: ArtifactPreviewSidebarDetail,
+  currentToolCallId: string | null,
+  incomingArtifact: ArtifactPreviewSidebarDetail,
+  incomingToolCallId?: string,
+): boolean {
+  if (currentToolCallId && incomingToolCallId) {
+    return currentToolCallId === incomingToolCallId
+  }
+  return artifactDetailsEqual(currentArtifact, incomingArtifact)
 }
 
 /**
@@ -415,8 +429,14 @@ function ArtifactPreviewInlineCard({
   description,
   source,
   footer,
+  isSelected = false,
   shouldAutoOpen,
-}: z.infer<typeof schema> & { shouldAutoOpen?: boolean }) {
+  toolCallId,
+}: z.infer<typeof schema> & {
+  isSelected?: boolean
+  shouldAutoOpen?: boolean
+  toolCallId?: string
+}) {
   const hasAutoOpenedRef = useRef(false)
   const detail = useMemo<ArtifactPreviewSidebarDetail>(
     () => ({ title, description, source, footer }),
@@ -434,25 +454,38 @@ function ArtifactPreviewInlineCard({
       return
     }
     hasAutoOpenedRef.current = true
-    openArtifactPreviewSidebar(detail, 'open')
-  }, [detail, shouldAutoOpen])
+    openArtifactPreviewSidebar(detail, 'open', toolCallId)
+  }, [detail, shouldAutoOpen, toolCallId])
 
   return (
-    <div className="my-3 flex w-full items-center rounded-lg border border-border-subtle bg-surface-card text-left transition-colors hover:bg-surface-chat-background">
+    <div
+      className={cn(
+        'my-3 flex w-full items-center rounded-lg border bg-surface-card text-left transition-colors',
+        isSelected
+          ? 'border-brand-accent-dark bg-brand-accent-dark/10 dark:border-brand-accent-light dark:bg-brand-accent-light/10'
+          : 'border-border-subtle hover:bg-surface-chat-background',
+      )}
+    >
       <button
         type="button"
-        onClick={() => openArtifactPreviewSidebar(detail)}
+        onClick={() => openArtifactPreviewSidebar(detail, 'toggle', toolCallId)}
         className="flex min-w-0 flex-1 cursor-pointer items-center gap-4 self-stretch px-4 py-4 text-left"
+        aria-pressed={isSelected}
       >
         <FileText
-          className="h-6 w-6 flex-shrink-0 text-content-muted"
+          className={cn(
+            'h-6 w-6 flex-shrink-0',
+            isSelected
+              ? 'text-brand-accent-dark dark:text-brand-accent-light'
+              : 'text-content-muted',
+          )}
           aria-hidden
         />
         <span className="flex min-w-0 flex-1 flex-col">
           <span className="truncate text-sm font-medium text-content-primary">
             {displayTitle}
           </span>
-          <span className="truncate text-xs text-content-muted">
+          <span className="whitespace-pre-wrap break-words text-xs leading-relaxed text-content-muted">
             {subtitle}
           </span>
         </span>
@@ -476,7 +509,12 @@ export const widget = defineGenUIWidget({
     'Display a visual artifact in a side panel: a hosted URL, a self-contained HTML snippet, or Markdown. Use for content worth inspecting at full size — interactive demos, long-form documents, or rich HTML mockups. For SVG illustrations and Mermaid diagrams, emit a fenced `svg` or `mermaid` code block in the regular assistant message instead. The chat shows a compact summary card; clicking it opens the full artifact in the right sidebar.',
   schema,
   promptHint: 'large artifacts (markdown/html/url) opened in a side panel',
-  render: (args, { isStreaming }) => (
-    <ArtifactPreviewInlineCard {...args} shouldAutoOpen={isStreaming} />
+  render: (args, { isActive, isStreaming, toolCallId }) => (
+    <ArtifactPreviewInlineCard
+      {...args}
+      isSelected={isActive}
+      shouldAutoOpen={isStreaming}
+      toolCallId={toolCallId}
+    />
   ),
 })

--- a/src/components/chat/genui/widgets/ArtifactPreview.tsx
+++ b/src/components/chat/genui/widgets/ArtifactPreview.tsx
@@ -120,7 +120,10 @@ export function artifactPreviewTargetsEqual(
   incomingToolCallId?: string,
 ): boolean {
   if (currentToolCallId && incomingToolCallId) {
-    return currentToolCallId === incomingToolCallId
+    return (
+      currentToolCallId === incomingToolCallId &&
+      artifactDetailsEqual(currentArtifact, incomingArtifact)
+    )
   }
   return artifactDetailsEqual(currentArtifact, incomingArtifact)
 }

--- a/src/components/chat/renderers/default/DefaultMessageRenderer.tsx
+++ b/src/components/chat/renderers/default/DefaultMessageRenderer.tsx
@@ -32,6 +32,7 @@ const DefaultMessageComponent = ({
   isDarkMode,
   isLastMessage,
   isStreaming,
+  activeArtifactToolCallId,
   hideActions,
   onEditMessage,
   onRegenerateMessage,
@@ -341,6 +342,7 @@ const DefaultMessageComponent = ({
                     ]}
                     isStreaming={!!isStreaming && !!isLastMessage}
                     isDarkMode={isDarkMode}
+                    activeArtifactToolCallId={activeArtifactToolCallId}
                     onRetry={
                       onRegenerateMessage && messageIndex > 0
                         ? () => onRegenerateMessage(messageIndex - 1)

--- a/src/components/chat/renderers/types.ts
+++ b/src/components/chat/renderers/types.ts
@@ -25,6 +25,7 @@ export interface MessageRenderProps {
   isDarkMode: boolean
   isLastMessage?: boolean
   isStreaming?: boolean
+  activeArtifactToolCallId?: string | null
   hideActions?: boolean
   onEditMessage?: (messageIndex: number, newContent: string) => void
   onRegenerateMessage?: (messageIndex: number) => void

--- a/tests/components/chat/genui/tool-call-renderer.test.tsx
+++ b/tests/components/chat/genui/tool-call-renderer.test.tsx
@@ -198,6 +198,14 @@ describe('GenUIToolCallRenderer', () => {
         'artifact-1',
       ),
     ).toBe(true)
+    expect(
+      artifactPreviewTargetsEqual(
+        artifact,
+        'artifact-1',
+        { ...artifact, description: 'Updated description' },
+        'artifact-1',
+      ),
+    ).toBe(false)
   })
 
   it('shows a simple generating state without raw data or a character count', () => {

--- a/tests/components/chat/genui/tool-call-renderer.test.tsx
+++ b/tests/components/chat/genui/tool-call-renderer.test.tsx
@@ -4,6 +4,7 @@ import { GENUI_WIDGETS_BY_NAME } from '@/components/chat/genui/registry'
 import { ArtifactRetryError } from '@/components/chat/genui/retry'
 import type { GenUIRenderContext } from '@/components/chat/genui/types'
 import {
+  artifactPreviewTargetsEqual,
   OPEN_ARTIFACT_PREVIEW_EVENT,
   type ArtifactPreviewSidebarEventDetail,
 } from '@/components/chat/genui/widgets/ArtifactPreview'
@@ -86,7 +87,11 @@ describe('GenUIToolCallRenderer', () => {
     expect(listener).toHaveBeenCalledTimes(1)
     const event = listener.mock
       .calls[0][0] as CustomEvent<ArtifactPreviewSidebarEventDetail>
-    expect(event.detail).toEqual({ action: 'open', artifact })
+    expect(event.detail).toEqual({
+      action: 'open',
+      artifact,
+      toolCallId: 'artifact-1',
+    })
     window.removeEventListener(OPEN_ARTIFACT_PREVIEW_EVENT, listener)
   })
 
@@ -154,8 +159,81 @@ describe('GenUIToolCallRenderer', () => {
     expect(listener).toHaveBeenCalledTimes(1)
     const event = listener.mock
       .calls[0][0] as CustomEvent<ArtifactPreviewSidebarEventDetail>
-    expect(event.detail).toEqual({ action: 'toggle', artifact })
+    expect(event.detail).toEqual({
+      action: 'toggle',
+      artifact,
+      toolCallId: 'artifact-1',
+    })
     window.removeEventListener(OPEN_ARTIFACT_PREVIEW_EVENT, listener)
+  })
+
+  it('highlights only the open artifact and shows its full description', () => {
+    const secondArtifact = {
+      ...artifact,
+      title: 'Second artifact',
+      description:
+        'A longer artifact description that should wrap across as many lines as needed.',
+      source: { type: 'html' as const, html: '<main>Second</main>' },
+    }
+    const toolCalls = [
+      {
+        id: 'artifact-1',
+        name: 'render_artifact_preview',
+        arguments: validArtifactPreview,
+      },
+      {
+        id: 'artifact-2',
+        name: 'render_artifact_preview',
+        arguments: JSON.stringify(secondArtifact),
+      },
+    ]
+    const { rerender } = render(
+      <GenUIToolCallRenderer
+        isStreaming={false}
+        activeArtifactToolCallId="artifact-2"
+        toolCalls={toolCalls}
+      />,
+    )
+
+    const firstButton = screen.getByRole('button', { name: /Snake game/ })
+    const secondButton = screen.getByRole('button', {
+      name: /Second artifact/,
+    })
+    const description = screen.getByText(secondArtifact.description)
+    expect(firstButton).toHaveAttribute('aria-pressed', 'false')
+    expect(secondButton).toHaveAttribute('aria-pressed', 'true')
+    expect(secondButton.parentElement).toHaveClass('border-brand-accent-dark')
+    expect(description).toHaveClass('whitespace-pre-wrap', 'break-words')
+    expect(description).not.toHaveClass('truncate')
+
+    rerender(
+      <GenUIToolCallRenderer
+        isStreaming={false}
+        activeArtifactToolCallId="artifact-1"
+        toolCalls={toolCalls}
+      />,
+    )
+    expect(firstButton).toHaveAttribute('aria-pressed', 'true')
+    expect(secondButton).toHaveAttribute('aria-pressed', 'false')
+  })
+
+  it('distinguishes identical artifacts by tool call', () => {
+    expect(
+      artifactPreviewTargetsEqual(
+        artifact,
+        'artifact-1',
+        artifact,
+        'artifact-2',
+      ),
+    ).toBe(false)
+    expect(
+      artifactPreviewTargetsEqual(
+        artifact,
+        'artifact-1',
+        artifact,
+        'artifact-1',
+      ),
+    ).toBe(true)
   })
 
   it('shows a simple generating state without raw data or a character count', () => {

--- a/tests/components/chat/genui/tool-call-renderer.test.tsx
+++ b/tests/components/chat/genui/tool-call-renderer.test.tsx
@@ -29,12 +29,32 @@ const artifact = {
 }
 
 const validArtifactPreview = JSON.stringify(artifact)
+const artifactPreviewListeners: EventListener[] = []
 
 function setWindowWidth(width: number): void {
   Object.defineProperty(window, 'innerWidth', {
     configurable: true,
     value: width,
   })
+}
+
+function renderArtifactPreview({ isStreaming }: { isStreaming: boolean }) {
+  const listener = vi.fn<(event: Event) => void>()
+  artifactPreviewListeners.push(listener)
+  window.addEventListener(OPEN_ARTIFACT_PREVIEW_EVENT, listener)
+  render(
+    <GenUIToolCallRenderer
+      isStreaming={isStreaming}
+      toolCalls={[
+        {
+          id: 'artifact-1',
+          name: 'render_artifact_preview',
+          arguments: validArtifactPreview,
+        },
+      ]}
+    />,
+  )
+  return listener
 }
 
 describe('GenUIToolCallRenderer', () => {
@@ -44,6 +64,10 @@ describe('GenUIToolCallRenderer', () => {
   })
 
   afterEach(() => {
+    for (const listener of artifactPreviewListeners) {
+      window.removeEventListener(OPEN_ARTIFACT_PREVIEW_EVENT, listener)
+    }
+    artifactPreviewListeners.length = 0
     vi.restoreAllMocks()
   })
 
@@ -68,21 +92,7 @@ describe('GenUIToolCallRenderer', () => {
   })
 
   it('opens a generated artifact automatically on desktop', () => {
-    const listener = vi.fn()
-    window.addEventListener(OPEN_ARTIFACT_PREVIEW_EVENT, listener)
-
-    render(
-      <GenUIToolCallRenderer
-        isStreaming
-        toolCalls={[
-          {
-            id: 'artifact-1',
-            name: 'render_artifact_preview',
-            arguments: validArtifactPreview,
-          },
-        ]}
-      />,
-    )
+    const listener = renderArtifactPreview({ isStreaming: true })
 
     expect(listener).toHaveBeenCalledTimes(1)
     const event = listener.mock
@@ -92,68 +102,23 @@ describe('GenUIToolCallRenderer', () => {
       artifact,
       toolCallId: 'artifact-1',
     })
-    window.removeEventListener(OPEN_ARTIFACT_PREVIEW_EVENT, listener)
   })
 
   it('does not auto-open generated artifacts on mobile', () => {
     setWindowWidth(CONSTANTS.MOBILE_BREAKPOINT - 1)
-    const listener = vi.fn()
-    window.addEventListener(OPEN_ARTIFACT_PREVIEW_EVENT, listener)
-
-    render(
-      <GenUIToolCallRenderer
-        isStreaming
-        toolCalls={[
-          {
-            id: 'artifact-1',
-            name: 'render_artifact_preview',
-            arguments: validArtifactPreview,
-          },
-        ]}
-      />,
-    )
+    const listener = renderArtifactPreview({ isStreaming: true })
 
     expect(listener).not.toHaveBeenCalled()
-    window.removeEventListener(OPEN_ARTIFACT_PREVIEW_EVENT, listener)
   })
 
   it('does not auto-open artifacts from chat history', () => {
-    const listener = vi.fn()
-    window.addEventListener(OPEN_ARTIFACT_PREVIEW_EVENT, listener)
-
-    render(
-      <GenUIToolCallRenderer
-        isStreaming={false}
-        toolCalls={[
-          {
-            id: 'artifact-1',
-            name: 'render_artifact_preview',
-            arguments: validArtifactPreview,
-          },
-        ]}
-      />,
-    )
+    const listener = renderArtifactPreview({ isStreaming: false })
 
     expect(listener).not.toHaveBeenCalled()
-    window.removeEventListener(OPEN_ARTIFACT_PREVIEW_EVENT, listener)
   })
 
   it('keeps artifact card clicks as sidebar toggles', () => {
-    const listener = vi.fn()
-    window.addEventListener(OPEN_ARTIFACT_PREVIEW_EVENT, listener)
-
-    render(
-      <GenUIToolCallRenderer
-        isStreaming={false}
-        toolCalls={[
-          {
-            id: 'artifact-1',
-            name: 'render_artifact_preview',
-            arguments: validArtifactPreview,
-          },
-        ]}
-      />,
-    )
+    const listener = renderArtifactPreview({ isStreaming: false })
     fireEvent.click(screen.getByRole('button', { name: /Snake game/ }))
 
     expect(listener).toHaveBeenCalledTimes(1)
@@ -164,7 +129,6 @@ describe('GenUIToolCallRenderer', () => {
       artifact,
       toolCallId: 'artifact-1',
     })
-    window.removeEventListener(OPEN_ARTIFACT_PREVIEW_EVENT, listener)
   })
 
   it('highlights only the open artifact and shows its full description', () => {

--- a/tests/components/chat/genui/tool-call-renderer.test.tsx
+++ b/tests/components/chat/genui/tool-call-renderer.test.tsx
@@ -1,7 +1,12 @@
+import { CONSTANTS } from '@/components/chat/constants'
 import { GenUIToolCallRenderer } from '@/components/chat/genui/GenUIToolCallRenderer'
 import { GENUI_WIDGETS_BY_NAME } from '@/components/chat/genui/registry'
 import { ArtifactRetryError } from '@/components/chat/genui/retry'
 import type { GenUIRenderContext } from '@/components/chat/genui/types'
+import {
+  OPEN_ARTIFACT_PREVIEW_EVENT,
+  type ArtifactPreviewSidebarEventDetail,
+} from '@/components/chat/genui/widgets/ArtifactPreview'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { useState } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -16,9 +21,25 @@ const validMessageCompose = JSON.stringify({
   variants: [{ label: 'Concise', body: 'Thanks, I will confirm.' }],
 })
 
+const artifact = {
+  title: 'Snake game',
+  description: 'An interactive game',
+  source: { type: 'html' as const, html: '<main>Snake</main>' },
+}
+
+const validArtifactPreview = JSON.stringify(artifact)
+
+function setWindowWidth(width: number): void {
+  Object.defineProperty(window, 'innerWidth', {
+    configurable: true,
+    value: width,
+  })
+}
+
 describe('GenUIToolCallRenderer', () => {
   beforeEach(() => {
     logErrorMock.mockReset()
+    setWindowWidth(CONSTANTS.MOBILE_BREAKPOINT)
   })
 
   afterEach(() => {
@@ -43,6 +64,98 @@ describe('GenUIToolCallRenderer', () => {
     expect(
       screen.queryByText(/Generating message compose/),
     ).not.toBeInTheDocument()
+  })
+
+  it('opens a generated artifact automatically on desktop', () => {
+    const listener = vi.fn()
+    window.addEventListener(OPEN_ARTIFACT_PREVIEW_EVENT, listener)
+
+    render(
+      <GenUIToolCallRenderer
+        isStreaming
+        toolCalls={[
+          {
+            id: 'artifact-1',
+            name: 'render_artifact_preview',
+            arguments: validArtifactPreview,
+          },
+        ]}
+      />,
+    )
+
+    expect(listener).toHaveBeenCalledTimes(1)
+    const event = listener.mock
+      .calls[0][0] as CustomEvent<ArtifactPreviewSidebarEventDetail>
+    expect(event.detail).toEqual({ action: 'open', artifact })
+    window.removeEventListener(OPEN_ARTIFACT_PREVIEW_EVENT, listener)
+  })
+
+  it('does not auto-open generated artifacts on mobile', () => {
+    setWindowWidth(CONSTANTS.MOBILE_BREAKPOINT - 1)
+    const listener = vi.fn()
+    window.addEventListener(OPEN_ARTIFACT_PREVIEW_EVENT, listener)
+
+    render(
+      <GenUIToolCallRenderer
+        isStreaming
+        toolCalls={[
+          {
+            id: 'artifact-1',
+            name: 'render_artifact_preview',
+            arguments: validArtifactPreview,
+          },
+        ]}
+      />,
+    )
+
+    expect(listener).not.toHaveBeenCalled()
+    window.removeEventListener(OPEN_ARTIFACT_PREVIEW_EVENT, listener)
+  })
+
+  it('does not auto-open artifacts from chat history', () => {
+    const listener = vi.fn()
+    window.addEventListener(OPEN_ARTIFACT_PREVIEW_EVENT, listener)
+
+    render(
+      <GenUIToolCallRenderer
+        isStreaming={false}
+        toolCalls={[
+          {
+            id: 'artifact-1',
+            name: 'render_artifact_preview',
+            arguments: validArtifactPreview,
+          },
+        ]}
+      />,
+    )
+
+    expect(listener).not.toHaveBeenCalled()
+    window.removeEventListener(OPEN_ARTIFACT_PREVIEW_EVENT, listener)
+  })
+
+  it('keeps artifact card clicks as sidebar toggles', () => {
+    const listener = vi.fn()
+    window.addEventListener(OPEN_ARTIFACT_PREVIEW_EVENT, listener)
+
+    render(
+      <GenUIToolCallRenderer
+        isStreaming={false}
+        toolCalls={[
+          {
+            id: 'artifact-1',
+            name: 'render_artifact_preview',
+            arguments: validArtifactPreview,
+          },
+        ]}
+      />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: /Snake game/ }))
+
+    expect(listener).toHaveBeenCalledTimes(1)
+    const event = listener.mock
+      .calls[0][0] as CustomEvent<ArtifactPreviewSidebarEventDetail>
+    expect(event.detail).toEqual({ action: 'toggle', artifact })
+    window.removeEventListener(OPEN_ARTIFACT_PREVIEW_EVENT, listener)
   })
 
   it('shows a simple generating state without raw data or a character count', () => {


### PR DESCRIPTION
## Summary
- auto-open newly generated artifact previews on desktop-sized viewports
- highlight the artifact currently shown in the preview sidebar, including identical artifacts from separate tool calls
- show complete artifact descriptions and let cards grow to fit wrapped text
- preserve mobile, history, and manual toggle behavior

## Testing
- `npx vitest run` (1,543 tests)
- `npx tsc --noEmit -p tsconfig.json`
- focused ESLint and Prettier checks