### PR TITLE
Separate attachment payloads from chat records

### DIFF
--- a/src/services/cloud/cloud-storage.ts
+++ b/src/services/cloud/cloud-storage.ts
@@ -1,4 +1,4 @@
-import type { Message } from '@/components/chat/types'
+import type { Attachment, Message } from '@/components/chat/types'
 import { AUTH_ACTIVE_USER_ID } from '@/constants/storage-keys'
 import { isLocalRecoveryEnvelope } from '@/types/chat-recovery'
 import {
@@ -172,11 +172,16 @@ function stripBase64FromMessages(messages: Message[]): Message[] {
   return messages.map((msg) => ({
     ...msg,
     attachments: msg.attachments?.map((att) => {
-      if (att.type === 'image' && att.base64) {
-        const { base64: _removed, ...rest } = att
+      const { storagePayloadId: _localReference, ...withoutLocalReference } =
+        att as Attachment & { storagePayloadId?: string }
+      if (
+        withoutLocalReference.type === 'image' &&
+        withoutLocalReference.base64
+      ) {
+        const { base64: _removed, ...rest } = withoutLocalReference
         return rest
       }
-      return att
+      return withoutLocalReference
     }),
   }))
 }
@@ -344,12 +349,16 @@ export class CloudStorageService {
             idempotencyKey: attachmentIdemKey,
           })
           const clientId = att.id
+          const storagePayloadId = (
+            att as Attachment & { storagePayloadId?: string }
+          ).storagePayloadId
           att.id = enclaveID
           att.encryptionKey = att_key
           rewrites.push({
             clientId,
             serverId: enclaveID,
             encryptionKey: att_key,
+            storagePayloadId,
           })
         }
         attachmentIndex++

--- a/src/services/cloud/cloud-sync.ts
+++ b/src/services/cloud/cloud-sync.ts
@@ -10,7 +10,11 @@ import { AuthTokenUnavailableError } from '@/services/auth'
 import { logError, logInfo, logWarning } from '@/utils/error-handling'
 import { chatEvents } from '../storage/chat-events'
 import { deletedChatsTracker } from '../storage/deleted-chats-tracker'
-import { indexedDBStorage, type StoredChat } from '../storage/indexed-db'
+import {
+  chatContentFingerprint,
+  indexedDBStorage,
+  type StoredChat,
+} from '../storage/indexed-db'
 import { decideRecovery } from '../sync-enclave/enclave-error-recovery'
 import { passkeyEvents } from '../sync-enclave/passkey-events'
 import { keyCurrent, newIdempotencyKey } from '../sync-enclave/sync-api'
@@ -799,6 +803,7 @@ export class CloudSyncService {
     }
 
     const preUploadUpdatedAt = chat.updatedAt
+    const preUploadFingerprint = chatContentFingerprint(chat)
     const preUploadVersion = chat.syncVersion ?? 0
     if (!this.isCurrentGeneration(generation)) return
     const { syncVersion, rewrites } = await cloudStorage.uploadChat(chat, {
@@ -811,6 +816,7 @@ export class CloudSyncService {
       chatId,
       rewrites,
       preUploadUpdatedAt,
+      preUploadFingerprint,
       syncVersion: syncVersion ?? preUploadVersion + 1,
     })
   }
@@ -910,6 +916,7 @@ export class CloudSyncService {
       }
 
       const preUploadUpdatedAt = chat.updatedAt
+      const preUploadFingerprint = chatContentFingerprint(chat)
       const preUploadVersion = chat.syncVersion ?? 0
       if (!this.isCurrentGeneration(generation)) return null
       return async () => {
@@ -924,6 +931,7 @@ export class CloudSyncService {
             chatId,
             rewrites,
             preUploadUpdatedAt,
+            preUploadFingerprint,
             syncVersion: syncVersion ?? preUploadVersion + 1,
           })
           reportChatSynced(chatId)

--- a/src/services/cloud/cloud-sync.ts
+++ b/src/services/cloud/cloud-sync.ts
@@ -214,7 +214,7 @@ export class CloudSyncService {
 
     try {
       // First check if we have local unsynced changes
-      const unsyncedChats = await indexedDBStorage.getUnsyncedChats()
+      const unsyncedChats = await indexedDBStorage.getUnsyncedChatMetadata()
       const chatsNeedingUpload = unsyncedChats.filter((chat) => {
         // Filter by project if specified
         if (projectId) {

--- a/src/services/storage/indexed-db.ts
+++ b/src/services/storage/indexed-db.ts
@@ -1,4 +1,8 @@
-import type { Chat as ChatType } from '@/components/chat/types'
+import type {
+  Attachment,
+  Chat as ChatType,
+  Message,
+} from '@/components/chat/types'
 import { ACCOUNT_RESET_FAILED_EVENT } from '@/constants/auth-events'
 import {
   AUTH_ACCOUNT_RESET_FAILED,
@@ -47,6 +51,19 @@ interface StoredProject {
   project: Project
 }
 
+interface StoredAttachmentPayload {
+  id: string
+  chatId: string
+  base64?: string
+  thumbnailBase64?: string
+  textContent?: string
+  pages?: Attachment['pages']
+}
+
+type StoredAttachmentReference = Attachment & {
+  storagePayloadId?: string
+}
+
 /**
  * Rewrite emitted by the upload path when the enclave mints a fresh
  * attachment id + per-attachment key. `clientId` is what the local
@@ -62,7 +79,7 @@ export interface AttachmentRewrite {
 }
 
 export const DB_NAME = 'tinfoil-chat'
-export const DB_VERSION = 4
+export const DB_VERSION = 5
 export const INDEXED_DB_UPGRADE_BLOCKED_EVENT = 'indexedDBUpgradeBlocked'
 const CHATS_STORE = 'chats'
 const CHATS_PROJECT_INDEX = 'projectId'
@@ -71,6 +88,8 @@ const PROJECTS_STORE = 'projects'
 const PROJECTS_USER_INDEX = 'userId'
 const MIGRATIONS_STORE = 'migrations'
 const SYNC_PENDING_MIGRATION_ID = 'sync-pending-v4'
+const ATTACHMENT_PAYLOADS_STORE = 'attachmentPayloads'
+const ATTACHMENT_PAYLOADS_CHAT_INDEX = 'chatId'
 const ACCOUNT_CHANGE_RESET_TIMEOUT_MS = 10_000
 const ACCOUNT_CHANGE_READ_ERROR = 'IndexedDB read superseded by account change'
 const ACCOUNT_CHANGE_WRITE_ERROR =
@@ -254,6 +273,100 @@ export function snapshotChatForStorage(chat: Chat): Chat {
   }
 }
 
+function attachmentHasPayload(attachment: Attachment): boolean {
+  return (
+    attachment.base64 !== undefined ||
+    attachment.thumbnailBase64 !== undefined ||
+    attachment.textContent !== undefined ||
+    attachment.pages !== undefined
+  )
+}
+
+function normalizeAttachmentPayloads(chat: Chat): {
+  messages: Message[]
+  payloads: StoredAttachmentPayload[]
+  replacePayloads: boolean
+} {
+  const payloads: StoredAttachmentPayload[] = []
+  let hasStoredReferences = false
+  let hasHydratedPayloads = false
+
+  const messages = chat.messages.map((message) => ({
+    ...message,
+    attachments: message.attachments?.map((attachment) => {
+      const storedAttachment = attachment as StoredAttachmentReference
+      if (storedAttachment.storagePayloadId) hasStoredReferences = true
+      if (attachmentHasPayload(attachment)) hasHydratedPayloads = true
+
+      const payloadId =
+        storedAttachment.storagePayloadId ?? `${chat.id}:${attachment.id}`
+      const { base64, thumbnailBase64, textContent, pages, ...metadata } =
+        storedAttachment
+
+      if (attachmentHasPayload(attachment)) {
+        payloads.push({
+          id: payloadId,
+          chatId: chat.id,
+          base64,
+          thumbnailBase64,
+          textContent,
+          pages,
+        })
+      }
+
+      return {
+        ...metadata,
+        storagePayloadId: payloadId,
+      }
+    }),
+  }))
+
+  return {
+    messages,
+    payloads,
+    replacePayloads: hasHydratedPayloads || !hasStoredReferences,
+  }
+}
+
+function hydrateAttachmentPayloads(
+  chat: StoredChat,
+  payloads: StoredAttachmentPayload[],
+): StoredChat {
+  const payloadById = new Map(payloads.map((payload) => [payload.id, payload]))
+
+  return {
+    ...chat,
+    messages: chat.messages.map((message) => ({
+      ...message,
+      attachments: message.attachments?.map((attachment) => {
+        const { storagePayloadId, ...metadata } =
+          attachment as StoredAttachmentReference
+        const payload = storagePayloadId
+          ? payloadById.get(storagePayloadId)
+          : undefined
+        if (!payload) return metadata
+        const { id, chatId, ...content } = payload
+        return { ...metadata, ...content }
+      }),
+    })),
+  }
+}
+
+function deleteAttachmentPayloadsForChat(
+  store: IDBObjectStore,
+  chatId: string,
+): void {
+  const request = store
+    .index(ATTACHMENT_PAYLOADS_CHAT_INDEX)
+    .openKeyCursor(IDBKeyRange.only(chatId))
+  request.onsuccess = () => {
+    const cursor = request.result
+    if (!cursor) return
+    store.delete(cursor.primaryKey)
+    cursor.continue()
+  }
+}
+
 export class IndexedDBStorage {
   private db: IDBDatabase | null = null
   private initializationPromise: Promise<void> | null = null
@@ -361,6 +474,16 @@ export class IndexedDBStorage {
           }
           if (!db.objectStoreNames.contains(MIGRATIONS_STORE)) {
             db.createObjectStore(MIGRATIONS_STORE, { keyPath: 'id' })
+          }
+          if (!db.objectStoreNames.contains(ATTACHMENT_PAYLOADS_STORE)) {
+            const store = db.createObjectStore(ATTACHMENT_PAYLOADS_STORE, {
+              keyPath: 'id',
+            })
+            store.createIndex(
+              ATTACHMENT_PAYLOADS_CHAT_INDEX,
+              ATTACHMENT_PAYLOADS_CHAT_INDEX,
+              { unique: false },
+            )
           }
           if ((event as IDBVersionChangeEvent).oldVersion === 0) {
             request.transaction?.objectStore(MIGRATIONS_STORE).put({
@@ -498,7 +621,7 @@ export class IndexedDBStorage {
       (resetDb) =>
         new Promise<void>((resolve, reject) => {
           const transaction = resetDb.transaction(
-            [CHATS_STORE, PROJECTS_STORE],
+            [CHATS_STORE, PROJECTS_STORE, ATTACHMENT_PAYLOADS_STORE],
             'readwrite',
           )
           const timeout = window.setTimeout(() => {
@@ -535,6 +658,17 @@ export class IndexedDBStorage {
           projectsRequest.onerror = () => {
             clearTimeout(timeout)
             reject(new Error('Failed to clear projects for account change'))
+          }
+          const payloadsRequest = transaction
+            .objectStore(ATTACHMENT_PAYLOADS_STORE)
+            .clear()
+          payloadsRequest.onerror = () => {
+            clearTimeout(timeout)
+            reject(
+              new Error(
+                'Failed to clear attachment payloads for account change',
+              ),
+            )
           }
         }),
     )
@@ -650,8 +784,12 @@ export class IndexedDBStorage {
     }
 
     return new Promise((resolve, reject) => {
-      const transaction = db.transaction([CHATS_STORE], 'readwrite')
+      const transaction = db.transaction(
+        [CHATS_STORE, ATTACHMENT_PAYLOADS_STORE],
+        'readwrite',
+      )
       const store = transaction.objectStore(CHATS_STORE)
+      const payloadStore = transaction.objectStore(ATTACHMENT_PAYLOADS_STORE)
       let result: SaveChatResult = {
         saved: false,
         isLocalOnly: (chat as StoredChat).isLocalOnly === true,
@@ -687,7 +825,7 @@ export class IndexedDBStorage {
             },
           )
         })
-        reject(new Error('Transaction aborted'))
+        reject(transaction.error ?? new Error('Transaction aborted'))
       }
 
       const getRequest = store.get(chat.id)
@@ -698,13 +836,16 @@ export class IndexedDBStorage {
           return
         }
 
-        const messagesForStorage = chat.messages.map((msg) => ({
-          ...msg,
-          timestamp:
-            msg.timestamp instanceof Date
-              ? msg.timestamp.toISOString()
-              : msg.timestamp,
-        }))
+        const normalizedAttachments = normalizeAttachmentPayloads(chat)
+        const messagesForStorage = normalizedAttachments.messages.map(
+          (msg) => ({
+            ...msg,
+            timestamp:
+              msg.timestamp instanceof Date
+                ? msg.timestamp.toISOString()
+                : msg.timestamp,
+          }),
+        )
 
         // Determine if the chat's meaningful content has changed compared to existing version.
         // NOTE: We intentionally ignore `updatedAt` so we don't create sync churn from timestamps.
@@ -794,10 +935,37 @@ export class IndexedDBStorage {
         }
         result = { saved: true, isLocalOnly }
 
-        const putRequest = store.put(storedChat)
+        const writeChatAndPayloads = () => {
+          for (const payload of normalizedAttachments.payloads) {
+            const payloadRequest = payloadStore.put(payload)
+            payloadRequest.onerror = () =>
+              reject(
+                payloadRequest.error ??
+                  new Error('Failed to save attachment payload'),
+              )
+          }
+          const putRequest = store.put(storedChat)
+          putRequest.onerror = () => reject(new Error('Failed to save chat'))
+        }
 
-        putRequest.onerror = () => {
-          reject(new Error('Failed to save chat'))
+        if (!normalizedAttachments.replacePayloads) {
+          writeChatAndPayloads()
+          return
+        }
+
+        const payloadCursor = payloadStore
+          .index(ATTACHMENT_PAYLOADS_CHAT_INDEX)
+          .openCursor(IDBKeyRange.only(chat.id))
+        payloadCursor.onerror = () =>
+          reject(new Error('Failed to replace attachment payloads'))
+        payloadCursor.onsuccess = () => {
+          const cursor = payloadCursor.result
+          if (cursor) {
+            cursor.delete()
+            cursor.continue()
+            return
+          }
+          writeChatAndPayloads()
         }
       }
 
@@ -806,7 +974,7 @@ export class IndexedDBStorage {
     })
   }
 
-  private async getChatInternal(id: string): Promise<StoredChat | null> {
+  private async getStoredChatInternal(id: string): Promise<StoredChat | null> {
     const db = await this.ensureDB()
 
     return new Promise((resolve, reject) => {
@@ -823,6 +991,33 @@ export class IndexedDBStorage {
         }
       }
       request.onerror = () => reject(new Error('Failed to get chat'))
+    })
+  }
+
+  private async getChatInternal(id: string): Promise<StoredChat | null> {
+    const chat = await this.getStoredChatInternal(id)
+    if (!chat) return null
+    const db = await this.ensureDB()
+
+    return new Promise((resolve, reject) => {
+      const transaction = db.transaction(
+        [ATTACHMENT_PAYLOADS_STORE],
+        'readonly',
+      )
+      const request = transaction
+        .objectStore(ATTACHMENT_PAYLOADS_STORE)
+        .index(ATTACHMENT_PAYLOADS_CHAT_INDEX)
+        .getAll(IDBKeyRange.only(id))
+
+      request.onsuccess = () =>
+        resolve(
+          hydrateAttachmentPayloads(
+            chat,
+            request.result as StoredAttachmentPayload[],
+          ),
+        )
+      request.onerror = () =>
+        reject(new Error('Failed to get attachment payloads'))
     })
   }
 
@@ -849,9 +1044,16 @@ export class IndexedDBStorage {
     return this.enqueueSave('deleteChat', async () => {
       const db = await this.ensureDB()
       return new Promise<void>((resolve, reject) => {
-        const transaction = db.transaction([CHATS_STORE], 'readwrite')
+        const transaction = db.transaction(
+          [CHATS_STORE, ATTACHMENT_PAYLOADS_STORE],
+          'readwrite',
+        )
         const store = transaction.objectStore(CHATS_STORE)
         const request = store.delete(id)
+        deleteAttachmentPayloadsForChat(
+          transaction.objectStore(ATTACHMENT_PAYLOADS_STORE),
+          id,
+        )
 
         transaction.oncomplete = () => resolve()
         transaction.onerror = () => reject(new Error('Failed to delete chat'))
@@ -870,7 +1072,10 @@ export class IndexedDBStorage {
       const db = await this.ensureDB()
       if (!isCurrent()) return false
       return new Promise<boolean>((resolve, reject) => {
-        const transaction = db.transaction([CHATS_STORE], 'readwrite')
+        const transaction = db.transaction(
+          [CHATS_STORE, ATTACHMENT_PAYLOADS_STORE],
+          'readwrite',
+        )
         const store = transaction.objectStore(CHATS_STORE)
         let deleted = false
         const getRequest = store.get(id)
@@ -880,6 +1085,10 @@ export class IndexedDBStorage {
           const chat = getRequest.result as StoredChat | undefined
           if (!chat || chat.updatedAt !== expectedUpdatedAt) return
           store.delete(id)
+          deleteAttachmentPayloadsForChat(
+            transaction.objectStore(ATTACHMENT_PAYLOADS_STORE),
+            id,
+          )
           deleted = true
         }
         transaction.oncomplete = () => resolve(deleted)
@@ -895,7 +1104,10 @@ export class IndexedDBStorage {
     return this.enqueueSave('deleteAllNonLocalChats', async () => {
       const db = await this.ensureDB()
       return new Promise((resolve, reject) => {
-        const transaction = db.transaction([CHATS_STORE], 'readwrite')
+        const transaction = db.transaction(
+          [CHATS_STORE, ATTACHMENT_PAYLOADS_STORE],
+          'readwrite',
+        )
         const store = transaction.objectStore(CHATS_STORE)
         const request = store.openCursor()
         let deletedCount = 0
@@ -906,14 +1118,19 @@ export class IndexedDBStorage {
             const chat = cursor.value as StoredChat
             if (!chat.isLocalOnly) {
               cursor.delete()
+              deleteAttachmentPayloadsForChat(
+                transaction.objectStore(ATTACHMENT_PAYLOADS_STORE),
+                chat.id,
+              )
               deletedCount++
             }
             cursor.continue()
-          } else {
-            resolve(deletedCount)
           }
         }
 
+        transaction.oncomplete = () => resolve(deletedCount)
+        transaction.onerror = () =>
+          reject(new Error('Failed to delete non-local chats'))
         request.onerror = () =>
           reject(new Error('Failed to delete non-local chats'))
       })
@@ -926,7 +1143,10 @@ export class IndexedDBStorage {
     return this.enqueueSave('deleteChatsByProject', async () => {
       const db = await this.ensureDB()
       return new Promise<string[]>((resolve, reject) => {
-        const transaction = db.transaction([CHATS_STORE], 'readwrite')
+        const transaction = db.transaction(
+          [CHATS_STORE, ATTACHMENT_PAYLOADS_STORE],
+          'readwrite',
+        )
         const store = transaction.objectStore(CHATS_STORE)
         const request = store.openCursor()
         const deletedIds: string[] = []
@@ -938,6 +1158,10 @@ export class IndexedDBStorage {
             if (chat.projectId === projectId) {
               deletedIds.push(chat.id)
               cursor.delete()
+              deleteAttachmentPayloadsForChat(
+                transaction.objectStore(ATTACHMENT_PAYLOADS_STORE),
+                chat.id,
+              )
             }
             cursor.continue()
           }
@@ -992,18 +1216,23 @@ export class IndexedDBStorage {
     return this.enqueueSave('deleteAllChats', async () => {
       const db = await this.ensureDB()
       return new Promise<number>((resolve, reject) => {
-        const transaction = db.transaction([CHATS_STORE], 'readwrite')
+        const transaction = db.transaction(
+          [CHATS_STORE, ATTACHMENT_PAYLOADS_STORE],
+          'readwrite',
+        )
         const store = transaction.objectStore(CHATS_STORE)
         const countRequest = store.count()
+        let count = 0
 
         countRequest.onsuccess = () => {
-          const count = countRequest.result
-          const clearRequest = store.clear()
-          clearRequest.onsuccess = () => resolve(count)
-          clearRequest.onerror = () =>
-            reject(new Error('Failed to clear chats store'))
+          count = countRequest.result
+          store.clear()
+          transaction.objectStore(ATTACHMENT_PAYLOADS_STORE).clear()
         }
 
+        transaction.oncomplete = () => resolve(count)
+        transaction.onerror = () =>
+          reject(new Error('Failed to clear chats store'))
         countRequest.onerror = () => reject(new Error('Failed to count chats'))
       })
     })
@@ -1152,12 +1381,24 @@ export class IndexedDBStorage {
 
     return this.protectRead(
       new Promise((resolve, reject) => {
-        const transaction = db.transaction([CHATS_STORE], 'readonly')
+        const transaction = db.transaction(
+          [CHATS_STORE, ATTACHMENT_PAYLOADS_STORE],
+          'readonly',
+        )
         const store = transaction.objectStore(CHATS_STORE)
         // Sort by ID (primary key) which contains reverse timestamp
         const request = store.openCursor(null, 'next') // Ascending order on reverse timestamp = most recent first
 
         const chats: StoredChat[] = []
+        let payloads: StoredAttachmentPayload[] = []
+        const payloadRequest = transaction
+          .objectStore(ATTACHMENT_PAYLOADS_STORE)
+          .getAll()
+        payloadRequest.onsuccess = () => {
+          payloads = payloadRequest.result as StoredAttachmentPayload[]
+        }
+        payloadRequest.onerror = () =>
+          reject(new Error('Failed to get attachment payloads'))
 
         request.onsuccess = (event) => {
           const cursor = (event.target as IDBRequest).result
@@ -1168,12 +1409,26 @@ export class IndexedDBStorage {
             } catch (error) {
               reject(error)
             }
-          } else {
-            resolve(chats)
           }
         }
 
         request.onerror = () => reject(new Error('Failed to get all chats'))
+        transaction.oncomplete = () => {
+          const payloadsByChat = new Map<string, StoredAttachmentPayload[]>()
+          for (const payload of payloads) {
+            const chatPayloads = payloadsByChat.get(payload.chatId)
+            if (chatPayloads) chatPayloads.push(payload)
+            else payloadsByChat.set(payload.chatId, [payload])
+          }
+          resolve(
+            chats.map((chat) =>
+              hydrateAttachmentPayloads(
+                chat,
+                payloadsByChat.get(chat.id) ?? [],
+              ),
+            ),
+          )
+        }
       }),
     )
   }
@@ -1287,11 +1542,16 @@ export class IndexedDBStorage {
     const db = await this.ensureDB()
 
     return new Promise((resolve, reject) => {
-      const transaction = db.transaction([CHATS_STORE], 'readwrite')
+      const transaction = db.transaction(
+        [CHATS_STORE, ATTACHMENT_PAYLOADS_STORE],
+        'readwrite',
+      )
       const store = transaction.objectStore(CHATS_STORE)
       const request = store.clear()
+      transaction.objectStore(ATTACHMENT_PAYLOADS_STORE).clear()
 
-      request.onsuccess = () => resolve()
+      transaction.oncomplete = () => resolve()
+      transaction.onerror = () => reject(new Error('Failed to clear all chats'))
       request.onerror = () => reject(new Error('Failed to clear all chats'))
     })
   }
@@ -1299,7 +1559,7 @@ export class IndexedDBStorage {
   private async updateLastAccessed(id: string): Promise<void> {
     return this.enqueueSave('updateLastAccessed', async () => {
       const db = await this.ensureDB()
-      const chat = await this.getChatInternal(id)
+      const chat = await this.getStoredChatInternal(id)
 
       if (chat) {
         return new Promise<void>((resolve, reject) => {
@@ -1421,7 +1681,7 @@ export class IndexedDBStorage {
   async markAsSynced(id: string, syncVersion: number): Promise<void> {
     return this.enqueueSave('markAsSynced', async () => {
       const db = await this.ensureDB()
-      const chat = await this.getChatInternal(id)
+      const chat = await this.getStoredChatInternal(id)
 
       if (chat) {
         return new Promise<void>((resolve, reject) => {
@@ -1459,7 +1719,7 @@ export class IndexedDBStorage {
   async rebaseSyncVersion(id: string, syncVersion: number): Promise<void> {
     return this.enqueueSave('rebaseSyncVersion', async () => {
       const db = await this.ensureDB()
-      const chat = await this.getChatInternal(id)
+      const chat = await this.getStoredChatInternal(id)
       if (!chat) {
         return
       }
@@ -1500,7 +1760,7 @@ export class IndexedDBStorage {
   }): Promise<void> {
     return this.enqueueSave('finalizeUpload', async () => {
       const db = await this.ensureDB()
-      const chat = await this.getChatInternal(opts.chatId)
+      const chat = await this.getStoredChatInternal(opts.chatId)
       if (!chat) {
         return
       }
@@ -1576,7 +1836,7 @@ export class IndexedDBStorage {
       if (!isCurrent()) return { applied: false }
       const db = await this.ensureDB()
       if (!isCurrent()) return { applied: false }
-      const existing = await this.getChatInternal(opts.chat.id)
+      const existing = await this.getStoredChatInternal(opts.chat.id)
       if (!isCurrent()) return { applied: false }
 
       if (opts.expectedLocalUpdatedAt !== undefined) {
@@ -1593,7 +1853,8 @@ export class IndexedDBStorage {
         }
       }
 
-      const messagesForStorage = opts.chat.messages.map((msg) => ({
+      const normalizedAttachments = normalizeAttachmentPayloads(opts.chat)
+      const messagesForStorage = normalizedAttachments.messages.map((msg) => ({
         ...msg,
         timestamp:
           msg.timestamp instanceof Date
@@ -1618,13 +1879,49 @@ export class IndexedDBStorage {
 
       if (!isCurrent()) return { applied: false }
       await new Promise<void>((resolve, reject) => {
-        const transaction = db.transaction([CHATS_STORE], 'readwrite')
+        const transaction = db.transaction(
+          [CHATS_STORE, ATTACHMENT_PAYLOADS_STORE],
+          'readwrite',
+        )
         const store = transaction.objectStore(CHATS_STORE)
+        const payloadStore = transaction.objectStore(ATTACHMENT_PAYLOADS_STORE)
         transaction.oncomplete = () => resolve()
         transaction.onerror = () =>
           reject(new Error('Failed to apply remote chat'))
-        const request = store.put(storedChat)
-        request.onerror = () => reject(new Error('Failed to apply remote chat'))
+
+        const writeChatAndPayloads = () => {
+          for (const payload of normalizedAttachments.payloads) {
+            const payloadRequest = payloadStore.put(payload)
+            payloadRequest.onerror = () =>
+              reject(
+                payloadRequest.error ??
+                  new Error('Failed to save remote attachment payload'),
+              )
+          }
+          const request = store.put(storedChat)
+          request.onerror = () =>
+            reject(new Error('Failed to apply remote chat'))
+        }
+
+        if (!normalizedAttachments.replacePayloads) {
+          writeChatAndPayloads()
+          return
+        }
+
+        const payloadCursor = payloadStore
+          .index(ATTACHMENT_PAYLOADS_CHAT_INDEX)
+          .openCursor(IDBKeyRange.only(opts.chat.id))
+        payloadCursor.onerror = () =>
+          reject(new Error('Failed to replace remote attachment payloads'))
+        payloadCursor.onsuccess = () => {
+          const cursor = payloadCursor.result
+          if (cursor) {
+            cursor.delete()
+            cursor.continue()
+            return
+          }
+          writeChatAndPayloads()
+        }
       })
       return { applied: true }
     })
@@ -1665,7 +1962,7 @@ export class IndexedDBStorage {
   async resetChatTimestamps(chatId: string): Promise<void> {
     return this.enqueueSave('resetChatTimestamps', async () => {
       const db = await this.ensureDB()
-      const chat = await this.getChatInternal(chatId)
+      const chat = await this.getStoredChatInternal(chatId)
 
       if (chat) {
         return new Promise<void>((resolve, reject) => {
@@ -1696,7 +1993,7 @@ export class IndexedDBStorage {
     projectId: string | null,
   ): Promise<void> {
     return this.enqueueSave('updateChatProject', async () => {
-      const chat = await this.getChatInternal(chatId)
+      const chat = await this.getStoredChatInternal(chatId)
       if (chat) {
         chat.projectId = projectId ?? undefined
         chat.locallyModified = true
@@ -1712,7 +2009,7 @@ export class IndexedDBStorage {
     expectedLocalUpdatedAt: string | null,
   ): Promise<boolean> {
     return this.enqueueSave('applyRemoteChatProject', async () => {
-      const chat = await this.getChatInternal(chatId)
+      const chat = await this.getStoredChatInternal(chatId)
       if (
         !chat ||
         chat.updatedAt !== expectedLocalUpdatedAt ||
@@ -1733,7 +2030,7 @@ export class IndexedDBStorage {
     isLocalOnly: boolean,
   ): Promise<void> {
     return this.enqueueSave('updateChatLocalOnly', async () => {
-      const chat = await this.getChatInternal(chatId)
+      const chat = await this.getStoredChatInternal(chatId)
       if (chat) {
         chat.isLocalOnly = isLocalOnly
         chat.locallyModified = true

--- a/src/services/storage/indexed-db.ts
+++ b/src/services/storage/indexed-db.ts
@@ -76,6 +76,7 @@ export interface AttachmentRewrite {
   clientId: string
   serverId: string
   encryptionKey: string
+  storagePayloadId?: string
 }
 
 export const DB_NAME = 'tinfoil-chat'
@@ -90,6 +91,7 @@ const MIGRATIONS_STORE = 'migrations'
 const SYNC_PENDING_MIGRATION_ID = 'sync-pending-v4'
 const ATTACHMENT_PAYLOADS_STORE = 'attachmentPayloads'
 const ATTACHMENT_PAYLOADS_CHAT_INDEX = 'chatId'
+const DUPLICATE_ATTACHMENT_PAYLOAD_MARKER = ':duplicate:'
 const ACCOUNT_CHANGE_RESET_TIMEOUT_MS = 10_000
 const ACCOUNT_CHANGE_READ_ERROR = 'IndexedDB read superseded by account change'
 const ACCOUNT_CHANGE_WRITE_ERROR =
@@ -289,13 +291,36 @@ function normalizeAttachmentPayloads(chat: Chat): {
 } {
   const payloads: StoredAttachmentPayload[] = []
   const referencedPayloadIds = new Set<string>()
+  const attachmentIdCounts = new Map<string, number>()
+  const attachmentIdOccurrences = new Map<string, number>()
+
+  for (const message of chat.messages) {
+    for (const attachment of message.attachments ?? []) {
+      attachmentIdCounts.set(
+        attachment.id,
+        (attachmentIdCounts.get(attachment.id) ?? 0) + 1,
+      )
+    }
+  }
 
   const messages = chat.messages.map((message) => ({
     ...message,
     attachments: message.attachments?.map((attachment) => {
       const storedAttachment = attachment as StoredAttachmentReference
+      const occurrence = attachmentIdOccurrences.get(attachment.id) ?? 0
+      attachmentIdOccurrences.set(attachment.id, occurrence + 1)
+      const legacyPayloadId = `${chat.id}:${attachment.id}`
+      const generatedPayloadId =
+        occurrence === 0
+          ? legacyPayloadId
+          : `${legacyPayloadId}${DUPLICATE_ATTACHMENT_PAYLOAD_MARKER}${occurrence}`
+      const referencedPayloadId = storedAttachment.storagePayloadId
       const payloadId =
-        storedAttachment.storagePayloadId ?? `${chat.id}:${attachment.id}`
+        referencedPayloadId && !referencedPayloadIds.has(referencedPayloadId)
+          ? referencedPayloadId
+          : attachmentIdCounts.get(attachment.id) === 1
+            ? legacyPayloadId
+            : generatedPayloadId
       referencedPayloadIds.add(payloadId)
       const { base64, thumbnailBase64, textContent, pages, ...metadata } =
         storedAttachment
@@ -330,15 +355,43 @@ function inheritAttachmentPayloadReferences(
   existing: StoredChat | null | undefined,
 ): Chat {
   if (!existing) return chat
-  const payloadIdByAttachmentId = new Map<string, string>()
+  type PayloadCandidate = {
+    payloadId: string
+    messageKey: string
+    attachmentKey: string
+    used: boolean
+  }
+  const candidatesByAttachmentId = new Map<string, PayloadCandidate[]>()
+
+  const messageKey = (message: Message): string => {
+    if (message.turnId) return `turn:${message.turnId}`
+    const timestamp =
+      message.timestamp instanceof Date
+        ? message.timestamp.toISOString()
+        : String(message.timestamp)
+    return `${message.role}:${timestamp}`
+  }
+  const attachmentKey = (attachment: Attachment): string =>
+    JSON.stringify([
+      attachment.type,
+      attachment.fileName,
+      attachment.mimeType ?? null,
+      attachment.fileSize ?? null,
+    ])
+
   for (const message of existing.messages) {
     for (const attachment of message.attachments ?? []) {
       const storedAttachment = attachment as StoredAttachmentReference
       if (storedAttachment.storagePayloadId) {
-        payloadIdByAttachmentId.set(
-          storedAttachment.id,
-          storedAttachment.storagePayloadId,
-        )
+        const candidates =
+          candidatesByAttachmentId.get(storedAttachment.id) ?? []
+        candidates.push({
+          payloadId: storedAttachment.storagePayloadId,
+          messageKey: messageKey(message),
+          attachmentKey: attachmentKey(storedAttachment),
+          used: false,
+        })
+        candidatesByAttachmentId.set(storedAttachment.id, candidates)
       }
     }
   }
@@ -349,7 +402,26 @@ function inheritAttachmentPayloadReferences(
       ...message,
       attachments: message.attachments?.map((attachment) => {
         if (attachmentHasPayload(attachment)) return attachment
-        const storagePayloadId = payloadIdByAttachmentId.get(attachment.id)
+        const candidates = candidatesByAttachmentId.get(attachment.id) ?? []
+        const incomingMessageKey = messageKey(message)
+        const incomingAttachmentKey = attachmentKey(attachment)
+        const candidate =
+          candidates.find(
+            (item) =>
+              !item.used &&
+              item.messageKey === incomingMessageKey &&
+              item.attachmentKey === incomingAttachmentKey,
+          ) ??
+          candidates.find(
+            (item) => !item.used && item.messageKey === incomingMessageKey,
+          ) ??
+          candidates.find(
+            (item) =>
+              !item.used && item.attachmentKey === incomingAttachmentKey,
+          ) ??
+          candidates.find((item) => !item.used)
+        if (candidate) candidate.used = true
+        const storagePayloadId = candidate?.payloadId
         return storagePayloadId
           ? { ...attachment, storagePayloadId }
           : attachment
@@ -376,7 +448,7 @@ function hydrateAttachmentPayloads(
           : undefined
         if (!payload) return metadata
         const { id, chatId, ...content } = payload
-        return { ...metadata, ...content }
+        return { ...metadata, storagePayloadId, ...content }
       }),
     })),
   }
@@ -1866,13 +1938,33 @@ export class IndexedDBStorage {
       }
 
       if (opts.rewrites.length > 0) {
-        const rewriteByClient = new Map(
-          opts.rewrites.map((r) => [r.clientId, r]),
+        const rewritesByPayloadId = new Map(
+          opts.rewrites
+            .filter((rewrite) => rewrite.storagePayloadId)
+            .map((rewrite) => [rewrite.storagePayloadId, rewrite]),
         )
+        const rewritesByClientId = new Map<string, AttachmentRewrite[]>()
+        for (const rewrite of opts.rewrites) {
+          if (rewrite.storagePayloadId) continue
+          const rewrites = rewritesByClientId.get(rewrite.clientId) ?? []
+          rewrites.push(rewrite)
+          rewritesByClientId.set(rewrite.clientId, rewrites)
+        }
+        const appliedRewrites = new Set<AttachmentRewrite>()
         for (const msg of chat.messages ?? []) {
           for (const att of msg.attachments ?? []) {
-            const rewrite = rewriteByClient.get(att.id)
+            const storedAttachment = att as StoredAttachmentReference
+            const rewriteByPayloadId = storedAttachment.storagePayloadId
+              ? rewritesByPayloadId.get(storedAttachment.storagePayloadId)
+              : undefined
+            const rewrite =
+              rewriteByPayloadId && !appliedRewrites.has(rewriteByPayloadId)
+                ? rewriteByPayloadId
+                : rewritesByClientId
+                    .get(att.id)
+                    ?.find((candidate) => !appliedRewrites.has(candidate))
             if (rewrite) {
+              appliedRewrites.add(rewrite)
               att.id = rewrite.serverId
               att.encryptionKey = rewrite.encryptionKey
             }

--- a/src/services/storage/indexed-db.ts
+++ b/src/services/storage/indexed-db.ts
@@ -2076,8 +2076,9 @@ export class IndexedDBStorage {
         let applied = false
         let cancelled = false
         transaction.oncomplete = () => resolve({ applied })
-        transaction.onerror = () =>
-          reject(new Error('Failed to apply remote chat'))
+        transaction.onerror = () => {
+          if (!cancelled) reject(new Error('Failed to apply remote chat'))
+        }
         transaction.onabort = () => {
           if (cancelled) resolve({ applied: false })
           else reject(new Error('Remote chat transaction aborted'))

--- a/src/services/storage/indexed-db.ts
+++ b/src/services/storage/indexed-db.ts
@@ -81,6 +81,15 @@ export interface AttachmentRewrite {
   storagePayloadId?: string
 }
 
+export class AttachmentPayloadIdUnavailableError extends Error {
+  readonly code = 'ATTACHMENT_PAYLOAD_ID_UNAVAILABLE'
+
+  constructor() {
+    super('Secure random UUID generation is unavailable')
+    this.name = 'AttachmentPayloadIdUnavailableError'
+  }
+}
+
 export const DB_NAME = 'tinfoil-chat'
 export const DB_VERSION = 5
 export const INDEXED_DB_UPGRADE_BLOCKED_EVENT = 'indexedDBUpgradeBlocked'
@@ -305,15 +314,15 @@ function attachmentHasPayload(attachment: Attachment): boolean {
   )
 }
 
-let fallbackAttachmentPayloadId = 0
-
 function createAttachmentPayloadId(
   chatId: string,
   reservedPayloadIds: Set<string>,
 ): string {
-  const token =
-    globalThis.crypto?.randomUUID?.() ??
-    `fallback-${fallbackAttachmentPayloadId++}`
+  if (typeof globalThis.crypto?.randomUUID !== 'function') {
+    throw new AttachmentPayloadIdUnavailableError()
+  }
+
+  const token = globalThis.crypto.randomUUID()
   const encodedChatId = bytesToHex(textEncoder.encode(chatId))
   const baseId = `${GENERATED_ATTACHMENT_PAYLOAD_PREFIX}${encodedChatId}:${token}`
   let payloadId = baseId
@@ -391,6 +400,20 @@ function normalizeAttachmentPayloads(chat: Chat): {
     messages,
     payloads,
     referencedPayloadIds,
+  }
+}
+
+function normalizeAttachmentPayloadsInTransaction(
+  chat: Chat,
+  transaction: IDBTransaction,
+  reject: (reason?: unknown) => void,
+): ReturnType<typeof normalizeAttachmentPayloads> | null {
+  try {
+    return normalizeAttachmentPayloads(chat)
+  } catch (error) {
+    transaction.abort()
+    reject(error)
+    return null
   }
 }
 
@@ -954,7 +977,13 @@ export class IndexedDBStorage {
             version: 1,
           }
           const mutated = updateSyncPending(output)
-          const normalizedAttachments = normalizeAttachmentPayloads(mutated)
+          const normalizedAttachments =
+            normalizeAttachmentPayloadsInTransaction(
+              mutated,
+              transaction,
+              reject,
+            )
+          if (!normalizedAttachments) return
           const writeChatAndPayloads = () => {
             for (const payload of normalizedAttachments.payloads) {
               const putRequest = payloadStore.put(payload)
@@ -1067,7 +1096,12 @@ export class IndexedDBStorage {
           return
         }
 
-        const normalizedAttachments = normalizeAttachmentPayloads(chat)
+        const normalizedAttachments = normalizeAttachmentPayloadsInTransaction(
+          chat,
+          transaction,
+          reject,
+        )
+        if (!normalizedAttachments) return
         const messagesForStorage = normalizedAttachments.messages.map(
           (msg) => ({
             ...msg,
@@ -2093,7 +2127,9 @@ export class IndexedDBStorage {
             // so the next upload re-stamps it.
             chat.clockVersion = opts.syncVersion
           }
-          const normalizedAttachments = normalizeAttachmentPayloads(chat)
+          const normalizedAttachments =
+            normalizeAttachmentPayloadsInTransaction(chat, transaction, reject)
+          if (!normalizedAttachments) return
           chat.messages = normalizedAttachments.messages
 
           const writeChatAndPayloads = () => {
@@ -2192,9 +2228,13 @@ export class IndexedDBStorage {
             }
           }
 
-          const normalizedAttachments = normalizeAttachmentPayloads(
-            inheritAttachmentPayloadReferences(opts.chat, existing),
-          )
+          const normalizedAttachments =
+            normalizeAttachmentPayloadsInTransaction(
+              inheritAttachmentPayloadReferences(opts.chat, existing),
+              transaction,
+              reject,
+            )
+          if (!normalizedAttachments) return
           const messagesForStorage = normalizedAttachments.messages.map(
             (msg) => ({
               ...msg,

--- a/src/services/storage/indexed-db.ts
+++ b/src/services/storage/indexed-db.ts
@@ -90,6 +90,33 @@ export class AttachmentPayloadIdUnavailableError extends Error {
   }
 }
 
+export class AttachmentPayloadReferenceAmbiguityError extends Error {
+  readonly code = 'ATTACHMENT_PAYLOAD_REFERENCE_AMBIGUOUS'
+
+  constructor() {
+    super('Attachment payload reference is ambiguous')
+    this.name = 'AttachmentPayloadReferenceAmbiguityError'
+  }
+}
+
+export class AttachmentPayloadReferenceMissingError extends Error {
+  readonly code = 'ATTACHMENT_PAYLOAD_REFERENCE_MISSING'
+
+  constructor() {
+    super('Attachment has no payload or remote retrieval identity')
+    this.name = 'AttachmentPayloadReferenceMissingError'
+  }
+}
+
+export class AttachmentPayloadMissingError extends Error {
+  readonly code = 'ATTACHMENT_PAYLOAD_MISSING'
+
+  constructor() {
+    super('Stored attachment payload is missing')
+    this.name = 'AttachmentPayloadMissingError'
+  }
+}
+
 export const DB_NAME = 'tinfoil-chat'
 export const DB_VERSION = 5
 export const INDEXED_DB_UPGRADE_BLOCKED_EVENT = 'indexedDBUpgradeBlocked'
@@ -314,6 +341,15 @@ function attachmentHasPayload(attachment: Attachment): boolean {
   )
 }
 
+function isLazilyRetrievableAttachment(attachment: Attachment): boolean {
+  return (
+    attachment.type === 'image' &&
+    attachment.id.trim().length > 0 &&
+    typeof attachment.encryptionKey === 'string' &&
+    attachment.encryptionKey.trim().length > 0
+  )
+}
+
 function createAttachmentPayloadId(
   chatId: string,
   reservedPayloadIds: Set<string>,
@@ -421,7 +457,6 @@ function inheritAttachmentPayloadReferences(
   chat: Chat,
   existing: StoredChat | null | undefined,
 ): Chat {
-  if (!existing) return chat
   type PayloadCandidate = {
     payloadId: string
     messageKey: string
@@ -450,9 +485,11 @@ function inheritAttachmentPayloadReferences(
       attachment.fileName,
       attachment.mimeType ?? null,
       attachment.fileSize ?? null,
+      attachment.description ?? null,
+      attachment.encryptionKey ?? null,
     ])
 
-  for (const message of existing.messages) {
+  for (const message of existing?.messages ?? []) {
     for (const attachment of message.attachments ?? []) {
       const storedAttachment = attachment as StoredAttachmentReference
       if (storedAttachment.storagePayloadId) {
@@ -488,38 +525,54 @@ function inheritAttachmentPayloadReferences(
     const candidates = candidatesByAttachmentId.get(attachmentId) ?? []
 
     for (const incoming of incomingAttachments) {
-      const exactCandidates = candidates.filter(
+      if (attachmentHasPayload(incoming.attachment)) {
+        continue
+      }
+
+      if (incoming.attachment.storagePayloadId) {
+        const referenceMatches = candidates.filter(
+          (candidate) =>
+            !candidate.used &&
+            candidate.payloadId === incoming.attachment.storagePayloadId &&
+            candidate.attachmentKey === incoming.attachmentKey,
+        )
+        if (referenceMatches.length > 1) {
+          throw new AttachmentPayloadReferenceAmbiguityError()
+        }
+        if (referenceMatches.length === 1) {
+          referenceMatches[0].used = true
+          continue
+        }
+        if (isLazilyRetrievableAttachment(incoming.attachment)) {
+          continue
+        }
+        throw new AttachmentPayloadReferenceMissingError()
+      }
+
+      const metadataMatches = candidates.filter(
         (candidate) =>
           !candidate.used && candidate.attachmentKey === incoming.attachmentKey,
       )
-      const candidate =
-        exactCandidates.find(
-          (item) => item.messageKey === incoming.messageKey,
-        ) ?? exactCandidates[0]
-      if (!candidate) continue
-      candidate.used = true
-      if (
-        !attachmentHasPayload(incoming.attachment) &&
-        !incoming.attachment.storagePayloadId
-      ) {
-        incoming.attachment.storagePayloadId = candidate.payloadId
-      }
-    }
+      const messageMatches = metadataMatches.filter(
+        (candidate) => candidate.messageKey === incoming.messageKey,
+      )
+      const exactMatches =
+        messageMatches.length > 0 ? messageMatches : metadataMatches
 
-    for (const incoming of incomingAttachments) {
-      if (
-        attachmentHasPayload(incoming.attachment) ||
-        incoming.attachment.storagePayloadId
-      ) {
+      if (exactMatches.length > 1) {
+        throw new AttachmentPayloadReferenceAmbiguityError()
+      }
+
+      const candidate = exactMatches[0]
+      if (candidate) {
+        candidate.used = true
+        incoming.attachment.storagePayloadId = candidate.payloadId
         continue
       }
-      const candidate =
-        candidates.find(
-          (item) => !item.used && item.messageKey === incoming.messageKey,
-        ) ?? candidates.find((item) => !item.used)
-      if (!candidate) continue
-      candidate.used = true
-      incoming.attachment.storagePayloadId = candidate.payloadId
+
+      if (!isLazilyRetrievableAttachment(incoming.attachment)) {
+        throw new AttachmentPayloadReferenceMissingError()
+      }
     }
   }
 
@@ -542,10 +595,24 @@ function hydrateAttachmentPayloads(
       attachments: message.attachments?.map((attachment) => {
         const { storagePayloadId, ...metadata } =
           attachment as StoredAttachmentReference
+        if (!storagePayloadId) {
+          if (
+            attachmentHasPayload(metadata) ||
+            isLazilyRetrievableAttachment(metadata)
+          ) {
+            return metadata
+          }
+          throw new AttachmentPayloadMissingError()
+        }
         const payload = storagePayloadId
           ? payloadById.get(storagePayloadId)
           : undefined
-        if (!payload) return metadata
+        if (!payload) {
+          if (isLazilyRetrievableAttachment(metadata)) {
+            return { ...metadata, storagePayloadId }
+          }
+          throw new AttachmentPayloadMissingError()
+        }
         const { id, chatId, ...content } = payload
         return { ...metadata, storagePayloadId, ...content }
       }),
@@ -945,10 +1012,17 @@ export class IndexedDBStorage {
           // The mutation sees (and callers receive) the hydrated chat so
           // attachment content survives the round trip; the write below
           // re-normalizes payloads back out of the chat record.
-          const current = hydrateAttachmentPayloads(
-            stored,
-            payloadRequest.result as StoredAttachmentPayload[],
-          )
+          let current: StoredChat
+          try {
+            current = hydrateAttachmentPayloads(
+              stored,
+              payloadRequest.result as StoredAttachmentPayload[],
+            )
+          } catch (error) {
+            transaction.abort()
+            reject(error)
+            return
+          }
           const result = mutation(current)
           if (!result.changed) {
             output = result.chat
@@ -1290,8 +1364,13 @@ export class IndexedDBStorage {
       }
       payloadRequest.onerror = () =>
         reject(new Error('Failed to get attachment payloads'))
-      transaction.oncomplete = () =>
-        resolve(chat ? hydrateAttachmentPayloads(chat, payloads) : null)
+      transaction.oncomplete = () => {
+        try {
+          resolve(chat ? hydrateAttachmentPayloads(chat, payloads) : null)
+        } catch (error) {
+          reject(error)
+        }
+      }
     })
   }
 
@@ -1688,20 +1767,24 @@ export class IndexedDBStorage {
 
         request.onerror = () => reject(new Error('Failed to get all chats'))
         transaction.oncomplete = () => {
-          const payloadsByChat = new Map<string, StoredAttachmentPayload[]>()
-          for (const payload of payloads) {
-            const chatPayloads = payloadsByChat.get(payload.chatId)
-            if (chatPayloads) chatPayloads.push(payload)
-            else payloadsByChat.set(payload.chatId, [payload])
-          }
-          resolve(
-            chats.map((chat) =>
-              hydrateAttachmentPayloads(
-                chat,
-                payloadsByChat.get(chat.id) ?? [],
+          try {
+            const payloadsByChat = new Map<string, StoredAttachmentPayload[]>()
+            for (const payload of payloads) {
+              const chatPayloads = payloadsByChat.get(payload.chatId)
+              if (chatPayloads) chatPayloads.push(payload)
+              else payloadsByChat.set(payload.chatId, [payload])
+            }
+            resolve(
+              chats.map((chat) =>
+                hydrateAttachmentPayloads(
+                  chat,
+                  payloadsByChat.get(chat.id) ?? [],
+                ),
               ),
-            ),
-          )
+            )
+          } catch (error) {
+            reject(error)
+          }
         }
       }),
     )
@@ -2072,12 +2155,18 @@ export class IndexedDBStorage {
           const chat = chatRequest.result as StoredChat | undefined
           if (!chat) return
 
-          const currentFingerprint = chatContentFingerprint(
-            hydrateAttachmentPayloads(
+          let hydratedChat: StoredChat
+          try {
+            hydratedChat = hydrateAttachmentPayloads(
               chat,
               payloadRequest.result as StoredAttachmentPayload[],
-            ),
-          )
+            )
+          } catch (error) {
+            transaction.abort()
+            reject(error)
+            return
+          }
+          const currentFingerprint = chatContentFingerprint(hydratedChat)
           const concurrentEdit =
             (opts.preUploadUpdatedAt !== undefined &&
               chat.updatedAt !== opts.preUploadUpdatedAt) ||
@@ -2228,9 +2317,20 @@ export class IndexedDBStorage {
             }
           }
 
+          let inheritedChat: Chat
+          try {
+            inheritedChat = inheritAttachmentPayloadReferences(
+              opts.chat,
+              existing,
+            )
+          } catch (error) {
+            transaction.abort()
+            reject(error)
+            return
+          }
           const normalizedAttachments =
             normalizeAttachmentPayloadsInTransaction(
-              inheritAttachmentPayloadReferences(opts.chat, existing),
+              inheritedChat,
               transaction,
               reject,
             )

--- a/src/services/storage/indexed-db.ts
+++ b/src/services/storage/indexed-db.ts
@@ -156,6 +156,30 @@ export function chatContentFingerprint(chat: {
             id: a.id,
             type: a.type,
             fileName: a.fileName,
+            mimeType: a.mimeType,
+            fileSize: a.fileSize,
+            description: a.description,
+            encryptionKey: a.encryptionKey,
+            base64Hash:
+              typeof a.base64 === 'string' ? hashString(a.base64) : null,
+            base64Length: typeof a.base64 === 'string' ? a.base64.length : 0,
+            thumbnailBase64Hash:
+              typeof a.thumbnailBase64 === 'string'
+                ? hashString(a.thumbnailBase64)
+                : null,
+            thumbnailBase64Length:
+              typeof a.thumbnailBase64 === 'string'
+                ? a.thumbnailBase64.length
+                : 0,
+            textContentHash:
+              typeof a.textContent === 'string'
+                ? hashString(a.textContent)
+                : null,
+            textContentLength:
+              typeof a.textContent === 'string' ? a.textContent.length : 0,
+            pagesHash: Array.isArray(a.pages)
+              ? hashString(JSON.stringify(a.pages))
+              : null,
           }))
         : [],
     // Legacy fields — still included for old messages that haven't been migrated
@@ -1971,9 +1995,8 @@ export class IndexedDBStorage {
    * Atomic upload finalization (§C6 / §H5).
    *
    * Runs inside `saveQueue` so it is serialized with any concurrent
-   * user saves. Re-reads the chat fresh, applies attachment id/key
-   * rewrites by stable client id (not by position), and only clears
-   * `locallyModified` if no edit happened since `preUploadUpdatedAt`.
+   * user saves. Re-reads the chat fresh and verifies its content fingerprint
+   * before applying attachment id/key rewrites or clearing `locallyModified`.
    *
    * If a concurrent edit is detected, the new sync version is still
    * persisted but the chat stays `locallyModified=true` so the next
@@ -1983,6 +2006,7 @@ export class IndexedDBStorage {
     chatId: string
     rewrites: AttachmentRewrite[]
     preUploadUpdatedAt: string | undefined
+    preUploadFingerprint: string
     syncVersion: number
   }): Promise<void> {
     return this.enqueueSave('finalizeUpload', async () => {
@@ -1995,6 +2019,9 @@ export class IndexedDBStorage {
         const store = transaction.objectStore(CHATS_STORE)
         const payloadStore = transaction.objectStore(ATTACHMENT_PAYLOADS_STORE)
         const chatRequest = store.get(opts.chatId)
+        const payloadRequest = payloadStore
+          .index(ATTACHMENT_PAYLOADS_CHAT_INDEX)
+          .getAll(IDBKeyRange.only(opts.chatId))
         transaction.oncomplete = () => resolve()
         transaction.onerror = () =>
           reject(new Error('Failed to finalize upload'))
@@ -2002,11 +2029,26 @@ export class IndexedDBStorage {
           reject(new Error('Upload finalization transaction aborted'))
         chatRequest.onerror = () =>
           reject(new Error('Failed to read chat before finalizing upload'))
-        chatRequest.onsuccess = () => {
+        payloadRequest.onerror = () =>
+          reject(
+            new Error('Failed to read attachment payloads before finalizing'),
+          )
+        payloadRequest.onsuccess = () => {
           const chat = chatRequest.result as StoredChat | undefined
           if (!chat) return
 
-          if (opts.rewrites.length > 0) {
+          const currentFingerprint = chatContentFingerprint(
+            hydrateAttachmentPayloads(
+              chat,
+              payloadRequest.result as StoredAttachmentPayload[],
+            ),
+          )
+          const concurrentEdit =
+            (opts.preUploadUpdatedAt !== undefined &&
+              chat.updatedAt !== opts.preUploadUpdatedAt) ||
+            currentFingerprint !== opts.preUploadFingerprint
+
+          if (!concurrentEdit && opts.rewrites.length > 0) {
             const rewritesByPayloadId = new Map(
               opts.rewrites
                 .filter((rewrite) => rewrite.storagePayloadId)
@@ -2041,9 +2083,6 @@ export class IndexedDBStorage {
             }
           }
 
-          const concurrentEdit =
-            opts.preUploadUpdatedAt !== undefined &&
-            chat.updatedAt !== opts.preUploadUpdatedAt
           chat.syncVersion = opts.syncVersion
           if (!concurrentEdit) {
             chat.locallyModified = false

--- a/src/services/storage/indexed-db.ts
+++ b/src/services/storage/indexed-db.ts
@@ -91,7 +91,7 @@ const MIGRATIONS_STORE = 'migrations'
 const SYNC_PENDING_MIGRATION_ID = 'sync-pending-v4'
 const ATTACHMENT_PAYLOADS_STORE = 'attachmentPayloads'
 const ATTACHMENT_PAYLOADS_CHAT_INDEX = 'chatId'
-const DUPLICATE_ATTACHMENT_PAYLOAD_MARKER = ':duplicate:'
+const GENERATED_ATTACHMENT_PAYLOAD_PREFIX = 'attachment-payload:'
 const ACCOUNT_CHANGE_RESET_TIMEOUT_MS = 10_000
 const ACCOUNT_CHANGE_READ_ERROR = 'IndexedDB read superseded by account change'
 const ACCOUNT_CHANGE_WRITE_ERROR =
@@ -284,6 +284,23 @@ function attachmentHasPayload(attachment: Attachment): boolean {
   )
 }
 
+let fallbackAttachmentPayloadId = 0
+
+function createAttachmentPayloadId(reservedPayloadIds: Set<string>): string {
+  const token =
+    globalThis.crypto?.randomUUID?.() ??
+    `fallback-${fallbackAttachmentPayloadId++}`
+  const baseId = `${GENERATED_ATTACHMENT_PAYLOAD_PREFIX}${token}`
+  let payloadId = baseId
+  let collision = 0
+  while (reservedPayloadIds.has(payloadId)) {
+    collision += 1
+    payloadId = `${baseId}:${collision}`
+  }
+  reservedPayloadIds.add(payloadId)
+  return payloadId
+}
+
 function normalizeAttachmentPayloads(chat: Chat): {
   messages: Message[]
   payloads: StoredAttachmentPayload[]
@@ -291,15 +308,19 @@ function normalizeAttachmentPayloads(chat: Chat): {
 } {
   const payloads: StoredAttachmentPayload[] = []
   const referencedPayloadIds = new Set<string>()
-  const attachmentIdCounts = new Map<string, number>()
   const attachmentIdOccurrences = new Map<string, number>()
+  const reservedPayloadIds = new Set<string>()
+  const explicitlyReferencedPayloadIds = new Set<string>()
 
   for (const message of chat.messages) {
     for (const attachment of message.attachments ?? []) {
-      attachmentIdCounts.set(
-        attachment.id,
-        (attachmentIdCounts.get(attachment.id) ?? 0) + 1,
-      )
+      reservedPayloadIds.add(`${chat.id}:${attachment.id}`)
+      const storagePayloadId = (attachment as StoredAttachmentReference)
+        .storagePayloadId
+      if (storagePayloadId) {
+        reservedPayloadIds.add(storagePayloadId)
+        explicitlyReferencedPayloadIds.add(storagePayloadId)
+      }
     }
   }
 
@@ -310,17 +331,15 @@ function normalizeAttachmentPayloads(chat: Chat): {
       const occurrence = attachmentIdOccurrences.get(attachment.id) ?? 0
       attachmentIdOccurrences.set(attachment.id, occurrence + 1)
       const legacyPayloadId = `${chat.id}:${attachment.id}`
-      const generatedPayloadId =
-        occurrence === 0
-          ? legacyPayloadId
-          : `${legacyPayloadId}${DUPLICATE_ATTACHMENT_PAYLOAD_MARKER}${occurrence}`
       const referencedPayloadId = storedAttachment.storagePayloadId
       const payloadId =
         referencedPayloadId && !referencedPayloadIds.has(referencedPayloadId)
           ? referencedPayloadId
-          : attachmentIdCounts.get(attachment.id) === 1
+          : occurrence === 0 &&
+              !referencedPayloadIds.has(legacyPayloadId) &&
+              !explicitlyReferencedPayloadIds.has(legacyPayloadId)
             ? legacyPayloadId
-            : generatedPayloadId
+            : createAttachmentPayloadId(reservedPayloadIds)
       referencedPayloadIds.add(payloadId)
       const { base64, thumbnailBase64, textContent, pages, ...metadata } =
         storedAttachment
@@ -361,7 +380,13 @@ function inheritAttachmentPayloadReferences(
     attachmentKey: string
     used: boolean
   }
+  type IncomingAttachment = {
+    attachment: StoredAttachmentReference
+    messageKey: string
+    attachmentKey: string
+  }
   const candidatesByAttachmentId = new Map<string, PayloadCandidate[]>()
+  const incomingByAttachmentId = new Map<string, IncomingAttachment[]>()
 
   const messageKey = (message: Message): string => {
     if (message.turnId) return `turn:${message.turnId}`
@@ -396,37 +421,63 @@ function inheritAttachmentPayloadReferences(
     }
   }
 
+  const messages = chat.messages.map((message) => ({
+    ...message,
+    attachments: message.attachments?.map((attachment) => {
+      const clonedAttachment = { ...attachment } as StoredAttachmentReference
+      const incoming = incomingByAttachmentId.get(attachment.id) ?? []
+      incoming.push({
+        attachment: clonedAttachment,
+        messageKey: messageKey(message),
+        attachmentKey: attachmentKey(attachment),
+      })
+      incomingByAttachmentId.set(attachment.id, incoming)
+      return clonedAttachment
+    }),
+  }))
+
+  for (const [attachmentId, incomingAttachments] of incomingByAttachmentId) {
+    const candidates = candidatesByAttachmentId.get(attachmentId) ?? []
+
+    for (const incoming of incomingAttachments) {
+      const exactCandidates = candidates.filter(
+        (candidate) =>
+          !candidate.used && candidate.attachmentKey === incoming.attachmentKey,
+      )
+      const candidate =
+        exactCandidates.find(
+          (item) => item.messageKey === incoming.messageKey,
+        ) ?? exactCandidates[0]
+      if (!candidate) continue
+      candidate.used = true
+      if (
+        !attachmentHasPayload(incoming.attachment) &&
+        !incoming.attachment.storagePayloadId
+      ) {
+        incoming.attachment.storagePayloadId = candidate.payloadId
+      }
+    }
+
+    for (const incoming of incomingAttachments) {
+      if (
+        attachmentHasPayload(incoming.attachment) ||
+        incoming.attachment.storagePayloadId
+      ) {
+        continue
+      }
+      const candidate =
+        candidates.find(
+          (item) => !item.used && item.messageKey === incoming.messageKey,
+        ) ?? candidates.find((item) => !item.used)
+      if (!candidate) continue
+      candidate.used = true
+      incoming.attachment.storagePayloadId = candidate.payloadId
+    }
+  }
+
   return {
     ...chat,
-    messages: chat.messages.map((message) => ({
-      ...message,
-      attachments: message.attachments?.map((attachment) => {
-        if (attachmentHasPayload(attachment)) return attachment
-        const candidates = candidatesByAttachmentId.get(attachment.id) ?? []
-        const incomingMessageKey = messageKey(message)
-        const incomingAttachmentKey = attachmentKey(attachment)
-        const candidate =
-          candidates.find(
-            (item) =>
-              !item.used &&
-              item.messageKey === incomingMessageKey &&
-              item.attachmentKey === incomingAttachmentKey,
-          ) ??
-          candidates.find(
-            (item) => !item.used && item.messageKey === incomingMessageKey,
-          ) ??
-          candidates.find(
-            (item) =>
-              !item.used && item.attachmentKey === incomingAttachmentKey,
-          ) ??
-          candidates.find((item) => !item.used)
-        if (candidate) candidate.used = true
-        const storagePayloadId = candidate?.payloadId
-        return storagePayloadId
-          ? { ...attachment, storagePayloadId }
-          : attachment
-      }),
-    })),
+    messages,
   }
 }
 

--- a/src/services/storage/indexed-db.ts
+++ b/src/services/storage/indexed-db.ts
@@ -11,6 +11,8 @@ import {
 import { nextClock } from '@/services/cloud/edit-clock'
 import type { Project } from '@/types/project'
 import { logError, logWarning } from '@/utils/error-handling'
+import { sha256 } from '@noble/hashes/sha2.js'
+import { bytesToHex } from '@noble/hashes/utils.js'
 
 export interface Chat extends Omit<ChatType, 'createdAt'> {
   createdAt: string
@@ -97,19 +99,14 @@ const ACCOUNT_CHANGE_READ_ERROR = 'IndexedDB read superseded by account change'
 const ACCOUNT_CHANGE_WRITE_ERROR =
   'IndexedDB write superseded by account change'
 let isUpgradeBlocked = false
+const textEncoder = new TextEncoder()
 
 export function isIndexedDBUpgradeBlocked(): boolean {
   return isUpgradeBlocked
 }
 
 function hashString(input: string): string {
-  // Small, deterministic 32-bit hash for change detection
-  let hash = 5381
-  for (let i = 0; i < input.length; i++) {
-    hash = (hash * 33) ^ input.charCodeAt(i)
-  }
-  // Unsigned hex string
-  return (hash >>> 0).toString(16)
+  return bytesToHex(sha256(textEncoder.encode(input)))
 }
 
 function deserializeStoredChat(chat: StoredChat): StoredChat {
@@ -310,11 +307,15 @@ function attachmentHasPayload(attachment: Attachment): boolean {
 
 let fallbackAttachmentPayloadId = 0
 
-function createAttachmentPayloadId(reservedPayloadIds: Set<string>): string {
+function createAttachmentPayloadId(
+  chatId: string,
+  reservedPayloadIds: Set<string>,
+): string {
   const token =
     globalThis.crypto?.randomUUID?.() ??
     `fallback-${fallbackAttachmentPayloadId++}`
-  const baseId = `${GENERATED_ATTACHMENT_PAYLOAD_PREFIX}${token}`
+  const encodedChatId = bytesToHex(textEncoder.encode(chatId))
+  const baseId = `${GENERATED_ATTACHMENT_PAYLOAD_PREFIX}${encodedChatId}:${token}`
   let payloadId = baseId
   let collision = 0
   while (reservedPayloadIds.has(payloadId)) {
@@ -363,7 +364,7 @@ function normalizeAttachmentPayloads(chat: Chat): {
               !referencedPayloadIds.has(legacyPayloadId) &&
               !explicitlyReferencedPayloadIds.has(legacyPayloadId)
             ? legacyPayloadId
-            : createAttachmentPayloadId(reservedPayloadIds)
+            : createAttachmentPayloadId(chat.id, reservedPayloadIds)
       referencedPayloadIds.add(payloadId)
       const { base64, thumbnailBase64, textContent, pages, ...metadata } =
         storedAttachment

--- a/src/services/storage/indexed-db.ts
+++ b/src/services/storage/indexed-db.ts
@@ -1723,24 +1723,25 @@ export class IndexedDBStorage {
   private async updateLastAccessed(id: string): Promise<void> {
     return this.enqueueSave('updateLastAccessed', async () => {
       const db = await this.ensureDB()
-      const chat = await this.getStoredChatInternal(id)
+      return new Promise<void>((resolve, reject) => {
+        const transaction = db.transaction([CHATS_STORE], 'readwrite')
+        const store = transaction.objectStore(CHATS_STORE)
+        const request = store.get(id)
 
-      if (chat) {
-        return new Promise<void>((resolve, reject) => {
-          const transaction = db.transaction([CHATS_STORE], 'readwrite')
-          const store = transaction.objectStore(CHATS_STORE)
-
-          transaction.oncomplete = () => resolve()
-          transaction.onerror = () =>
-            reject(new Error('Failed to update last accessed'))
-
+        transaction.oncomplete = () => resolve()
+        transaction.onerror = () =>
+          reject(new Error('Failed to update last accessed'))
+        transaction.onabort = () =>
+          reject(new Error('Last accessed update transaction aborted'))
+        request.onerror = () =>
+          reject(new Error('Failed to read chat for last accessed update'))
+        request.onsuccess = () => {
+          const chat = request.result as StoredChat | undefined
+          if (!chat) return
           chat.lastAccessedAt = Date.now()
-          const request = store.put(updateSyncPending(chat))
-
-          request.onerror = () =>
-            reject(new Error('Failed to update last accessed'))
-        })
-      }
+          store.put(updateSyncPending(chat))
+        }
+      })
     })
   }
 
@@ -1853,29 +1854,30 @@ export class IndexedDBStorage {
   async markAsSynced(id: string, syncVersion: number): Promise<void> {
     return this.enqueueSave('markAsSynced', async () => {
       const db = await this.ensureDB()
-      const chat = await this.getStoredChatInternal(id)
+      return new Promise<void>((resolve, reject) => {
+        const transaction = db.transaction([CHATS_STORE], 'readwrite')
+        const store = transaction.objectStore(CHATS_STORE)
+        const request = store.get(id)
 
-      if (chat) {
-        return new Promise<void>((resolve, reject) => {
-          const transaction = db.transaction([CHATS_STORE], 'readwrite')
-          const store = transaction.objectStore(CHATS_STORE)
-
-          transaction.oncomplete = () => resolve()
-          transaction.onerror = () =>
-            reject(new Error('Failed to mark as synced'))
-
+        transaction.oncomplete = () => resolve()
+        transaction.onerror = () =>
+          reject(new Error('Failed to mark as synced'))
+        transaction.onabort = () =>
+          reject(new Error('Mark as synced transaction aborted'))
+        request.onerror = () =>
+          reject(new Error('Failed to read chat before marking as synced'))
+        request.onsuccess = () => {
+          const chat = request.result as StoredChat | undefined
+          if (!chat) return
           chat.syncedAt = Date.now()
           chat.locallyModified = false
           chat.syncVersion = syncVersion
           // The clock is now current as of this synced version, so a
           // later reader trusts it for arbitration.
           chat.clockVersion = syncVersion
-
-          const request = store.put(updateSyncPending(chat))
-
-          request.onerror = () => reject(new Error('Failed to mark as synced'))
-        })
-      }
+          store.put(updateSyncPending(chat))
+        }
+      })
     })
   }
 
@@ -1891,23 +1893,25 @@ export class IndexedDBStorage {
   async rebaseSyncVersion(id: string, syncVersion: number): Promise<void> {
     return this.enqueueSave('rebaseSyncVersion', async () => {
       const db = await this.ensureDB()
-      const chat = await this.getStoredChatInternal(id)
-      if (!chat) {
-        return
-      }
-
-      chat.syncVersion = syncVersion
-      chat.locallyModified = true
-
-      await new Promise<void>((resolve, reject) => {
+      return new Promise<void>((resolve, reject) => {
         const transaction = db.transaction([CHATS_STORE], 'readwrite')
         const store = transaction.objectStore(CHATS_STORE)
+        const request = store.get(id)
+
         transaction.oncomplete = () => resolve()
         transaction.onerror = () =>
           reject(new Error('Failed to rebase sync version'))
-        const request = store.put(updateSyncPending(chat))
+        transaction.onabort = () =>
+          reject(new Error('Sync version rebase transaction aborted'))
         request.onerror = () =>
-          reject(new Error('Failed to rebase sync version'))
+          reject(new Error('Failed to read chat before rebasing sync version'))
+        request.onsuccess = () => {
+          const chat = request.result as StoredChat | undefined
+          if (!chat) return
+          chat.syncVersion = syncVersion
+          chat.locallyModified = true
+          store.put(updateSyncPending(chat))
+        }
       })
     })
   }
@@ -1932,62 +1936,6 @@ export class IndexedDBStorage {
   }): Promise<void> {
     return this.enqueueSave('finalizeUpload', async () => {
       const db = await this.ensureDB()
-      const chat = await this.getStoredChatInternal(opts.chatId)
-      if (!chat) {
-        return
-      }
-
-      if (opts.rewrites.length > 0) {
-        const rewritesByPayloadId = new Map(
-          opts.rewrites
-            .filter((rewrite) => rewrite.storagePayloadId)
-            .map((rewrite) => [rewrite.storagePayloadId, rewrite]),
-        )
-        const rewritesByClientId = new Map<string, AttachmentRewrite[]>()
-        for (const rewrite of opts.rewrites) {
-          if (rewrite.storagePayloadId) continue
-          const rewrites = rewritesByClientId.get(rewrite.clientId) ?? []
-          rewrites.push(rewrite)
-          rewritesByClientId.set(rewrite.clientId, rewrites)
-        }
-        const appliedRewrites = new Set<AttachmentRewrite>()
-        for (const msg of chat.messages ?? []) {
-          for (const att of msg.attachments ?? []) {
-            const storedAttachment = att as StoredAttachmentReference
-            const rewriteByPayloadId = storedAttachment.storagePayloadId
-              ? rewritesByPayloadId.get(storedAttachment.storagePayloadId)
-              : undefined
-            const rewrite =
-              rewriteByPayloadId && !appliedRewrites.has(rewriteByPayloadId)
-                ? rewriteByPayloadId
-                : rewritesByClientId
-                    .get(att.id)
-                    ?.find((candidate) => !appliedRewrites.has(candidate))
-            if (rewrite) {
-              appliedRewrites.add(rewrite)
-              att.id = rewrite.serverId
-              att.encryptionKey = rewrite.encryptionKey
-            }
-          }
-        }
-      }
-
-      const concurrentEdit =
-        opts.preUploadUpdatedAt !== undefined &&
-        chat.updatedAt !== opts.preUploadUpdatedAt
-
-      chat.syncVersion = opts.syncVersion
-      if (!concurrentEdit) {
-        chat.locallyModified = false
-        chat.syncedAt = Date.now()
-        // Clock is current as of the uploaded version. On a concurrent
-        // edit the chat stays dirty and clockVersion intentionally lags
-        // so the next upload re-stamps it.
-        chat.clockVersion = opts.syncVersion
-      }
-      const normalizedAttachments = normalizeAttachmentPayloads(chat)
-      chat.messages = normalizedAttachments.messages
-
       return new Promise<void>((resolve, reject) => {
         const transaction = db.transaction(
           [CHATS_STORE, ATTACHMENT_PAYLOADS_STORE],
@@ -1995,36 +1943,94 @@ export class IndexedDBStorage {
         )
         const store = transaction.objectStore(CHATS_STORE)
         const payloadStore = transaction.objectStore(ATTACHMENT_PAYLOADS_STORE)
+        const chatRequest = store.get(opts.chatId)
         transaction.oncomplete = () => resolve()
         transaction.onerror = () =>
           reject(new Error('Failed to finalize upload'))
+        transaction.onabort = () =>
+          reject(new Error('Upload finalization transaction aborted'))
+        chatRequest.onerror = () =>
+          reject(new Error('Failed to read chat before finalizing upload'))
+        chatRequest.onsuccess = () => {
+          const chat = chatRequest.result as StoredChat | undefined
+          if (!chat) return
 
-        const writeChatAndPayloads = () => {
-          for (const payload of normalizedAttachments.payloads) {
-            payloadStore.put(payload)
-          }
-          const request = store.put(updateSyncPending(chat))
-          request.onerror = () => reject(new Error('Failed to finalize upload'))
-        }
-        const payloadCursor = payloadStore
-          .index(ATTACHMENT_PAYLOADS_CHAT_INDEX)
-          .openCursor(IDBKeyRange.only(chat.id))
-        payloadCursor.onerror = () =>
-          reject(new Error('Failed to reconcile finalized attachments'))
-        payloadCursor.onsuccess = () => {
-          const cursor = payloadCursor.result
-          if (cursor) {
-            if (
-              !normalizedAttachments.referencedPayloadIds.has(
-                String(cursor.primaryKey),
-              )
-            ) {
-              cursor.delete()
+          if (opts.rewrites.length > 0) {
+            const rewritesByPayloadId = new Map(
+              opts.rewrites
+                .filter((rewrite) => rewrite.storagePayloadId)
+                .map((rewrite) => [rewrite.storagePayloadId, rewrite]),
+            )
+            const rewritesByClientId = new Map<string, AttachmentRewrite[]>()
+            for (const rewrite of opts.rewrites) {
+              if (rewrite.storagePayloadId) continue
+              const rewrites = rewritesByClientId.get(rewrite.clientId) ?? []
+              rewrites.push(rewrite)
+              rewritesByClientId.set(rewrite.clientId, rewrites)
             }
-            cursor.continue()
-            return
+            const appliedRewrites = new Set<AttachmentRewrite>()
+            for (const msg of chat.messages ?? []) {
+              for (const att of msg.attachments ?? []) {
+                const storedAttachment = att as StoredAttachmentReference
+                const rewriteByPayloadId = storedAttachment.storagePayloadId
+                  ? rewritesByPayloadId.get(storedAttachment.storagePayloadId)
+                  : undefined
+                const rewrite =
+                  rewriteByPayloadId && !appliedRewrites.has(rewriteByPayloadId)
+                    ? rewriteByPayloadId
+                    : rewritesByClientId
+                        .get(att.id)
+                        ?.find((candidate) => !appliedRewrites.has(candidate))
+                if (rewrite) {
+                  appliedRewrites.add(rewrite)
+                  att.id = rewrite.serverId
+                  att.encryptionKey = rewrite.encryptionKey
+                }
+              }
+            }
           }
-          writeChatAndPayloads()
+
+          const concurrentEdit =
+            opts.preUploadUpdatedAt !== undefined &&
+            chat.updatedAt !== opts.preUploadUpdatedAt
+          chat.syncVersion = opts.syncVersion
+          if (!concurrentEdit) {
+            chat.locallyModified = false
+            chat.syncedAt = Date.now()
+            // Clock is current as of the uploaded version. On a concurrent
+            // edit the chat stays dirty and clockVersion intentionally lags
+            // so the next upload re-stamps it.
+            chat.clockVersion = opts.syncVersion
+          }
+          const normalizedAttachments = normalizeAttachmentPayloads(chat)
+          chat.messages = normalizedAttachments.messages
+
+          const writeChatAndPayloads = () => {
+            for (const payload of normalizedAttachments.payloads) {
+              payloadStore.put(payload)
+            }
+            store.put(updateSyncPending(chat))
+          }
+          const payloadCursor = payloadStore
+            .index(ATTACHMENT_PAYLOADS_CHAT_INDEX)
+            .openCursor(IDBKeyRange.only(chat.id))
+          payloadCursor.onerror = () =>
+            reject(new Error('Failed to reconcile finalized attachments'))
+          payloadCursor.onsuccess = () => {
+            const cursor = payloadCursor.result
+            if (cursor) {
+              if (
+                !normalizedAttachments.referencedPayloadIds.has(
+                  String(cursor.primaryKey),
+                )
+              ) {
+                cursor.delete()
+              }
+              cursor.continue()
+              return
+            }
+            writeChatAndPayloads()
+          }
         }
       })
     })
@@ -2059,97 +2065,103 @@ export class IndexedDBStorage {
       if (!isCurrent()) return { applied: false }
       const db = await this.ensureDB()
       if (!isCurrent()) return { applied: false }
-      const existing = await this.getStoredChatInternal(opts.chat.id)
-      if (!isCurrent()) return { applied: false }
-
-      if (opts.expectedLocalUpdatedAt !== undefined) {
-        if (opts.expectedLocalUpdatedAt === null) {
-          if (existing) {
-            return { applied: false }
-          }
-        } else if (
-          !existing ||
-          existing.updatedAt !== opts.expectedLocalUpdatedAt ||
-          (existing.locallyModified === true && !opts.allowLocallyModified)
-        ) {
-          return { applied: false }
-        }
-      }
-
-      const normalizedAttachments = normalizeAttachmentPayloads(
-        inheritAttachmentPayloadReferences(opts.chat, existing),
-      )
-      const messagesForStorage = normalizedAttachments.messages.map((msg) => ({
-        ...msg,
-        timestamp:
-          msg.timestamp instanceof Date
-            ? msg.timestamp.toISOString()
-            : msg.timestamp,
-      }))
-
-      const storedChat: StoredChat = {
-        ...opts.chat,
-        messages: messagesForStorage as any,
-        lastAccessedAt: Date.now(),
-        syncedAt: Date.now(),
-        locallyModified: false,
-        syncPending: 0,
-        syncVersion: opts.syncVersion,
-        version: 1,
-        loadedAt: opts.setLoadedAt
-          ? Date.now()
-          : ((opts.chat as StoredChat).loadedAt ?? existing?.loadedAt),
-        isLocalOnly: (opts.chat as any).isLocalOnly ?? false,
-      }
-
-      if (!isCurrent()) return { applied: false }
-      await new Promise<void>((resolve, reject) => {
+      return new Promise<{ applied: boolean }>((resolve, reject) => {
         const transaction = db.transaction(
           [CHATS_STORE, ATTACHMENT_PAYLOADS_STORE],
           'readwrite',
         )
         const store = transaction.objectStore(CHATS_STORE)
         const payloadStore = transaction.objectStore(ATTACHMENT_PAYLOADS_STORE)
-        transaction.oncomplete = () => resolve()
+        const chatRequest = store.get(opts.chat.id)
+        let applied = false
+        let cancelled = false
+        transaction.oncomplete = () => resolve({ applied })
         transaction.onerror = () =>
           reject(new Error('Failed to apply remote chat'))
-
-        const writeChatAndPayloads = () => {
-          for (const payload of normalizedAttachments.payloads) {
-            const payloadRequest = payloadStore.put(payload)
-            payloadRequest.onerror = () =>
-              reject(
-                payloadRequest.error ??
-                  new Error('Failed to save remote attachment payload'),
-              )
-          }
-          const request = store.put(storedChat)
-          request.onerror = () =>
-            reject(new Error('Failed to apply remote chat'))
+        transaction.onabort = () => {
+          if (cancelled) resolve({ applied: false })
+          else reject(new Error('Remote chat transaction aborted'))
         }
+        chatRequest.onerror = () =>
+          reject(new Error('Failed to read local chat before remote apply'))
+        chatRequest.onsuccess = () => {
+          if (!isCurrent()) return
+          const existing = chatRequest.result as StoredChat | undefined
 
-        const payloadCursor = payloadStore
-          .index(ATTACHMENT_PAYLOADS_CHAT_INDEX)
-          .openCursor(IDBKeyRange.only(opts.chat.id))
-        payloadCursor.onerror = () =>
-          reject(new Error('Failed to reconcile remote attachment payloads'))
-        payloadCursor.onsuccess = () => {
-          const cursor = payloadCursor.result
-          if (cursor) {
-            if (
-              !normalizedAttachments.referencedPayloadIds.has(
-                String(cursor.primaryKey),
-              )
+          if (opts.expectedLocalUpdatedAt !== undefined) {
+            if (opts.expectedLocalUpdatedAt === null) {
+              if (existing) return
+            } else if (
+              !existing ||
+              existing.updatedAt !== opts.expectedLocalUpdatedAt ||
+              (existing.locallyModified === true && !opts.allowLocallyModified)
             ) {
-              cursor.delete()
+              return
             }
-            cursor.continue()
-            return
           }
-          writeChatAndPayloads()
+
+          const normalizedAttachments = normalizeAttachmentPayloads(
+            inheritAttachmentPayloadReferences(opts.chat, existing),
+          )
+          const messagesForStorage = normalizedAttachments.messages.map(
+            (msg) => ({
+              ...msg,
+              timestamp:
+                msg.timestamp instanceof Date
+                  ? msg.timestamp.toISOString()
+                  : msg.timestamp,
+            }),
+          )
+          const storedChat: StoredChat = {
+            ...opts.chat,
+            messages: messagesForStorage as any,
+            lastAccessedAt: Date.now(),
+            syncedAt: Date.now(),
+            locallyModified: false,
+            syncPending: 0,
+            syncVersion: opts.syncVersion,
+            version: 1,
+            loadedAt: opts.setLoadedAt
+              ? Date.now()
+              : ((opts.chat as StoredChat).loadedAt ?? existing?.loadedAt),
+            isLocalOnly: (opts.chat as any).isLocalOnly ?? false,
+          }
+          if (!isCurrent()) return
+
+          const writeChatAndPayloads = () => {
+            for (const payload of normalizedAttachments.payloads) {
+              payloadStore.put(payload)
+            }
+            store.put(storedChat)
+            applied = true
+          }
+          const payloadCursor = payloadStore
+            .index(ATTACHMENT_PAYLOADS_CHAT_INDEX)
+            .openCursor(IDBKeyRange.only(opts.chat.id))
+          payloadCursor.onerror = () =>
+            reject(new Error('Failed to reconcile remote attachment payloads'))
+          payloadCursor.onsuccess = () => {
+            if (!isCurrent()) {
+              cancelled = true
+              transaction.abort()
+              return
+            }
+            const cursor = payloadCursor.result
+            if (cursor) {
+              if (
+                !normalizedAttachments.referencedPayloadIds.has(
+                  String(cursor.primaryKey),
+                )
+              ) {
+                cursor.delete()
+              }
+              cursor.continue()
+              return
+            }
+            writeChatAndPayloads()
+          }
         }
       })
-      return { applied: true }
     })
   }
 

--- a/src/services/storage/indexed-db.ts
+++ b/src/services/storage/indexed-db.ts
@@ -745,8 +745,12 @@ export class IndexedDBStorage {
     return this.enqueueSave('mutateChat', async () => {
       const db = await this.ensureDB()
       return new Promise<StoredChat | null>((resolve, reject) => {
-        const transaction = db.transaction([CHATS_STORE], 'readwrite')
+        const transaction = db.transaction(
+          [CHATS_STORE, ATTACHMENT_PAYLOADS_STORE],
+          'readwrite',
+        )
         const store = transaction.objectStore(CHATS_STORE)
+        const payloadStore = transaction.objectStore(ATTACHMENT_PAYLOADS_STORE)
         let output: StoredChat | null = null
 
         transaction.oncomplete = () => resolve(output)
@@ -756,10 +760,24 @@ export class IndexedDBStorage {
 
         const request = store.get(chatId)
         request.onerror = () => reject(new Error('Failed to read chat'))
-        request.onsuccess = () => {
-          const current = request.result as StoredChat | undefined
-          if (!current) return
+        const payloadRequest = payloadStore
+          .index(ATTACHMENT_PAYLOADS_CHAT_INDEX)
+          .getAll(IDBKeyRange.only(chatId))
+        payloadRequest.onerror = () =>
+          reject(new Error('Failed to read attachment payloads'))
+        // Requests fire in issue order within a transaction, so the chat
+        // read has settled by the time the payload read succeeds.
+        payloadRequest.onsuccess = () => {
+          const stored = request.result as StoredChat | undefined
+          if (!stored) return
 
+          // The mutation sees (and callers receive) the hydrated chat so
+          // attachment content survives the round trip; the write below
+          // re-normalizes payloads back out of the chat record.
+          const current = hydrateAttachmentPayloads(
+            stored,
+            payloadRequest.result as StoredAttachmentPayload[],
+          )
           const result = mutation(current)
           if (!result.changed) {
             output = result.chat
@@ -787,7 +805,42 @@ export class IndexedDBStorage {
             }),
             version: 1,
           }
-          store.put(updateSyncPending(output))
+          const mutated = updateSyncPending(output)
+          const normalizedAttachments = normalizeAttachmentPayloads(mutated)
+          const writeChatAndPayloads = () => {
+            for (const payload of normalizedAttachments.payloads) {
+              const putRequest = payloadStore.put(payload)
+              putRequest.onerror = () =>
+                reject(
+                  putRequest.error ??
+                    new Error('Failed to save attachment payload'),
+                )
+            }
+            store.put({
+              ...mutated,
+              messages: normalizedAttachments.messages as any,
+            })
+          }
+          const payloadCursor = payloadStore
+            .index(ATTACHMENT_PAYLOADS_CHAT_INDEX)
+            .openCursor(IDBKeyRange.only(chatId))
+          payloadCursor.onerror = () =>
+            reject(new Error('Failed to reconcile attachment payloads'))
+          payloadCursor.onsuccess = () => {
+            const cursor = payloadCursor.result
+            if (cursor) {
+              if (
+                !normalizedAttachments.referencedPayloadIds.has(
+                  String(cursor.primaryKey),
+                )
+              ) {
+                cursor.delete()
+              }
+              cursor.continue()
+              return
+            }
+            writeChatAndPayloads()
+          }
         }
       })
     })

--- a/src/services/storage/indexed-db.ts
+++ b/src/services/storage/indexed-db.ts
@@ -285,21 +285,18 @@ function attachmentHasPayload(attachment: Attachment): boolean {
 function normalizeAttachmentPayloads(chat: Chat): {
   messages: Message[]
   payloads: StoredAttachmentPayload[]
-  replacePayloads: boolean
+  referencedPayloadIds: Set<string>
 } {
   const payloads: StoredAttachmentPayload[] = []
-  let hasStoredReferences = false
-  let hasHydratedPayloads = false
+  const referencedPayloadIds = new Set<string>()
 
   const messages = chat.messages.map((message) => ({
     ...message,
     attachments: message.attachments?.map((attachment) => {
       const storedAttachment = attachment as StoredAttachmentReference
-      if (storedAttachment.storagePayloadId) hasStoredReferences = true
-      if (attachmentHasPayload(attachment)) hasHydratedPayloads = true
-
       const payloadId =
         storedAttachment.storagePayloadId ?? `${chat.id}:${attachment.id}`
+      referencedPayloadIds.add(payloadId)
       const { base64, thumbnailBase64, textContent, pages, ...metadata } =
         storedAttachment
 
@@ -324,7 +321,40 @@ function normalizeAttachmentPayloads(chat: Chat): {
   return {
     messages,
     payloads,
-    replacePayloads: hasHydratedPayloads || !hasStoredReferences,
+    referencedPayloadIds,
+  }
+}
+
+function inheritAttachmentPayloadReferences(
+  chat: Chat,
+  existing: StoredChat | null | undefined,
+): Chat {
+  if (!existing) return chat
+  const payloadIdByAttachmentId = new Map<string, string>()
+  for (const message of existing.messages) {
+    for (const attachment of message.attachments ?? []) {
+      const storedAttachment = attachment as StoredAttachmentReference
+      if (storedAttachment.storagePayloadId) {
+        payloadIdByAttachmentId.set(
+          storedAttachment.id,
+          storedAttachment.storagePayloadId,
+        )
+      }
+    }
+  }
+
+  return {
+    ...chat,
+    messages: chat.messages.map((message) => ({
+      ...message,
+      attachments: message.attachments?.map((attachment) => {
+        if (attachmentHasPayload(attachment)) return attachment
+        const storagePayloadId = payloadIdByAttachmentId.get(attachment.id)
+        return storagePayloadId
+          ? { ...attachment, storagePayloadId }
+          : attachment
+      }),
+    })),
   }
 }
 
@@ -948,20 +978,21 @@ export class IndexedDBStorage {
           putRequest.onerror = () => reject(new Error('Failed to save chat'))
         }
 
-        if (!normalizedAttachments.replacePayloads) {
-          writeChatAndPayloads()
-          return
-        }
-
         const payloadCursor = payloadStore
           .index(ATTACHMENT_PAYLOADS_CHAT_INDEX)
           .openCursor(IDBKeyRange.only(chat.id))
         payloadCursor.onerror = () =>
-          reject(new Error('Failed to replace attachment payloads'))
+          reject(new Error('Failed to reconcile attachment payloads'))
         payloadCursor.onsuccess = () => {
           const cursor = payloadCursor.result
           if (cursor) {
-            cursor.delete()
+            if (
+              !normalizedAttachments.referencedPayloadIds.has(
+                String(cursor.primaryKey),
+              )
+            ) {
+              cursor.delete()
+            }
             cursor.continue()
             return
           }
@@ -995,29 +1026,37 @@ export class IndexedDBStorage {
   }
 
   private async getChatInternal(id: string): Promise<StoredChat | null> {
-    const chat = await this.getStoredChatInternal(id)
-    if (!chat) return null
     const db = await this.ensureDB()
 
     return new Promise((resolve, reject) => {
       const transaction = db.transaction(
-        [ATTACHMENT_PAYLOADS_STORE],
+        [CHATS_STORE, ATTACHMENT_PAYLOADS_STORE],
         'readonly',
       )
-      const request = transaction
+      let chat: StoredChat | null = null
+      let payloads: StoredAttachmentPayload[] = []
+      const chatRequest = transaction.objectStore(CHATS_STORE).get(id)
+      const payloadRequest = transaction
         .objectStore(ATTACHMENT_PAYLOADS_STORE)
         .index(ATTACHMENT_PAYLOADS_CHAT_INDEX)
         .getAll(IDBKeyRange.only(id))
 
-      request.onsuccess = () =>
-        resolve(
-          hydrateAttachmentPayloads(
-            chat,
-            request.result as StoredAttachmentPayload[],
-          ),
-        )
-      request.onerror = () =>
+      chatRequest.onsuccess = () => {
+        try {
+          const stored = chatRequest.result as StoredChat | undefined
+          chat = stored ? deserializeStoredChat(stored) : null
+        } catch (error) {
+          reject(error)
+        }
+      }
+      chatRequest.onerror = () => reject(new Error('Failed to get chat'))
+      payloadRequest.onsuccess = () => {
+        payloads = payloadRequest.result as StoredAttachmentPayload[]
+      }
+      payloadRequest.onerror = () =>
         reject(new Error('Failed to get attachment payloads'))
+      transaction.oncomplete = () =>
+        resolve(chat ? hydrateAttachmentPayloads(chat, payloads) : null)
     })
   }
 
@@ -1581,6 +1620,14 @@ export class IndexedDBStorage {
   }
 
   async getUnsyncedChats(): Promise<StoredChat[]> {
+    const metadata = await this.getUnsyncedChatMetadata()
+    const hydrated = await Promise.all(
+      metadata.map((chat) => this.getChatInternal(chat.id)),
+    )
+    return hydrated.filter((chat): chat is StoredChat => chat !== null)
+  }
+
+  async getUnsyncedChatMetadata(): Promise<StoredChat[]> {
     await this.ensureSyncPendingIndex()
     await this.waitForSaveQueue()
     const db = await this.ensureDB()
@@ -1793,16 +1840,47 @@ export class IndexedDBStorage {
         // so the next upload re-stamps it.
         chat.clockVersion = opts.syncVersion
       }
+      const normalizedAttachments = normalizeAttachmentPayloads(chat)
+      chat.messages = normalizedAttachments.messages
 
       return new Promise<void>((resolve, reject) => {
-        const transaction = db.transaction([CHATS_STORE], 'readwrite')
+        const transaction = db.transaction(
+          [CHATS_STORE, ATTACHMENT_PAYLOADS_STORE],
+          'readwrite',
+        )
         const store = transaction.objectStore(CHATS_STORE)
+        const payloadStore = transaction.objectStore(ATTACHMENT_PAYLOADS_STORE)
         transaction.oncomplete = () => resolve()
         transaction.onerror = () =>
           reject(new Error('Failed to finalize upload'))
 
-        const request = store.put(updateSyncPending(chat))
-        request.onerror = () => reject(new Error('Failed to finalize upload'))
+        const writeChatAndPayloads = () => {
+          for (const payload of normalizedAttachments.payloads) {
+            payloadStore.put(payload)
+          }
+          const request = store.put(updateSyncPending(chat))
+          request.onerror = () => reject(new Error('Failed to finalize upload'))
+        }
+        const payloadCursor = payloadStore
+          .index(ATTACHMENT_PAYLOADS_CHAT_INDEX)
+          .openCursor(IDBKeyRange.only(chat.id))
+        payloadCursor.onerror = () =>
+          reject(new Error('Failed to reconcile finalized attachments'))
+        payloadCursor.onsuccess = () => {
+          const cursor = payloadCursor.result
+          if (cursor) {
+            if (
+              !normalizedAttachments.referencedPayloadIds.has(
+                String(cursor.primaryKey),
+              )
+            ) {
+              cursor.delete()
+            }
+            cursor.continue()
+            return
+          }
+          writeChatAndPayloads()
+        }
       })
     })
   }
@@ -1853,7 +1931,9 @@ export class IndexedDBStorage {
         }
       }
 
-      const normalizedAttachments = normalizeAttachmentPayloads(opts.chat)
+      const normalizedAttachments = normalizeAttachmentPayloads(
+        inheritAttachmentPayloadReferences(opts.chat, existing),
+      )
       const messagesForStorage = normalizedAttachments.messages.map((msg) => ({
         ...msg,
         timestamp:
@@ -1903,20 +1983,21 @@ export class IndexedDBStorage {
             reject(new Error('Failed to apply remote chat'))
         }
 
-        if (!normalizedAttachments.replacePayloads) {
-          writeChatAndPayloads()
-          return
-        }
-
         const payloadCursor = payloadStore
           .index(ATTACHMENT_PAYLOADS_CHAT_INDEX)
           .openCursor(IDBKeyRange.only(opts.chat.id))
         payloadCursor.onerror = () =>
-          reject(new Error('Failed to replace remote attachment payloads'))
+          reject(new Error('Failed to reconcile remote attachment payloads'))
         payloadCursor.onsuccess = () => {
           const cursor = payloadCursor.result
           if (cursor) {
-            cursor.delete()
+            if (
+              !normalizedAttachments.referencedPayloadIds.has(
+                String(cursor.primaryKey),
+              )
+            ) {
+              cursor.delete()
+            }
             cursor.continue()
             return
           }

--- a/tests/services/chat-export/export-archive.test.ts
+++ b/tests/services/chat-export/export-archive.test.ts
@@ -6,6 +6,7 @@ import {
   buildChatExport,
   sanitizeFilename,
 } from '@/services/chat-export/export-archive'
+import { parseLocalTinfoilExport } from '@/services/chat-import/local-tinfoil-import'
 
 function chat(overrides: Partial<Chat>): Chat {
   return {
@@ -226,6 +227,77 @@ describe('buildChatExport', () => {
     expect(conversations[0].chat_messages[0].attachments[1].exportPath).toBe(
       'attachments/id/pic-2.png',
     )
+  })
+
+  it('round-trips duplicate attachment ids without swapping bytes', async () => {
+    const firstBytes = new Uint8Array([1, 2, 3])
+    const secondBytes = new Uint8Array([4, 5, 6])
+    const result = await buildChatExport(
+      [
+        chat({
+          messages: [
+            {
+              role: 'user',
+              content: 'first',
+              timestamp: new Date('2023-11-14T22:13:21.000Z'),
+              attachments: [
+                {
+                  id: 'legacy-image',
+                  type: 'image',
+                  fileName: 'first.png',
+                },
+              ],
+            },
+            {
+              role: 'user',
+              content: 'second',
+              timestamp: new Date('2023-11-14T22:13:22.000Z'),
+              attachments: [
+                {
+                  id: 'legacy-image',
+                  type: 'image',
+                  fileName: 'second.png',
+                },
+              ],
+            },
+          ],
+        }),
+      ],
+      async (attachment) =>
+        attachment.fileName === 'first.png' ? firstBytes : secondBytes,
+    )
+    const imported = await parseLocalTinfoilExport(
+      new File(
+        [new Uint8Array(result.data as Uint8Array)],
+        'tinfoil-chats.zip',
+        {
+          type: 'application/zip',
+        },
+      ),
+      {
+        generateChatId: () => 'imported-chat',
+        isCloudSyncEnabled: false,
+      },
+    )
+
+    expect(
+      imported[0].messages.map((message) => ({
+        id: message.attachments?.[0].id,
+        fileName: message.attachments?.[0].fileName,
+        base64: message.attachments?.[0].base64,
+      })),
+    ).toEqual([
+      {
+        id: 'legacy-image',
+        fileName: 'first.png',
+        base64: 'AQID',
+      },
+      {
+        id: 'legacy-image',
+        fileName: 'second.png',
+        base64: 'BAUG',
+      },
+    ])
   })
 })
 

--- a/tests/services/cloud/cloud-storage.test.ts
+++ b/tests/services/cloud/cloud-storage.test.ts
@@ -204,6 +204,47 @@ describe('CloudStorageService auth readiness', () => {
     expect(mockAttachmentPut.mock.calls[1][0].idempotencyKey).toBe(firstKey)
   })
 
+  it('returns local payload identity without including it in cloud plaintext', async () => {
+    const service = new CloudStorageService()
+    const result = await service.uploadChat(
+      {
+        id: 'chat-1',
+        title: 'Local chat',
+        messages: [
+          {
+            role: 'user',
+            content: 'hi',
+            attachments: [
+              {
+                id: 'local-att',
+                type: 'image',
+                fileName: 'image.png',
+                base64: 'AQID',
+                storagePayloadId: 'local-payload-reference',
+              },
+            ],
+          },
+        ],
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+        lastAccessedAt: 0,
+      } as any,
+      { idempotencyKey: 'upload-idem-1' },
+    )
+
+    expect(result.rewrites).toEqual([
+      expect.objectContaining({
+        clientId: 'local-att',
+        storagePayloadId: 'local-payload-reference',
+      }),
+    ])
+    const plaintext = new TextDecoder().decode(
+      mockEnclavePush.mock.calls[0][0].plaintext,
+    )
+    expect(plaintext).not.toContain('storagePayloadId')
+    expect(plaintext).not.toContain('local-payload-reference')
+  })
+
   it('does not re-upload attachments that already have enclave keys', async () => {
     const service = new CloudStorageService()
     const chat = {

--- a/tests/services/cloud/cloud-sync.test.ts
+++ b/tests/services/cloud/cloud-sync.test.ts
@@ -84,6 +84,7 @@ vi.mock('@/services/storage/indexed-db', () => ({
     isChatHistoryAuthoritative: (...args: any[]) =>
       mockIsChatHistoryAuthoritative(...args),
     getUnsyncedChats: (...args: any[]) => mockGetUnsyncedChats(...args),
+    getUnsyncedChatMetadata: (...args: any[]) => mockGetUnsyncedChats(...args),
     saveChat: (...args: any[]) => mockSaveChat(...args),
     saveExistingChat: (...args: any[]) => mockSaveExistingChat(...args),
     markAsSynced: (...args: any[]) => mockMarkAsSynced(...args),

--- a/tests/services/cloud/cloud-sync.test.ts
+++ b/tests/services/cloud/cloud-sync.test.ts
@@ -77,6 +77,7 @@ vi.mock('@/utils/error-handling', () => ({
 }))
 
 vi.mock('@/services/storage/indexed-db', () => ({
+  chatContentFingerprint: (chat: unknown) => JSON.stringify(chat),
   indexedDBStorage: {
     getAllChats: (...args: any[]) => mockGetAllChats(...args),
     getCloudChatCount: (...args: any[]) => mockGetCloudChatCount(...args),
@@ -359,6 +360,7 @@ describe('CloudSyncService', () => {
           chatId: 'cloud-1',
           syncVersion: 8,
           rewrites: [],
+          preUploadFingerprint: expect.any(String),
         }),
       )
     })

--- a/tests/services/storage/indexed-db-account-reset.test.ts
+++ b/tests/services/storage/indexed-db-account-reset.test.ts
@@ -23,20 +23,26 @@ describe('IndexedDBStorage account reset', () => {
   function prepareReset(storage: IndexedDBStorage) {
     const clear = vi.fn(() => ({ onerror: null }))
     const clearProjects = vi.fn(() => ({ onerror: null }))
+    const clearPayloads = vi.fn(() => ({ onerror: null }))
     const transaction: FakeResetTransaction = {
       oncomplete: null,
       onerror: null,
       onabort: null,
       abort: vi.fn(),
       objectStore: (storeName) => ({
-        clear: storeName === 'chats' ? clear : clearProjects,
+        clear:
+          storeName === 'chats'
+            ? clear
+            : storeName === 'projects'
+              ? clearProjects
+              : clearPayloads,
       }),
     }
     const resetDb = {
       transaction: vi.fn(() => transaction),
     }
     vi.spyOn(storage as any, 'ensureDB').mockResolvedValue(resetDb)
-    return { clear, clearProjects, transaction }
+    return { clear, clearProjects, clearPayloads, transaction }
   }
 
   async function completeReset(transaction: FakeResetTransaction) {
@@ -55,7 +61,8 @@ describe('IndexedDBStorage account reset', () => {
 
   it('bypasses a stalled write queue and closes the old connection', async () => {
     const storage = new IndexedDBStorage()
-    const { clear, clearProjects, transaction } = prepareReset(storage)
+    const { clear, clearProjects, clearPayloads, transaction } =
+      prepareReset(storage)
     const close = vi.fn()
     Object.assign(storage as any, {
       db: { close },
@@ -67,6 +74,7 @@ describe('IndexedDBStorage account reset', () => {
     expect(close).toHaveBeenCalledTimes(1)
     await vi.waitFor(() => expect(clear).toHaveBeenCalledTimes(1))
     expect(clearProjects).toHaveBeenCalledTimes(1)
+    expect(clearPayloads).toHaveBeenCalledTimes(1)
     await completeReset(transaction)
     await reset
   })
@@ -248,11 +256,13 @@ describe('IndexedDBStorage account reset', () => {
   it('rejects a final write after reset interrupts a multi-stage mutation', async () => {
     const storage = new IndexedDBStorage()
     let finishRead!: (chat: any) => void
-    const getChat = vi.spyOn(storage as any, 'getChatInternal').mockReturnValue(
-      new Promise((resolve) => {
-        finishRead = resolve
-      }),
-    )
+    const getChat = vi
+      .spyOn(storage as any, 'getStoredChatInternal')
+      .mockReturnValue(
+        new Promise((resolve) => {
+          finishRead = resolve
+        }),
+      )
 
     const update = storage.updateChatProject('chat_123', 'project_123')
     await vi.waitFor(() => expect(getChat).toHaveBeenCalledTimes(1))
@@ -301,10 +311,16 @@ describe('IndexedDBStorage account reset', () => {
       onerror: (() => void) | null
     }
     const openCursor = vi.fn(() => cursorRequest)
+    const payloadRequest = { onsuccess: null, onerror: null, result: [] }
+    const transaction = {
+      oncomplete: null,
+      objectStore: (storeName: string) =>
+        storeName === 'chats'
+          ? { openCursor }
+          : { getAll: () => payloadRequest },
+    }
     vi.spyOn(storage as any, 'ensureDB').mockResolvedValue({
-      transaction: () => ({
-        objectStore: () => ({ openCursor }),
-      }),
+      transaction: () => transaction,
     })
 
     const chats = storage.getAllChats()

--- a/tests/services/storage/indexed-db-content-fingerprint.test.ts
+++ b/tests/services/storage/indexed-db-content-fingerprint.test.ts
@@ -172,6 +172,38 @@ describe('chatContentFingerprint', () => {
     })
     expect(fp1).not.toBe(fp2)
   })
+
+  it('captures normalized attachment payload changes', () => {
+    const attachment = {
+      id: 'attachment',
+      type: 'image',
+      fileName: 'image.png',
+    }
+    const fp1 = chatContentFingerprint({
+      title: 'T',
+      messages: [
+        {
+          role: 'user',
+          content: 'x',
+          timestamp: '2024-01-01T00:00:00Z',
+          attachments: [{ ...attachment, base64: 'AAA' }],
+        },
+      ],
+    })
+    const fp2 = chatContentFingerprint({
+      title: 'T',
+      messages: [
+        {
+          role: 'user',
+          content: 'x',
+          timestamp: '2024-01-01T00:00:00Z',
+          attachments: [{ ...attachment, base64: 'BBB' }],
+        },
+      ],
+    })
+
+    expect(fp1).not.toBe(fp2)
+  })
 })
 
 describe('chatNeedsSync', () => {

--- a/tests/services/storage/indexed-db-content-fingerprint.test.ts
+++ b/tests/services/storage/indexed-db-content-fingerprint.test.ts
@@ -204,6 +204,33 @@ describe('chatContentFingerprint', () => {
 
     expect(fp1).not.toBe(fp2)
   })
+
+  it('uses collision-resistant SHA-256 attachment hashes', () => {
+    const attachment = {
+      id: 'attachment',
+      type: 'image',
+      fileName: 'image.png',
+    }
+    const fingerprint = (base64: string) =>
+      chatContentFingerprint({
+        title: 'T',
+        messages: [
+          {
+            role: 'user',
+            content: 'x',
+            timestamp: '2024-01-01T00:00:00Z',
+            attachments: [{ ...attachment, base64 }],
+          },
+        ],
+      })
+
+    const knownHash = JSON.parse(fingerprint('AAA')).messages[0].attachments[0]
+      .base64Hash
+    expect(knownHash).toBe(
+      'cb1ad2119d8fafb69566510ee712661f9f14b83385006ef92aec47f523a38358',
+    )
+    expect(fingerprint('up/Gwn25')).not.toBe(fingerprint('XND8FyWq'))
+  })
 })
 
 describe('chatNeedsSync', () => {

--- a/tests/services/storage/indexed-db-sync-index.test.ts
+++ b/tests/services/storage/indexed-db-sync-index.test.ts
@@ -1,4 +1,5 @@
 import {
+  AttachmentPayloadIdUnavailableError,
   chatContentFingerprint,
   DB_NAME,
   DB_VERSION,
@@ -701,68 +702,102 @@ describe('IndexedDB pending sync index', () => {
     ])
   })
 
-  it('keeps fallback payload ids unique across module reloads and chats', async () => {
+  it('rejects duplicate payload saves atomically without randomUUID', async () => {
+    const storage = new IndexedDBStorage()
+    await storage.initialize()
+    await storage.saveChat(
+      storedChat('uuid-required', {
+        title: 'Original',
+        messages: [
+          {
+            role: 'user',
+            content: 'Original',
+            timestamp: new Date('2026-08-12T00:00:00.000Z'),
+            attachments: [
+              {
+                id: 'shared',
+                type: 'image',
+                fileName: 'original.png',
+                base64: 'original',
+              },
+            ],
+          },
+        ],
+      }),
+    )
+
     vi.stubGlobal('crypto', {})
-    vi.resetModules()
-    const { IndexedDBStorage: FirstStorage } =
-      await import('@/services/storage/indexed-db')
-    const firstStorage = new FirstStorage()
-    await firstStorage.initialize()
-    await firstStorage.saveChat(
-      storedChat('first/chat', {
+    await expect(
+      storage.saveChat(
+        storedChat('uuid-required', {
+          title: 'Changed',
+          messages: [
+            {
+              role: 'user',
+              content: 'Changed',
+              timestamp: new Date('2026-08-12T00:00:00.000Z'),
+              attachments: [
+                {
+                  id: 'shared',
+                  type: 'image',
+                  fileName: 'changed.png',
+                  base64: 'changed',
+                },
+                {
+                  id: 'shared',
+                  type: 'image',
+                  fileName: 'duplicate.png',
+                  base64: 'duplicate',
+                },
+              ],
+            },
+          ],
+        }),
+      ),
+    ).rejects.toBeInstanceOf(AttachmentPayloadIdUnavailableError)
+
+    const stored = await storage.getChat('uuid-required')
+    expect(stored?.title).toBe('Original')
+    expect(stored?.messages[0].content).toBe('Original')
+    expect(stored?.messages[0].attachments).toEqual([
+      expect.objectContaining({
+        fileName: 'original.png',
+        base64: 'original',
+      }),
+    ])
+  })
+
+  it('uses deterministic legacy payload ids without randomUUID', async () => {
+    vi.stubGlobal('crypto', {})
+    const storage = new IndexedDBStorage()
+    await storage.initialize()
+    await storage.saveChat(
+      storedChat('legacy-only', {
         messages: [
           {
             role: 'user',
-            content: 'First',
+            content: 'Legacy',
             timestamp: new Date('2026-08-12T00:00:00.000Z'),
             attachments: [
-              { id: 'shared', type: 'image', fileName: 'a.png', base64: 'a' },
-              { id: 'shared', type: 'image', fileName: 'b.png', base64: 'b' },
+              {
+                id: 'unique',
+                type: 'image',
+                fileName: 'legacy.png',
+                base64: 'legacy',
+              },
             ],
           },
         ],
       }),
     )
 
-    vi.resetModules()
-    const { IndexedDBStorage: SecondStorage } =
-      await import('@/services/storage/indexed-db')
-    const secondStorage = new SecondStorage()
-    await secondStorage.initialize()
-    await secondStorage.saveChat(
-      storedChat('second:chat', {
-        messages: [
-          {
-            role: 'user',
-            content: 'Second',
-            timestamp: new Date('2026-08-12T00:00:00.000Z'),
-            attachments: [
-              { id: 'shared', type: 'image', fileName: 'c.png', base64: 'c' },
-              { id: 'shared', type: 'image', fileName: 'd.png', base64: 'd' },
-            ],
-          },
-        ],
+    const stored = await storage.getChat('legacy-only')
+    expect(stored?.messages[0].attachments).toEqual([
+      expect.objectContaining({
+        storagePayloadId: 'legacy-only:unique',
+        base64: 'legacy',
       }),
-    )
-
-    const first = await secondStorage.getChat('first/chat')
-    const second = await secondStorage.getChat('second:chat')
-    const firstAttachments = first?.messages[0].attachments ?? []
-    const secondAttachments = second?.messages[0].attachments ?? []
-
-    expect(firstAttachments.map((attachment) => attachment.base64)).toEqual([
-      'a',
-      'b',
     ])
-    expect(secondAttachments.map((attachment) => attachment.base64)).toEqual([
-      'c',
-      'd',
-    ])
-    expect(
-      (firstAttachments[1] as { storagePayloadId?: string }).storagePayloadId,
-    ).not.toBe(
-      (secondAttachments[1] as { storagePayloadId?: string }).storagePayloadId,
-    )
   })
 
   it('finalizes duplicate client ids using their payload identities', async () => {

--- a/tests/services/storage/indexed-db-sync-index.test.ts
+++ b/tests/services/storage/indexed-db-sync-index.test.ts
@@ -570,6 +570,132 @@ describe('IndexedDB pending sync index', () => {
     )
   })
 
+  it('reserves an exact legacy payload match before duplicate fallback', async () => {
+    const storage = new IndexedDBStorage()
+    await storage.initialize()
+    await storage.saveChat(
+      storedChat('inserted-duplicate', {
+        messages: [
+          {
+            role: 'user',
+            content: 'Original',
+            timestamp: new Date('2026-08-12T00:00:00.000Z'),
+            attachments: [
+              {
+                id: 'shared-id',
+                type: 'image',
+                fileName: 'old.png',
+                mimeType: 'image/png',
+                fileSize: 3,
+                base64: 'old',
+              },
+            ],
+          },
+        ],
+      }),
+    )
+
+    await storage.applyRemoteChatIfFresh({
+      chat: storedChat('inserted-duplicate', {
+        messages: [
+          {
+            role: 'user',
+            content: 'Inserted',
+            timestamp: new Date('2026-08-12T00:00:01.000Z'),
+            attachments: [
+              {
+                id: 'shared-id',
+                type: 'image',
+                fileName: 'new.png',
+                mimeType: 'image/png',
+                fileSize: 3,
+              },
+            ],
+          },
+          {
+            role: 'user',
+            content: 'Original',
+            timestamp: new Date('2026-08-12T00:00:00.000Z'),
+            attachments: [
+              {
+                id: 'shared-id',
+                type: 'image',
+                fileName: 'old.png',
+                mimeType: 'image/png',
+                fileSize: 3,
+              },
+            ],
+          },
+        ],
+      }),
+      syncVersion: 2,
+      expectedLocalUpdatedAt: undefined,
+    })
+
+    const updated = await storage.getChat('inserted-duplicate')
+    expect(
+      updated?.messages.map((message) => ({
+        fileName: message.attachments?.[0].fileName,
+        base64: message.attachments?.[0].base64,
+      })),
+    ).toEqual([
+      { fileName: 'new.png', base64: undefined },
+      { fileName: 'old.png', base64: 'old' },
+    ])
+  })
+
+  it('keeps generated payload ids separate from adversarial legacy ids', async () => {
+    const storage = new IndexedDBStorage()
+    await storage.initialize()
+    await storage.saveChat(
+      storedChat('payload-id-collision', {
+        messages: [
+          {
+            role: 'user',
+            content: 'Attachments',
+            timestamp: new Date('2026-08-12T00:00:00.000Z'),
+            attachments: [
+              {
+                id: 'x',
+                type: 'image',
+                fileName: 'first.png',
+                base64: 'first',
+              },
+              {
+                id: 'x',
+                type: 'image',
+                fileName: 'second.png',
+                base64: 'second',
+              },
+              {
+                id: 'x:duplicate:1',
+                type: 'image',
+                fileName: 'adversarial.png',
+                base64: 'adversarial',
+              },
+            ],
+          },
+        ],
+      }),
+    )
+
+    const stored = await storage.getChat('payload-id-collision')
+    const attachments = stored?.messages[0].attachments ?? []
+    expect(
+      new Set(
+        attachments.map(
+          (attachment) =>
+            (attachment as { storagePayloadId?: string }).storagePayloadId,
+        ),
+      ).size,
+    ).toBe(3)
+    expect(attachments.map((attachment) => attachment.base64)).toEqual([
+      'first',
+      'second',
+      'adversarial',
+    ])
+  })
+
   it('finalizes duplicate client ids using their payload identities', async () => {
     const storage = new IndexedDBStorage()
     await storage.initialize()

--- a/tests/services/storage/indexed-db-sync-index.test.ts
+++ b/tests/services/storage/indexed-db-sync-index.test.ts
@@ -208,6 +208,48 @@ describe('IndexedDB pending sync index', () => {
       'Document text',
     )
 
+    await storage.applyRemoteChatIfFresh({
+      chat: {
+        ...storedChat('with-attachment'),
+        messages: [
+          {
+            role: 'user',
+            content: 'Read this remotely',
+            timestamp: new Date('2026-08-12T00:00:00.000Z'),
+            attachments: [
+              {
+                id: 'attachment-1',
+                type: 'document',
+                fileName: 'document.pdf',
+              },
+            ],
+          },
+        ],
+      },
+      syncVersion: 2,
+      expectedLocalUpdatedAt: undefined,
+    })
+    expect(
+      (await storage.getChat('with-attachment'))?.messages[0].attachments?.[0]
+        .base64,
+    ).toBe(base64)
+
+    const chatWithoutAttachment = await storage.getChat('with-attachment')
+    if (!chatWithoutAttachment) throw new Error('Expected stored chat')
+    chatWithoutAttachment.messages[0].attachments = []
+    await storage.saveChat(chatWithoutAttachment)
+    const payloadCountAfterRemoval = await new Promise<number>(
+      (resolve, reject) => {
+        const request = db
+          .transaction('attachmentPayloads')
+          .objectStore('attachmentPayloads')
+          .count()
+        request.onerror = () => reject(request.error)
+        request.onsuccess = () => resolve(request.result)
+      },
+    )
+    expect(payloadCountAfterRemoval).toBe(0)
+
     await storage.deleteChat('with-attachment')
     const payloadCount = await new Promise<number>((resolve, reject) => {
       const request = db

--- a/tests/services/storage/indexed-db-sync-index.test.ts
+++ b/tests/services/storage/indexed-db-sync-index.test.ts
@@ -1,5 +1,8 @@
 import {
   AttachmentPayloadIdUnavailableError,
+  AttachmentPayloadMissingError,
+  AttachmentPayloadReferenceAmbiguityError,
+  AttachmentPayloadReferenceMissingError,
   chatContentFingerprint,
   DB_NAME,
   DB_VERSION,
@@ -322,6 +325,122 @@ describe('IndexedDB pending sync index', () => {
     db.close()
   })
 
+  it('fails reads when a local attachment payload row is missing', async () => {
+    const storage = new IndexedDBStorage()
+    await storage.initialize()
+    await storage.saveChat(
+      storedChat('missing-payload', {
+        messages: [
+          {
+            role: 'user',
+            content: 'Read this',
+            timestamp: new Date('2026-08-12T00:00:00.000Z'),
+            attachments: [
+              {
+                id: 'document-1',
+                type: 'document',
+                fileName: 'document.pdf',
+                textContent: 'Important document text',
+              },
+            ],
+          },
+        ],
+      }),
+    )
+    const stored = await storage.getChat('missing-payload')
+    const payloadId = (
+      stored?.messages[0].attachments?.[0] as { storagePayloadId?: string }
+    ).storagePayloadId
+    if (!payloadId) throw new Error('Expected attachment payload id')
+
+    const db = await new Promise<IDBDatabase>((resolve, reject) => {
+      const request = indexedDB.open(DB_NAME, DB_VERSION)
+      request.onerror = () => reject(request.error)
+      request.onsuccess = () => resolve(request.result)
+    })
+    await new Promise<void>((resolve, reject) => {
+      const transaction = db.transaction('attachmentPayloads', 'readwrite')
+      transaction.objectStore('attachmentPayloads').delete(payloadId)
+      transaction.oncomplete = () => resolve()
+      transaction.onerror = () => reject(transaction.error)
+    })
+    db.close()
+
+    await expect(storage.getChat('missing-payload')).rejects.toBeInstanceOf(
+      AttachmentPayloadMissingError,
+    )
+  })
+
+  it('keeps remotely retrievable images metadata-only until lazy loading', async () => {
+    const storage = new IndexedDBStorage()
+    await storage.initialize()
+
+    await expect(
+      storage.applyRemoteChatIfFresh({
+        chat: storedChat('lazy-image', {
+          messages: [
+            {
+              role: 'assistant',
+              content: 'Generated image',
+              timestamp: new Date('2026-08-12T00:00:00.000Z'),
+              attachments: [
+                {
+                  id: 'remote-image',
+                  type: 'image',
+                  fileName: 'image.png',
+                  mimeType: 'image/png',
+                  encryptionKey: 'remote-image-key',
+                },
+              ],
+            },
+          ],
+        }),
+        syncVersion: 1,
+        expectedLocalUpdatedAt: null,
+      }),
+    ).resolves.toEqual({ applied: true })
+
+    const attachment = (await storage.getChat('lazy-image'))?.messages[0]
+      .attachments?.[0] as
+      ({ storagePayloadId?: string } & Record<string, unknown>) | undefined
+    expect(attachment).toMatchObject({
+      id: 'remote-image',
+      type: 'image',
+      encryptionKey: 'remote-image-key',
+    })
+    expect(attachment?.storagePayloadId).toBeTruthy()
+    expect(attachment?.base64).toBeUndefined()
+  })
+
+  it('rejects remote attachments without payload or retrieval identity', async () => {
+    const storage = new IndexedDBStorage()
+    await storage.initialize()
+
+    await expect(
+      storage.applyRemoteChatIfFresh({
+        chat: storedChat('missing-remote-payload', {
+          messages: [
+            {
+              role: 'user',
+              content: 'Missing document',
+              timestamp: new Date('2026-08-12T00:00:00.000Z'),
+              attachments: [
+                {
+                  id: 'document-1',
+                  type: 'document',
+                  fileName: 'document.pdf',
+                },
+              ],
+            },
+          ],
+        }),
+        syncVersion: 1,
+        expectedLocalUpdatedAt: null,
+      }),
+    ).rejects.toBeInstanceOf(AttachmentPayloadReferenceMissingError)
+    await expect(storage.getChat('missing-remote-payload')).resolves.toBeNull()
+  })
+
   it('hydrates attachment payloads through mutateChat without reinlining them', async () => {
     const storage = new IndexedDBStorage()
     await storage.initialize()
@@ -576,6 +695,92 @@ describe('IndexedDB pending sync index', () => {
     )
   })
 
+  it('rejects ambiguous remote payload inheritance without changing local data', async () => {
+    const storage = new IndexedDBStorage()
+    await storage.initialize()
+    await storage.saveChat(
+      storedChat('ambiguous-payloads', {
+        title: 'Local title',
+        messages: [
+          {
+            role: 'user',
+            content: 'Local content',
+            timestamp: new Date('2026-08-12T00:00:00.000Z'),
+            attachments: [
+              {
+                id: 'duplicate-id',
+                type: 'document',
+                fileName: 'same.pdf',
+                mimeType: 'application/pdf',
+                fileSize: 4,
+                textContent: 'first payload',
+              },
+              {
+                id: 'duplicate-id',
+                type: 'document',
+                fileName: 'same.pdf',
+                mimeType: 'application/pdf',
+                fileSize: 4,
+                textContent: 'second payload',
+              },
+            ],
+          },
+        ],
+      }),
+    )
+
+    await expect(
+      storage.applyRemoteChatIfFresh({
+        chat: storedChat('ambiguous-payloads', {
+          title: 'Remote title',
+          messages: [
+            {
+              role: 'user',
+              content: 'Remote content',
+              timestamp: new Date('2026-08-12T00:00:00.000Z'),
+              attachments: [
+                {
+                  id: 'duplicate-id',
+                  type: 'document',
+                  fileName: 'same.pdf',
+                  mimeType: 'application/pdf',
+                  fileSize: 4,
+                },
+              ],
+            },
+          ],
+        }),
+        syncVersion: 2,
+        expectedLocalUpdatedAt: undefined,
+      }),
+    ).rejects.toBeInstanceOf(AttachmentPayloadReferenceAmbiguityError)
+
+    const preserved = await storage.getChat('ambiguous-payloads')
+    expect(preserved?.title).toBe('Local title')
+    expect(preserved?.messages[0].content).toBe('Local content')
+    expect(
+      preserved?.messages[0].attachments?.map(
+        (attachment) => attachment.textContent,
+      ),
+    ).toEqual(['first payload', 'second payload'])
+
+    const db = await new Promise<IDBDatabase>((resolve, reject) => {
+      const request = indexedDB.open(DB_NAME, DB_VERSION)
+      request.onerror = () => reject(request.error)
+      request.onsuccess = () => resolve(request.result)
+    })
+    const payloadCount = await new Promise<number>((resolve, reject) => {
+      const request = db
+        .transaction('attachmentPayloads')
+        .objectStore('attachmentPayloads')
+        .count()
+      request.onerror = () => reject(request.error)
+      request.onsuccess = () => resolve(request.result)
+    })
+    expect(payloadCount).toBe(2)
+    db.close()
+  })
+
   it('reserves an exact legacy payload match before duplicate fallback', async () => {
     const storage = new IndexedDBStorage()
     await storage.initialize()
@@ -615,6 +820,7 @@ describe('IndexedDB pending sync index', () => {
                 fileName: 'new.png',
                 mimeType: 'image/png',
                 fileSize: 3,
+                encryptionKey: 'new-image-key',
               },
             ],
           },

--- a/tests/services/storage/indexed-db-sync-index.test.ts
+++ b/tests/services/storage/indexed-db-sync-index.test.ts
@@ -7,7 +7,7 @@ import {
   type StoredChat,
 } from '@/services/storage/indexed-db'
 import { IDBKeyRange as FakeIDBKeyRange, IDBFactory } from 'fake-indexeddb'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 function storedChat(
   id: string,
@@ -114,6 +114,10 @@ function blockChatTransaction(
 }
 
 describe('IndexedDB pending sync index', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
   beforeEach(() => {
     Object.defineProperty(globalThis, 'indexedDB', {
       configurable: true,
@@ -695,6 +699,70 @@ describe('IndexedDB pending sync index', () => {
       'second',
       'adversarial',
     ])
+  })
+
+  it('keeps fallback payload ids unique across module reloads and chats', async () => {
+    vi.stubGlobal('crypto', {})
+    vi.resetModules()
+    const { IndexedDBStorage: FirstStorage } =
+      await import('@/services/storage/indexed-db')
+    const firstStorage = new FirstStorage()
+    await firstStorage.initialize()
+    await firstStorage.saveChat(
+      storedChat('first/chat', {
+        messages: [
+          {
+            role: 'user',
+            content: 'First',
+            timestamp: new Date('2026-08-12T00:00:00.000Z'),
+            attachments: [
+              { id: 'shared', type: 'image', fileName: 'a.png', base64: 'a' },
+              { id: 'shared', type: 'image', fileName: 'b.png', base64: 'b' },
+            ],
+          },
+        ],
+      }),
+    )
+
+    vi.resetModules()
+    const { IndexedDBStorage: SecondStorage } =
+      await import('@/services/storage/indexed-db')
+    const secondStorage = new SecondStorage()
+    await secondStorage.initialize()
+    await secondStorage.saveChat(
+      storedChat('second:chat', {
+        messages: [
+          {
+            role: 'user',
+            content: 'Second',
+            timestamp: new Date('2026-08-12T00:00:00.000Z'),
+            attachments: [
+              { id: 'shared', type: 'image', fileName: 'c.png', base64: 'c' },
+              { id: 'shared', type: 'image', fileName: 'd.png', base64: 'd' },
+            ],
+          },
+        ],
+      }),
+    )
+
+    const first = await secondStorage.getChat('first/chat')
+    const second = await secondStorage.getChat('second:chat')
+    const firstAttachments = first?.messages[0].attachments ?? []
+    const secondAttachments = second?.messages[0].attachments ?? []
+
+    expect(firstAttachments.map((attachment) => attachment.base64)).toEqual([
+      'a',
+      'b',
+    ])
+    expect(secondAttachments.map((attachment) => attachment.base64)).toEqual([
+      'c',
+      'd',
+    ])
+    expect(
+      (firstAttachments[1] as { storagePayloadId?: string }).storagePayloadId,
+    ).not.toBe(
+      (secondAttachments[1] as { storagePayloadId?: string }).storagePayloadId,
+    )
   })
 
   it('finalizes duplicate client ids using their payload identities', async () => {

--- a/tests/services/storage/indexed-db-sync-index.test.ts
+++ b/tests/services/storage/indexed-db-sync-index.test.ts
@@ -352,4 +352,249 @@ describe('IndexedDB pending sync index', () => {
     expect(hydrated?.messages[0].attachments?.[0].base64).toBe(base64)
     db.close()
   })
+
+  it('keeps duplicate attachment ids bound to their original payloads', async () => {
+    const storage = new IndexedDBStorage()
+    await storage.initialize()
+    const firstBase64 = 'first-base64'
+    const secondBase64 = 'second-base64'
+    await storage.saveChat(
+      storedChat('duplicate-attachments', {
+        messages: [
+          {
+            role: 'user',
+            content: 'First message',
+            timestamp: new Date('2026-08-12T00:00:00.000Z'),
+            attachments: [
+              {
+                id: 'legacy-attachment',
+                type: 'document',
+                fileName: 'first.pdf',
+                base64: firstBase64,
+                textContent: 'First text',
+                pages: [
+                  {
+                    page: 1,
+                    text: 'First page',
+                    image: firstBase64,
+                    is_scanned: true,
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            role: 'user',
+            content: 'Second message',
+            timestamp: new Date('2026-08-12T00:00:01.000Z'),
+            attachments: [
+              {
+                id: 'legacy-attachment',
+                type: 'document',
+                fileName: 'second.pdf',
+                base64: secondBase64,
+                textContent: 'Second text',
+                pages: [
+                  {
+                    page: 1,
+                    text: 'Second page',
+                    image: secondBase64,
+                    is_scanned: true,
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }),
+    )
+
+    const original = await storage.getChat('duplicate-attachments')
+    if (!original) throw new Error('Expected stored chat')
+    expect(
+      original.messages.map((message) => message.attachments?.[0].textContent),
+    ).toEqual(['First text', 'Second text'])
+    const originalPayloadIds = original.messages.map(
+      (message) =>
+        (
+          message.attachments?.[0] as
+            | ({ storagePayloadId?: string } & Record<string, unknown>)
+            | undefined
+        )?.storagePayloadId,
+    )
+    expect(new Set(originalPayloadIds).size).toBe(2)
+
+    await storage.saveChat({ ...original, title: 'Second save' })
+    const secondSave = await storage.getChat('duplicate-attachments')
+    if (!secondSave) throw new Error('Expected stored chat')
+    await storage.saveChat({
+      ...secondSave,
+      messages: [...secondSave.messages].reverse(),
+    })
+
+    const reordered = await storage.getChat('duplicate-attachments')
+    expect(
+      reordered?.messages.map(
+        (message) => message.attachments?.[0].textContent,
+      ),
+    ).toEqual(['Second text', 'First text'])
+    expect(reordered?.messages[0].attachments?.[0].pages?.[0].image).toBe(
+      secondBase64,
+    )
+
+    await storage.applyRemoteChatIfFresh({
+      chat: {
+        ...storedChat('duplicate-attachments'),
+        messages: [
+          {
+            role: 'user',
+            content: 'First message updated remotely',
+            timestamp: new Date('2026-08-12T00:00:00.000Z'),
+            attachments: [
+              {
+                id: 'legacy-attachment',
+                type: 'document',
+                fileName: 'first.pdf',
+              },
+            ],
+          },
+          {
+            role: 'user',
+            content: 'Second message updated remotely',
+            timestamp: new Date('2026-08-12T00:00:01.000Z'),
+            attachments: [
+              {
+                id: 'legacy-attachment',
+                type: 'document',
+                fileName: 'second.pdf',
+              },
+            ],
+          },
+        ],
+      },
+      syncVersion: 2,
+      expectedLocalUpdatedAt: undefined,
+    })
+
+    const remotelyUpdated = await storage.getChat('duplicate-attachments')
+    expect(
+      remotelyUpdated?.messages.map(
+        (message) => message.attachments?.[0].textContent,
+      ),
+    ).toEqual(['First text', 'Second text'])
+
+    if (!remotelyUpdated) throw new Error('Expected stored chat')
+    const exportStyleCopy = storedChat('duplicate-export-copy', {
+      messages: remotelyUpdated.messages.map((message) => ({
+        ...message,
+        attachments: message.attachments?.map((attachment) => {
+          const { storagePayloadId: _storagePayloadId, ...exported } =
+            attachment as typeof attachment & { storagePayloadId?: string }
+          return exported
+        }),
+      })),
+    })
+    await storage.saveChat(exportStyleCopy)
+    expect(
+      (await storage.getChat('duplicate-export-copy'))?.messages.map(
+        (message) => ({
+          base64: message.attachments?.[0].base64,
+          text: message.attachments?.[0].textContent,
+          page: message.attachments?.[0].pages?.[0].text,
+        }),
+      ),
+    ).toEqual([
+      { base64: firstBase64, text: 'First text', page: 'First page' },
+      { base64: secondBase64, text: 'Second text', page: 'Second page' },
+    ])
+
+    remotelyUpdated.messages[0].attachments = []
+    await storage.saveChat(remotelyUpdated)
+    const afterRemoval = await storage.getChat('duplicate-attachments')
+    expect(afterRemoval?.messages[0].attachments).toEqual([])
+    expect(afterRemoval?.messages[1].attachments?.[0].textContent).toBe(
+      'Second text',
+    )
+  })
+
+  it('finalizes duplicate client ids using their payload identities', async () => {
+    const storage = new IndexedDBStorage()
+    await storage.initialize()
+    await storage.saveChat(
+      storedChat('duplicate-rewrites', {
+        messages: [
+          {
+            role: 'user',
+            content: 'First',
+            timestamp: new Date('2026-08-12T00:00:00.000Z'),
+            attachments: [
+              {
+                id: 'client-id',
+                type: 'image',
+                fileName: 'first.png',
+                base64: 'first-image',
+              },
+            ],
+          },
+          {
+            role: 'user',
+            content: 'Second',
+            timestamp: new Date('2026-08-12T00:00:01.000Z'),
+            attachments: [
+              {
+                id: 'client-id',
+                type: 'image',
+                fileName: 'second.png',
+                base64: 'second-image',
+              },
+            ],
+          },
+        ],
+      }),
+    )
+    const uploaded = await storage.getChat('duplicate-rewrites')
+    if (!uploaded) throw new Error('Expected stored chat')
+    const firstPayloadId = (
+      uploaded.messages[0].attachments?.[0] as {
+        storagePayloadId?: string
+      }
+    ).storagePayloadId
+    const secondPayloadId = (
+      uploaded.messages[1].attachments?.[0] as {
+        storagePayloadId?: string
+      }
+    ).storagePayloadId
+
+    await storage.finalizeUpload({
+      chatId: uploaded.id,
+      rewrites: [
+        {
+          clientId: 'client-id',
+          serverId: 'server-second',
+          encryptionKey: 'key-second',
+          storagePayloadId: secondPayloadId,
+        },
+        {
+          clientId: 'client-id',
+          serverId: 'server-first',
+          encryptionKey: 'key-first',
+          storagePayloadId: firstPayloadId,
+        },
+      ],
+      preUploadUpdatedAt: uploaded.updatedAt,
+      syncVersion: 2,
+    })
+
+    const finalized = await storage.getChat(uploaded.id)
+    expect(
+      finalized?.messages.map((message) => ({
+        id: message.attachments?.[0].id,
+        key: message.attachments?.[0].encryptionKey,
+        base64: message.attachments?.[0].base64,
+      })),
+    ).toEqual([
+      { id: 'server-first', key: 'key-first', base64: 'first-image' },
+      { id: 'server-second', key: 'key-second', base64: 'second-image' },
+    ])
+  })
 })

--- a/tests/services/storage/indexed-db-sync-index.test.ts
+++ b/tests/services/storage/indexed-db-sync-index.test.ts
@@ -5,7 +5,7 @@ import {
   IndexedDBStorage,
   type StoredChat,
 } from '@/services/storage/indexed-db'
-import { IDBFactory } from 'fake-indexeddb'
+import { IDBKeyRange as FakeIDBKeyRange, IDBFactory } from 'fake-indexeddb'
 import { beforeEach, describe, expect, it } from 'vitest'
 
 function storedChat(
@@ -64,6 +64,10 @@ describe('IndexedDB pending sync index', () => {
     Object.defineProperty(globalThis, 'indexedDB', {
       configurable: true,
       value: new IDBFactory(),
+    })
+    Object.defineProperty(globalThis, 'IDBKeyRange', {
+      configurable: true,
+      value: FakeIDBKeyRange,
     })
   })
 
@@ -127,5 +131,93 @@ describe('IndexedDB pending sync index', () => {
     await expect(chatsPromise).resolves.toEqual([
       expect.objectContaining({ id: 'cloud-chat' }),
     ])
+  })
+
+  it('stores attachment payloads separately and hydrates them on read', async () => {
+    const storage = new IndexedDBStorage()
+    await storage.initialize()
+    const initializedDatabase = await new Promise<IDBDatabase>(
+      (resolve, reject) => {
+        const request = indexedDB.open(DB_NAME, DB_VERSION)
+        request.onerror = () => reject(request.error)
+        request.onsuccess = () => resolve(request.result)
+      },
+    )
+    expect(
+      initializedDatabase.objectStoreNames.contains('attachmentPayloads'),
+    ).toBe(true)
+    expect(
+      initializedDatabase
+        .transaction('attachmentPayloads')
+        .objectStore('attachmentPayloads')
+        .indexNames.contains('chatId'),
+    ).toBe(true)
+    initializedDatabase.close()
+    const base64 = 'A'.repeat(20_000)
+    await storage.saveChat(
+      storedChat('with-attachment', {
+        messages: [
+          {
+            role: 'user',
+            content: 'Read this',
+            timestamp: new Date('2026-08-12T00:00:00.000Z'),
+            attachments: [
+              {
+                id: 'attachment-1',
+                type: 'document',
+                fileName: 'document.pdf',
+                base64,
+                textContent: 'Document text',
+                pages: [
+                  {
+                    page: 1,
+                    text: 'Page text',
+                    image: base64,
+                    is_scanned: true,
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }),
+    )
+
+    const db = await new Promise<IDBDatabase>((resolve, reject) => {
+      const request = indexedDB.open(DB_NAME, DB_VERSION)
+      request.onerror = () => reject(request.error)
+      request.onsuccess = () => resolve(request.result)
+    })
+    const rawChat = await new Promise<StoredChat>((resolve, reject) => {
+      const request = db
+        .transaction('chats')
+        .objectStore('chats')
+        .get('with-attachment')
+      request.onerror = () => reject(request.error)
+      request.onsuccess = () => resolve(request.result as StoredChat)
+    })
+    const rawAttachment = rawChat.messages[0].attachments?.[0] as
+      (Record<string, unknown> & { storagePayloadId?: string }) | undefined
+    expect(rawAttachment?.base64).toBeUndefined()
+    expect(rawAttachment?.textContent).toBeUndefined()
+    expect(rawAttachment?.storagePayloadId).toBeTruthy()
+
+    const hydrated = await storage.getChat('with-attachment')
+    expect(hydrated?.messages[0].attachments?.[0].base64).toBe(base64)
+    expect(hydrated?.messages[0].attachments?.[0].textContent).toBe(
+      'Document text',
+    )
+
+    await storage.deleteChat('with-attachment')
+    const payloadCount = await new Promise<number>((resolve, reject) => {
+      const request = db
+        .transaction('attachmentPayloads')
+        .objectStore('attachmentPayloads')
+        .count()
+      request.onerror = () => reject(request.error)
+      request.onsuccess = () => resolve(request.result)
+    })
+    expect(payloadCount).toBe(0)
+    db.close()
   })
 })

--- a/tests/services/storage/indexed-db-sync-index.test.ts
+++ b/tests/services/storage/indexed-db-sync-index.test.ts
@@ -6,7 +6,7 @@ import {
   type StoredChat,
 } from '@/services/storage/indexed-db'
 import { IDBKeyRange as FakeIDBKeyRange, IDBFactory } from 'fake-indexeddb'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 function storedChat(
   id: string,
@@ -57,6 +57,59 @@ async function openVersionThree(chats: StoredChat[]): Promise<IDBDatabase> {
 async function seedVersionThree(chats: StoredChat[]): Promise<void> {
   const db = await openVersionThree(chats)
   db.close()
+}
+
+function blockChatTransaction(
+  storage: IndexedDBStorage,
+  chatId: string,
+  mutation: (chat: StoredChat, transaction: IDBTransaction) => void,
+): {
+  ready: Promise<void>
+  release: () => void
+  complete: Promise<void>
+} {
+  const db = (storage as any).db as IDBDatabase
+  const transaction = db.transaction(
+    ['chats', 'attachmentPayloads'],
+    'readwrite',
+  )
+  const store = transaction.objectStore('chats')
+  let released = false
+  let readyResolved = false
+  let resolveReady!: () => void
+  const ready = new Promise<void>((resolve) => {
+    resolveReady = resolve
+  })
+  const complete = new Promise<void>((resolve, reject) => {
+    transaction.oncomplete = () => resolve()
+    transaction.onerror = () => reject(transaction.error)
+    transaction.onabort = () => reject(transaction.error)
+  })
+
+  const keepAlive = () => {
+    const request = store.get(chatId)
+    request.onerror = () => transaction.abort()
+    request.onsuccess = () => {
+      if (!readyResolved) {
+        readyResolved = true
+        resolveReady()
+      }
+      if (!released) {
+        keepAlive()
+        return
+      }
+      mutation(request.result as StoredChat, transaction)
+    }
+  }
+  keepAlive()
+
+  return {
+    ready,
+    release: () => {
+      released = true
+    },
+    complete,
+  }
 }
 
 describe('IndexedDB pending sync index', () => {
@@ -596,5 +649,327 @@ describe('IndexedDB pending sync index', () => {
       { id: 'server-first', key: 'key-first', base64: 'first-image' },
       { id: 'server-second', key: 'key-second', base64: 'second-image' },
     ])
+  })
+
+  it('serializes metadata updates after a concurrent tab write', async () => {
+    const writer = new IndexedDBStorage()
+    const metadataWriter = new IndexedDBStorage()
+    await Promise.all([writer.initialize(), metadataWriter.initialize()])
+    await writer.saveChat(
+      storedChat('metadata-race', {
+        locallyModified: true,
+        messages: [
+          {
+            role: 'user',
+            content: 'Original',
+            timestamp: new Date('2026-08-12T00:00:00.000Z'),
+            attachments: [
+              {
+                id: 'attachment',
+                type: 'document',
+                fileName: 'document.txt',
+                textContent: 'Keep this payload',
+              },
+            ],
+          },
+        ],
+      }),
+    )
+
+    const blocker = blockChatTransaction(
+      writer,
+      'metadata-race',
+      (chat, transaction) => {
+        chat.messages.push({
+          role: 'assistant',
+          content: 'Newer tab message',
+          timestamp: new Date('2026-08-12T00:00:01.000Z'),
+        })
+        chat.updatedAt = '2026-08-12T00:00:01.000Z'
+        transaction.objectStore('chats').put(chat)
+      },
+    )
+    await blocker.ready
+    const metadataDb = (metadataWriter as any).db as IDBDatabase
+    const transactionSpy = vi.spyOn(metadataDb, 'transaction')
+    const marking = metadataWriter.markAsSynced('metadata-race', 3)
+    await vi.waitFor(() =>
+      expect(transactionSpy).toHaveBeenCalledWith(['chats'], 'readwrite'),
+    )
+    blocker.release()
+    await Promise.all([blocker.complete, marking])
+
+    const result = await writer.getChat('metadata-race')
+    expect(result?.messages.map((message) => message.content)).toEqual([
+      'Original',
+      'Newer tab message',
+    ])
+    expect(result?.messages[0].attachments?.[0].textContent).toBe(
+      'Keep this payload',
+    )
+    expect(result).toMatchObject({
+      locallyModified: false,
+      syncVersion: 3,
+      clockVersion: 3,
+    })
+  })
+
+  it('uses one chat transaction for every metadata-only mutation', async () => {
+    const storage = new IndexedDBStorage()
+    await storage.initialize()
+    await storage.saveChat(storedChat('metadata-transactions'))
+    const db = (storage as any).db as IDBDatabase
+    const transactionSpy = vi.spyOn(db, 'transaction')
+
+    await (storage as any).updateLastAccessed('metadata-transactions')
+    expect(transactionSpy).toHaveBeenCalledTimes(1)
+    expect(transactionSpy).toHaveBeenLastCalledWith(['chats'], 'readwrite')
+
+    transactionSpy.mockClear()
+    await storage.markAsSynced('metadata-transactions', 2)
+    expect(transactionSpy).toHaveBeenCalledTimes(1)
+    expect(transactionSpy).toHaveBeenLastCalledWith(['chats'], 'readwrite')
+
+    transactionSpy.mockClear()
+    await storage.rebaseSyncVersion('metadata-transactions', 3)
+    expect(transactionSpy).toHaveBeenCalledTimes(1)
+    expect(transactionSpy).toHaveBeenLastCalledWith(['chats'], 'readwrite')
+  })
+
+  it('finalizes against the latest cross-tab messages and payloads', async () => {
+    const writer = new IndexedDBStorage()
+    const finalizer = new IndexedDBStorage()
+    await Promise.all([writer.initialize(), finalizer.initialize()])
+    await writer.saveChat(
+      storedChat('finalize-race', {
+        locallyModified: true,
+        messages: [
+          {
+            role: 'user',
+            content: 'Uploaded message',
+            timestamp: new Date('2026-08-12T00:00:00.000Z'),
+            attachments: [
+              {
+                id: 'uploaded-attachment',
+                type: 'image',
+                fileName: 'uploaded.png',
+                base64: 'uploaded-payload',
+              },
+            ],
+          },
+        ],
+      }),
+    )
+    const uploaded = await writer.getChat('finalize-race')
+    if (!uploaded) throw new Error('Expected stored chat')
+    const uploadedPayloadId = (
+      uploaded.messages[0].attachments?.[0] as {
+        storagePayloadId?: string
+      }
+    ).storagePayloadId
+
+    const blocker = blockChatTransaction(
+      writer,
+      uploaded.id,
+      (chat, transaction) => {
+        const newPayloadId = 'cross-tab-new-payload'
+        chat.messages.push({
+          role: 'user',
+          content: 'Newer tab message',
+          timestamp: new Date('2026-08-12T00:00:01.000Z'),
+          attachments: [
+            {
+              id: 'new-attachment',
+              type: 'document',
+              fileName: 'new.txt',
+              storagePayloadId: newPayloadId,
+            } as any,
+          ],
+        })
+        chat.updatedAt = '2026-08-12T00:00:01.000Z'
+        chat.locallyModified = true
+        transaction.objectStore('attachmentPayloads').put({
+          id: newPayloadId,
+          chatId: chat.id,
+          textContent: 'Newer tab payload',
+        })
+        transaction.objectStore('chats').put(chat)
+      },
+    )
+    await blocker.ready
+    const finalizerDb = (finalizer as any).db as IDBDatabase
+    const transactionSpy = vi.spyOn(finalizerDb, 'transaction')
+    const finalizing = finalizer.finalizeUpload({
+      chatId: uploaded.id,
+      rewrites: [
+        {
+          clientId: 'uploaded-attachment',
+          serverId: 'server-attachment',
+          encryptionKey: 'server-key',
+          storagePayloadId: uploadedPayloadId,
+        },
+      ],
+      preUploadUpdatedAt: uploaded.updatedAt,
+      syncVersion: 4,
+    })
+    await vi.waitFor(() =>
+      expect(transactionSpy).toHaveBeenCalledWith(
+        ['chats', 'attachmentPayloads'],
+        'readwrite',
+      ),
+    )
+    blocker.release()
+    await Promise.all([blocker.complete, finalizing])
+
+    const result = await writer.getChat(uploaded.id)
+    expect(result?.messages.map((message) => message.content)).toEqual([
+      'Uploaded message',
+      'Newer tab message',
+    ])
+    expect(result?.messages[0].attachments?.[0]).toMatchObject({
+      id: 'server-attachment',
+      encryptionKey: 'server-key',
+      base64: 'uploaded-payload',
+    })
+    expect(result?.messages[1].attachments?.[0].textContent).toBe(
+      'Newer tab payload',
+    )
+    expect(result?.locallyModified).toBe(true)
+    expect(result?.syncVersion).toBe(4)
+  })
+
+  it('rechecks remote apply CAS after an overlapping tab transaction', async () => {
+    const writer = new IndexedDBStorage()
+    const remoteWriter = new IndexedDBStorage()
+    await Promise.all([writer.initialize(), remoteWriter.initialize()])
+    await writer.saveChat(
+      storedChat('remote-race', {
+        locallyModified: false,
+        messages: [
+          {
+            role: 'user',
+            content: 'Original',
+            timestamp: new Date('2026-08-12T00:00:00.000Z'),
+            attachments: [
+              {
+                id: 'attachment',
+                type: 'document',
+                fileName: 'original.txt',
+                textContent: 'Original payload',
+              },
+            ],
+          },
+        ],
+      }),
+    )
+    const expectedUpdatedAt = '2026-08-12T00:00:00.000Z'
+    const blocker = blockChatTransaction(
+      writer,
+      'remote-race',
+      (chat, transaction) => {
+        chat.messages.push({
+          role: 'assistant',
+          content: 'Local tab won',
+          timestamp: new Date('2026-08-12T00:00:01.000Z'),
+        })
+        chat.updatedAt = '2026-08-12T00:00:01.000Z'
+        chat.locallyModified = true
+        transaction.objectStore('chats').put(chat)
+      },
+    )
+    await blocker.ready
+    const remoteDb = (remoteWriter as any).db as IDBDatabase
+    const transactionSpy = vi.spyOn(remoteDb, 'transaction')
+    const applying = remoteWriter.applyRemoteChatIfFresh({
+      chat: storedChat('remote-race', {
+        updatedAt: '2026-08-12T00:00:02.000Z',
+        messages: [
+          {
+            role: 'assistant',
+            content: 'Remote replacement',
+            timestamp: new Date('2026-08-12T00:00:02.000Z'),
+          },
+        ],
+      }),
+      syncVersion: 5,
+      expectedLocalUpdatedAt: expectedUpdatedAt,
+    })
+    await vi.waitFor(() =>
+      expect(transactionSpy).toHaveBeenCalledWith(
+        ['chats', 'attachmentPayloads'],
+        'readwrite',
+      ),
+    )
+    blocker.release()
+    const [applyResult] = await Promise.all([applying, blocker.complete])
+
+    expect(applyResult).toEqual({ applied: false })
+    const result = await writer.getChat('remote-race')
+    expect(result?.messages.map((message) => message.content)).toEqual([
+      'Original',
+      'Local tab won',
+    ])
+    expect(result?.messages[0].attachments?.[0].textContent).toBe(
+      'Original payload',
+    )
+  })
+
+  it('rolls back payload reconciliation when a remote apply becomes stale', async () => {
+    const storage = new IndexedDBStorage()
+    await storage.initialize()
+    await storage.saveChat(
+      storedChat('cancelled-remote-apply', {
+        locallyModified: false,
+        messages: [
+          {
+            role: 'user',
+            content: 'Original',
+            timestamp: new Date('2026-08-12T00:00:00.000Z'),
+            attachments: [
+              {
+                id: 'first',
+                type: 'document',
+                fileName: 'first.txt',
+                textContent: 'First payload',
+              },
+              {
+                id: 'second',
+                type: 'document',
+                fileName: 'second.txt',
+                textContent: 'Second payload',
+              },
+            ],
+          },
+        ],
+      }),
+    )
+    let currentCheckCount = 0
+    const result = await storage.applyRemoteChatIfFresh({
+      chat: storedChat('cancelled-remote-apply', {
+        updatedAt: '2026-08-12T00:00:01.000Z',
+        messages: [
+          {
+            role: 'assistant',
+            content: 'Remote replacement',
+            timestamp: new Date('2026-08-12T00:00:01.000Z'),
+          },
+        ],
+      }),
+      syncVersion: 2,
+      expectedLocalUpdatedAt: undefined,
+      isCurrent: () => {
+        currentCheckCount += 1
+        return currentCheckCount < 6
+      },
+    })
+
+    expect(result).toEqual({ applied: false })
+    const stored = await storage.getChat('cancelled-remote-apply')
+    expect(stored?.messages[0].content).toBe('Original')
+    expect(
+      stored?.messages[0].attachments?.map(
+        (attachment) => attachment.textContent,
+      ),
+    ).toEqual(['First payload', 'Second payload'])
   })
 })

--- a/tests/services/storage/indexed-db-sync-index.test.ts
+++ b/tests/services/storage/indexed-db-sync-index.test.ts
@@ -262,4 +262,94 @@ describe('IndexedDB pending sync index', () => {
     expect(payloadCount).toBe(0)
     db.close()
   })
+
+  it('hydrates attachment payloads through mutateChat without reinlining them', async () => {
+    const storage = new IndexedDBStorage()
+    await storage.initialize()
+    const base64 = 'B'.repeat(20_000)
+    await storage.saveChat(
+      storedChat('mutated-attachment', {
+        messages: [
+          {
+            role: 'user',
+            content: 'Read this',
+            timestamp: new Date('2026-08-12T00:00:00.000Z'),
+            attachments: [
+              {
+                id: 'attachment-1',
+                type: 'document',
+                fileName: 'document.pdf',
+                base64,
+                textContent: 'Document text',
+                pages: [
+                  {
+                    page: 1,
+                    text: 'Page text',
+                    image: base64,
+                    is_scanned: true,
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }),
+    )
+
+    const mutated = await storage.mutateChat('mutated-attachment', (chat) => ({
+      chat: {
+        ...chat,
+        messages: [
+          ...chat.messages,
+          {
+            role: 'assistant',
+            content: 'Recovered response',
+            timestamp: '2026-08-12T00:00:01.000Z',
+          },
+        ],
+      },
+      changed: true,
+    }))
+
+    const mutatedAttachment = mutated?.messages[0].attachments?.[0]
+    expect(mutatedAttachment?.base64).toBe(base64)
+    expect(mutatedAttachment?.textContent).toBe('Document text')
+    expect(mutatedAttachment?.pages?.[0].image).toBe(base64)
+    expect(mutated?.messages[1].content).toBe('Recovered response')
+
+    const db = await new Promise<IDBDatabase>((resolve, reject) => {
+      const request = indexedDB.open(DB_NAME, DB_VERSION)
+      request.onerror = () => reject(request.error)
+      request.onsuccess = () => resolve(request.result)
+    })
+    const rawChat = await new Promise<StoredChat>((resolve, reject) => {
+      const request = db
+        .transaction('chats')
+        .objectStore('chats')
+        .get('mutated-attachment')
+      request.onerror = () => reject(request.error)
+      request.onsuccess = () => resolve(request.result as StoredChat)
+    })
+    const rawAttachment = rawChat.messages[0].attachments?.[0] as
+      (Record<string, unknown> & { storagePayloadId?: string }) | undefined
+    expect(rawAttachment?.base64).toBeUndefined()
+    expect(rawAttachment?.textContent).toBeUndefined()
+    expect(rawAttachment?.pages).toBeUndefined()
+    expect(rawAttachment?.storagePayloadId).toBeTruthy()
+    expect(rawChat.messages[1].content).toBe('Recovered response')
+
+    const payloadCount = await new Promise<number>((resolve, reject) => {
+      const request = db
+        .transaction('attachmentPayloads')
+        .objectStore('attachmentPayloads')
+        .count()
+      request.onerror = () => reject(request.error)
+      request.onsuccess = () => resolve(request.result)
+    })
+    expect(payloadCount).toBe(1)
+
+    const hydrated = await storage.getChat('mutated-attachment')
+    expect(hydrated?.messages[0].attachments?.[0].base64).toBe(base64)
+    db.close()
+  })
 })

--- a/tests/services/storage/indexed-db-sync-index.test.ts
+++ b/tests/services/storage/indexed-db-sync-index.test.ts
@@ -1,4 +1,5 @@
 import {
+  chatContentFingerprint,
   DB_NAME,
   DB_VERSION,
   INDEXED_DB_UPGRADE_BLOCKED_EVENT,
@@ -761,6 +762,7 @@ describe('IndexedDB pending sync index', () => {
         },
       ],
       preUploadUpdatedAt: uploaded.updatedAt,
+      preUploadFingerprint: chatContentFingerprint(uploaded),
       syncVersion: 2,
     })
 
@@ -862,7 +864,7 @@ describe('IndexedDB pending sync index', () => {
     expect(transactionSpy).toHaveBeenLastCalledWith(['chats'], 'readwrite')
   })
 
-  it('finalizes against the latest cross-tab messages and payloads', async () => {
+  it('does not rewrite attachments after a cross-tab content edit', async () => {
     const writer = new IndexedDBStorage()
     const finalizer = new IndexedDBStorage()
     await Promise.all([writer.initialize(), finalizer.initialize()])
@@ -936,6 +938,7 @@ describe('IndexedDB pending sync index', () => {
         },
       ],
       preUploadUpdatedAt: uploaded.updatedAt,
+      preUploadFingerprint: chatContentFingerprint(uploaded),
       syncVersion: 4,
     })
     await vi.waitFor(() =>
@@ -953,15 +956,123 @@ describe('IndexedDB pending sync index', () => {
       'Newer tab message',
     ])
     expect(result?.messages[0].attachments?.[0]).toMatchObject({
-      id: 'server-attachment',
-      encryptionKey: 'server-key',
+      id: 'uploaded-attachment',
       base64: 'uploaded-payload',
     })
+    expect(result?.messages[0].attachments?.[0].encryptionKey).toBeUndefined()
     expect(result?.messages[1].attachments?.[0].textContent).toBe(
       'Newer tab payload',
     )
     expect(result?.locallyModified).toBe(true)
     expect(result?.syncVersion).toBe(4)
+  })
+
+  it('keeps replacement bytes uploadable when finalization was blocked', async () => {
+    const writer = new IndexedDBStorage()
+    const finalizer = new IndexedDBStorage()
+    await Promise.all([writer.initialize(), finalizer.initialize()])
+    await writer.saveChat(
+      storedChat('replacement-race', {
+        locallyModified: true,
+        messages: [
+          {
+            role: 'user',
+            content: 'Image',
+            timestamp: new Date('2026-08-12T00:00:00.000Z'),
+            attachments: [
+              {
+                id: 'client-image',
+                type: 'image',
+                fileName: 'image.png',
+                base64: 'old-bytes',
+              },
+            ],
+          },
+        ],
+      }),
+    )
+    const uploaded = await writer.getChat('replacement-race')
+    if (!uploaded) throw new Error('Expected stored chat')
+    const payloadId = (
+      uploaded.messages[0].attachments?.[0] as {
+        storagePayloadId?: string
+      }
+    ).storagePayloadId
+    if (!payloadId) throw new Error('Expected attachment payload id')
+
+    const blocker = blockChatTransaction(
+      writer,
+      uploaded.id,
+      (chat, transaction) => {
+        chat.updatedAt = '2026-08-12T00:00:01.000Z'
+        chat.locallyModified = true
+        transaction.objectStore('attachmentPayloads').put({
+          id: payloadId,
+          chatId: chat.id,
+          base64: 'new-bytes',
+        })
+        transaction.objectStore('chats').put(chat)
+      },
+    )
+    await blocker.ready
+    const finalizing = finalizer.finalizeUpload({
+      chatId: uploaded.id,
+      rewrites: [
+        {
+          clientId: 'client-image',
+          serverId: 'old-server-image',
+          encryptionKey: 'old-server-key',
+          storagePayloadId: payloadId,
+        },
+      ],
+      preUploadUpdatedAt: uploaded.updatedAt,
+      preUploadFingerprint: chatContentFingerprint(uploaded),
+      syncVersion: 4,
+    })
+    blocker.release()
+    await Promise.all([blocker.complete, finalizing])
+
+    const result = await writer.getChat(uploaded.id)
+    expect(result?.messages[0].attachments?.[0]).toMatchObject({
+      id: 'client-image',
+      base64: 'new-bytes',
+    })
+    expect(result?.messages[0].attachments?.[0].encryptionKey).toBeUndefined()
+    expect(result).toMatchObject({ locallyModified: true, syncVersion: 4 })
+  })
+
+  it('keeps same-timestamp edits dirty using the upload fingerprint', async () => {
+    const storage = new IndexedDBStorage()
+    await storage.initialize()
+    await storage.saveChat(
+      storedChat('same-timestamp-finalize', {
+        title: 'Before upload',
+        locallyModified: true,
+      }),
+    )
+    const uploaded = await storage.getChat('same-timestamp-finalize')
+    if (!uploaded) throw new Error('Expected stored chat')
+    const preUploadFingerprint = chatContentFingerprint(uploaded)
+
+    await storage.saveChat({
+      ...uploaded,
+      title: 'Edited during upload',
+      updatedAt: uploaded.updatedAt,
+    })
+    await storage.finalizeUpload({
+      chatId: uploaded.id,
+      rewrites: [],
+      preUploadUpdatedAt: uploaded.updatedAt,
+      preUploadFingerprint,
+      syncVersion: 5,
+    })
+
+    expect(await storage.getChat(uploaded.id)).toMatchObject({
+      title: 'Edited during upload',
+      updatedAt: uploaded.updatedAt,
+      locallyModified: true,
+      syncVersion: 5,
+    })
   })
 
   it('rechecks remote apply CAS after an overlapping tab transaction', async () => {


### PR DESCRIPTION
## Summary
- store document text, page data, thumbnails, and base64 payloads in a dedicated IndexedDB object store
- keep chat rows lightweight while transparently hydrating payloads through atomic multi-store reads
- preserve payloads across remote metadata updates, reconcile removed attachments, and normalize legacy rows during finalization

## Testing
- `npx vitest run` (1568 tests)
- `npm run lint`
- `npx tsc --noEmit`