### PR TITLE
refactor: use numeric model context windows

### DIFF
--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -2,7 +2,7 @@ import {
   findSelectableModel,
   getAIModels,
   getReasoningHistoryPolicy,
-  getResolvedModelContextWindow,
+  getResolvedModelContextWindowTokens,
   getSystemPromptAndRules,
   resolveModelSelection,
   type BaseModel,
@@ -1566,7 +1566,9 @@ export function ChatInterface({
   const reasoningHistoryPolicy = getReasoningHistoryPolicy(
     contextModelSelection,
   )
-  const contextWindow = getResolvedModelContextWindow(contextModelSelection)
+  const contextWindowTokens = getResolvedModelContextWindowTokens(
+    contextModelSelection,
+  )
   const pendingAttachments = buildCompletedAttachments(processedDocuments)
   const pendingContextTokens = estimateMessageTokens({
     role: 'user',
@@ -2296,9 +2298,7 @@ export function ChatInterface({
         file,
         (content, documentId, imageData, hasDescription, pages) => {
           const newDocTokens = estimateTokenCount(content)
-          const contextBudget = getContextTokenBudget(
-            selectedModelDetails?.contextWindow,
-          )
+          const contextBudget = getContextTokenBudget(contextWindowTokens)
 
           // Attachments are part of the next message, which cannot be
           // archived, so all pending attachments together must fit within
@@ -2386,12 +2386,7 @@ export function ChatInterface({
         },
       )
     },
-    [
-      handleDocumentUpload,
-      processedDocuments,
-      selectedModelDetails?.contextWindow,
-      toast,
-    ],
+    [handleDocumentUpload, processedDocuments, contextWindowTokens, toast],
   )
 
   // Helper to process file and add to project context
@@ -2596,7 +2591,7 @@ export function ChatInterface({
 
   // Calculate context usage (memoized to prevent re-calculation during streaming)
   const contextUsage = useMemo(() => {
-    const limitTokens = getContextTokenBudget(contextWindow)
+    const limitTokens = getContextTokenBudget(contextWindowTokens)
 
     let usedTokens = pendingContextTokens
 
@@ -2605,7 +2600,7 @@ export function ChatInterface({
     if (currentChat?.messages) {
       const messages = currentChat.messages
       const historyBudget = getHistoryTokenBudget(
-        contextWindow,
+        contextWindowTokens,
         pendingContextTokens,
       )
       const startIndex = findContextStartIndex(messages, historyBudget, {
@@ -2626,7 +2621,7 @@ export function ChatInterface({
     }
   }, [
     currentChat?.messages,
-    contextWindow,
+    contextWindowTokens,
     reasoningHistoryPolicy,
     pendingContextTokens,
   ])
@@ -3718,7 +3713,7 @@ export function ChatInterface({
                     recoveryDrafts={recoveryDrafts}
                     activeRecoveryTurnIds={activeRecoveryTurnIds}
                     reasoningHistoryPolicy={reasoningHistoryPolicy}
-                    contextWindow={contextWindow}
+                    contextWindowTokens={contextWindowTokens}
                     pendingContextTokens={pendingContextTokens}
                     isDarkMode={isDarkMode}
                     chatId={currentChat.id}

--- a/src/components/chat/chat-messages.tsx
+++ b/src/components/chat/chat-messages.tsx
@@ -8,6 +8,7 @@ import {
 import {
   findContextStartIndex,
   getHistoryTokenBudget,
+  resolveContextWindowTokens,
 } from '@/utils/token-estimation'
 import 'katex/dist/katex.min.css'
 import React, { memo, useEffect, useId, useMemo, useRef, useState } from 'react'
@@ -28,7 +29,7 @@ type ChatMessagesProps = {
   recoveryDrafts?: ReadonlyArray<{ turnId: string; message: Message }>
   activeRecoveryTurnIds?: readonly string[]
   reasoningHistoryPolicy?: ReasoningHistoryPolicy
-  contextWindow?: string
+  contextWindowTokens?: number
   pendingContextTokens?: number
   isDarkMode: boolean
   chatId: string
@@ -246,7 +247,7 @@ export function ChatMessages({
   recoveryDrafts = [],
   activeRecoveryTurnIds = [],
   reasoningHistoryPolicy = REASONING_HISTORY_POLICIES.none,
-  contextWindow,
+  contextWindowTokens,
   pendingContextTokens = 0,
   isDarkMode,
   chatId,
@@ -345,7 +346,8 @@ export function ChatMessages({
   // Separate messages into archived and live sections - memoize this calculation
   const { archivedMessages, liveMessages } = useMemo(() => {
     const budget = getHistoryTokenBudget(
-      contextWindow ?? currentModel?.contextWindow,
+      contextWindowTokens ??
+        resolveContextWindowTokens(currentModel ?? undefined),
       pendingContextTokens,
     )
     const startIndex = findContextStartIndex(messages, budget, {
@@ -358,8 +360,8 @@ export function ChatMessages({
     }
   }, [
     messages,
-    contextWindow,
-    currentModel?.contextWindow,
+    contextWindowTokens,
+    currentModel,
     reasoningHistoryPolicy,
     pendingContextTokens,
   ])

--- a/src/components/chat/genui/retry.ts
+++ b/src/components/chat/genui/retry.ts
@@ -10,7 +10,7 @@ import {
   estimateTokenCount,
   findContextStartIndex,
   getHistoryTokenBudget,
-  getSmallestContextWindow,
+  getSmallestContextWindowTokens,
 } from '@/utils/token-estimation'
 import { zodToJsonSchema } from 'zod-to-json-schema'
 import { GENUI_WIDGETS_BY_NAME, isGenUIToolName } from './registry'
@@ -58,7 +58,7 @@ function toPlainText(message: Message): string {
 
 export function selectArtifactRetryContext(
   contextMessages: Message[],
-  contextWindow: string | undefined,
+  contextWindowTokens: number | undefined,
   mandatoryPrompt: string,
 ): Array<{ role: 'user' | 'assistant'; content: string }> {
   const messages = contextMessages
@@ -80,7 +80,7 @@ export function selectArtifactRetryContext(
     searchReasoning: undefined,
   }))
   const budget = getHistoryTokenBudget(
-    contextWindow,
+    contextWindowTokens,
     estimateTokenCount(mandatoryPrompt),
   )
   const startIndex = findContextStartIndex(projected, budget, {
@@ -145,12 +145,12 @@ export async function regenerateToolCallArguments({
     'including the matching fields for the selected variant. Do not generate or revise prose.'
   const malformedArtifact = `Malformed arguments to repair:\n${originalArguments}`
   const mandatoryPrompt = `${instruction}\n${JSON.stringify(jsonSchema)}\n${malformedArtifact}`
-  const contextWindow = getSmallestContextWindow(
-    (autoCandidates ?? [model]).map((candidate) => candidate.contextWindow),
+  const contextWindowTokens = getSmallestContextWindowTokens(
+    autoCandidates ?? [model],
   )
   const conversation = selectArtifactRetryContext(
     contextMessages,
-    contextWindow,
+    contextWindowTokens,
     mandatoryPrompt,
   )
 

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -8,7 +8,10 @@ import {
   REASONING_HISTORY_POLICIES,
   type ReasoningHistoryPolicy,
 } from '@/utils/reasoning-history'
-import { getSmallestContextWindow } from '@/utils/token-estimation'
+import {
+  getSmallestContextWindowTokens,
+  resolveContextWindowTokens,
+} from '@/utils/token-estimation'
 
 const DEV_MODELS: BaseModel[] = [
   {
@@ -114,6 +117,7 @@ export type BaseModel = {
   details?: string
   parameters?: string
   contextWindow?: string
+  contextWindowTokens?: number
   recommendedUse?: string
   supportedLanguages?: string
   type: 'chat' | 'code' | 'embedding' | 'audio' | 'tts' | 'document' | 'title'
@@ -172,6 +176,11 @@ export const getAutoModels = (models: BaseModel[]): BaseModel[] => {
   const add = (tier: AutoTier, modelName: string, name: string): void => {
     const members = tierModels(models, tier)
     if (members.length === 0) return
+    const smallestMember = members.reduce((smallest, member) =>
+      resolveContextWindowTokens(member) < resolveContextWindowTokens(smallest)
+        ? member
+        : smallest,
+    )
     entries.push({
       modelName,
       image: '',
@@ -186,9 +195,8 @@ export const getAutoModels = (models: BaseModel[]): BaseModel[] => {
       isAuto: true,
       tier,
       multimodal: members.some((m) => m.multimodal === true),
-      contextWindow: getSmallestContextWindow(
-        members.map((member) => member.contextWindow),
-      ),
+      contextWindow: smallestMember.contextWindow,
+      contextWindowTokens: resolveContextWindowTokens(smallestMember),
     })
   }
   add('smart', AUTO_SMART_ID, 'Auto · Smart')
@@ -263,14 +271,10 @@ export const getReasoningHistoryPolicy = (
   )
 }
 
-export const getResolvedModelContextWindow = (
+export const getResolvedModelContextWindowTokens = (
   selection: ResolvedModelSelection,
-): string | undefined => {
-  return getSmallestContextWindow(
-    getResolvedCandidates(selection).map(
-      (candidate) => candidate.contextWindow,
-    ),
-  )
+): number | undefined => {
+  return getSmallestContextWindowTokens(getResolvedCandidates(selection))
 }
 
 /**

--- a/src/services/inference/chat-query-builder.ts
+++ b/src/services/inference/chat-query-builder.ts
@@ -6,7 +6,7 @@ import { buildGenUIPromptHint } from '@/components/chat/genui/system-prompt'
 import type { Message } from '@/components/chat/types'
 import {
   getReasoningHistoryPolicy,
-  getResolvedModelContextWindow,
+  getResolvedModelContextWindowTokens,
   type BaseModel,
 } from '@/config/models'
 import { shouldIncludeReasoning } from '@/utils/reasoning-history'
@@ -82,7 +82,7 @@ export class ChatQueryBuilder {
       model,
       autoCandidates,
     })
-    const contextWindow = getResolvedModelContextWindow({
+    const contextWindowTokens = getResolvedModelContextWindowTokens({
       model,
       autoCandidates,
     })
@@ -122,7 +122,7 @@ export class ChatQueryBuilder {
     // Add conversation history that fits within the model's context budget
     const recentMessages = selectMessagesWithinBudget(
       conversationMessages,
-      contextWindow,
+      contextWindowTokens,
       { reasoningHistoryPolicy },
     )
     let addedSystemInstructions = useSystemRole

--- a/src/utils/dev-simulator.ts
+++ b/src/utils/dev-simulator.ts
@@ -11,7 +11,7 @@ export const DEV_SIMULATOR_MODEL: BaseModel = {
   details:
     'Simulates various streaming patterns including thinking, content generation, and edge cases',
   parameters: 'Configurable via query patterns',
-  contextWindow: '32k tokens',
+  contextWindowTokens: 32000,
   recommendedUse: 'Testing and development only',
   type: 'chat',
   chat: true,

--- a/src/utils/token-estimation.ts
+++ b/src/utils/token-estimation.ts
@@ -11,6 +11,11 @@ export const CONTEXT_WINDOW_USAGE_RATIO = 0.9
 
 export const DEFAULT_CONTEXT_WINDOW_TOKENS = 64000
 
+export type ContextWindowConfig = {
+  contextWindowTokens?: number
+  contextWindow?: string
+}
+
 // Roughly estimate token count based on character length (≈4 chars per token)
 export function estimateTokenCount(text: string | undefined): number {
   if (!text) return 0
@@ -38,20 +43,25 @@ export function parseContextWindowTokens(contextWindow?: string): number {
   return tokens
 }
 
-export function getSmallestContextWindow(
-  contextWindows: Array<string | undefined>,
-): string | undefined {
-  if (contextWindows.length === 0) return undefined
-  let smallest = contextWindows[0]
-  for (let index = 1; index < contextWindows.length; index++) {
-    const candidate = contextWindows[index]
-    if (
-      parseContextWindowTokens(candidate) < parseContextWindowTokens(smallest)
-    ) {
-      smallest = candidate
-    }
+export function resolveContextWindowTokens(
+  config: ContextWindowConfig | undefined,
+): number {
+  const configuredTokens = config?.contextWindowTokens
+  if (
+    Number.isFinite(configuredTokens) &&
+    configuredTokens !== undefined &&
+    configuredTokens >= MIN_PLAUSIBLE_CONTEXT_WINDOW_TOKENS
+  ) {
+    return Math.round(configuredTokens)
   }
-  return smallest
+  return parseContextWindowTokens(config?.contextWindow)
+}
+
+export function getSmallestContextWindowTokens(
+  configs: ContextWindowConfig[],
+): number | undefined {
+  if (configs.length === 0) return undefined
+  return Math.min(...configs.map(resolveContextWindowTokens))
 }
 
 export type TokenEstimationOptions = {
@@ -100,17 +110,18 @@ export function estimateMessageTokens(
   return tokens
 }
 
-export function getContextTokenBudget(contextWindow?: string): number {
+export function getContextTokenBudget(contextWindowTokens?: number): number {
   return Math.floor(
-    parseContextWindowTokens(contextWindow) * CONTEXT_WINDOW_USAGE_RATIO,
+    (contextWindowTokens ?? DEFAULT_CONTEXT_WINDOW_TOKENS) *
+      CONTEXT_WINDOW_USAGE_RATIO,
   )
 }
 
 export function getHistoryTokenBudget(
-  contextWindow?: string,
+  contextWindowTokens?: number,
   pendingTokens = 0,
 ): number {
-  return Math.max(0, getContextTokenBudget(contextWindow) - pendingTokens)
+  return Math.max(0, getContextTokenBudget(contextWindowTokens) - pendingTokens)
 }
 
 /**
@@ -144,9 +155,9 @@ export function findContextStartIndex(
  */
 export function selectMessagesWithinBudget(
   messages: Message[],
-  contextWindow?: string,
+  contextWindowTokens?: number,
   options: TokenEstimationOptions = {},
 ): Message[] {
-  const budget = getContextTokenBudget(contextWindow)
+  const budget = getContextTokenBudget(contextWindowTokens)
   return messages.slice(findContextStartIndex(messages, budget, options))
 }

--- a/tests/components/chat/chat-messages-recovery.test.tsx
+++ b/tests/components/chat/chat-messages-recovery.test.tsx
@@ -46,6 +46,7 @@ vi.mock('@/utils/token-estimation', () => ({
   findContextStartIndex: () => 0,
   getContextTokenBudget: () => 1000,
   getHistoryTokenBudget: () => 1000,
+  resolveContextWindowTokens: () => 1000,
 }))
 
 vi.mock('@/components/chat/PrintableChat', () => ({

--- a/tests/components/chat/genui/retry.test.ts
+++ b/tests/components/chat/genui/retry.test.ts
@@ -39,7 +39,7 @@ vi.mock('@/utils/error-handling', () => ({ logError: logErrorMock }))
 
 const model = {
   modelName: 'gpt-oss-120b',
-  contextWindow: '64k',
+  contextWindowTokens: 64000,
 } as BaseModel
 
 function message(role: Message['role'], content: string): Message {
@@ -124,7 +124,7 @@ describe('artifact retry', () => {
     const recent = 'b'.repeat(200)
     const selected = selectArtifactRetryContext(
       [message('user', older), message('assistant', recent)],
-      '1k',
+      1000,
       'm'.repeat(3200),
     )
 
@@ -139,7 +139,7 @@ describe('artifact retry', () => {
     }
 
     expect(
-      selectArtifactRetryContext([contextualMessage], '1k', 'm'.repeat(3200)),
+      selectArtifactRetryContext([contextualMessage], 1000, 'm'.repeat(3200)),
     ).toEqual([{ role: 'assistant', content: 'visible' }])
   })
 

--- a/tests/config/models-reasoning-history.test.ts
+++ b/tests/config/models-reasoning-history.test.ts
@@ -1,6 +1,7 @@
 import {
+  getAutoModels,
   getReasoningHistoryPolicy,
-  getResolvedModelContextWindow,
+  getResolvedModelContextWindowTokens,
   type BaseModel,
 } from '@/config/models'
 import {
@@ -13,6 +14,7 @@ const model = (
   modelName: string,
   policy?: ReasoningHistoryPolicy,
   contextWindow?: string,
+  contextWindowTokens?: number,
 ): BaseModel => ({
   modelName,
   image: '',
@@ -22,6 +24,7 @@ const model = (
   type: 'chat',
   chat: true,
   contextWindow,
+  contextWindowTokens,
   reasoningConfig: policy ? { reasoningHistoryPolicy: policy } : undefined,
 })
 
@@ -63,13 +66,31 @@ describe('getReasoningHistoryPolicy', () => {
 
   it('uses the smallest Auto candidate context window', () => {
     expect(
-      getResolvedModelContextWindow({
+      getResolvedModelContextWindowTokens({
         model: model('large', undefined, '256k tokens'),
         autoCandidates: [
           model('large', undefined, '256k tokens'),
           model('small', undefined, '128k tokens'),
         ],
       }),
-    ).toBe('128k tokens')
+    ).toBe(128000)
+  })
+
+  it('prefers numeric context windows for Auto candidates', () => {
+    const candidates = [
+      model('large', undefined, '1k tokens', 256000),
+      model('small', undefined, '999k tokens', 128000),
+    ]
+    candidates.forEach((candidate) => {
+      candidate.attributes = ['smart']
+    })
+
+    expect(
+      getResolvedModelContextWindowTokens({
+        model: candidates[0],
+        autoCandidates: candidates,
+      }),
+    ).toBe(128000)
+    expect(getAutoModels(candidates)[0].contextWindowTokens).toBe(128000)
   })
 })

--- a/tests/services/inference/chat-query-builder.test.ts
+++ b/tests/services/inference/chat-query-builder.test.ts
@@ -37,6 +37,26 @@ const toolCallHistoryModel: BaseModel = {
 }
 
 describe('ChatQueryBuilder', () => {
+  it('archives history using numeric context metadata', () => {
+    const messages = ChatQueryBuilder.buildMessages({
+      model: {
+        ...model,
+        contextWindow: '256k tokens',
+        contextWindowTokens: 1000,
+      },
+      systemPrompt: '',
+      rules: '',
+      messages: [
+        { ...userMessage, content: 'a'.repeat(1600) },
+        { ...userMessage, content: 'b'.repeat(1600) },
+        { ...userMessage, content: 'c'.repeat(1600) },
+      ],
+    })
+
+    expect(messages).toHaveLength(2)
+    expect(messages[0]).toEqual({ role: 'user', content: 'b'.repeat(1600) })
+  })
+
   it('omits system messages when there is no prompt content', () => {
     const messages = ChatQueryBuilder.buildMessages({
       model,

--- a/tests/utils/token-estimation.test.ts
+++ b/tests/utils/token-estimation.test.ts
@@ -7,7 +7,9 @@ import {
   findContextStartIndex,
   getContextTokenBudget,
   getHistoryTokenBudget,
+  getSmallestContextWindowTokens,
   parseContextWindowTokens,
+  resolveContextWindowTokens,
   selectMessagesWithinBudget,
 } from '@/utils/token-estimation'
 import { describe, expect, it } from 'vitest'
@@ -55,16 +57,48 @@ describe('parseContextWindowTokens', () => {
   })
 })
 
+describe('resolveContextWindowTokens', () => {
+  it('prefers numeric model metadata', () => {
+    expect(
+      resolveContextWindowTokens({
+        contextWindowTokens: 128000,
+        contextWindow: '1k tokens',
+      }),
+    ).toBe(128000)
+  })
+
+  it('falls back to legacy display metadata', () => {
+    expect(resolveContextWindowTokens({ contextWindow: '256k tokens' })).toBe(
+      256000,
+    )
+    expect(
+      resolveContextWindowTokens({
+        contextWindowTokens: 0,
+        contextWindow: '32k tokens',
+      }),
+    ).toBe(32000)
+  })
+
+  it('finds the smallest mixed-format context window', () => {
+    expect(
+      getSmallestContextWindowTokens([
+        { contextWindowTokens: 256000, contextWindow: '1k tokens' },
+        { contextWindow: '128k tokens' },
+      ]),
+    ).toBe(128000)
+  })
+})
+
 describe('getContextTokenBudget', () => {
   it('reserves headroom below the full context window', () => {
-    expect(getContextTokenBudget('100k tokens')).toBe(
+    expect(getContextTokenBudget(100000)).toBe(
       Math.floor(100000 * CONTEXT_WINDOW_USAGE_RATIO),
     )
   })
 
   it('reserves pending input tokens before budgeting persisted history', () => {
-    expect(getHistoryTokenBudget('1k tokens', 250)).toBe(650)
-    expect(getHistoryTokenBudget('1k tokens', 1000)).toBe(0)
+    expect(getHistoryTokenBudget(1000, 250)).toBe(650)
+    expect(getHistoryTokenBudget(1000, 1000)).toBe(0)
   })
 })
 
@@ -181,7 +215,7 @@ describe('selectMessagesWithinBudget', () => {
       makeMessage('assistant', 1600),
       makeMessage('user', 1600),
     ]
-    const selected = selectMessagesWithinBudget(messages, '1k tokens')
+    const selected = selectMessagesWithinBudget(messages, 1000)
     expect(selected).toHaveLength(2)
     expect(selected[0]).toBe(messages[1])
     expect(selected[1]).toBe(messages[2])


### PR DESCRIPTION
## Summary
- prefer canonical numeric context-window metadata for budgeting and Auto routing
- migrate history archiving, context usage, attachments, and artifact retries to numeric limits
- retain legacy string parsing for older controlplane responses

## Dependency
- https://github.com/tinfoilsh/controlplane/pull/565

## Testing
- focused Vitest suite (59 tests)
- `npx tsc -p tsconfig.json --noEmit --incremental false`
- `npm run lint`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches context-window handling from display strings like “32k tokens” to numeric token counts. This standardizes budgeting, archiving, and Auto routing; legacy string parsing remains for older controlplane responses.

- Populate `BaseModel.contextWindowTokens` in model sources; keep `contextWindow` for display only if needed.
- Use numeric helpers and pass token counts:
  - Replace getResolvedModelContextWindow → getResolvedModelContextWindowTokens, getSmallestContextWindow → getSmallestContextWindowTokens; use resolveContextWindowTokens for mixed metadata.
  - getContextTokenBudget/getHistoryTokenBudget/selectMessagesWithinBudget now take numbers; `ChatMessages` expects `contextWindowTokens`.
- Auto models now compute and expose the smallest context window by tokens; downstream logic should read `contextWindowTokens` for limits.

<sup>Written for commit a2c3fdab50839b23e0d13cbe1eee1218bda291d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/484?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

