### PR TITLE
Coordinate cloud sync across browser tabs

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -43,6 +43,9 @@ export const CLOUD_SYNC = {
   PROFILE_SYNC_INTERVAL: 60000, // 60 seconds (1 minute) - frequency for syncing profile
   PROFILE_SYNC_DEBOUNCE: 2000,
   KEY_VALIDATION_PROBE_LIMIT: 3,
+  // Max time to wait for the cross-tab sync lock before giving up with
+  // SyncInProgressError. Bounded so a hung tab can't stall other tabs.
+  CROSS_TAB_SYNC_LOCK_TIMEOUT: 15000,
 } as const
 
 export const PASSKEY = {

--- a/src/config.ts
+++ b/src/config.ts
@@ -31,6 +31,11 @@ export const SYNC_ENCLAVE_URL =
 export const SYNC_ENCLAVE_REPO =
   process.env.NEXT_PUBLIC_SYNC_ENCLAVE_REPO || 'tinfoilsh/confidential-sync'
 
+export const SYNC_ENCLAVE_TIMEOUTS = {
+  READY_MS: 30000,
+  REQUEST_MS: 30000,
+} as const
+
 // Pagination settings
 export const PAGINATION = {
   CHATS_PER_PAGE: 20,
@@ -43,9 +48,6 @@ export const CLOUD_SYNC = {
   PROFILE_SYNC_INTERVAL: 60000, // 60 seconds (1 minute) - frequency for syncing profile
   PROFILE_SYNC_DEBOUNCE: 2000,
   KEY_VALIDATION_PROBE_LIMIT: 3,
-  // Max time to wait for the cross-tab sync lock before giving up with
-  // SyncInProgressError. Bounded so a hung tab can't stall other tabs.
-  CROSS_TAB_SYNC_LOCK_TIMEOUT: 15000,
 } as const
 
 export const PASSKEY = {

--- a/src/constants/storage-keys.ts
+++ b/src/constants/storage-keys.ts
@@ -126,6 +126,7 @@ export const SYNC_CHAT_STATUS = 'tinfoil-sync-chat-status'
 // a disposable freshness snapshot, while this watermark encodes durable
 // reconciliation progress and must never advance past an unapplied tombstone.
 export const SYNC_CHAT_DELETES_WATERMARK = 'tinfoil-sync-chat-deletes-watermark'
+export const SYNC_CHAT_DELETION_REVISION = 'tinfoil-sync-chat-deletion-revision'
 export const SYNC_ALL_CHATS_STATUS = 'tinfoil-sync-all-chats-status'
 export const SYNC_PROJECT_CHAT_STATUS_PREFIX =
   'tinfoil-sync-project-chat-status-'

--- a/src/services/cloud/chat-deletes-watermark.ts
+++ b/src/services/cloud/chat-deletes-watermark.ts
@@ -13,7 +13,10 @@
  * resurrectable on this device.
  */
 
-import { SYNC_CHAT_DELETES_WATERMARK } from '@/constants/storage-keys'
+import {
+  SYNC_CHAT_DELETES_WATERMARK,
+  SYNC_CHAT_DELETION_REVISION,
+} from '@/constants/storage-keys'
 
 /**
  * Seed for devices with no persisted watermark. The first pass replays every
@@ -69,6 +72,15 @@ export function clearChatDeletesWatermark(): void {
   if (typeof window === 'undefined') return
   try {
     localStorage.removeItem(SYNC_CHAT_DELETES_WATERMARK)
+  } catch {
+    // best-effort
+  }
+}
+
+export function publishChatDeletionRevision(): void {
+  if (typeof window === 'undefined') return
+  try {
+    localStorage.setItem(SYNC_CHAT_DELETION_REVISION, crypto.randomUUID())
   } catch {
     // best-effort
   }

--- a/src/services/cloud/chat-ingestion.ts
+++ b/src/services/cloud/chat-ingestion.ts
@@ -18,6 +18,7 @@ import {
 import {
   advanceChatDeletesWatermark,
   loadChatDeletesWatermark,
+  publishChatDeletionRevision,
 } from './chat-deletes-watermark'
 import { cloudStorage } from './cloud-storage'
 import { shouldIngestRemoteChat } from './sync-predicates'
@@ -315,6 +316,7 @@ export async function syncRemoteDeletions(
     }
     if (successfulIds.length > 0 && isCurrent()) {
       chatEvents.emit({ reason: 'sync', ids: successfulIds })
+      publishChatDeletionRevision()
     }
     if (allResolved && Number.isFinite(latestEventAtMs) && isCurrent()) {
       advanceChatDeletesWatermark(latestEventAtMs)

--- a/src/services/cloud/cloud-sync.ts
+++ b/src/services/cloud/cloud-sync.ts
@@ -4,6 +4,7 @@ import {
   MIGRATION_EXHAUSTED_KEYSET_PREFIX,
   SETTINGS_CLOUD_SYNC_ENABLED,
   SYNC_ALL_CHATS_STATUS,
+  SYNC_CHAT_DELETES_WATERMARK,
   SYNC_CHAT_STATUS,
   SYNC_PROJECT_CHAT_STATUS_PREFIX,
 } from '@/constants/storage-keys'
@@ -154,6 +155,8 @@ export class CloudSyncService {
       window.addEventListener('storage', (e) => {
         if (e.key === SETTINGS_CLOUD_SYNC_ENABLED) {
           this.handleCloudSyncSettingChange()
+        } else if (e.key === SYNC_CHAT_DELETES_WATERMARK) {
+          this.queueCrossTabReload()
         } else if (e.key === SYNC_CHAT_STATUS) {
           // Another tab updated sync status, invalidate our cache
           this.chatSyncCache.invalidate()

--- a/src/services/cloud/cloud-sync.ts
+++ b/src/services/cloud/cloud-sync.ts
@@ -1,4 +1,4 @@
-import { PAGINATION } from '@/config'
+import { CLOUD_SYNC, PAGINATION } from '@/config'
 import {
   AUTH_ACTIVE_USER_ID,
   MIGRATION_EXHAUSTED_KEYSET_PREFIX,
@@ -95,14 +95,9 @@ const UPLOADS_SKIPPED_UNRECONCILED_DELETIONS_ERROR =
   'Skipped uploading local changes: remote deletions could not be reconciled'
 export const CROSS_TAB_SYNC_LOCK = 'tinfoil-cloud-sync'
 export const CROSS_TAB_SYNC_LOCK_OPTIONS = {
-  ifAvailable: true,
   mode: 'exclusive',
 } as const
 const isStreaming = (id: string) => streamingTracker.isStreaming(id)
-
-function emptySyncResult(): SyncResult {
-  return { uploaded: 0, downloaded: 0, errors: [] }
-}
 
 export class CloudSyncService {
   private syncLock: Promise<void> | null = null
@@ -203,31 +198,16 @@ export class CloudSyncService {
 
   /**
    * Execute a function with sync lock protection.
-   * Only one sync operation can run at a time.
-   * Throws if a sync is already in progress.
+   * Only one sync operation can run at a time across all tabs.
+   * Throws SyncInProgressError if a sync is already in progress in this
+   * tab, or if waiting for another tab's sync times out.
    */
-  private async withSyncLock<T>(fn: () => Promise<T>): Promise<T | undefined> {
-    if (typeof navigator !== 'undefined' && navigator.locks) {
-      return navigator.locks.request(
-        CROSS_TAB_SYNC_LOCK,
-        CROSS_TAB_SYNC_LOCK_OPTIONS,
-        async (lock) => {
-          if (!lock) {
-            logInfo('[CloudSync] Sync active in another tab, skipping', {
-              component: 'CloudSync',
-              action: 'withSyncLock',
-            })
-            return undefined
-          }
-          return this.trackSync(fn)
-        },
-      )
-    }
-
-    return this.withInstanceSyncLock(fn)
-  }
-
-  private async withInstanceSyncLock<T>(fn: () => Promise<T>): Promise<T> {
+  private async withSyncLock<T>(fn: () => Promise<T>): Promise<T> {
+    // A sync already running (or queued) in this tab keeps the
+    // pre-cross-tab contract: throw immediately so callers can
+    // waitForCurrentSync() and retry. Web Locks are not reentrant, so
+    // this check must come before the lock request to avoid the same
+    // tab queueing on itself.
     if (this.syncLock) {
       logInfo('[CloudSync] Sync already in progress, skipping', {
         component: 'CloudSync',
@@ -236,7 +216,49 @@ export class CloudSyncService {
       throw new SyncInProgressError()
     }
 
-    return this.trackSync(fn)
+    if (typeof navigator === 'undefined' || !navigator.locks) {
+      return this.trackSync(fn)
+    }
+
+    // Queue for the cross-tab lock instead of skipping so callers that
+    // need a real result (initial sync pagination, manual deep sync,
+    // post-eviction resync) still get one when another tab is mid-sync.
+    // The wait is bounded so a hung leader tab cannot stall sync in
+    // every other tab; on timeout we throw SyncInProgressError, which
+    // existing callers already handle. The timer only bounds the
+    // waiting phase: it is cleared once the lock is granted so a
+    // long-running sync of our own is never aborted. trackSync wraps
+    // the wait as well, so waitForCurrentSync() covers queued attempts.
+    return this.trackSync(async () => {
+      const abortController = new AbortController()
+      let acquired = false
+      const waitTimer = setTimeout(
+        () => abortController.abort(),
+        CLOUD_SYNC.CROSS_TAB_SYNC_LOCK_TIMEOUT,
+      )
+      try {
+        return await navigator.locks.request(
+          CROSS_TAB_SYNC_LOCK,
+          { ...CROSS_TAB_SYNC_LOCK_OPTIONS, signal: abortController.signal },
+          () => {
+            acquired = true
+            clearTimeout(waitTimer)
+            return fn()
+          },
+        )
+      } catch (error) {
+        if (!acquired && abortController.signal.aborted) {
+          logInfo('[CloudSync] Timed out waiting for sync in another tab', {
+            component: 'CloudSync',
+            action: 'withSyncLock',
+          })
+          throw new SyncInProgressError()
+        }
+        throw error
+      } finally {
+        clearTimeout(waitTimer)
+      }
+    })
   }
 
   private async trackSync<T>(fn: () => Promise<T>): Promise<T> {
@@ -521,10 +543,7 @@ export class CloudSyncService {
 
   // Perform a delta sync - only fetch chats that changed since last sync
   async syncChangedChats(): Promise<SyncResult> {
-    return (
-      (await this.withSyncLock(() => this.doSyncChangedChats())) ??
-      emptySyncResult()
-    )
+    return this.withSyncLock(() => this.doSyncChangedChats())
   }
 
   private async doSyncChangedChats(): Promise<SyncResult> {
@@ -1285,10 +1304,7 @@ export class CloudSyncService {
 
   // Sync all chats (upload local changes, download remote changes)
   async syncAllChats(options?: { deep?: boolean }): Promise<SyncResult> {
-    return (
-      (await this.withSyncLock(() => this.doSyncAllChats(options))) ??
-      emptySyncResult()
-    )
+    return this.withSyncLock(() => this.doSyncAllChats(options))
   }
 
   private async listChatsWithRetry(options: {
@@ -1743,10 +1759,7 @@ export class CloudSyncService {
    * @param projectId - Optional project ID. If provided, syncs project chats.
    */
   async smartSync(projectId?: string): Promise<SyncResult> {
-    return (
-      (await this.withSyncLock(() => this.doSmartSync(projectId))) ??
-      emptySyncResult()
-    )
+    return this.withSyncLock(() => this.doSmartSync(projectId))
   }
 
   private async doSmartSync(projectId?: string): Promise<SyncResult> {
@@ -2104,10 +2117,7 @@ export class CloudSyncService {
   }
 
   async syncProjectChats(projectId: string): Promise<SyncResult> {
-    return (
-      (await this.withSyncLock(() => this.doSyncProjectChats(projectId))) ??
-      emptySyncResult()
-    )
+    return this.withSyncLock(() => this.doSyncProjectChats(projectId))
   }
 
   private async doSyncProjectChats(
@@ -2225,11 +2235,7 @@ export class CloudSyncService {
    * Perform a delta sync for project chats - only fetch chats that changed since last sync.
    */
   async syncProjectChatsChanged(projectId: string): Promise<SyncResult> {
-    return (
-      (await this.withSyncLock(() =>
-        this.doSyncProjectChatsChanged(projectId),
-      )) ?? emptySyncResult()
-    )
+    return this.withSyncLock(() => this.doSyncProjectChatsChanged(projectId))
   }
 
   private async doSyncProjectChatsChanged(

--- a/src/services/cloud/cloud-sync.ts
+++ b/src/services/cloud/cloud-sync.ts
@@ -5,6 +5,7 @@ import {
   SETTINGS_CLOUD_SYNC_ENABLED,
   SYNC_ALL_CHATS_STATUS,
   SYNC_CHAT_DELETES_WATERMARK,
+  SYNC_CHAT_DELETION_REVISION,
   SYNC_CHAT_STATUS,
   SYNC_PROJECT_CHAT_STATUS_PREFIX,
 } from '@/constants/storage-keys'
@@ -26,6 +27,7 @@ import { passkeyEvents } from '../sync-enclave/passkey-events'
 import { keyCurrent, newIdempotencyKey } from '../sync-enclave/sync-api'
 import {
   abortSyncEnclaveRequests,
+  resetSyncEnclaveRequestScope,
   SyncEnclaveError,
 } from '../sync-enclave/sync-enclave-client'
 import {
@@ -90,6 +92,15 @@ export class CloudSyncDisabledError extends Error {
   }
 }
 
+export class CloudSyncLifecycleCanceledError extends Error {
+  readonly code = 'CLOUD_SYNC_LIFECYCLE_CANCELED'
+
+  constructor(public readonly reason: 'disabled' | 'account-reset') {
+    super('Cloud synchronization was canceled')
+    this.name = 'CloudSyncLifecycleCanceledError'
+  }
+}
+
 export interface PaginatedChatsResult {
   chats: StoredChat[]
   hasMore: boolean
@@ -121,6 +132,7 @@ export class CloudSyncService {
   private uploadCoalescer: UploadCoalescer
   private streamingCallbacks: Set<string> = new Set()
   private accountGeneration = 0
+  private lockAcquisitionController = new AbortController()
   private crossTabReloadFrame: number | null = null
   private cloudSyncEnabled = isCloudSyncEnabled()
   /**
@@ -155,7 +167,10 @@ export class CloudSyncService {
       window.addEventListener('storage', (e) => {
         if (e.key === SETTINGS_CLOUD_SYNC_ENABLED) {
           this.handleCloudSyncSettingChange()
-        } else if (e.key === SYNC_CHAT_DELETES_WATERMARK) {
+        } else if (
+          e.key === SYNC_CHAT_DELETES_WATERMARK ||
+          e.key === SYNC_CHAT_DELETION_REVISION
+        ) {
           this.queueCrossTabReload()
         } else if (e.key === SYNC_CHAT_STATUS) {
           // Another tab updated sync status, invalidate our cache
@@ -181,6 +196,9 @@ export class CloudSyncService {
     const enabled = isCloudSyncEnabled()
     if (this.cloudSyncEnabled && !enabled) {
       this.invalidateForCloudSyncDisable()
+    } else if (!this.cloudSyncEnabled && enabled) {
+      this.lockAcquisitionController = new AbortController()
+      resetSyncEnclaveRequestScope('cloud-sync')
     }
     this.cloudSyncEnabled = enabled
   }
@@ -190,11 +208,17 @@ export class CloudSyncService {
     this.uploadCoalescer.clear()
     this.streamingCallbacks.clear()
     this.legacyMigrationKicked = false
-    abortSyncEnclaveRequests()
+    this.cancelSyncLifecycle('disabled')
     if (this.crossTabReloadFrame !== null) {
       cancelAnimationFrame(this.crossTabReloadFrame)
       this.crossTabReloadFrame = null
     }
+  }
+
+  private cancelSyncLifecycle(reason: 'disabled' | 'account-reset'): void {
+    const cancellation = new CloudSyncLifecycleCanceledError(reason)
+    this.lockAcquisitionController.abort(cancellation)
+    abortSyncEnclaveRequests('cloud-sync')
   }
 
   private getProjectSyncCache(
@@ -222,6 +246,9 @@ export class CloudSyncService {
 
   resetForAccountChange(): void {
     this.accountGeneration++
+    this.cancelSyncLifecycle('account-reset')
+    this.lockAcquisitionController = new AbortController()
+    resetSyncEnclaveRequestScope('cloud-sync')
     this.uploadCoalescer.clear()
     this.streamingCallbacks.clear()
     if (this.crossTabReloadFrame !== null) {
@@ -261,6 +288,7 @@ export class CloudSyncService {
     }
 
     const generation = this.accountGeneration
+    const lockSignal = this.lockAcquisitionController.signal
     const runIfCurrent = () => {
       if (!isCloudSyncEnabled() || !this.isCurrentGeneration(generation)) {
         throw new CloudSyncDisabledError()
@@ -278,11 +306,20 @@ export class CloudSyncService {
     // trackSync wraps the wait as well, so waitForCurrentSync() covers
     // queued attempts.
     return this.trackSync(async () => {
-      return navigator.locks.request(
-        CROSS_TAB_SYNC_LOCK,
-        CROSS_TAB_SYNC_LOCK_OPTIONS,
-        runIfCurrent,
-      )
+      try {
+        return await navigator.locks.request(
+          CROSS_TAB_SYNC_LOCK,
+          { ...CROSS_TAB_SYNC_LOCK_OPTIONS, signal: lockSignal },
+          runIfCurrent,
+        )
+      } catch (error) {
+        if (lockSignal.aborted) {
+          throw lockSignal.reason instanceof Error
+            ? lockSignal.reason
+            : new CloudSyncLifecycleCanceledError('disabled')
+        }
+        throw error
+      }
     })
   }
 
@@ -1055,9 +1092,9 @@ export class CloudSyncService {
     error: unknown,
   ): Promise<void> {
     if (!this.isCurrentGeneration(generation)) return
-    // Silently fail if no auth token set
+    // Keep the chat dirty and let bulk sync report the skipped upload.
     if (error instanceof AuthTokenUnavailableError) {
-      return
+      throw error
     }
     // §9.6 R4 — surface the typed decision and ACT on the codes
     // that have a defined client-side recovery (§C5). For STALE_BLOB
@@ -2066,37 +2103,44 @@ export class CloudSyncService {
     const failed = allChats.filter((chat) => chat.decryptionFailed)
     if (failed.length === 0) return 0
 
-    for (let i = 0; i < failed.length; i++) {
-      try {
-        await indexedDBStorage.deleteChat(failed[i].id)
-      } catch (error) {
-        logError(`Failed to evict placeholder chat ${failed[i].id}`, error, {
-          component: 'CloudSync',
-          action: 'retryDecryptionWithNewKey',
-        })
-      }
-      if (!this.isCurrentGeneration(generation)) return 0
-      if ((i + 1) % batchSize === 0 || i === failed.length - 1) {
-        onProgress?.(i + 1, failed.length)
-        await new Promise((resolve) => setTimeout(resolve, 0))
-      }
-    }
-
-    // The just-evicted chats still exist on the server, so the cached
-    // sync-status snapshot would match remote and `smartSync` would
-    // no-op. Drop the cache before resyncing so the next pass takes
-    // the full-sync path and repopulates them.
-    this.invalidateChatSyncCaches()
+    const deletedPlaceholders: StoredChat[] = []
 
     try {
+      for (let i = 0; i < failed.length; i++) {
+        try {
+          await indexedDBStorage.deleteChat(failed[i].id)
+          deletedPlaceholders.push(failed[i])
+        } catch (error) {
+          logError(`Failed to evict placeholder chat ${failed[i].id}`, error, {
+            component: 'CloudSync',
+            action: 'retryDecryptionWithNewKey',
+          })
+        }
+        if (!this.isCurrentGeneration(generation)) return 0
+        if ((i + 1) % batchSize === 0 || i === failed.length - 1) {
+          onProgress?.(i + 1, failed.length)
+          await new Promise((resolve) => setTimeout(resolve, 0))
+        }
+      }
+
+      // The just-evicted chats still exist on the server, so the cached
+      // sync-status snapshot would match remote and `smartSync` would
+      // no-op. Drop the cache before resyncing so the next pass takes
+      // the full-sync path and repopulates them.
+      this.invalidateChatSyncCaches()
+
       await this.doSyncAllChats({ deep: true }, generation)
     } catch (error) {
       logError('Resync after eviction failed', error, {
         component: 'CloudSync',
         action: 'retryDecryptionWithNewKey',
       })
-      await this.restoreFailedDecryptionPlaceholders(failed, generation)
       return 0
+    } finally {
+      if (deletedPlaceholders.length > 0) {
+        this.invalidateChatSyncCaches()
+        await this.restoreFailedDecryptionPlaceholders(deletedPlaceholders)
+      }
     }
 
     if (!this.isCurrentGeneration(generation)) return 0
@@ -2107,32 +2151,22 @@ export class CloudSyncService {
       const restored = restoredById.get(placeholder.id)
       return restored !== undefined && !restored.decryptionFailed
     }).length
-    await this.restoreFailedDecryptionPlaceholders(
-      failed.filter((placeholder) => !restoredById.has(placeholder.id)),
-      generation,
-    )
 
     return recovered
   }
 
   private async restoreFailedDecryptionPlaceholders(
     placeholders: StoredChat[],
-    generation: number,
   ): Promise<void> {
-    if (!this.isCurrentGeneration(generation) || !isCloudSyncEnabled()) return
     let restoredAny = false
     for (const placeholder of placeholders) {
-      if (
-        !this.isCurrentGeneration(generation) ||
-        deletedChatsTracker.isDeleted(placeholder.id)
-      ) {
+      if (deletedChatsTracker.isDeleted(placeholder.id)) {
         continue
       }
       try {
         const existing = await indexedDBStorage.getChat(placeholder.id)
-        if (!this.isCurrentGeneration(generation)) return
         if (!existing) {
-          await indexedDBStorage.saveExistingChat(placeholder)
+          await indexedDBStorage.restoreDecryptionPlaceholder(placeholder)
           restoredAny = true
         }
       } catch (error) {
@@ -2146,7 +2180,7 @@ export class CloudSyncService {
         )
       }
     }
-    if (restoredAny && this.isCurrentGeneration(generation)) {
+    if (restoredAny) {
       this.invalidateChatSyncCaches()
     }
   }

--- a/src/services/cloud/cloud-sync.ts
+++ b/src/services/cloud/cloud-sync.ts
@@ -2,11 +2,16 @@ import { PAGINATION } from '@/config'
 import {
   AUTH_ACTIVE_USER_ID,
   MIGRATION_EXHAUSTED_KEYSET_PREFIX,
+  SETTINGS_CLOUD_SYNC_ENABLED,
   SYNC_ALL_CHATS_STATUS,
   SYNC_CHAT_STATUS,
   SYNC_PROJECT_CHAT_STATUS_PREFIX,
 } from '@/constants/storage-keys'
 import { AuthTokenUnavailableError } from '@/services/auth'
+import {
+  CLOUD_SYNC_SETTING_CHANGED_EVENT,
+  isCloudSyncEnabled,
+} from '@/utils/cloud-sync-settings'
 import { logError, logInfo, logWarning } from '@/utils/error-handling'
 import { chatEvents } from '../storage/chat-events'
 import { deletedChatsTracker } from '../storage/deleted-chats-tracker'
@@ -18,7 +23,10 @@ import {
 import { decideRecovery } from '../sync-enclave/enclave-error-recovery'
 import { passkeyEvents } from '../sync-enclave/passkey-events'
 import { keyCurrent, newIdempotencyKey } from '../sync-enclave/sync-api'
-import { SyncEnclaveError } from '../sync-enclave/sync-enclave-client'
+import {
+  abortSyncEnclaveRequests,
+  SyncEnclaveError,
+} from '../sync-enclave/sync-enclave-client'
 import {
   hasPrimaryKey,
   migrationKeySetFingerprint,
@@ -74,6 +82,13 @@ export class SyncInProgressError extends Error {
   }
 }
 
+export class CloudSyncDisabledError extends Error {
+  constructor() {
+    super('Cloud synchronization is disabled')
+    this.name = 'CloudSyncDisabledError'
+  }
+}
+
 export interface PaginatedChatsResult {
   chats: StoredChat[]
   hasMore: boolean
@@ -106,6 +121,7 @@ export class CloudSyncService {
   private streamingCallbacks: Set<string> = new Set()
   private accountGeneration = 0
   private crossTabReloadFrame: number | null = null
+  private cloudSyncEnabled = isCloudSyncEnabled()
   /**
    * Set once per session after the first successful syncAllChats so
    * the enclave-driven legacy-blob migration (§8.7.2 trigger 1) runs
@@ -132,8 +148,13 @@ export class CloudSyncService {
     )
     // Listen for storage changes from other tabs to invalidate sync status cache
     if (typeof window !== 'undefined') {
+      window.addEventListener(CLOUD_SYNC_SETTING_CHANGED_EVENT, () => {
+        this.handleCloudSyncSettingChange()
+      })
       window.addEventListener('storage', (e) => {
-        if (e.key === SYNC_CHAT_STATUS) {
+        if (e.key === SETTINGS_CLOUD_SYNC_ENABLED) {
+          this.handleCloudSyncSettingChange()
+        } else if (e.key === SYNC_CHAT_STATUS) {
           // Another tab updated sync status, invalidate our cache
           this.chatSyncCache.invalidate()
           this.queueCrossTabReload()
@@ -150,6 +171,26 @@ export class CloudSyncService {
           this.queueCrossTabReload()
         }
       })
+    }
+  }
+
+  private handleCloudSyncSettingChange(): void {
+    const enabled = isCloudSyncEnabled()
+    if (this.cloudSyncEnabled && !enabled) {
+      this.invalidateForCloudSyncDisable()
+    }
+    this.cloudSyncEnabled = enabled
+  }
+
+  private invalidateForCloudSyncDisable(): void {
+    this.accountGeneration++
+    this.uploadCoalescer.clear()
+    this.streamingCallbacks.clear()
+    this.legacyMigrationKicked = false
+    abortSyncEnclaveRequests()
+    if (this.crossTabReloadFrame !== null) {
+      cancelAnimationFrame(this.crossTabReloadFrame)
+      this.crossTabReloadFrame = null
     }
   }
 
@@ -216,8 +257,16 @@ export class CloudSyncService {
       throw new SyncInProgressError()
     }
 
+    const generation = this.accountGeneration
+    const runIfCurrent = () => {
+      if (!isCloudSyncEnabled() || !this.isCurrentGeneration(generation)) {
+        throw new CloudSyncDisabledError()
+      }
+      return fn()
+    }
+
     if (typeof navigator === 'undefined' || !navigator.locks) {
-      return this.trackSync(fn)
+      return this.trackSync(runIfCurrent)
     }
 
     // Queue for the cross-tab lock instead of skipping so callers that
@@ -229,7 +278,7 @@ export class CloudSyncService {
       return navigator.locks.request(
         CROSS_TAB_SYNC_LOCK,
         CROSS_TAB_SYNC_LOCK_OPTIONS,
-        () => fn(),
+        runIfCurrent,
       )
     })
   }

--- a/src/services/cloud/cloud-sync.ts
+++ b/src/services/cloud/cloud-sync.ts
@@ -92,6 +92,13 @@ export class CloudSyncDisabledError extends Error {
   }
 }
 
+export class CloudSyncCoordinationUnavailableError extends Error {
+  constructor() {
+    super('Cross-tab cloud synchronization coordination is unavailable')
+    this.name = 'CloudSyncCoordinationUnavailableError'
+  }
+}
+
 export class CloudSyncLifecycleCanceledError extends Error {
   readonly code = 'CLOUD_SYNC_LIFECYCLE_CANCELED'
 
@@ -296,8 +303,11 @@ export class CloudSyncService {
       return fn()
     }
 
-    if (typeof navigator === 'undefined' || !navigator.locks) {
+    if (typeof window === 'undefined') {
       return this.trackSync(runIfCurrent)
+    }
+    if (typeof navigator === 'undefined' || !navigator.locks) {
+      throw new CloudSyncCoordinationUnavailableError()
     }
 
     // Queue for the cross-tab lock instead of skipping so callers that

--- a/src/services/cloud/cloud-sync.ts
+++ b/src/services/cloud/cloud-sync.ts
@@ -2048,10 +2048,21 @@ export class CloudSyncService {
       batchSize?: number
     } = {},
   ): Promise<number> {
+    return this.withSyncLock(() => this.doRetryDecryptionWithNewKey(options))
+  }
+
+  private async doRetryDecryptionWithNewKey(
+    options: {
+      onProgress?: (current: number, total: number) => void
+      batchSize?: number
+    } = {},
+  ): Promise<number> {
+    const generation = this.accountGeneration
     const { onProgress } = options
     const batchSize = Math.max(1, Math.floor(options.batchSize || 5))
 
     const allChats = await indexedDBStorage.getAllChats()
+    if (!this.isCurrentGeneration(generation)) return 0
     const failed = allChats.filter((chat) => chat.decryptionFailed)
     if (failed.length === 0) return 0
 
@@ -2064,6 +2075,7 @@ export class CloudSyncService {
           action: 'retryDecryptionWithNewKey',
         })
       }
+      if (!this.isCurrentGeneration(generation)) return 0
       if ((i + 1) % batchSize === 0 || i === failed.length - 1) {
         onProgress?.(i + 1, failed.length)
         await new Promise((resolve) => setTimeout(resolve, 0))
@@ -2077,20 +2089,66 @@ export class CloudSyncService {
     this.invalidateChatSyncCaches()
 
     try {
-      await this.smartSync()
+      await this.doSyncAllChats({ deep: true }, generation)
     } catch (error) {
       logError('Resync after eviction failed', error, {
         component: 'CloudSync',
         action: 'retryDecryptionWithNewKey',
       })
+      await this.restoreFailedDecryptionPlaceholders(failed, generation)
       return 0
     }
 
-    const remaining = (await indexedDBStorage.getAllChats()).filter(
-      (chat) => chat.decryptionFailed,
-    ).length
+    if (!this.isCurrentGeneration(generation)) return 0
+    const restoredChats = await indexedDBStorage.getAllChats()
+    if (!this.isCurrentGeneration(generation)) return 0
+    const restoredById = new Map(restoredChats.map((chat) => [chat.id, chat]))
+    const recovered = failed.filter((placeholder) => {
+      const restored = restoredById.get(placeholder.id)
+      return restored !== undefined && !restored.decryptionFailed
+    }).length
+    await this.restoreFailedDecryptionPlaceholders(
+      failed.filter((placeholder) => !restoredById.has(placeholder.id)),
+      generation,
+    )
 
-    return Math.max(0, failed.length - remaining)
+    return recovered
+  }
+
+  private async restoreFailedDecryptionPlaceholders(
+    placeholders: StoredChat[],
+    generation: number,
+  ): Promise<void> {
+    if (!this.isCurrentGeneration(generation) || !isCloudSyncEnabled()) return
+    let restoredAny = false
+    for (const placeholder of placeholders) {
+      if (
+        !this.isCurrentGeneration(generation) ||
+        deletedChatsTracker.isDeleted(placeholder.id)
+      ) {
+        continue
+      }
+      try {
+        const existing = await indexedDBStorage.getChat(placeholder.id)
+        if (!this.isCurrentGeneration(generation)) return
+        if (!existing) {
+          await indexedDBStorage.saveExistingChat(placeholder)
+          restoredAny = true
+        }
+      } catch (error) {
+        logError(
+          `Failed to restore placeholder chat ${placeholder.id}`,
+          error,
+          {
+            component: 'CloudSync',
+            action: 'retryDecryptionWithNewKey.restorePlaceholder',
+          },
+        )
+      }
+    }
+    if (restoredAny && this.isCurrentGeneration(generation)) {
+      this.invalidateChatSyncCaches()
+    }
   }
 
   // Fetch a page of remote chats, decrypt, persist to IndexedDB, and return pagination info

--- a/src/services/cloud/cloud-sync.ts
+++ b/src/services/cloud/cloud-sync.ts
@@ -93,6 +93,7 @@ const UPLOAD_MAX_RETRIES = 3
 const REMOTE_LIST_MAX_ATTEMPTS = 2
 const UPLOADS_SKIPPED_UNRECONCILED_DELETIONS_ERROR =
   'Skipped uploading local changes: remote deletions could not be reconciled'
+const CROSS_TAB_SYNC_LOCK = 'tinfoil-cloud-sync'
 const isStreaming = (id: string) => streamingTracker.isStreaming(id)
 
 export class CloudSyncService {
@@ -101,6 +102,7 @@ export class CloudSyncService {
   private uploadCoalescer: UploadCoalescer
   private streamingCallbacks: Set<string> = new Set()
   private accountGeneration = 0
+  private crossTabReloadQueued = false
   /**
    * Set once per session after the first successful syncAllChats so
    * the enclave-driven legacy-blob migration (§8.7.2 trigger 1) runs
@@ -131,8 +133,10 @@ export class CloudSyncService {
         if (e.key === SYNC_CHAT_STATUS) {
           // Another tab updated sync status, invalidate our cache
           this.chatSyncCache.invalidate()
+          this.queueCrossTabReload()
         } else if (e.key === SYNC_ALL_CHATS_STATUS) {
           this.allChatsSyncCache.invalidate()
+          this.queueCrossTabReload()
         } else if (e.key?.startsWith(SYNC_PROJECT_CHAT_STATUS_PREFIX)) {
           // Another tab updated project sync status, invalidate that project's cache
           const projectId = e.key.slice(SYNC_PROJECT_CHAT_STATUS_PREFIX.length)
@@ -140,6 +144,7 @@ export class CloudSyncService {
           if (existingCache) {
             existingCache.invalidate()
           }
+          this.queueCrossTabReload()
         }
       })
     }
@@ -154,6 +159,15 @@ export class CloudSyncService {
       this.projectSyncCaches.set(projectId, cache)
     }
     return cache
+  }
+
+  private queueCrossTabReload(): void {
+    if (this.crossTabReloadQueued) return
+    this.crossTabReloadQueued = true
+    queueMicrotask(() => {
+      this.crossTabReloadQueued = false
+      chatEvents.emit({ reason: 'sync', ids: [] })
+    })
   }
 
   private isCurrentGeneration(generation: number): boolean {
@@ -182,6 +196,27 @@ export class CloudSyncService {
    * Throws if a sync is already in progress.
    */
   private async withSyncLock<T>(fn: () => Promise<T>): Promise<T> {
+    if (typeof navigator !== 'undefined' && navigator.locks) {
+      return navigator.locks.request(
+        CROSS_TAB_SYNC_LOCK,
+        { ifAvailable: true, mode: 'exclusive' },
+        async (lock) => {
+          if (!lock) {
+            logInfo('[CloudSync] Sync active in another tab, skipping', {
+              component: 'CloudSync',
+              action: 'withSyncLock',
+            })
+            throw new SyncInProgressError()
+          }
+          return this.withInstanceSyncLock(fn)
+        },
+      )
+    }
+
+    return this.withInstanceSyncLock(fn)
+  }
+
+  private async withInstanceSyncLock<T>(fn: () => Promise<T>): Promise<T> {
     if (this.syncLock) {
       logInfo('[CloudSync] Sync already in progress, skipping', {
         component: 'CloudSync',

--- a/src/services/cloud/cloud-sync.ts
+++ b/src/services/cloud/cloud-sync.ts
@@ -1,4 +1,4 @@
-import { CLOUD_SYNC, PAGINATION } from '@/config'
+import { PAGINATION } from '@/config'
 import {
   AUTH_ACTIVE_USER_ID,
   MIGRATION_EXHAUSTED_KEYSET_PREFIX,
@@ -222,42 +222,15 @@ export class CloudSyncService {
 
     // Queue for the cross-tab lock instead of skipping so callers that
     // need a real result (initial sync pagination, manual deep sync,
-    // post-eviction resync) still get one when another tab is mid-sync.
-    // The wait is bounded so a hung leader tab cannot stall sync in
-    // every other tab; on timeout we throw SyncInProgressError, which
-    // existing callers already handle. The timer only bounds the
-    // waiting phase: it is cleared once the lock is granted so a
-    // long-running sync of our own is never aborted. trackSync wraps
-    // the wait as well, so waitForCurrentSync() covers queued attempts.
+    // post-eviction resync) retain their intent while another tab syncs.
+    // trackSync wraps the wait as well, so waitForCurrentSync() covers
+    // queued attempts.
     return this.trackSync(async () => {
-      const abortController = new AbortController()
-      let acquired = false
-      const waitTimer = setTimeout(
-        () => abortController.abort(),
-        CLOUD_SYNC.CROSS_TAB_SYNC_LOCK_TIMEOUT,
+      return navigator.locks.request(
+        CROSS_TAB_SYNC_LOCK,
+        CROSS_TAB_SYNC_LOCK_OPTIONS,
+        () => fn(),
       )
-      try {
-        return await navigator.locks.request(
-          CROSS_TAB_SYNC_LOCK,
-          { ...CROSS_TAB_SYNC_LOCK_OPTIONS, signal: abortController.signal },
-          () => {
-            acquired = true
-            clearTimeout(waitTimer)
-            return fn()
-          },
-        )
-      } catch (error) {
-        if (!acquired && abortController.signal.aborted) {
-          logInfo('[CloudSync] Timed out waiting for sync in another tab', {
-            component: 'CloudSync',
-            action: 'withSyncLock',
-          })
-          throw new SyncInProgressError()
-        }
-        throw error
-      } finally {
-        clearTimeout(waitTimer)
-      }
     })
   }
 

--- a/src/services/cloud/cloud-sync.ts
+++ b/src/services/cloud/cloud-sync.ts
@@ -93,8 +93,16 @@ const UPLOAD_MAX_RETRIES = 3
 const REMOTE_LIST_MAX_ATTEMPTS = 2
 const UPLOADS_SKIPPED_UNRECONCILED_DELETIONS_ERROR =
   'Skipped uploading local changes: remote deletions could not be reconciled'
-const CROSS_TAB_SYNC_LOCK = 'tinfoil-cloud-sync'
+export const CROSS_TAB_SYNC_LOCK = 'tinfoil-cloud-sync'
+export const CROSS_TAB_SYNC_LOCK_OPTIONS = {
+  ifAvailable: true,
+  mode: 'exclusive',
+} as const
 const isStreaming = (id: string) => streamingTracker.isStreaming(id)
+
+function emptySyncResult(): SyncResult {
+  return { uploaded: 0, downloaded: 0, errors: [] }
+}
 
 export class CloudSyncService {
   private syncLock: Promise<void> | null = null
@@ -102,7 +110,7 @@ export class CloudSyncService {
   private uploadCoalescer: UploadCoalescer
   private streamingCallbacks: Set<string> = new Set()
   private accountGeneration = 0
-  private crossTabReloadQueued = false
+  private crossTabReloadFrame: number | null = null
   /**
    * Set once per session after the first successful syncAllChats so
    * the enclave-driven legacy-blob migration (§8.7.2 trigger 1) runs
@@ -162,10 +170,9 @@ export class CloudSyncService {
   }
 
   private queueCrossTabReload(): void {
-    if (this.crossTabReloadQueued) return
-    this.crossTabReloadQueued = true
-    queueMicrotask(() => {
-      this.crossTabReloadQueued = false
+    if (this.crossTabReloadFrame !== null) return
+    this.crossTabReloadFrame = requestAnimationFrame(() => {
+      this.crossTabReloadFrame = null
       chatEvents.emit({ reason: 'sync', ids: [] })
     })
   }
@@ -178,6 +185,10 @@ export class CloudSyncService {
     this.accountGeneration++
     this.uploadCoalescer.clear()
     this.streamingCallbacks.clear()
+    if (this.crossTabReloadFrame !== null) {
+      cancelAnimationFrame(this.crossTabReloadFrame)
+      this.crossTabReloadFrame = null
+    }
     resetAlternativesFinalizationState()
     this.clearSyncStatus()
     // The deletes watermark is scoped to the account's tombstone history,
@@ -195,20 +206,20 @@ export class CloudSyncService {
    * Only one sync operation can run at a time.
    * Throws if a sync is already in progress.
    */
-  private async withSyncLock<T>(fn: () => Promise<T>): Promise<T> {
+  private async withSyncLock<T>(fn: () => Promise<T>): Promise<T | undefined> {
     if (typeof navigator !== 'undefined' && navigator.locks) {
       return navigator.locks.request(
         CROSS_TAB_SYNC_LOCK,
-        { ifAvailable: true, mode: 'exclusive' },
+        CROSS_TAB_SYNC_LOCK_OPTIONS,
         async (lock) => {
           if (!lock) {
             logInfo('[CloudSync] Sync active in another tab, skipping', {
               component: 'CloudSync',
               action: 'withSyncLock',
             })
-            throw new SyncInProgressError()
+            return undefined
           }
-          return this.withInstanceSyncLock(fn)
+          return this.trackSync(fn)
         },
       )
     }
@@ -225,6 +236,10 @@ export class CloudSyncService {
       throw new SyncInProgressError()
     }
 
+    return this.trackSync(fn)
+  }
+
+  private async trackSync<T>(fn: () => Promise<T>): Promise<T> {
     let resolve: () => void
     this.syncLock = new Promise<void>((r) => {
       resolve = r
@@ -506,7 +521,10 @@ export class CloudSyncService {
 
   // Perform a delta sync - only fetch chats that changed since last sync
   async syncChangedChats(): Promise<SyncResult> {
-    return this.withSyncLock(() => this.doSyncChangedChats())
+    return (
+      (await this.withSyncLock(() => this.doSyncChangedChats())) ??
+      emptySyncResult()
+    )
   }
 
   private async doSyncChangedChats(): Promise<SyncResult> {
@@ -1267,7 +1285,10 @@ export class CloudSyncService {
 
   // Sync all chats (upload local changes, download remote changes)
   async syncAllChats(options?: { deep?: boolean }): Promise<SyncResult> {
-    return this.withSyncLock(() => this.doSyncAllChats(options))
+    return (
+      (await this.withSyncLock(() => this.doSyncAllChats(options))) ??
+      emptySyncResult()
+    )
   }
 
   private async listChatsWithRetry(options: {
@@ -1722,6 +1743,13 @@ export class CloudSyncService {
    * @param projectId - Optional project ID. If provided, syncs project chats.
    */
   async smartSync(projectId?: string): Promise<SyncResult> {
+    return (
+      (await this.withSyncLock(() => this.doSmartSync(projectId))) ??
+      emptySyncResult()
+    )
+  }
+
+  private async doSmartSync(projectId?: string): Promise<SyncResult> {
     const generation = this.accountGeneration
     // Kick the legacy-blob migration before any sync work runs.
     // Previously this only fired at the end of a successful
@@ -1732,13 +1760,8 @@ export class CloudSyncService {
     // every smartSync entry is safe.
     void this.kickLegacyBlobMigration()
 
-    // Note: smartSync doesn't need its own lock because it delegates to
-    // syncChangedChats/syncAllChats/syncProjectChats which have their own locks
-    if (this.syncLock) {
-      throw new SyncInProgressError()
-    }
     if (!projectId && needsRecoveryHistorySync()) {
-      return this.syncAllChats({ deep: true })
+      return this.doSyncAllChats({ deep: true })
     }
 
     const status = await this.checkSyncStatus(projectId)
@@ -1792,11 +1815,13 @@ export class CloudSyncService {
 
     if (cachedStatus?.lastUpdated && status.reason !== 'count_changed') {
       return projectId
-        ? this.syncProjectChatsChanged(projectId)
-        : this.syncChangedChats()
+        ? this.doSyncProjectChatsChanged(projectId)
+        : this.doSyncChangedChats()
     }
 
-    return projectId ? this.syncProjectChats(projectId) : this.syncAllChats()
+    return projectId
+      ? this.doSyncProjectChats(projectId)
+      : this.doSyncAllChats()
   }
 
   // Check if currently syncing
@@ -2079,7 +2104,10 @@ export class CloudSyncService {
   }
 
   async syncProjectChats(projectId: string): Promise<SyncResult> {
-    return this.withSyncLock(() => this.doSyncProjectChats(projectId))
+    return (
+      (await this.withSyncLock(() => this.doSyncProjectChats(projectId))) ??
+      emptySyncResult()
+    )
   }
 
   private async doSyncProjectChats(
@@ -2197,7 +2225,11 @@ export class CloudSyncService {
    * Perform a delta sync for project chats - only fetch chats that changed since last sync.
    */
   async syncProjectChatsChanged(projectId: string): Promise<SyncResult> {
-    return this.withSyncLock(() => this.doSyncProjectChatsChanged(projectId))
+    return (
+      (await this.withSyncLock(() =>
+        this.doSyncProjectChatsChanged(projectId),
+      )) ?? emptySyncResult()
+    )
   }
 
   private async doSyncProjectChatsChanged(

--- a/src/services/cloud/edit-clock.ts
+++ b/src/services/cloud/edit-clock.ts
@@ -24,6 +24,13 @@ export interface EditClock {
   w: string
 }
 
+export class EditClockRandomnessUnavailableError extends Error {
+  constructor() {
+    super('Secure edit clock identifier generation is unavailable')
+    this.name = 'EditClockRandomnessUnavailableError'
+  }
+}
+
 // Upper bound for the logical counter. Far above any value a legitimate
 // edit history could reach, yet capped at the JS safe-integer ceiling so
 // the counter never loses precision and an observed remote value can
@@ -46,14 +53,12 @@ function safeCounter(value?: number | null): number {
 
 function randomId(): string {
   if (
-    typeof crypto !== 'undefined' &&
-    typeof crypto.randomUUID === 'function'
+    typeof crypto === 'undefined' ||
+    typeof crypto.randomUUID !== 'function'
   ) {
-    return crypto.randomUUID()
+    throw new EditClockRandomnessUnavailableError()
   }
-  // Non-crypto fallback for environments without randomUUID. The id is
-  // only a tiebreak label, never a security boundary.
-  return `dev-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`
+  return crypto.randomUUID()
 }
 
 // Persisted per-installation id, reused for the life of the browser

--- a/src/services/cloud/upload-coalescer.ts
+++ b/src/services/cloud/upload-coalescer.ts
@@ -9,6 +9,7 @@
  */
 
 import { logError, logInfo } from '@/utils/error-handling'
+import { AuthTokenUnavailableError } from '../auth'
 import { decideRecovery } from '../sync-enclave/enclave-error-recovery'
 import {
   computeBackoffDelay,
@@ -453,6 +454,9 @@ export class UploadCoalescer {
 }
 
 function shouldRetryUploadError(error: Error): boolean {
+  if (error instanceof AuthTokenUnavailableError) {
+    return false
+  }
   const decision = decideRecovery(error)
   if (decision.action.type === 'retry') {
     return true

--- a/src/services/storage/indexed-db.ts
+++ b/src/services/storage/indexed-db.ts
@@ -1095,7 +1095,7 @@ export class IndexedDBStorage {
 
   async restoreDecryptionPlaceholder(chat: StoredChat): Promise<void> {
     const chatSnapshot = snapshotChatForStorage(chat)
-    return this.enqueueSave('restoreDecryptionPlaceholder', () =>
+    await this.enqueueSave('restoreDecryptionPlaceholder', () =>
       this.saveChatInternal(chatSnapshot, { markContentChangesAsLocal: false }),
     )
   }

--- a/src/services/storage/indexed-db.ts
+++ b/src/services/storage/indexed-db.ts
@@ -1093,6 +1093,13 @@ export class IndexedDBStorage {
     )
   }
 
+  async restoreDecryptionPlaceholder(chat: StoredChat): Promise<void> {
+    const chatSnapshot = snapshotChatForStorage(chat)
+    return this.enqueueSave('restoreDecryptionPlaceholder', () =>
+      this.saveChatInternal(chatSnapshot, { markContentChangesAsLocal: false }),
+    )
+  }
+
   async mutateChat(
     chatId: string,
     mutation: (chat: StoredChat) => {

--- a/src/services/sync-enclave/sync-api.ts
+++ b/src/services/sync-enclave/sync-api.ts
@@ -361,11 +361,7 @@ export interface SearchReindexStatusResponse {
 export type ImportSource = 'chatgpt' | 'claude' | 'tinfoil'
 
 export type ImportJobStatus =
-  | 'idle'
-  | 'staging'
-  | 'running'
-  | 'completed'
-  | 'failed'
+  'idle' | 'staging' | 'running' | 'completed' | 'failed'
 
 export interface ImportCreateRequest {
   source: ImportSource
@@ -486,27 +482,37 @@ function b64ToBytes(s: string): Uint8Array {
 
 export async function push(req: PushRequest): Promise<PushResponse> {
   const client = await getSyncEnclaveClient()
-  return client.post<PushResponse>('/v1/sync/push', {
-    scope: req.scope,
-    id: req.id ?? '',
-    key: req.keyB64,
-    plaintext: bytesToB64(req.plaintext),
-    if_match: req.ifMatch,
-    idempotency_key: req.idempotencyKey,
-    metadata: req.metadata,
-  })
+  return client.post<PushResponse>(
+    '/v1/sync/push',
+    {
+      scope: req.scope,
+      id: req.id ?? '',
+      key: req.keyB64,
+      plaintext: bytesToB64(req.plaintext),
+      if_match: req.ifMatch,
+      idempotency_key: req.idempotencyKey,
+      metadata: req.metadata,
+    },
+    undefined,
+    { requestScope: 'cloud-sync' },
+  )
 }
 
 export async function pull(req: PullRequest): Promise<PullResponse> {
   const client = await getSyncEnclaveClient()
-  const resp = await client.post<PullResponse>('/v1/sync/pull', {
-    scope: req.scope,
-    ids: req.ids,
-    all: req.all,
-    cursor: req.cursor,
-    limit: req.limit,
-    keys: req.keys,
-  })
+  const resp = await client.post<PullResponse>(
+    '/v1/sync/pull',
+    {
+      scope: req.scope,
+      ids: req.ids,
+      all: req.all,
+      cursor: req.cursor,
+      limit: req.limit,
+      keys: req.keys,
+    },
+    undefined,
+    { requestScope: 'cloud-sync' },
+  )
   // Go marshals an empty slice as JSON null, which would crash every
   // downstream `for (const item of resp.items)` consumer. Force a
   // stable [] at the boundary so callers can iterate without guards.
@@ -533,13 +539,18 @@ export async function listStatus(
   req: ListStatusRequest,
 ): Promise<ListStatusResponse> {
   const client = await getSyncEnclaveClient()
-  const resp = await client.post<ListStatusResponse>('/v1/sync/list-status', {
-    scope: req.scope,
-    cursor: req.cursor,
-    limit: req.limit,
-    project_id: req.projectId,
-    direction: req.direction,
-  })
+  const resp = await client.post<ListStatusResponse>(
+    '/v1/sync/list-status',
+    {
+      scope: req.scope,
+      cursor: req.cursor,
+      limit: req.limit,
+      project_id: req.projectId,
+      direction: req.direction,
+    },
+    undefined,
+    { requestScope: 'cloud-sync' },
+  )
   // Both arrays land as JSON null when the server has nothing to
   // report for the page; normalize so iteration in cloud-storage /
   // project-storage / profile-sync stays branchless.
@@ -552,13 +563,18 @@ export async function listStatus(
 
 export async function deleteRow(req: DeleteRequest): Promise<OKResponse> {
   const client = await getSyncEnclaveClient()
-  return client.post<OKResponse>('/v1/sync/delete', {
-    scope: req.scope,
-    id: req.id,
-    if_match: req.ifMatch,
-    idempotency_key: req.idempotencyKey,
-    key: req.keyB64,
-  })
+  return client.post<OKResponse>(
+    '/v1/sync/delete',
+    {
+      scope: req.scope,
+      id: req.id,
+      if_match: req.ifMatch,
+      idempotency_key: req.idempotencyKey,
+      key: req.keyB64,
+    },
+    undefined,
+    { requestScope: 'cloud-sync' },
+  )
 }
 
 export async function registerKey(
@@ -768,11 +784,16 @@ export async function attachmentPut(
   req: AttachmentPutRequest,
 ): Promise<AttachmentPutResponse> {
   const client = await getSyncEnclaveClient()
-  return client.post<AttachmentPutResponse>('/v1/attachment/put', {
-    chat_id: req.chatId,
-    plaintext: bytesToB64(req.plaintext),
-    idempotency_key: req.idempotencyKey,
-  })
+  return client.post<AttachmentPutResponse>(
+    '/v1/attachment/put',
+    {
+      chat_id: req.chatId,
+      plaintext: bytesToB64(req.plaintext),
+      idempotency_key: req.idempotencyKey,
+    },
+    undefined,
+    { requestScope: 'cloud-sync' },
+  )
 }
 
 /** Fetch an attachment through the sync enclave; returns raw bytes. */
@@ -780,10 +801,15 @@ export async function attachmentGet(
   req: AttachmentGetRequest,
 ): Promise<Uint8Array> {
   const client = await getSyncEnclaveClient()
-  const resp = await client.post<AttachmentGetResponse>('/v1/attachment/get', {
-    id: req.id,
-    att_key: req.attKeyB64,
-  })
+  const resp = await client.post<AttachmentGetResponse>(
+    '/v1/attachment/get',
+    {
+      id: req.id,
+      att_key: req.attKeyB64,
+    },
+    undefined,
+    { requestScope: 'cloud-sync' },
+  )
   return b64ToBytes(resp.plaintext)
 }
 
@@ -818,9 +844,14 @@ export async function attachmentDelete(req: {
   id: string
 }): Promise<OKResponse> {
   const client = await getSyncEnclaveClient()
-  return client.post<OKResponse>('/v1/attachment/delete', {
-    id: req.id,
-  })
+  return client.post<OKResponse>(
+    '/v1/attachment/delete',
+    {
+      id: req.id,
+    },
+    undefined,
+    { requestScope: 'cloud-sync' },
+  )
 }
 
 /* -------------------------------------------------------------------------- */

--- a/src/services/sync-enclave/sync-enclave-client.ts
+++ b/src/services/sync-enclave/sync-enclave-client.ts
@@ -374,12 +374,16 @@ function assertRelativeSyncEnclavePath(path: string): void {
  */
 export function getSyncEnclaveClient(): Promise<SyncEnclaveClient> {
   if (!clientPromise) {
-    clientPromise = SyncEnclaveClient.create().catch((err) => {
+    const pendingClient = SyncEnclaveClient.create()
+    const trackedClient = pendingClient.catch((err) => {
       // Surface attestation failures to the UI and allow a retry on the
       // next call rather than caching a permanent rejection.
-      clientPromise = null
+      if (clientPromise === trackedClient) {
+        clientPromise = null
+      }
       throw err
     })
+    clientPromise = trackedClient
   }
   return clientPromise
 }

--- a/src/services/sync-enclave/sync-enclave-client.ts
+++ b/src/services/sync-enclave/sync-enclave-client.ts
@@ -1,4 +1,8 @@
-import { SYNC_ENCLAVE_REPO, SYNC_ENCLAVE_URL } from '@/config'
+import {
+  SYNC_ENCLAVE_REPO,
+  SYNC_ENCLAVE_TIMEOUTS,
+  SYNC_ENCLAVE_URL,
+} from '@/config'
 import { authTokenManager } from '@/services/auth'
 import { reportSyncPaused } from '@/services/cloud/sync-health'
 import { logError, logInfo } from '@/utils/error-handling'
@@ -16,6 +20,7 @@ import { SecureClient } from 'tinfoil'
  */
 
 let clientPromise: Promise<SyncEnclaveClient> | null = null
+const activeOperationControllers = new Set<AbortController>()
 const SYNC_ENCLAVE_REQUIRED_PROTOCOL = 'https:'
 const ABSOLUTE_URL_PROTOCOL_PATTERN = /^[a-z][a-z\d+\-.]*:/i
 
@@ -55,6 +60,27 @@ export class SyncNetworkError extends SyncEnclaveError {
   }
 }
 
+export class SyncRequestTimeoutError extends SyncNetworkError {
+  constructor(options?: ErrorOptions) {
+    super(options)
+    this.name = 'SyncRequestTimeoutError'
+  }
+}
+
+export class SyncAttestationTimeoutError extends SyncNetworkError {
+  constructor(options?: ErrorOptions) {
+    super(options)
+    this.name = 'SyncAttestationTimeoutError'
+  }
+}
+
+export class SyncRequestAbortedError extends Error {
+  constructor(options?: ErrorOptions) {
+    super('Sync enclave request was canceled', options)
+    this.name = 'SyncRequestAbortedError'
+  }
+}
+
 type SyncRequestInit = Omit<RequestInit, 'body'> & {
   body?: string
   skipAuth?: boolean
@@ -75,7 +101,11 @@ export class SyncEnclaveClient {
       enclaveURL: SYNC_ENCLAVE_URL,
       configRepo: SYNC_ENCLAVE_REPO,
     })
-    await secure.ready()
+    await runBoundedOperation(
+      () => secure.ready(),
+      SYNC_ENCLAVE_TIMEOUTS.READY_MS,
+      () => new SyncAttestationTimeoutError(),
+    )
     logInfo('sync enclave verified', {
       component: 'sync-enclave-client',
       action: 'create',
@@ -108,7 +138,7 @@ export class SyncEnclaveClient {
     init: SyncRequestInit = {},
   ): Promise<T> {
     assertRelativeSyncEnclavePath(path)
-    const { skipAuth: _skipAuth, ...fetchInit } = init
+    const { skipAuth: _skipAuth, signal: callerSignal, ...fetchInit } = init
     const requestUrl = new URL(path, SYNC_ENCLAVE_URL).toString()
     const baseHeaders = new Headers(init.headers)
     baseHeaders.set('Accept', 'application/json')
@@ -116,72 +146,94 @@ export class SyncEnclaveClient {
       baseHeaders.set('Content-Type', 'application/json')
     }
 
-    let token: string | null = null
-    if (!init.skipAuth) {
-      token = await authTokenManager.getValidToken()
-    }
-
-    const send = async (authToken: string | null) => {
-      const headers = new Headers(baseHeaders)
-      if (authToken) headers.set('Authorization', `Bearer ${authToken}`)
-      try {
-        return await this.secure.fetch(requestUrl, { ...fetchInit, headers })
-      } catch (error) {
-        if (error instanceof TypeError) {
-          throw new SyncNetworkError({ cause: error })
+    return runBoundedOperation(
+      async (signal) => {
+        let token: string | null = null
+        if (!init.skipAuth) {
+          token = await settleWithSignal(
+            authTokenManager.getValidToken(),
+            signal,
+          )
         }
-        throw error
-      }
-    }
 
-    let resp = await send(token)
-    if (!init.skipAuth && resp.status === 401) {
-      token = await authTokenManager.refreshToken(token as string)
-      resp = await send(token)
-      if (resp.status === 401) {
-        // A 401 that survives a token refresh is usually a server-side
-        // condition (enclave JWKS staleness after a signing-key
-        // rotation, clock skew) rather than a revoked session, so it
-        // must never force a sign-out. Pause sync and surface it; the
-        // periodic sync retries and clears the gate on success. A
-        // genuinely ended Clerk session is detected by Clerk itself
-        // and handled by the sign-out cleanup path.
-        reportSyncPaused('auth')
-        throw new SyncPersistentAuthError()
-      }
-    }
+        const send = async (authToken: string | null) => {
+          const headers = new Headers(baseHeaders)
+          if (authToken) headers.set('Authorization', `Bearer ${authToken}`)
+          try {
+            return await settleWithSignal(
+              this.secure.fetch(requestUrl, {
+                ...fetchInit,
+                headers,
+                signal,
+              }),
+              signal,
+            )
+          } catch (error) {
+            if (signal.aborted) throw signal.reason
+            if (error instanceof TypeError) {
+              throw new SyncNetworkError({ cause: error })
+            }
+            throw error
+          }
+        }
 
-    if (!resp.ok) {
-      let body: Record<string, unknown> = {}
-      try {
-        body = await resp.json()
-      } catch {
-        // body is empty or non-JSON; treat as opaque error
-      }
-      const message =
-        typeof body.error === 'string'
-          ? body.error
-          : typeof body.message === 'string'
-            ? body.message
-            : `sync enclave request failed: ${resp.status} ${resp.statusText}`
-      const code =
-        typeof body.code === 'string' ? body.code : `HTTP_${resp.status}`
-      logError(`sync enclave request failed`, undefined, {
-        component: 'sync-enclave-client',
-        action: 'request',
-        metadata: { path, status: resp.status, code },
-      })
-      throw new SyncEnclaveError(message, resp.status, code, body)
-    }
+        let resp = await send(token)
+        if (!init.skipAuth && resp.status === 401) {
+          token = await settleWithSignal(
+            authTokenManager.refreshToken(token as string),
+            signal,
+          )
+          resp = await send(token)
+          if (resp.status === 401) {
+            // A 401 that survives a token refresh is usually a server-side
+            // condition (enclave JWKS staleness after a signing-key
+            // rotation, clock skew) rather than a revoked session, so it
+            // must never force a sign-out. Pause sync and surface it; the
+            // periodic sync retries and clears the gate on success. A
+            // genuinely ended Clerk session is detected by Clerk itself
+            // and handled by the sign-out cleanup path.
+            reportSyncPaused('auth')
+            throw new SyncPersistentAuthError()
+          }
+        }
 
-    if (resp.status === 204) {
-      return undefined as T
-    }
-    const contentType = resp.headers.get('content-type') || ''
-    if (contentType.includes('application/json')) {
-      return (await resp.json()) as T
-    }
-    return undefined as T
+        if (!resp.ok) {
+          let body: Record<string, unknown> = {}
+          try {
+            body = await settleWithSignal(resp.json(), signal)
+          } catch (error) {
+            if (signal.aborted) throw signal.reason
+            // body is empty or non-JSON; treat as opaque error
+          }
+          const message =
+            typeof body.error === 'string'
+              ? body.error
+              : typeof body.message === 'string'
+                ? body.message
+                : `sync enclave request failed: ${resp.status} ${resp.statusText}`
+          const code =
+            typeof body.code === 'string' ? body.code : `HTTP_${resp.status}`
+          logError(`sync enclave request failed`, undefined, {
+            component: 'sync-enclave-client',
+            action: 'request',
+            metadata: { path, status: resp.status, code },
+          })
+          throw new SyncEnclaveError(message, resp.status, code, body)
+        }
+
+        if (resp.status === 204) {
+          return undefined as T
+        }
+        const contentType = resp.headers.get('content-type') || ''
+        if (contentType.includes('application/json')) {
+          return (await settleWithSignal(resp.json(), signal)) as T
+        }
+        return undefined as T
+      },
+      SYNC_ENCLAVE_TIMEOUTS.REQUEST_MS,
+      () => new SyncRequestTimeoutError(),
+      callerSignal ?? undefined,
+    )
   }
 
   /**
@@ -225,6 +277,60 @@ export class SyncEnclaveClient {
   delete<T>(path: string, headers?: Record<string, string>) {
     return this.request<T>(path, { method: 'DELETE', headers })
   }
+}
+
+function settleWithSignal<T>(
+  promise: Promise<T>,
+  signal: AbortSignal,
+): Promise<T> {
+  if (signal.aborted) return Promise.reject(signal.reason)
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(signal.reason)
+    signal.addEventListener('abort', onAbort, { once: true })
+    promise.then(
+      (value) => {
+        signal.removeEventListener('abort', onAbort)
+        resolve(value)
+      },
+      (error) => {
+        signal.removeEventListener('abort', onAbort)
+        reject(error)
+      },
+    )
+  })
+}
+
+async function runBoundedOperation<T>(
+  operation: (signal: AbortSignal) => Promise<T>,
+  timeoutMs: number,
+  timeoutError: () => Error,
+  callerSignal?: AbortSignal,
+): Promise<T> {
+  const controller = new AbortController()
+  const abortFromCaller = () =>
+    controller.abort(callerSignal?.reason ?? new SyncRequestAbortedError())
+  if (callerSignal?.aborted) abortFromCaller()
+  else callerSignal?.addEventListener('abort', abortFromCaller, { once: true })
+
+  activeOperationControllers.add(controller)
+  const timer = setTimeout(() => controller.abort(timeoutError()), timeoutMs)
+  try {
+    return await settleWithSignal(
+      operation(controller.signal),
+      controller.signal,
+    )
+  } finally {
+    clearTimeout(timer)
+    callerSignal?.removeEventListener('abort', abortFromCaller)
+    activeOperationControllers.delete(controller)
+  }
+}
+
+export function abortSyncEnclaveRequests(): void {
+  for (const controller of activeOperationControllers) {
+    controller.abort(new SyncRequestAbortedError())
+  }
+  clientPromise = null
 }
 
 function assertSecureSyncEnclaveUrl(enclaveURL: string): void {
@@ -283,5 +389,5 @@ export function getSyncEnclaveClient(): Promise<SyncEnclaveClient> {
  * re-verifies. Used by sign-out cleanup.
  */
 export function resetSyncEnclaveClient(): void {
-  clientPromise = null
+  abortSyncEnclaveRequests()
 }

--- a/src/services/sync-enclave/sync-enclave-client.ts
+++ b/src/services/sync-enclave/sync-enclave-client.ts
@@ -21,6 +21,11 @@ import { SecureClient } from 'tinfoil'
 
 let clientPromise: Promise<SyncEnclaveClient> | null = null
 const activeOperationControllers = new Set<AbortController>()
+export type SyncEnclaveRequestScope = 'cloud-sync'
+const requestScopeControllers = new Map<
+  SyncEnclaveRequestScope,
+  AbortController
+>()
 const SYNC_ENCLAVE_REQUIRED_PROTOCOL = 'https:'
 const ABSOLUTE_URL_PROTOCOL_PATTERN = /^[a-z][a-z\d+\-.]*:/i
 
@@ -84,7 +89,10 @@ export class SyncRequestAbortedError extends Error {
 type SyncRequestInit = Omit<RequestInit, 'body'> & {
   body?: string
   skipAuth?: boolean
+  requestScope?: SyncEnclaveRequestScope
 }
+
+type SyncRequestOptions = Pick<SyncRequestInit, 'requestScope' | 'signal'>
 
 export class SyncEnclaveClient {
   private constructor(private readonly secure: SecureClient) {}
@@ -138,7 +146,12 @@ export class SyncEnclaveClient {
     init: SyncRequestInit = {},
   ): Promise<T> {
     assertRelativeSyncEnclavePath(path)
-    const { skipAuth: _skipAuth, signal: callerSignal, ...fetchInit } = init
+    const {
+      skipAuth: _skipAuth,
+      signal: callerSignal,
+      requestScope,
+      ...fetchInit
+    } = init
     const requestUrl = new URL(path, SYNC_ENCLAVE_URL).toString()
     const baseHeaders = new Headers(init.headers)
     baseHeaders.set('Accept', 'application/json')
@@ -232,7 +245,7 @@ export class SyncEnclaveClient {
       },
       SYNC_ENCLAVE_TIMEOUTS.REQUEST_MS,
       () => new SyncRequestTimeoutError(),
-      callerSignal ?? undefined,
+      [callerSignal, requestScope ? getRequestScopeSignal(requestScope) : null],
     )
   }
 
@@ -245,11 +258,17 @@ export class SyncEnclaveClient {
     return this.request<T>(path, { method: 'GET', headers })
   }
 
-  post<T>(path: string, body?: unknown, headers?: Record<string, string>) {
+  post<T>(
+    path: string,
+    body?: unknown,
+    headers?: Record<string, string>,
+    options: SyncRequestOptions = {},
+  ) {
     return this.request<T>(path, {
       method: 'POST',
       body: body !== undefined ? JSON.stringify(body) : undefined,
       headers,
+      ...options,
     })
   }
 
@@ -304,13 +323,18 @@ async function runBoundedOperation<T>(
   operation: (signal: AbortSignal) => Promise<T>,
   timeoutMs: number,
   timeoutError: () => Error,
-  callerSignal?: AbortSignal,
+  callerSignals: Array<AbortSignal | null | undefined> = [],
 ): Promise<T> {
   const controller = new AbortController()
-  const abortFromCaller = () =>
-    controller.abort(callerSignal?.reason ?? new SyncRequestAbortedError())
-  if (callerSignal?.aborted) abortFromCaller()
-  else callerSignal?.addEventListener('abort', abortFromCaller, { once: true })
+  const signalListeners = callerSignals
+    .filter((signal): signal is AbortSignal => signal !== null && !!signal)
+    .map((signal) => {
+      const abortFromSignal = () =>
+        controller.abort(signal.reason ?? new SyncRequestAbortedError())
+      if (signal.aborted) abortFromSignal()
+      else signal.addEventListener('abort', abortFromSignal, { once: true })
+      return { signal, abortFromSignal }
+    })
 
   activeOperationControllers.add(controller)
   const timer = setTimeout(() => controller.abort(timeoutError()), timeoutMs)
@@ -321,15 +345,46 @@ async function runBoundedOperation<T>(
     )
   } finally {
     clearTimeout(timer)
-    callerSignal?.removeEventListener('abort', abortFromCaller)
+    for (const { signal, abortFromSignal } of signalListeners) {
+      signal.removeEventListener('abort', abortFromSignal)
+    }
     activeOperationControllers.delete(controller)
   }
 }
 
-export function abortSyncEnclaveRequests(): void {
+function getRequestScopeSignal(scope: SyncEnclaveRequestScope): AbortSignal {
+  let controller = requestScopeControllers.get(scope)
+  if (!controller) {
+    controller = new AbortController()
+    requestScopeControllers.set(scope, controller)
+  }
+  return controller.signal
+}
+
+export function resetSyncEnclaveRequestScope(
+  scope: SyncEnclaveRequestScope,
+): void {
+  requestScopeControllers.set(scope, new AbortController())
+}
+
+export function abortSyncEnclaveRequests(
+  scope?: SyncEnclaveRequestScope,
+): void {
+  if (scope) {
+    const controller = requestScopeControllers.get(scope)
+    if (controller) {
+      controller.abort(new SyncRequestAbortedError())
+    } else {
+      const abortedController = new AbortController()
+      abortedController.abort(new SyncRequestAbortedError())
+      requestScopeControllers.set(scope, abortedController)
+    }
+    return
+  }
   for (const controller of activeOperationControllers) {
     controller.abort(new SyncRequestAbortedError())
   }
+  requestScopeControllers.clear()
   clientPromise = null
 }
 

--- a/tests/components/chat/use-chat-messaging.cancel-generation.test.tsx
+++ b/tests/components/chat/use-chat-messaging.cancel-generation.test.tsx
@@ -63,6 +63,7 @@ vi.mock('@/services/inference/tinfoil-client', async () => {
 })
 
 vi.mock('@/utils/cloud-sync-settings', () => ({
+  CLOUD_SYNC_SETTING_CHANGED_EVENT: 'cloudSyncSettingChanged',
   isCloudSyncEnabled: () => cloudSyncState.enabled,
 }))
 

--- a/tests/services/cloud/chat-ingestion.test.ts
+++ b/tests/services/cloud/chat-ingestion.test.ts
@@ -1,4 +1,7 @@
-import { SYNC_CHAT_DELETES_WATERMARK } from '@/constants/storage-keys'
+import {
+  SYNC_CHAT_DELETES_WATERMARK,
+  SYNC_CHAT_DELETION_REVISION,
+} from '@/constants/storage-keys'
 import {
   CHAT_DELETES_WATERMARK_EPOCH,
   CHAT_DELETES_WATERMARK_OVERLAP_MS,
@@ -67,6 +70,7 @@ describe('syncRemoteDeletions', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     localStorage.removeItem(SYNC_CHAT_DELETES_WATERMARK)
+    localStorage.removeItem(SYNC_CHAT_DELETION_REVISION)
     mockDeleteChatIfUnchanged.mockResolvedValue(true)
     mockApplyRemoteChatIfFresh.mockResolvedValue({ applied: true })
     mockIsDeleted.mockReturnValue(false)
@@ -221,6 +225,28 @@ describe('syncRemoteDeletions', () => {
           CHAT_DELETES_WATERMARK_OVERLAP_MS,
       ).toISOString(),
     )
+  })
+
+  it('publishes a deletion revision when an equal watermark cannot advance', async () => {
+    const existingWatermark = new Date(
+      Date.parse(deletedAt) - CHAT_DELETES_WATERMARK_OVERLAP_MS,
+    ).toISOString()
+    localStorage.setItem(SYNC_CHAT_DELETES_WATERMARK, existingWatermark)
+    mockListChatEventsSince.mockResolvedValue(
+      events([{ id: 'gone-at-equal-watermark', deletedAt }]),
+    )
+    mockGetChat.mockResolvedValue({
+      id: 'gone-at-equal-watermark',
+      isLocalOnly: false,
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    })
+
+    await syncRemoteDeletions('test')
+
+    expect(localStorage.getItem(SYNC_CHAT_DELETES_WATERMARK)).toBe(
+      existingWatermark,
+    )
+    expect(localStorage.getItem(SYNC_CHAT_DELETION_REVISION)).not.toBeNull()
   })
 
   it('holds the watermark when applying a tombstone fails', async () => {

--- a/tests/services/cloud/cloud-sync.test.ts
+++ b/tests/services/cloud/cloud-sync.test.ts
@@ -1,11 +1,13 @@
 import {
   SETTINGS_CLOUD_SYNC_ENABLED,
   SYNC_CHAT_DELETES_WATERMARK,
+  SYNC_CHAT_DELETION_REVISION,
   SYNC_CHAT_STATUS,
   SYNC_PROJECT_CHAT_STATUS_PREFIX,
 } from '@/constants/storage-keys'
+import { AuthTokenUnavailableError } from '@/services/auth'
 import {
-  CloudSyncDisabledError,
+  CloudSyncLifecycleCanceledError,
   CloudSyncService,
   CROSS_TAB_SYNC_LOCK,
   SyncInProgressError,
@@ -27,6 +29,7 @@ const mockGetChatSyncMetadata = vi.fn()
 const mockGetChat = vi.fn()
 const mockSaveChat = vi.fn()
 const mockSaveExistingChat = vi.fn()
+const mockRestoreDecryptionPlaceholder = vi.fn()
 const mockMarkAsSynced = vi.fn()
 const mockFinalizeUpload = vi.fn()
 const mockApplyRemoteChatIfFresh = vi.fn()
@@ -97,6 +100,8 @@ vi.mock('@/services/storage/indexed-db', () => ({
       mockGetUnsyncedChatMetadata(...args),
     saveChat: (...args: any[]) => mockSaveChat(...args),
     saveExistingChat: (...args: any[]) => mockSaveExistingChat(...args),
+    restoreDecryptionPlaceholder: (...args: any[]) =>
+      mockRestoreDecryptionPlaceholder(...args),
     markAsSynced: (...args: any[]) => mockMarkAsSynced(...args),
     finalizeUpload: (...args: any[]) => mockFinalizeUpload(...args),
     applyRemoteChatIfFresh: (...args: any[]) =>
@@ -229,6 +234,7 @@ describe('CloudSyncService', () => {
     localStorage.removeItem(SYNC_CHAT_DELETES_WATERMARK)
     mockSaveChat.mockResolvedValue(undefined)
     mockSaveExistingChat.mockResolvedValue(undefined)
+    mockRestoreDecryptionPlaceholder.mockResolvedValue(undefined)
     mockMarkAsSynced.mockResolvedValue(undefined)
     mockFinalizeUpload.mockResolvedValue(undefined)
     mockApplyRemoteChatIfFresh.mockResolvedValue({ applied: true })
@@ -326,7 +332,7 @@ describe('CloudSyncService', () => {
     ).resolves.toBe('synced')
     expect(request).toHaveBeenCalledWith(
       CROSS_TAB_SYNC_LOCK,
-      { mode: 'exclusive' },
+      { mode: 'exclusive', signal: expect.any(AbortSignal) },
       expect.any(Function),
     )
   })
@@ -476,34 +482,58 @@ describe('CloudSyncService', () => {
     ).resolves.toBe('fallback')
   })
 
-  it('cancels a queued lock callback when cloud sync is disabled locally', async () => {
-    let grantLock!: () => void
-    const leaderFinished = new Promise<void>((resolve) => {
-      grantLock = resolve
-    })
+  it('cancels a never-granted lock on opt-out and syncs after re-enable', async () => {
     const request = vi.fn(
-      async (
+      (
         _name: string,
-        _options: LockOptions,
+        options: LockOptions,
         callback: (lock: Lock) => Promise<unknown>,
-      ) => {
-        await leaderFinished
-        return callback({ name: CROSS_TAB_SYNC_LOCK, mode: 'exclusive' })
-      },
+      ) =>
+        request.mock.calls.length === 1
+          ? new Promise((_resolve, reject) => {
+              options.signal?.addEventListener('abort', () =>
+                reject(new DOMException('Canceled', 'AbortError')),
+              )
+            })
+          : callback({ name: CROSS_TAB_SYNC_LOCK, mode: 'exclusive' }),
     )
     vi.stubGlobal('navigator', { locks: { request } })
     const service = new CloudSyncService()
     const pending = service.smartSync()
 
     setCloudSyncEnabled(false)
+    await expect(pending).rejects.toBeInstanceOf(
+      CloudSyncLifecycleCanceledError,
+    )
     setCloudSyncEnabled(true)
-    grantLock()
 
-    await expect(pending).rejects.toBeInstanceOf(CloudSyncDisabledError)
     await expect(service.smartSync()).resolves.toMatchObject({
       uploaded: 0,
       downloaded: 0,
     })
+  })
+
+  it('cancels a queued lock when the account resets', async () => {
+    const request = vi.fn(
+      (_name: string, options: LockOptions) =>
+        new Promise((_resolve, reject) => {
+          options.signal?.addEventListener('abort', () =>
+            reject(new DOMException('Canceled', 'AbortError')),
+          )
+        }),
+    )
+    vi.stubGlobal('navigator', { locks: { request } })
+    const service = new CloudSyncService()
+    const pending = service.smartSync()
+
+    service.resetForAccountChange()
+
+    await expect(pending).rejects.toMatchObject({
+      name: 'CloudSyncLifecycleCanceledError',
+      code: 'CLOUD_SYNC_LIFECYCLE_CANCELED',
+      reason: 'account-reset',
+    })
+    expect(service.syncing).toBe(false)
   })
 
   it('cancels queued work after another tab disables cloud sync', async () => {
@@ -531,7 +561,9 @@ describe('CloudSyncService', () => {
     )
     grantLock()
 
-    await expect(pending).rejects.toBeInstanceOf(CloudSyncDisabledError)
+    await expect(pending).rejects.toBeInstanceOf(
+      CloudSyncLifecycleCanceledError,
+    )
     expect(mockIsAuthenticated).not.toHaveBeenCalled()
   })
 
@@ -583,7 +615,7 @@ describe('CloudSyncService', () => {
     expect(mockChatEventsEmit).toHaveBeenCalledWith({ reason: 'sync', ids: [] })
   })
 
-  it('refreshes follower chat state when another tab advances deletions', () => {
+  it('refreshes follower chat state when another tab publishes a deletion', () => {
     let publishFrame!: FrameRequestCallback
     vi.stubGlobal(
       'requestAnimationFrame',
@@ -595,7 +627,7 @@ describe('CloudSyncService', () => {
     new CloudSyncService()
 
     window.dispatchEvent(
-      new StorageEvent('storage', { key: SYNC_CHAT_DELETES_WATERMARK }),
+      new StorageEvent('storage', { key: SYNC_CHAT_DELETION_REVISION }),
     )
     expect(mockChatEventsEmit).not.toHaveBeenCalled()
     publishFrame(performance.now())
@@ -992,6 +1024,32 @@ describe('CloudSyncService', () => {
       expect(result.errors).toHaveLength(1)
       expect(mockFinalizeUpload).not.toHaveBeenCalled()
     })
+
+    it('does not count an unavailable auth token as uploaded', async () => {
+      const chat = {
+        id: 'auth-pending-chat',
+        title: 'Unsynced',
+        messages: [{ role: 'user', content: 'hi' }],
+        createdAt: '2024-01-01T00:00:00.000Z',
+        updatedAt: '2024-01-01T00:00:00.000Z',
+        isBlankChat: false,
+        isLocalOnly: false,
+        locallyModified: true,
+        syncVersion: 1,
+      }
+      mockGetUnsyncedChats.mockResolvedValue([chat])
+      mockGetChat.mockResolvedValue(chat)
+      mockUploadChat.mockRejectedValue(
+        new AuthTokenUnavailableError('not-initialized'),
+      )
+
+      const result = await new CloudSyncService().backupUnsyncedChats()
+
+      expect(result.uploaded).toBe(0)
+      expect(result.errors).toHaveLength(1)
+      expect(mockUploadChat).toHaveBeenCalledOnce()
+      expect(mockFinalizeUpload).not.toHaveBeenCalled()
+    })
   })
 
   describe('checkSyncStatus', () => {
@@ -1351,7 +1409,15 @@ describe('CloudSyncService', () => {
             messages: [{ role: 'user' }],
           },
         ])
-      mockGetChat.mockResolvedValue(null)
+      mockGetChat.mockImplementation(async (id: string) =>
+        id === failedOne.id
+          ? {
+              ...failedOne,
+              decryptionFailed: false,
+              messages: [{ role: 'user' }],
+            }
+          : null,
+      )
       mockGetUnsyncedChats.mockResolvedValue([])
       mockListChats
         .mockResolvedValueOnce({
@@ -1374,7 +1440,7 @@ describe('CloudSyncService', () => {
       expect(mockDeleteChat).toHaveBeenCalledTimes(2)
       expect(mockListChats).toHaveBeenCalledTimes(2)
       expect(mockListChats.mock.calls[1]?.[0]?.continuationToken).toBe('older')
-      expect(mockSaveExistingChat).toHaveBeenCalledWith(failedTwo)
+      expect(mockRestoreDecryptionPlaceholder).toHaveBeenCalledWith(failedTwo)
     })
 
     it('restores placeholders and reports zero when the deep pull fails', async () => {
@@ -1387,7 +1453,22 @@ describe('CloudSyncService', () => {
       await expect(service.retryDecryptionWithNewKey()).resolves.toBe(0)
 
       expect(mockListChats).toHaveBeenCalledTimes(2)
-      expect(mockSaveExistingChat).toHaveBeenCalledWith(failedOne)
+      expect(mockRestoreDecryptionPlaceholder).toHaveBeenCalledWith(failedOne)
+    })
+
+    it('restores an evicted placeholder when opt-out invalidates the generation', async () => {
+      mockGetAllChats.mockResolvedValueOnce([failedOne])
+      mockGetChat.mockResolvedValue(null)
+      mockDeleteChat.mockImplementationOnce(async () => {
+        setCloudSyncEnabled(false)
+      })
+      const service = new CloudSyncService()
+
+      await expect(service.retryDecryptionWithNewKey()).resolves.toBe(0)
+
+      expect(mockRestoreDecryptionPlaceholder).toHaveBeenCalledWith(failedOne)
+      expect(localStorage.getItem(SYNC_CHAT_STATUS)).toBeNull()
+      expect(mockListChats).not.toHaveBeenCalled()
     })
   })
 

--- a/tests/services/cloud/cloud-sync.test.ts
+++ b/tests/services/cloud/cloud-sync.test.ts
@@ -1,9 +1,11 @@
 import {
+  SETTINGS_CLOUD_SYNC_ENABLED,
   SYNC_CHAT_DELETES_WATERMARK,
   SYNC_CHAT_STATUS,
   SYNC_PROJECT_CHAT_STATUS_PREFIX,
 } from '@/constants/storage-keys'
 import {
+  CloudSyncDisabledError,
   CloudSyncService,
   CROSS_TAB_SYNC_LOCK,
   SyncInProgressError,
@@ -13,6 +15,7 @@ import {
   SyncEnclaveError,
   SyncNetworkError,
 } from '@/services/sync-enclave/sync-enclave-client'
+import { setCloudSyncEnabled } from '@/utils/cloud-sync-settings'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mockGetAllChats = vi.fn()
@@ -221,6 +224,7 @@ vi.mock('@/services/cloud/legacy-chat-eviction', () => ({
 describe('CloudSyncService', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    localStorage.setItem(SETTINGS_CLOUD_SYNC_ENABLED, 'true')
     localStorage.removeItem(SYNC_CHAT_STATUS)
     localStorage.removeItem(SYNC_CHAT_DELETES_WATERMARK)
     mockSaveChat.mockResolvedValue(undefined)
@@ -470,6 +474,93 @@ describe('CloudSyncService', () => {
     await expect(
       (service as any).withSyncLock(async () => 'fallback'),
     ).resolves.toBe('fallback')
+  })
+
+  it('cancels a queued lock callback when cloud sync is disabled locally', async () => {
+    let grantLock!: () => void
+    const leaderFinished = new Promise<void>((resolve) => {
+      grantLock = resolve
+    })
+    const request = vi.fn(
+      async (
+        _name: string,
+        _options: LockOptions,
+        callback: (lock: Lock) => Promise<unknown>,
+      ) => {
+        await leaderFinished
+        return callback({ name: CROSS_TAB_SYNC_LOCK, mode: 'exclusive' })
+      },
+    )
+    vi.stubGlobal('navigator', { locks: { request } })
+    const service = new CloudSyncService()
+    const pending = service.smartSync()
+
+    setCloudSyncEnabled(false)
+    setCloudSyncEnabled(true)
+    grantLock()
+
+    await expect(pending).rejects.toBeInstanceOf(CloudSyncDisabledError)
+    await expect(service.smartSync()).resolves.toMatchObject({
+      uploaded: 0,
+      downloaded: 0,
+    })
+  })
+
+  it('cancels queued work after another tab disables cloud sync', async () => {
+    let grantLock!: () => void
+    const leaderFinished = new Promise<void>((resolve) => {
+      grantLock = resolve
+    })
+    const request = vi.fn(
+      async (
+        _name: string,
+        _options: LockOptions,
+        callback: (lock: Lock) => Promise<unknown>,
+      ) => {
+        await leaderFinished
+        return callback({ name: CROSS_TAB_SYNC_LOCK, mode: 'exclusive' })
+      },
+    )
+    vi.stubGlobal('navigator', { locks: { request } })
+    const service = new CloudSyncService()
+    const pending = service.smartSync()
+
+    localStorage.setItem(SETTINGS_CLOUD_SYNC_ENABLED, 'false')
+    window.dispatchEvent(
+      new StorageEvent('storage', { key: SETTINGS_CLOUD_SYNC_ENABLED }),
+    )
+    grantLock()
+
+    await expect(pending).rejects.toBeInstanceOf(CloudSyncDisabledError)
+    expect(mockIsAuthenticated).not.toHaveBeenCalled()
+  })
+
+  it('does not ingest a remote response after cloud sync is disabled', async () => {
+    let finishList:
+      | ((value: {
+          conversations: Array<{ id: string; content: string }>
+          hasMore: boolean
+        }) => void)
+      | undefined
+    mockGetUnsyncedChats.mockResolvedValue([])
+    mockGetAllChats.mockResolvedValue([])
+    mockListChats.mockReturnValue(
+      new Promise((resolve) => {
+        finishList = resolve
+      }),
+    )
+    const service = new CloudSyncService()
+    const sync = service.syncAllChats()
+    await vi.waitFor(() => expect(mockListChats).toHaveBeenCalledOnce())
+
+    setCloudSyncEnabled(false)
+    finishList?.({
+      conversations: [{ id: 'remote-after-opt-out', content: 'plaintext' }],
+      hasMore: false,
+    })
+
+    await expect(sync).resolves.toMatchObject({ downloaded: 0 })
+    expect(mockIngestRemoteChats).not.toHaveBeenCalled()
   })
 
   it('coalesces cross-tab storage updates into one chat refresh', async () => {

--- a/tests/services/cloud/cloud-sync.test.ts
+++ b/tests/services/cloud/cloud-sync.test.ts
@@ -392,7 +392,7 @@ describe('CloudSyncService', () => {
     )
     vi.stubGlobal('navigator', { locks: { request } })
     mockNeedsRecoveryHistorySync.mockReturnValue(true)
-    mockGetUnsyncedChats.mockResolvedValue([])
+    mockGetUnsyncedChatMetadata.mockResolvedValue([])
     mockGetAllChats.mockResolvedValue([])
     mockGetChatSyncStatus.mockResolvedValue({
       count: 2,
@@ -587,7 +587,7 @@ describe('CloudSyncService', () => {
           hasMore: boolean
         }) => void)
       | undefined
-    mockGetUnsyncedChats.mockResolvedValue([])
+    mockGetUnsyncedChatMetadata.mockResolvedValue([])
     mockGetAllChats.mockResolvedValue([])
     mockListChats.mockReturnValue(
       new Promise((resolve) => {
@@ -1050,7 +1050,7 @@ describe('CloudSyncService', () => {
         locallyModified: true,
         syncVersion: 1,
       }
-      mockGetUnsyncedChats.mockResolvedValue([chat])
+      mockGetUnsyncedChatMetadata.mockResolvedValue([chat])
       mockGetChat.mockResolvedValue(chat)
       mockUploadChat.mockRejectedValue(
         new AuthTokenUnavailableError('not-initialized'),
@@ -1414,7 +1414,6 @@ describe('CloudSyncService', () => {
       vi.stubGlobal('navigator', { locks: { request } })
       mockGetAllChats
         .mockResolvedValueOnce([failedOne, failedTwo])
-        .mockResolvedValueOnce([])
         .mockResolvedValueOnce([
           {
             ...failedOne,
@@ -1431,7 +1430,7 @@ describe('CloudSyncService', () => {
             }
           : null,
       )
-      mockGetUnsyncedChats.mockResolvedValue([])
+      mockGetUnsyncedChatMetadata.mockResolvedValue([])
       mockListChats
         .mockResolvedValueOnce({
           conversations: [{ id: 'failed-one', content: 'first' }],
@@ -1459,7 +1458,7 @@ describe('CloudSyncService', () => {
     it('restores placeholders and reports zero when the deep pull fails', async () => {
       mockGetAllChats.mockResolvedValueOnce([failedOne])
       mockGetChat.mockResolvedValue(null)
-      mockGetUnsyncedChats.mockResolvedValue([])
+      mockGetUnsyncedChatMetadata.mockResolvedValue([])
       mockListChats.mockRejectedValue(new SyncNetworkError())
       const service = new CloudSyncService()
 

--- a/tests/services/cloud/cloud-sync.test.ts
+++ b/tests/services/cloud/cloud-sync.test.ts
@@ -583,6 +583,26 @@ describe('CloudSyncService', () => {
     expect(mockChatEventsEmit).toHaveBeenCalledWith({ reason: 'sync', ids: [] })
   })
 
+  it('refreshes follower chat state when another tab advances deletions', () => {
+    let publishFrame!: FrameRequestCallback
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      vi.fn((callback: FrameRequestCallback) => {
+        publishFrame = callback
+        return 1
+      }),
+    )
+    new CloudSyncService()
+
+    window.dispatchEvent(
+      new StorageEvent('storage', { key: SYNC_CHAT_DELETES_WATERMARK }),
+    )
+    expect(mockChatEventsEmit).not.toHaveBeenCalled()
+    publishFrame(performance.now())
+
+    expect(mockChatEventsEmit).toHaveBeenCalledWith({ reason: 'sync', ids: [] })
+  })
+
   describe('backupChat', () => {
     it('skips local-only chats', async () => {
       mockGetChat.mockResolvedValue({

--- a/tests/services/cloud/cloud-sync.test.ts
+++ b/tests/services/cloud/cloud-sync.test.ts
@@ -1,4 +1,3 @@
-import { CLOUD_SYNC } from '@/config'
 import {
   SYNC_CHAT_DELETES_WATERMARK,
   SYNC_CHAT_STATUS,
@@ -323,10 +322,7 @@ describe('CloudSyncService', () => {
     ).resolves.toBe('synced')
     expect(request).toHaveBeenCalledWith(
       CROSS_TAB_SYNC_LOCK,
-      expect.objectContaining({
-        mode: 'exclusive',
-        signal: expect.any(AbortSignal),
-      }),
+      { mode: 'exclusive' },
       expect.any(Function),
     )
   })
@@ -358,60 +354,54 @@ describe('CloudSyncService', () => {
     await expect(pending).resolves.toBe('synced')
   })
 
-  it('throws SyncInProgressError when waiting for the lock times out', async () => {
-    vi.useFakeTimers()
-    try {
-      const request = vi.fn(
-        (_name: string, options: LockOptions) =>
-          new Promise((_resolve, reject) => {
-            options.signal?.addEventListener('abort', () =>
-              reject(new DOMException('Aborted', 'AbortError')),
-            )
-          }),
-      )
-      vi.stubGlobal('navigator', { locks: { request } })
-      const service = new CloudSyncService()
+  it('preserves a queued deep sync and its pagination result', async () => {
+    let grantLock!: () => void
+    const leaderFinished = new Promise<void>((resolve) => {
+      grantLock = resolve
+    })
+    const request = vi.fn(
+      async (
+        _name: string,
+        _options: LockOptions,
+        callback: (lock: Lock) => Promise<unknown>,
+      ) => {
+        await leaderFinished
+        return callback({ name: CROSS_TAB_SYNC_LOCK, mode: 'exclusive' })
+      },
+    )
+    vi.stubGlobal('navigator', { locks: { request } })
+    mockNeedsRecoveryHistorySync.mockReturnValue(true)
+    mockGetUnsyncedChats.mockResolvedValue([])
+    mockGetAllChats.mockResolvedValue([])
+    mockGetChatSyncStatus.mockResolvedValue({
+      count: 2,
+      lastUpdated: '2026-08-12T00:00:00.000Z',
+    })
+    mockListChats
+      .mockResolvedValueOnce({
+        conversations: [{ id: 'first', syncVersion: 1 }],
+        hasMore: true,
+        nextContinuationToken: 'next',
+      })
+      .mockResolvedValueOnce({
+        conversations: [{ id: 'second', syncVersion: 1 }],
+        hasMore: false,
+      })
+    mockIngestRemoteChats.mockResolvedValue({
+      downloaded: 1,
+      errors: [],
+      savedIds: ['saved'],
+    })
+    const service = new CloudSyncService()
 
-      const pending = service.smartSync()
-      const assertion =
-        expect(pending).rejects.toBeInstanceOf(SyncInProgressError)
-      await vi.advanceTimersByTimeAsync(CLOUD_SYNC.CROSS_TAB_SYNC_LOCK_TIMEOUT)
-      await assertion
-      expect(mockIsAuthenticated).not.toHaveBeenCalled()
-    } finally {
-      vi.useRealTimers()
-    }
-  })
+    const pending = service.smartSync()
+    await Promise.resolve()
+    expect(mockListChats).not.toHaveBeenCalled()
 
-  it('does not abort a sync that already acquired the lock', async () => {
-    vi.useFakeTimers()
-    try {
-      const request = vi.fn(
-        async (
-          _name: string,
-          _options: LockOptions,
-          callback: (lock: Lock) => Promise<string>,
-        ) => callback({ name: CROSS_TAB_SYNC_LOCK, mode: 'exclusive' }),
-      )
-      vi.stubGlobal('navigator', { locks: { request } })
-      const service = new CloudSyncService()
-
-      let finishSync!: () => void
-      const pending = (service as any).withSyncLock(
-        () =>
-          new Promise<string>((resolve) => {
-            finishSync = () => resolve('synced')
-          }),
-      ) as Promise<string>
-      await vi.advanceTimersByTimeAsync(
-        CLOUD_SYNC.CROSS_TAB_SYNC_LOCK_TIMEOUT * 2,
-      )
-
-      finishSync()
-      await expect(pending).resolves.toBe('synced')
-    } finally {
-      vi.useRealTimers()
-    }
+    grantLock()
+    await expect(pending).resolves.toMatchObject({ downloaded: 2 })
+    expect(mockListChats).toHaveBeenCalledTimes(2)
+    expect(mockListChats.mock.calls[1]?.[0]?.continuationToken).toBe('next')
   })
 
   it('throws SyncInProgressError for a reentrant sync in the same tab', async () => {
@@ -460,6 +450,26 @@ describe('CloudSyncService', () => {
 
     finishFirst()
     await expect(first).resolves.toBe('first')
+  })
+
+  it('releases tracked state when the Web Locks request is rejected', async () => {
+    const request = vi
+      .fn()
+      .mockRejectedValue(
+        new DOMException('Document inactive', 'InvalidStateError'),
+      )
+    vi.stubGlobal('navigator', { locks: { request } })
+    const service = new CloudSyncService()
+
+    await expect(
+      (service as any).withSyncLock(async () => 'never'),
+    ).rejects.toMatchObject({ name: 'InvalidStateError' })
+    expect(service.syncing).toBe(false)
+
+    vi.stubGlobal('navigator', {})
+    await expect(
+      (service as any).withSyncLock(async () => 'fallback'),
+    ).resolves.toBe('fallback')
   })
 
   it('coalesces cross-tab storage updates into one chat refresh', async () => {

--- a/tests/services/cloud/cloud-sync.test.ts
+++ b/tests/services/cloud/cloud-sync.test.ts
@@ -1313,6 +1313,84 @@ describe('CloudSyncService', () => {
     })
   })
 
+  describe('retryDecryptionWithNewKey', () => {
+    const failedOne = {
+      id: 'failed-one',
+      title: 'Failed one',
+      messages: [],
+      createdAt: '2026-08-01T00:00:00.000Z',
+      updatedAt: '2026-08-01T00:00:00.000Z',
+      decryptionFailed: true,
+      isLocalOnly: false,
+    }
+    const failedTwo = { ...failedOne, id: 'failed-two', title: 'Failed two' }
+
+    it('waits for ownership, deep-syncs, and counts only restored IDs', async () => {
+      let grantLock!: () => void
+      const leaderFinished = new Promise<void>((resolve) => {
+        grantLock = resolve
+      })
+      const request = vi.fn(
+        async (
+          _name: string,
+          _options: LockOptions,
+          callback: (lock: Lock) => Promise<unknown>,
+        ) => {
+          await leaderFinished
+          return callback({ name: CROSS_TAB_SYNC_LOCK, mode: 'exclusive' })
+        },
+      )
+      vi.stubGlobal('navigator', { locks: { request } })
+      mockGetAllChats
+        .mockResolvedValueOnce([failedOne, failedTwo])
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([
+          {
+            ...failedOne,
+            decryptionFailed: false,
+            messages: [{ role: 'user' }],
+          },
+        ])
+      mockGetChat.mockResolvedValue(null)
+      mockGetUnsyncedChats.mockResolvedValue([])
+      mockListChats
+        .mockResolvedValueOnce({
+          conversations: [{ id: 'failed-one', content: 'first' }],
+          hasMore: true,
+          nextContinuationToken: 'older',
+        })
+        .mockResolvedValueOnce({
+          conversations: [{ id: 'failed-two', content: 'second' }],
+          hasMore: false,
+        })
+      const service = new CloudSyncService()
+
+      const retry = service.retryDecryptionWithNewKey()
+      await Promise.resolve()
+      expect(mockDeleteChat).not.toHaveBeenCalled()
+      grantLock()
+
+      await expect(retry).resolves.toBe(1)
+      expect(mockDeleteChat).toHaveBeenCalledTimes(2)
+      expect(mockListChats).toHaveBeenCalledTimes(2)
+      expect(mockListChats.mock.calls[1]?.[0]?.continuationToken).toBe('older')
+      expect(mockSaveExistingChat).toHaveBeenCalledWith(failedTwo)
+    })
+
+    it('restores placeholders and reports zero when the deep pull fails', async () => {
+      mockGetAllChats.mockResolvedValueOnce([failedOne])
+      mockGetChat.mockResolvedValue(null)
+      mockGetUnsyncedChats.mockResolvedValue([])
+      mockListChats.mockRejectedValue(new SyncNetworkError())
+      const service = new CloudSyncService()
+
+      await expect(service.retryDecryptionWithNewKey()).resolves.toBe(0)
+
+      expect(mockListChats).toHaveBeenCalledTimes(2)
+      expect(mockSaveExistingChat).toHaveBeenCalledWith(failedOne)
+    })
+  })
+
   describe('syncAllChats', () => {
     it('builds the ingest map from lightweight sync metadata', async () => {
       const metadata = {

--- a/tests/services/cloud/cloud-sync.test.ts
+++ b/tests/services/cloud/cloud-sync.test.ts
@@ -1,3 +1,4 @@
+import { CLOUD_SYNC } from '@/config'
 import {
   SYNC_CHAT_DELETES_WATERMARK,
   SYNC_CHAT_STATUS,
@@ -6,7 +7,7 @@ import {
 import {
   CloudSyncService,
   CROSS_TAB_SYNC_LOCK,
-  CROSS_TAB_SYNC_LOCK_OPTIONS,
+  SyncInProgressError,
 } from '@/services/cloud/cloud-sync'
 import { deletedChatsTracker } from '@/services/storage/deleted-chats-tracker'
 import {
@@ -311,7 +312,7 @@ describe('CloudSyncService', () => {
       async (
         _name: string,
         _options: LockOptions,
-        callback: (lock: Lock | null) => Promise<string>,
+        callback: (lock: Lock) => Promise<string>,
       ) => callback({ name: CROSS_TAB_SYNC_LOCK, mode: 'exclusive' }),
     )
     vi.stubGlobal('navigator', { locks: { request } })
@@ -322,44 +323,143 @@ describe('CloudSyncService', () => {
     ).resolves.toBe('synced')
     expect(request).toHaveBeenCalledWith(
       CROSS_TAB_SYNC_LOCK,
-      CROSS_TAB_SYNC_LOCK_OPTIONS,
+      expect.objectContaining({
+        mode: 'exclusive',
+        signal: expect.any(AbortSignal),
+      }),
       expect.any(Function),
     )
   })
 
-  it('skips sync when another tab owns the Web Lock', async () => {
+  it('waits for the Web Lock held by another tab, then syncs', async () => {
+    let grantLock!: () => void
+    const lockReleased = new Promise<void>((resolve) => {
+      grantLock = resolve
+    })
     const request = vi.fn(
       async (
         _name: string,
         _options: LockOptions,
-        callback: (lock: Lock | null) => Promise<unknown>,
-      ) => callback(null),
+        callback: (lock: Lock) => Promise<string>,
+      ) => {
+        await lockReleased
+        return callback({ name: CROSS_TAB_SYNC_LOCK, mode: 'exclusive' })
+      },
     )
     vi.stubGlobal('navigator', { locks: { request } })
     const service = new CloudSyncService()
 
-    await expect(
-      (service as any).withSyncLock(async () => 'synced'),
-    ).resolves.toBeUndefined()
+    const fn = vi.fn(async () => 'synced')
+    const pending = (service as any).withSyncLock(fn) as Promise<string>
+    await Promise.resolve()
+    expect(fn).not.toHaveBeenCalled()
+
+    grantLock()
+    await expect(pending).resolves.toBe('synced')
   })
 
-  it('skips smart sync before network checks when another tab owns the lock', async () => {
+  it('throws SyncInProgressError when waiting for the lock times out', async () => {
+    vi.useFakeTimers()
+    try {
+      const request = vi.fn(
+        (_name: string, options: LockOptions) =>
+          new Promise((_resolve, reject) => {
+            options.signal?.addEventListener('abort', () =>
+              reject(new DOMException('Aborted', 'AbortError')),
+            )
+          }),
+      )
+      vi.stubGlobal('navigator', { locks: { request } })
+      const service = new CloudSyncService()
+
+      const pending = service.smartSync()
+      const assertion =
+        expect(pending).rejects.toBeInstanceOf(SyncInProgressError)
+      await vi.advanceTimersByTimeAsync(CLOUD_SYNC.CROSS_TAB_SYNC_LOCK_TIMEOUT)
+      await assertion
+      expect(mockIsAuthenticated).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('does not abort a sync that already acquired the lock', async () => {
+    vi.useFakeTimers()
+    try {
+      const request = vi.fn(
+        async (
+          _name: string,
+          _options: LockOptions,
+          callback: (lock: Lock) => Promise<string>,
+        ) => callback({ name: CROSS_TAB_SYNC_LOCK, mode: 'exclusive' }),
+      )
+      vi.stubGlobal('navigator', { locks: { request } })
+      const service = new CloudSyncService()
+
+      let finishSync!: () => void
+      const pending = (service as any).withSyncLock(
+        () =>
+          new Promise<string>((resolve) => {
+            finishSync = () => resolve('synced')
+          }),
+      ) as Promise<string>
+      await vi.advanceTimersByTimeAsync(
+        CLOUD_SYNC.CROSS_TAB_SYNC_LOCK_TIMEOUT * 2,
+      )
+
+      finishSync()
+      await expect(pending).resolves.toBe('synced')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('throws SyncInProgressError for a reentrant sync in the same tab', async () => {
     const request = vi.fn(
       async (
         _name: string,
         _options: LockOptions,
-        callback: (lock: Lock | null) => Promise<unknown>,
-      ) => callback(null),
+        callback: (lock: Lock) => Promise<string>,
+      ) => callback({ name: CROSS_TAB_SYNC_LOCK, mode: 'exclusive' }),
     )
     vi.stubGlobal('navigator', { locks: { request } })
     const service = new CloudSyncService()
 
-    await expect(service.smartSync()).resolves.toEqual({
-      uploaded: 0,
-      downloaded: 0,
-      errors: [],
-    })
-    expect(mockIsAuthenticated).not.toHaveBeenCalled()
+    let finishFirst!: () => void
+    const first = (service as any).withSyncLock(
+      () =>
+        new Promise<string>((resolve) => {
+          finishFirst = () => resolve('first')
+        }),
+    ) as Promise<string>
+    await vi.waitFor(() => expect(request).toHaveBeenCalled())
+
+    await expect(
+      (service as any).withSyncLock(async () => 'second'),
+    ).rejects.toBeInstanceOf(SyncInProgressError)
+
+    finishFirst()
+    await expect(first).resolves.toBe('first')
+  })
+
+  it('falls back to the in-tab lock when Web Locks are unavailable', async () => {
+    vi.stubGlobal('navigator', {})
+    const service = new CloudSyncService()
+
+    let finishFirst!: () => void
+    const first = (service as any).withSyncLock(
+      () =>
+        new Promise<string>((resolve) => {
+          finishFirst = () => resolve('first')
+        }),
+    ) as Promise<string>
+
+    await expect(
+      (service as any).withSyncLock(async () => 'second'),
+    ).rejects.toBeInstanceOf(SyncInProgressError)
+
+    finishFirst()
+    await expect(first).resolves.toBe('first')
   })
 
   it('coalesces cross-tab storage updates into one chat refresh', async () => {

--- a/tests/services/cloud/cloud-sync.test.ts
+++ b/tests/services/cloud/cloud-sync.test.ts
@@ -3,13 +3,16 @@ import {
   SYNC_CHAT_STATUS,
   SYNC_PROJECT_CHAT_STATUS_PREFIX,
 } from '@/constants/storage-keys'
-import { CloudSyncService } from '@/services/cloud/cloud-sync'
+import {
+  CloudSyncService,
+  SyncInProgressError,
+} from '@/services/cloud/cloud-sync'
 import { deletedChatsTracker } from '@/services/storage/deleted-chats-tracker'
 import {
   SyncEnclaveError,
   SyncNetworkError,
 } from '@/services/sync-enclave/sync-enclave-client'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mockGetAllChats = vi.fn()
 const mockGetCloudChatCount = vi.fn()
@@ -296,6 +299,58 @@ describe('CloudSyncService', () => {
       reconciled: true,
       failed: false,
     })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('coordinates sync ownership through the Web Locks API', async () => {
+    const request = vi.fn(
+      async (
+        _name: string,
+        _options: LockOptions,
+        callback: (lock: Lock | null) => Promise<string>,
+      ) => callback({ name: 'tinfoil-cloud-sync', mode: 'exclusive' }),
+    )
+    vi.stubGlobal('navigator', { locks: { request } })
+    const service = new CloudSyncService()
+
+    await expect(
+      (service as any).withSyncLock(async () => 'synced'),
+    ).resolves.toBe('synced')
+    expect(request).toHaveBeenCalledWith(
+      'tinfoil-cloud-sync',
+      { ifAvailable: true, mode: 'exclusive' },
+      expect.any(Function),
+    )
+  })
+
+  it('skips sync when another tab owns the Web Lock', async () => {
+    const request = vi.fn(
+      async (
+        _name: string,
+        _options: LockOptions,
+        callback: (lock: Lock | null) => Promise<unknown>,
+      ) => callback(null),
+    )
+    vi.stubGlobal('navigator', { locks: { request } })
+    const service = new CloudSyncService()
+
+    await expect(
+      (service as any).withSyncLock(async () => 'synced'),
+    ).rejects.toBeInstanceOf(SyncInProgressError)
+  })
+
+  it('coalesces cross-tab storage updates into one chat refresh', async () => {
+    const service = new CloudSyncService()
+
+    ;(service as any).queueCrossTabReload()
+    ;(service as any).queueCrossTabReload()
+    await Promise.resolve()
+
+    expect(mockChatEventsEmit).toHaveBeenCalledTimes(1)
+    expect(mockChatEventsEmit).toHaveBeenCalledWith({ reason: 'sync', ids: [] })
   })
 
   describe('backupChat', () => {

--- a/tests/services/cloud/cloud-sync.test.ts
+++ b/tests/services/cloud/cloud-sync.test.ts
@@ -7,6 +7,8 @@ import {
 } from '@/constants/storage-keys'
 import { AuthTokenUnavailableError } from '@/services/auth'
 import {
+  CloudSyncCoordinationUnavailableError,
+  CloudSyncDisabledError,
   CloudSyncLifecycleCanceledError,
   CloudSyncService,
   CROSS_TAB_SYNC_LOCK,
@@ -229,6 +231,15 @@ vi.mock('@/services/cloud/legacy-chat-eviction', () => ({
 describe('CloudSyncService', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.stubGlobal('navigator', {
+      locks: {
+        request: async (
+          _name: string,
+          _options: LockOptions,
+          callback: (lock: Lock) => Promise<unknown>,
+        ) => callback({ name: CROSS_TAB_SYNC_LOCK, mode: 'exclusive' }),
+      },
+    })
     localStorage.setItem(SETTINGS_CLOUD_SYNC_ENABLED, 'true')
     localStorage.removeItem(SYNC_CHAT_STATUS)
     localStorage.removeItem(SYNC_CHAT_DELETES_WATERMARK)
@@ -442,24 +453,25 @@ describe('CloudSyncService', () => {
     await expect(first).resolves.toBe('first')
   })
 
-  it('falls back to the in-tab lock when Web Locks are unavailable', async () => {
+  it('fails before sync work when Web Locks are unavailable', async () => {
     vi.stubGlobal('navigator', {})
     const service = new CloudSyncService()
+    const sync = vi.fn(async () => 'synced')
 
-    let finishFirst!: () => void
-    const first = (service as any).withSyncLock(
-      () =>
-        new Promise<string>((resolve) => {
-          finishFirst = () => resolve('first')
-        }),
-    ) as Promise<string>
+    await expect((service as any).withSyncLock(sync)).rejects.toBeInstanceOf(
+      CloudSyncCoordinationUnavailableError,
+    )
+    expect(sync).not.toHaveBeenCalled()
+    expect(service.syncing).toBe(false)
+  })
+
+  it('handles non-browser sync callers without requiring Web Locks', async () => {
+    const service = new CloudSyncService()
+    vi.stubGlobal('window', undefined)
 
     await expect(
-      (service as any).withSyncLock(async () => 'second'),
-    ).rejects.toBeInstanceOf(SyncInProgressError)
-
-    finishFirst()
-    await expect(first).resolves.toBe('first')
+      (service as any).withSyncLock(async () => 'synced'),
+    ).rejects.toBeInstanceOf(CloudSyncDisabledError)
   })
 
   it('releases tracked state when the Web Locks request is rejected', async () => {
@@ -479,7 +491,8 @@ describe('CloudSyncService', () => {
     vi.stubGlobal('navigator', {})
     await expect(
       (service as any).withSyncLock(async () => 'fallback'),
-    ).resolves.toBe('fallback')
+    ).rejects.toBeInstanceOf(CloudSyncCoordinationUnavailableError)
+    expect(service.syncing).toBe(false)
   })
 
   it('cancels a never-granted lock on opt-out and syncs after re-enable', async () => {

--- a/tests/services/cloud/cloud-sync.test.ts
+++ b/tests/services/cloud/cloud-sync.test.ts
@@ -5,7 +5,8 @@ import {
 } from '@/constants/storage-keys'
 import {
   CloudSyncService,
-  SyncInProgressError,
+  CROSS_TAB_SYNC_LOCK,
+  CROSS_TAB_SYNC_LOCK_OPTIONS,
 } from '@/services/cloud/cloud-sync'
 import { deletedChatsTracker } from '@/services/storage/deleted-chats-tracker'
 import {
@@ -311,7 +312,7 @@ describe('CloudSyncService', () => {
         _name: string,
         _options: LockOptions,
         callback: (lock: Lock | null) => Promise<string>,
-      ) => callback({ name: 'tinfoil-cloud-sync', mode: 'exclusive' }),
+      ) => callback({ name: CROSS_TAB_SYNC_LOCK, mode: 'exclusive' }),
     )
     vi.stubGlobal('navigator', { locks: { request } })
     const service = new CloudSyncService()
@@ -320,8 +321,8 @@ describe('CloudSyncService', () => {
       (service as any).withSyncLock(async () => 'synced'),
     ).resolves.toBe('synced')
     expect(request).toHaveBeenCalledWith(
-      'tinfoil-cloud-sync',
-      { ifAvailable: true, mode: 'exclusive' },
+      CROSS_TAB_SYNC_LOCK,
+      CROSS_TAB_SYNC_LOCK_OPTIONS,
       expect.any(Function),
     )
   })
@@ -339,15 +340,43 @@ describe('CloudSyncService', () => {
 
     await expect(
       (service as any).withSyncLock(async () => 'synced'),
-    ).rejects.toBeInstanceOf(SyncInProgressError)
+    ).resolves.toBeUndefined()
+  })
+
+  it('skips smart sync before network checks when another tab owns the lock', async () => {
+    const request = vi.fn(
+      async (
+        _name: string,
+        _options: LockOptions,
+        callback: (lock: Lock | null) => Promise<unknown>,
+      ) => callback(null),
+    )
+    vi.stubGlobal('navigator', { locks: { request } })
+    const service = new CloudSyncService()
+
+    await expect(service.smartSync()).resolves.toEqual({
+      uploaded: 0,
+      downloaded: 0,
+      errors: [],
+    })
+    expect(mockIsAuthenticated).not.toHaveBeenCalled()
   })
 
   it('coalesces cross-tab storage updates into one chat refresh', async () => {
+    let publishFrame!: FrameRequestCallback
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      vi.fn((callback: FrameRequestCallback) => {
+        publishFrame = callback
+        return 1
+      }),
+    )
     const service = new CloudSyncService()
 
     ;(service as any).queueCrossTabReload()
     ;(service as any).queueCrossTabReload()
-    await Promise.resolve()
+    expect(mockChatEventsEmit).not.toHaveBeenCalled()
+    publishFrame(performance.now())
 
     expect(mockChatEventsEmit).toHaveBeenCalledTimes(1)
     expect(mockChatEventsEmit).toHaveBeenCalledWith({ reason: 'sync', ids: [] })

--- a/tests/services/cloud/edit-clock.test.ts
+++ b/tests/services/cloud/edit-clock.test.ts
@@ -9,15 +9,21 @@
 import { SYNC_EDIT_CLOCK } from '@/constants/storage-keys'
 import {
   deviceId,
+  EditClockRandomnessUnavailableError,
   nextClock,
   observe,
   resetEditClockCache,
 } from '@/services/cloud/edit-clock'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 beforeEach(() => {
   localStorage.clear()
   resetEditClockCache()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
 })
 
 describe('edit clock', () => {
@@ -51,6 +57,33 @@ describe('edit clock', () => {
     expect(id).toBeTruthy()
     expect(deviceId()).toBe(id)
     expect(nextClock().w).toBe(id)
+  })
+
+  it('fails explicitly when secure randomness is unavailable', () => {
+    vi.stubGlobal('crypto', {})
+
+    expect(() => deviceId()).toThrow(EditClockRandomnessUnavailableError)
+  })
+
+  it('uses strong in-memory IDs when local storage is unavailable', () => {
+    const randomUUID = vi
+      .spyOn(globalThis.crypto, 'randomUUID')
+      .mockReturnValueOnce('11111111-1111-4111-8111-111111111111')
+      .mockReturnValueOnce('22222222-2222-4222-8222-222222222222')
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new DOMException('Storage unavailable', 'SecurityError')
+    })
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new DOMException('Storage unavailable', 'SecurityError')
+    })
+
+    const id = deviceId()
+
+    expect(id).toBe(
+      '22222222-2222-4222-8222-222222222222.11111111-1111-4111-8111-111111111111',
+    )
+    expect(deviceId()).toBe(id)
+    expect(randomUUID).toHaveBeenCalledTimes(2)
   })
 
   it('persists the counter across cache resets via storage', () => {

--- a/tests/services/storage/indexed-db-metadata-only-save.test.ts
+++ b/tests/services/storage/indexed-db-metadata-only-save.test.ts
@@ -99,6 +99,30 @@ describe('IndexedDB metadata-only chat saves', () => {
     })
   })
 
+  it('recreates an evicted decryption placeholder without marking it dirty', async () => {
+    const storage = new IndexedDBStorage()
+    const placeholder = storedChat('locked-chat', {
+      decryptionFailed: true,
+      locallyModified: false,
+      syncPending: 0,
+      syncVersion: 7,
+    })
+
+    await storage.saveChat(placeholder)
+    await storage.deleteChat(placeholder.id)
+    expect(await storage.getChat(placeholder.id)).toBeNull()
+
+    await storage.restoreDecryptionPlaceholder(placeholder)
+
+    expect(await storage.getChat(placeholder.id)).toMatchObject({
+      id: placeholder.id,
+      decryptionFailed: true,
+      locallyModified: false,
+      syncPending: 0,
+      syncVersion: 7,
+    })
+  })
+
   it('does not resurrect a deleted chat from a stale summary save', async () => {
     const storage = new IndexedDBStorage()
     await storage.saveChat(

--- a/tests/services/sync-enclave/sync-enclave-client.test.ts
+++ b/tests/services/sync-enclave/sync-enclave-client.test.ts
@@ -363,6 +363,26 @@ describe('SyncEnclaveClient', () => {
     expect(vi.getTimerCount()).toBe(0)
   })
 
+  it('aborts active requests during synchronization cleanup', async () => {
+    let requestSignal: AbortSignal | null | undefined
+    mockFetch.mockImplementationOnce((_input, init) => {
+      requestSignal = init?.signal
+      return new Promise(() => {})
+    })
+    const { abortSyncEnclaveRequests, getSyncEnclaveClient } =
+      await import('@/services/sync-enclave/sync-enclave-client')
+    const client = await getSyncEnclaveClient()
+    const request = client.get('/api/keys/current')
+    await vi.waitFor(() => expect(mockFetch).toHaveBeenCalledOnce())
+
+    abortSyncEnclaveRequests()
+
+    await expect(request).rejects.toMatchObject({
+      name: 'SyncRequestAbortedError',
+    })
+    expect(requestSignal?.aborted).toBe(true)
+  })
+
   it('exposes SyncEnclaveError as a real Error subclass', () => {
     const err = new SyncEnclaveError('boom', 409, 'CONFLICT', { foo: 'bar' })
     expect(err).toBeInstanceOf(Error)

--- a/tests/services/sync-enclave/sync-enclave-client.test.ts
+++ b/tests/services/sync-enclave/sync-enclave-client.test.ts
@@ -383,6 +383,25 @@ describe('SyncEnclaveClient', () => {
     expect(requestSignal?.aborted).toBe(true)
   })
 
+  it('does not let canceled initialization evict a fresh client', async () => {
+    mockReady
+      .mockReturnValueOnce(new Promise(() => {}))
+      .mockResolvedValueOnce(undefined)
+    const { abortSyncEnclaveRequests, getSyncEnclaveClient } =
+      await import('@/services/sync-enclave/sync-enclave-client')
+    const canceledClient = getSyncEnclaveClient()
+
+    abortSyncEnclaveRequests()
+    const freshClient = getSyncEnclaveClient()
+
+    await expect(canceledClient).rejects.toMatchObject({
+      name: 'SyncRequestAbortedError',
+    })
+    await expect(freshClient).resolves.toBeDefined()
+    expect(getSyncEnclaveClient()).toBe(freshClient)
+    expect(mockSecureClientConstructor).toHaveBeenCalledTimes(2)
+  })
+
   it('exposes SyncEnclaveError as a real Error subclass', () => {
     const err = new SyncEnclaveError('boom', 409, 'CONFLICT', { foo: 'bar' })
     expect(err).toBeInstanceOf(Error)

--- a/tests/services/sync-enclave/sync-enclave-client.test.ts
+++ b/tests/services/sync-enclave/sync-enclave-client.test.ts
@@ -73,6 +73,7 @@ describe('SyncEnclaveClient', () => {
   })
 
   afterEach(() => {
+    vi.useRealTimers()
     vi.clearAllMocks()
     vi.doUnmock('@/config')
     vi.resetModules()
@@ -105,6 +106,7 @@ describe('SyncEnclaveClient', () => {
     vi.doMock('@/config', () => ({
       SYNC_ENCLAVE_URL: 'http://sync.tinfoil.sh',
       SYNC_ENCLAVE_REPO: 'tinfoilsh/confidential-sync',
+      SYNC_ENCLAVE_TIMEOUTS: { READY_MS: 30000, REQUEST_MS: 30000 },
     }))
     const { getSyncEnclaveClient } =
       await import('@/services/sync-enclave/sync-enclave-client')
@@ -267,6 +269,98 @@ describe('SyncEnclaveClient', () => {
     mockFetch.mockResolvedValueOnce(jsonResponse({ ok: true }))
     const client = await getSyncEnclaveClient()
     expect(client).toBeDefined()
+  })
+
+  it('bounds hung attestation and allows a fresh client retry', async () => {
+    vi.useFakeTimers()
+    vi.resetModules()
+    vi.doMock('@/config', () => ({
+      SYNC_ENCLAVE_URL: 'https://sync.tinfoil.sh',
+      SYNC_ENCLAVE_REPO: 'tinfoilsh/confidential-sync',
+      SYNC_ENCLAVE_TIMEOUTS: { READY_MS: 25, REQUEST_MS: 25 },
+    }))
+    mockReady.mockReturnValueOnce(new Promise(() => {}))
+    const { getSyncEnclaveClient } =
+      await import('@/services/sync-enclave/sync-enclave-client')
+
+    const timedOut = getSyncEnclaveClient()
+    const assertion = expect(timedOut).rejects.toMatchObject({
+      name: 'SyncAttestationTimeoutError',
+      code: 'NETWORK',
+    })
+    await vi.advanceTimersByTimeAsync(25)
+    await assertion
+
+    mockReady.mockResolvedValueOnce(undefined)
+    await expect(getSyncEnclaveClient()).resolves.toBeDefined()
+    expect(mockSecureClientConstructor).toHaveBeenCalledTimes(2)
+  })
+
+  it('aborts a hung fetch when the overall request budget expires', async () => {
+    vi.useFakeTimers()
+    vi.resetModules()
+    vi.doMock('@/config', () => ({
+      SYNC_ENCLAVE_URL: 'https://sync.tinfoil.sh',
+      SYNC_ENCLAVE_REPO: 'tinfoilsh/confidential-sync',
+      SYNC_ENCLAVE_TIMEOUTS: { READY_MS: 25, REQUEST_MS: 25 },
+    }))
+    let requestSignal: AbortSignal | null | undefined
+    mockFetch.mockImplementationOnce((_input, init) => {
+      requestSignal = init?.signal
+      return new Promise(() => {})
+    })
+    const { getSyncEnclaveClient } =
+      await import('@/services/sync-enclave/sync-enclave-client')
+    const client = await getSyncEnclaveClient()
+
+    const request = client.get('/api/keys/current')
+    const assertion = expect(request).rejects.toMatchObject({
+      name: 'SyncRequestTimeoutError',
+      code: 'NETWORK',
+    })
+    await vi.advanceTimersByTimeAsync(25)
+    await assertion
+    expect(requestSignal?.aborted).toBe(true)
+    expect(requestSignal?.reason).toMatchObject({
+      name: 'SyncRequestTimeoutError',
+    })
+  })
+
+  it('uses one overall budget for authentication refresh and replay', async () => {
+    vi.useFakeTimers()
+    vi.resetModules()
+    vi.doMock('@/config', () => ({
+      SYNC_ENCLAVE_URL: 'https://sync.tinfoil.sh',
+      SYNC_ENCLAVE_REPO: 'tinfoilsh/confidential-sync',
+      SYNC_ENCLAVE_TIMEOUTS: { READY_MS: 25, REQUEST_MS: 25 },
+    }))
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ code: 'AUTH' }, { status: 401 }),
+    )
+    mockRefreshToken.mockReturnValueOnce(new Promise(() => {}))
+    const { getSyncEnclaveClient } =
+      await import('@/services/sync-enclave/sync-enclave-client')
+    const client = await getSyncEnclaveClient()
+
+    const request = client.get('/api/keys/current')
+    const assertion = expect(request).rejects.toMatchObject({
+      name: 'SyncRequestTimeoutError',
+    })
+    await vi.advanceTimersByTimeAsync(25)
+    await assertion
+    expect(mockFetch).toHaveBeenCalledOnce()
+  })
+
+  it('cleans up request timers after a successful response', async () => {
+    vi.useFakeTimers()
+    const { getSyncEnclaveClient } =
+      await import('@/services/sync-enclave/sync-enclave-client')
+    mockFetch.mockResolvedValueOnce(jsonResponse({ ok: true }))
+    const client = await getSyncEnclaveClient()
+
+    await client.get('/api/keys/current')
+
+    expect(vi.getTimerCount()).toBe(0)
   })
 
   it('exposes SyncEnclaveError as a real Error subclass', () => {

--- a/tests/services/sync-enclave/sync-enclave-client.test.ts
+++ b/tests/services/sync-enclave/sync-enclave-client.test.ts
@@ -383,6 +383,41 @@ describe('SyncEnclaveClient', () => {
     expect(requestSignal?.aborted).toBe(true)
   })
 
+  it('keeps public requests alive when cloud sync requests are canceled', async () => {
+    let cloudSignal: AbortSignal | null | undefined
+    let publicSignal: AbortSignal | null | undefined
+    let resolvePublic!: (response: Response) => void
+    mockFetch.mockImplementation((input, init) => {
+      if (input.includes('/v1/share/open')) {
+        publicSignal = init?.signal
+        return new Promise<Response>((resolve) => {
+          resolvePublic = resolve
+        })
+      }
+      cloudSignal = init?.signal
+      return new Promise(() => {})
+    })
+    const { abortSyncEnclaveRequests, getSyncEnclaveClient } =
+      await import('@/services/sync-enclave/sync-enclave-client')
+    const client = await getSyncEnclaveClient()
+    const cloudRequest = client.post('/v1/sync/pull', {}, undefined, {
+      requestScope: 'cloud-sync',
+    })
+    const cloudAssertion = expect(cloudRequest).rejects.toMatchObject({
+      name: 'SyncRequestAbortedError',
+    })
+    const publicRequest = client.postPublic('/v1/share/open', {})
+    await vi.waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(2))
+
+    abortSyncEnclaveRequests('cloud-sync')
+
+    await cloudAssertion
+    expect(cloudSignal?.aborted).toBe(true)
+    expect(publicSignal?.aborted).toBe(false)
+    resolvePublic(jsonResponse({ ok: true }))
+    await expect(publicRequest).resolves.toEqual({ ok: true })
+  })
+
   it('does not let canceled initialization evict a fresh client', async () => {
     mockReady
       .mockReturnValueOnce(new Promise(() => {}))


### PR DESCRIPTION
## Summary
- use the Web Locks API so only one tab performs an entire smart-sync cycle for shared account storage
- return a successful no-op in follower tabs while retaining tracked in-tab sync state as a browser fallback
- batch cross-tab status events into one animation-frame metadata refresh

## Testing
- `npx vitest run` (1574 tests)
- `npm run lint`
- `npx tsc --noEmit`