### PR TITLE
Defer archived and intermediate message rendering

### DIFF
--- a/src/components/chat/chat-messages.tsx
+++ b/src/components/chat/chat-messages.tsx
@@ -330,7 +330,6 @@ export function ChatMessages({
   const [expandedArchiveChatId, setExpandedArchiveChatId] = useState<
     string | null
   >(null)
-  const showArchivedMessages = expandedArchiveChatId === chatId
 
   const preparePrint = useCallback(async () => {
     await new Promise<void>((resolve) => {
@@ -514,6 +513,13 @@ export function ChatMessages({
       pendingRecoveryTurnIds.has(turnId),
     ),
   )
+  const archiveHasActiveRecovery = archivedMessages.some(
+    (message) =>
+      message.turnId !== undefined &&
+      pendingRecoveryTurnIds.has(message.turnId),
+  )
+  const showArchivedMessages =
+    expandedArchiveChatId === chatId || archiveHasActiveRecovery
   const hasActiveRecovery =
     activeRecoveryTurns.size > 0 ||
     recoveryDrafts.some((draft) => pendingRecoveryTurnIds.has(draft.turnId))
@@ -630,7 +636,9 @@ export function ChatMessages({
               </div>
             )}
 
-            <MessagesSeparator isDarkMode={isDarkMode} />
+            {showArchivedMessages && (
+              <MessagesSeparator isDarkMode={isDarkMode} />
+            )}
           </>
         )}
 

--- a/src/components/chat/chat-messages.tsx
+++ b/src/components/chat/chat-messages.tsx
@@ -327,6 +327,10 @@ export function ChatMessages({
   const printRef = useRef<HTMLDivElement>(null)
   const printReadyResolverRef = useRef<(() => void) | null>(null)
   const [printRequested, setPrintRequested] = useState(false)
+  const [expandedArchiveChatId, setExpandedArchiveChatId] = useState<
+    string | null
+  >(null)
+  const showArchivedMessages = expandedArchiveChatId === chatId
 
   const preparePrint = useCallback(async () => {
     await new Promise<void>((resolve) => {
@@ -579,39 +583,53 @@ export function ChatMessages({
         {/* Archived Messages - only shown if there are more than the max prompt messages */}
         {archivedMessages.length > 0 && (
           <>
-            <div className={`opacity-70`}>
-              {archivedMessages.map((message, i) => {
-                const key = getMessageKey(`${chatId}-archived`, message, i)
-                const recoveryDraft = recoveryDraftForMessage(message)
-                return (
-                  <React.Fragment key={key}>
-                    <ChatMessage
-                      message={recoveryDraft ?? message}
-                      messageIndex={i}
-                      model={currentModel}
-                      isDarkMode={isDarkMode}
-                      isLastMessage={Boolean(recoveryDraft)}
-                      isStreaming={Boolean(recoveryDraft)}
-                      activeArtifactToolCallId={getMessageActiveArtifactToolCallId(
-                        recoveryDraft ?? message,
-                        activeArtifactToolCallId,
-                      )}
-                      onEditMessage={recoveryDraft ? undefined : onEditMessage}
-                      onRegenerateMessage={
-                        recoveryDraft ? undefined : onRegenerateMessage
-                      }
-                      onRetryToolCall={
-                        recoveryDraft ? undefined : onRetryToolCall
-                      }
-                    />
-                    {showRecoveryStatusAfter(message) && <RecoveryMessage />}
-                    {renderRecoveryAfter(message, i)}
-                  </React.Fragment>
-                )
-              })}
-            </div>
+            {!showArchivedMessages && (
+              <div className="flex justify-center px-4 pb-8">
+                <button
+                  type="button"
+                  onClick={() => setExpandedArchiveChatId(chatId)}
+                  className="hover:bg-surface-secondary rounded-full border border-border-subtle bg-surface-chat px-4 py-2 text-sm text-content-secondary transition-colors hover:text-content-primary"
+                >
+                  Show {archivedMessages.length} earlier messages
+                </button>
+              </div>
+            )}
+            {showArchivedMessages && (
+              <div className="opacity-70">
+                {archivedMessages.map((message, i) => {
+                  const key = getMessageKey(`${chatId}-archived`, message, i)
+                  const recoveryDraft = recoveryDraftForMessage(message)
+                  return (
+                    <React.Fragment key={key}>
+                      <ChatMessage
+                        message={recoveryDraft ?? message}
+                        messageIndex={i}
+                        model={currentModel}
+                        isDarkMode={isDarkMode}
+                        isLastMessage={Boolean(recoveryDraft)}
+                        isStreaming={Boolean(recoveryDraft)}
+                        activeArtifactToolCallId={getMessageActiveArtifactToolCallId(
+                          recoveryDraft ?? message,
+                          activeArtifactToolCallId,
+                        )}
+                        onEditMessage={
+                          recoveryDraft ? undefined : onEditMessage
+                        }
+                        onRegenerateMessage={
+                          recoveryDraft ? undefined : onRegenerateMessage
+                        }
+                        onRetryToolCall={
+                          recoveryDraft ? undefined : onRetryToolCall
+                        }
+                      />
+                      {showRecoveryStatusAfter(message) && <RecoveryMessage />}
+                      {renderRecoveryAfter(message, i)}
+                    </React.Fragment>
+                  )
+                })}
+              </div>
+            )}
 
-            {/* Separator */}
             <MessagesSeparator isDarkMode={isDarkMode} />
           </>
         )}

--- a/src/components/chat/chat-messages.tsx
+++ b/src/components/chat/chat-messages.tsx
@@ -518,6 +518,11 @@ export function ChatMessages({
       message.turnId !== undefined &&
       pendingRecoveryTurnIds.has(message.turnId),
   )
+  // Latch the archive open while a recovery streams into it, so the recovered
+  // turn stays visible after its envelope clears instead of collapsing away.
+  if (archiveHasActiveRecovery && expandedArchiveChatId !== chatId) {
+    setExpandedArchiveChatId(chatId)
+  }
   const showArchivedMessages =
     expandedArchiveChatId === chatId || archiveHasActiveRecovery
   const hasActiveRecovery =

--- a/src/components/chat/chat-messages.tsx
+++ b/src/components/chat/chat-messages.tsx
@@ -410,20 +410,16 @@ export function ChatMessages({
   }, [models, selectedModel])
 
   // Separate messages into archived and live sections - memoize this calculation
-  const { archivedMessages, liveMessages } = useMemo(() => {
+  const computedArchiveStartIndex = useMemo(() => {
     const budget = getHistoryTokenBudget(
       contextWindowTokens ??
         resolveContextWindowTokens(currentModel ?? undefined),
       pendingContextTokens,
     )
-    const startIndex = findContextStartIndex(messages, budget, {
+    return findContextStartIndex(messages, budget, {
       reasoningHistoryPolicy,
       keepMostRecent: pendingContextTokens === 0,
     })
-    return {
-      archivedMessages: messages.slice(0, startIndex),
-      liveMessages: messages.slice(startIndex),
-    }
   }, [
     messages,
     contextWindowTokens,
@@ -431,6 +427,46 @@ export function ChatMessages({
     reasoningHistoryPolicy,
     pendingContextTokens,
   ])
+  const [archiveBoundary, setArchiveBoundary] = useState(() => ({
+    chatId,
+    initialized: messages.length > 0,
+    startIndex: computedArchiveStartIndex,
+  }))
+  let archiveStartIndex: number
+  if (archiveBoundary.chatId !== chatId) {
+    archiveStartIndex = computedArchiveStartIndex
+    setArchiveBoundary({
+      chatId,
+      initialized: messages.length > 0,
+      startIndex: archiveStartIndex,
+    })
+  } else if (!archiveBoundary.initialized && messages.length > 0) {
+    archiveStartIndex = computedArchiveStartIndex
+    setArchiveBoundary({
+      chatId,
+      initialized: true,
+      startIndex: archiveStartIndex,
+    })
+  } else {
+    archiveStartIndex = Math.min(
+      archiveBoundary.startIndex,
+      computedArchiveStartIndex,
+      messages.length,
+    )
+    if (archiveStartIndex !== archiveBoundary.startIndex) {
+      setArchiveBoundary({
+        ...archiveBoundary,
+        startIndex: archiveStartIndex,
+      })
+    }
+  }
+  const { archivedMessages, liveMessages } = useMemo(
+    () => ({
+      archivedMessages: messages.slice(0, archiveStartIndex),
+      liveMessages: messages.slice(archiveStartIndex),
+    }),
+    [archiveStartIndex, messages],
+  )
 
   useEffect(() => {
     setMounted(true)
@@ -513,10 +549,16 @@ export function ChatMessages({
       pendingRecoveryTurnIds.has(turnId),
     ),
   )
+  const activeOrDraftingRecoveryTurns = new Set(activeRecoveryTurns)
+  for (const draft of recoveryDrafts) {
+    if (pendingRecoveryTurnIds.has(draft.turnId)) {
+      activeOrDraftingRecoveryTurns.add(draft.turnId)
+    }
+  }
   const archiveHasActiveRecovery = archivedMessages.some(
     (message) =>
       message.turnId !== undefined &&
-      pendingRecoveryTurnIds.has(message.turnId),
+      activeOrDraftingRecoveryTurns.has(message.turnId),
   )
   // Latch the archive open while a recovery streams into it, so the recovered
   // turn stays visible after its envelope clears instead of collapsing away.

--- a/src/components/chat/chat-messages.tsx
+++ b/src/components/chat/chat-messages.tsx
@@ -440,6 +440,15 @@ export function ChatMessages({
       initialized: messages.length > 0,
       startIndex: archiveStartIndex,
     })
+  } else if (messages.length === 0) {
+    archiveStartIndex = 0
+    if (archiveBoundary.initialized || archiveBoundary.startIndex !== 0) {
+      setArchiveBoundary({
+        chatId,
+        initialized: false,
+        startIndex: 0,
+      })
+    }
   } else if (!archiveBoundary.initialized && messages.length > 0) {
     archiveStartIndex = computedArchiveStartIndex
     setArchiveBoundary({

--- a/src/components/chat/hooks/streaming/animation-frame-publisher.ts
+++ b/src/components/chat/hooks/streaming/animation-frame-publisher.ts
@@ -3,8 +3,7 @@ type UpdateCallback<T> = (value: T) => void | Promise<void>
 export class AnimationFramePublisher<T> {
   private leadingPublished = false
   private cancelled = false
-  private pendingValue: T | undefined
-  private hasPendingValue = false
+  private pendingFactory: (() => T) | null = null
   private frameId: number | null = null
   private frameCompletion: Promise<void> | null = null
   private resolveFrame: (() => void) | null = null
@@ -13,14 +12,17 @@ export class AnimationFramePublisher<T> {
   constructor(private readonly onUpdate: UpdateCallback<T>) {}
 
   publish(value: T): void {
+    this.publishLazy(() => value)
+  }
+
+  publishLazy(factory: () => T): void {
     if (this.cancelled) return
     if (!this.leadingPublished) {
       this.leadingPublished = true
-      this.publication = this.invoke(value)
+      this.publication = this.invoke(factory())
       return
     }
-    this.pendingValue = value
-    this.hasPendingValue = true
+    this.pendingFactory = factory
     if (this.frameCompletion === null) this.scheduleFrame()
   }
 
@@ -29,8 +31,7 @@ export class AnimationFramePublisher<T> {
     if (!this.leadingPublished) {
       this.publish(value)
     } else {
-      this.pendingValue = value
-      this.hasPendingValue = true
+      this.pendingFactory = () => value
       if (document.visibilityState === 'hidden') this.publishPendingNow()
       else if (this.frameCompletion === null) this.scheduleFrame()
     }
@@ -49,8 +50,7 @@ export class AnimationFramePublisher<T> {
 
   cancel(): void {
     this.cancelled = true
-    this.pendingValue = undefined
-    this.hasPendingValue = false
+    this.pendingFactory = null
     if (this.frameId !== null) cancelAnimationFrame(this.frameId)
     this.frameId = null
     this.resolveFrame?.()
@@ -65,17 +65,15 @@ export class AnimationFramePublisher<T> {
     const completion = this.frameCompletion
     this.frameId = requestAnimationFrame(() => {
       this.frameId = null
-      const value = this.pendingValue
-      this.pendingValue = undefined
-      const hasValue = this.hasPendingValue
-      this.hasPendingValue = false
-      if (this.cancelled || !hasValue) {
+      const factory = this.pendingFactory
+      this.pendingFactory = null
+      if (this.cancelled || !factory) {
         this.finishFrame(completion)
         return
       }
       this.publication = this.publication.then(() => {
         if (this.cancelled) return
-        return this.onUpdate(value as T)
+        return this.onUpdate(factory())
       })
       void this.publication.then(
         () => this.finishFrame(completion),
@@ -97,11 +95,10 @@ export class AnimationFramePublisher<T> {
   }
 
   private publishPendingNow(): void {
-    if (!this.hasPendingValue) return
-    const value = this.pendingValue as T
+    const factory = this.pendingFactory
+    if (!factory) return
 
-    this.pendingValue = undefined
-    this.hasPendingValue = false
+    this.pendingFactory = null
     if (this.frameId !== null) cancelAnimationFrame(this.frameId)
     this.frameId = null
     this.resolveFrame?.()
@@ -109,7 +106,7 @@ export class AnimationFramePublisher<T> {
     this.frameCompletion = null
     this.publication = this.publication.then(() => {
       if (this.cancelled) return
-      return this.onUpdate(value)
+      return this.onUpdate(factory())
     })
   }
 
@@ -118,6 +115,6 @@ export class AnimationFramePublisher<T> {
     this.resolveFrame?.()
     this.resolveFrame = null
     this.frameCompletion = null
-    if (!this.cancelled && this.hasPendingValue) this.scheduleFrame()
+    if (!this.cancelled && this.pendingFactory) this.scheduleFrame()
   }
 }

--- a/src/components/chat/hooks/streaming/process-stream.ts
+++ b/src/components/chat/hooks/streaming/process-stream.ts
@@ -47,7 +47,7 @@ export async function processStreamingResponse(
       if (ctx.signal?.aborted) break
       streamLogger?.logParsedEvent(chunk)
       if (session.processChunk(chunk, streamLogger)) {
-        publisher.publish(session.snapshot(ctx.turnId))
+        publisher.publishLazy(() => session.snapshot(ctx.turnId))
       }
     }
 

--- a/src/components/chat/renderers/components/ThoughtProcess.tsx
+++ b/src/components/chat/renderers/components/ThoughtProcess.tsx
@@ -13,6 +13,7 @@ import {
   useCallback,
   useEffect,
   useId,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -36,6 +37,7 @@ export const ThoughtProcess = memo(function ThoughtProcess({
   thinkingDuration,
 }: ThoughtProcessProps) {
   const [isExpanded, setIsExpanded] = useState(false)
+  const [renderContent, setRenderContent] = useState(false)
   const contentId = useId()
 
   const contentRef = useRef<HTMLDivElement>(null)
@@ -52,6 +54,14 @@ export const ThoughtProcess = memo(function ThoughtProcess({
   const handleToggle = () => {
     setIsExpanded((prev) => !prev)
   }
+
+  useEffect(() => {
+    if (isExpanded) {
+      setRenderContent(true)
+    } else if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      setRenderContent(false)
+    }
+  }, [isExpanded])
 
   const generateSummary = useCallback(
     async (
@@ -229,8 +239,9 @@ export const ThoughtProcess = memo(function ThoughtProcess({
   }, [isThinking])
 
   // Measure content height for smooth animation
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (contentRef.current) {
+      setContentHeight(contentRef.current.scrollHeight)
       const resizeObserver = new ResizeObserver(() => {
         if (contentRef.current) {
           setContentHeight((prevHeight) => {
@@ -247,15 +258,15 @@ export const ThoughtProcess = memo(function ThoughtProcess({
       resizeObserver.observe(contentRef.current)
       return () => resizeObserver.disconnect()
     }
-  }, [thoughts, isThinking, isExpanded])
+  }, [thoughts, isThinking, isExpanded, renderContent])
 
   const { remarkPlugins, rehypePlugins } = useMathPlugins()
   const sanitizedThoughts = useMemo(() => {
-    if (!isExpanded) return ''
+    if (!renderContent) return ''
     const preprocessed = preprocessMarkdown(thoughts)
     const processedThoughts = processLatexTags(preprocessed)
     return sanitizeUnsupportedMathBlocks(processedThoughts)
-  }, [isExpanded, thoughts])
+  }, [renderContent, thoughts])
 
   if (shouldDiscard || (!thoughts.trim() && !isThinking)) {
     return null
@@ -333,8 +344,13 @@ export const ThoughtProcess = memo(function ThoughtProcess({
         style={{
           maxHeight: isExpanded ? `${contentHeight}px` : '0px',
         }}
+        onTransitionEnd={(event) => {
+          if (event.target === event.currentTarget && !isExpanded) {
+            setRenderContent(false)
+          }
+        }}
       >
-        {isExpanded && (
+        {renderContent && (
           <div
             ref={contentRef}
             className="ml-2 border-l-2 border-border-subtle py-2 pl-3 pr-1 text-sm text-content-primary/70"

--- a/src/components/chat/renderers/components/ThoughtProcess.tsx
+++ b/src/components/chat/renderers/components/ThoughtProcess.tsx
@@ -241,7 +241,13 @@ export const ThoughtProcess = memo(function ThoughtProcess({
   // Measure content height for smooth animation
   useLayoutEffect(() => {
     if (contentRef.current) {
-      setContentHeight(contentRef.current.scrollHeight)
+      const measuredHeight = contentRef.current.scrollHeight
+      setContentHeight((prevHeight) =>
+        // Same never-shrink guard as the ResizeObserver below: this effect
+        // re-runs on every streaming chunk, and shrinking mid-stream causes
+        // scroll resets when content temporarily contracts.
+        isThinking ? Math.max(prevHeight, measuredHeight) : measuredHeight,
+      )
       const resizeObserver = new ResizeObserver(() => {
         if (contentRef.current) {
           setContentHeight((prevHeight) => {

--- a/src/components/chat/renderers/components/ThoughtProcess.tsx
+++ b/src/components/chat/renderers/components/ThoughtProcess.tsx
@@ -8,7 +8,15 @@ import {
 } from '@/utils/latex-processing'
 import { preprocessMarkdown } from '@/utils/markdown-preprocessing'
 import { sanitizeUrl } from '@braintree/sanitize-url'
-import { memo, useCallback, useEffect, useId, useRef, useState } from 'react'
+import {
+  memo,
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
 import ReactMarkdown from 'react-markdown'
 import { useMathPlugins } from './use-math-plugins'
 
@@ -239,12 +247,15 @@ export const ThoughtProcess = memo(function ThoughtProcess({
       resizeObserver.observe(contentRef.current)
       return () => resizeObserver.disconnect()
     }
-  }, [thoughts, isThinking])
+  }, [thoughts, isThinking, isExpanded])
 
   const { remarkPlugins, rehypePlugins } = useMathPlugins()
-  const preprocessed = preprocessMarkdown(thoughts)
-  const processedThoughts = processLatexTags(preprocessed)
-  const sanitizedThoughts = sanitizeUnsupportedMathBlocks(processedThoughts)
+  const sanitizedThoughts = useMemo(() => {
+    if (!isExpanded) return ''
+    const preprocessed = preprocessMarkdown(thoughts)
+    const processedThoughts = processLatexTags(preprocessed)
+    return sanitizeUnsupportedMathBlocks(processedThoughts)
+  }, [isExpanded, thoughts])
 
   if (shouldDiscard || (!thoughts.trim() && !isThinking)) {
     return null
@@ -323,100 +334,102 @@ export const ThoughtProcess = memo(function ThoughtProcess({
           maxHeight: isExpanded ? `${contentHeight}px` : '0px',
         }}
       >
-        <div
-          ref={contentRef}
-          className="ml-2 border-l-2 border-border-subtle py-2 pl-3 pr-1 text-sm text-content-primary/70"
-          translate="no"
-        >
-          <ReactMarkdown
-            remarkPlugins={remarkPlugins}
-            rehypePlugins={rehypePlugins}
-            components={{
-              p: ({ children }: { children?: React.ReactNode }) => (
-                <p className="mb-1.5 break-words last:mb-0">{children}</p>
-              ),
-              pre: ({ children }: { children?: React.ReactNode }) => (
-                <pre className="my-1.5 overflow-x-auto rounded-md border border-border-subtle bg-surface-chat p-2.5 font-mono text-[11px] text-content-primary">
-                  {children}
-                </pre>
-              ),
-              code: ({
-                inline,
-                children,
-              }: {
-                inline?: boolean
-                children?: React.ReactNode
-              }) =>
-                inline ? (
-                  <code className="inline break-words rounded border border-border-subtle bg-surface-chat px-1 py-0.5 align-baseline font-mono text-[11px] text-content-primary">
-                    {children}
-                  </code>
-                ) : (
-                  <code className="block break-all font-mono text-[11px] text-content-primary">
-                    {children}
-                  </code>
+        {isExpanded && (
+          <div
+            ref={contentRef}
+            className="ml-2 border-l-2 border-border-subtle py-2 pl-3 pr-1 text-sm text-content-primary/70"
+            translate="no"
+          >
+            <ReactMarkdown
+              remarkPlugins={remarkPlugins}
+              rehypePlugins={rehypePlugins}
+              components={{
+                p: ({ children }: { children?: React.ReactNode }) => (
+                  <p className="mb-1.5 break-words last:mb-0">{children}</p>
                 ),
-              a: ({ children, href }: any) => {
-                if (href?.startsWith('#cite-')) {
-                  const tildeIndex = href.indexOf('~')
-                  if (tildeIndex !== -1) {
-                    const rest = href.slice(tildeIndex + 1)
-                    const secondTildeIndex = rest.indexOf('~')
-                    if (secondTildeIndex !== -1) {
-                      const url = rest.slice(0, secondTildeIndex)
-                      let title: string
-                      try {
-                        title = decodeURIComponent(
-                          rest.slice(secondTildeIndex + 1),
+                pre: ({ children }: { children?: React.ReactNode }) => (
+                  <pre className="my-1.5 overflow-x-auto rounded-md border border-border-subtle bg-surface-chat p-2.5 font-mono text-[11px] text-content-primary">
+                    {children}
+                  </pre>
+                ),
+                code: ({
+                  inline,
+                  children,
+                }: {
+                  inline?: boolean
+                  children?: React.ReactNode
+                }) =>
+                  inline ? (
+                    <code className="inline break-words rounded border border-border-subtle bg-surface-chat px-1 py-0.5 align-baseline font-mono text-[11px] text-content-primary">
+                      {children}
+                    </code>
+                  ) : (
+                    <code className="block break-all font-mono text-[11px] text-content-primary">
+                      {children}
+                    </code>
+                  ),
+                a: ({ children, href }: any) => {
+                  if (href?.startsWith('#cite-')) {
+                    const tildeIndex = href.indexOf('~')
+                    if (tildeIndex !== -1) {
+                      const rest = href.slice(tildeIndex + 1)
+                      const secondTildeIndex = rest.indexOf('~')
+                      if (secondTildeIndex !== -1) {
+                        const url = rest.slice(0, secondTildeIndex)
+                        let title: string
+                        try {
+                          title = decodeURIComponent(
+                            rest.slice(secondTildeIndex + 1),
+                          )
+                        } catch {
+                          title = rest.slice(secondTildeIndex + 1)
+                        }
+                        const sanitizedHref = sanitizeUrl(url)
+                        return (
+                          <a
+                            href={sanitizedHref}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="mx-0.5 inline-flex h-[1.5em] items-center gap-1 whitespace-nowrap rounded-full bg-blue-500/10 px-1.5 !align-baseline text-[10px] font-medium text-blue-500 transition-colors hover:bg-blue-500/20"
+                            title={title || url}
+                          >
+                            {children}
+                          </a>
                         )
-                      } catch {
-                        title = rest.slice(secondTildeIndex + 1)
                       }
-                      const sanitizedHref = sanitizeUrl(url)
+                      const sanitizedHref = sanitizeUrl(rest)
                       return (
                         <a
                           href={sanitizedHref}
                           target="_blank"
                           rel="noopener noreferrer"
                           className="mx-0.5 inline-flex h-[1.5em] items-center gap-1 whitespace-nowrap rounded-full bg-blue-500/10 px-1.5 !align-baseline text-[10px] font-medium text-blue-500 transition-colors hover:bg-blue-500/20"
-                          title={title || url}
                         >
                           {children}
                         </a>
                       )
                     }
-                    const sanitizedHref = sanitizeUrl(rest)
-                    return (
-                      <a
-                        href={sanitizedHref}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="mx-0.5 inline-flex h-[1.5em] items-center gap-1 whitespace-nowrap rounded-full bg-blue-500/10 px-1.5 !align-baseline text-[10px] font-medium text-blue-500 transition-colors hover:bg-blue-500/20"
-                      >
-                        {children}
-                      </a>
-                    )
                   }
-                }
-                if (!href) {
-                  return <span>{children}</span>
-                }
-                return (
-                  <a
-                    href={sanitizeUrl(href)}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-blue-500 underline hover:text-blue-600"
-                  >
-                    {children}
-                  </a>
-                )
-              },
-            }}
-          >
-            {sanitizedThoughts}
-          </ReactMarkdown>
-        </div>
+                  if (!href) {
+                    return <span>{children}</span>
+                  }
+                  return (
+                    <a
+                      href={sanitizeUrl(href)}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-blue-500 underline hover:text-blue-600"
+                    >
+                      {children}
+                    </a>
+                  )
+                },
+              }}
+            >
+              {sanitizedThoughts}
+            </ReactMarkdown>
+          </div>
+        )}
       </div>
     </div>
   )

--- a/tests/components/chat/chat-messages-archive-boundary.test.tsx
+++ b/tests/components/chat/chat-messages-archive-boundary.test.tsx
@@ -157,4 +157,47 @@ describe('ChatMessages archive boundary', () => {
     expect(screen.queryByTestId('message-hydrated-1')).not.toBeInTheDocument()
     expect(screen.getByTestId('message-hydrated-2')).toBeInTheDocument()
   })
+
+  it('reinitializes the collapsed prefix after the same chat temporarily empties', () => {
+    const longChat = [
+      message('user', 'rehydrated-1', 300, 1),
+      message('assistant', 'rehydrated-2', 300, 2),
+      message('user', 'rehydrated-3', 300, 3),
+      message('assistant', 'rehydrated-4', 300, 4),
+    ]
+    const { rerender } = render(
+      <ChatMessages {...props('same-chat', longChat)} />,
+    )
+
+    rerender(<ChatMessages {...props('same-chat', [])} />)
+    rerender(<ChatMessages {...props('same-chat', longChat)} />)
+
+    expect(screen.queryByTestId('message-rehydrated-1')).not.toBeInTheDocument()
+    expect(screen.getByTestId('message-rehydrated-2')).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Show 1 earlier messages' }),
+    ).toBeInTheDocument()
+  })
+
+  it('keeps a blank chat first turn live as the response grows', () => {
+    const firstUserMessage = message('user', 'blank-user', 100, 1)
+    const { rerender } = render(<ChatMessages {...props('blank-chat', [])} />)
+
+    rerender(<ChatMessages {...props('blank-chat', [firstUserMessage])} />)
+    rerender(
+      <ChatMessages
+        {...props('blank-chat', [
+          firstUserMessage,
+          message('assistant', 'blank-assistant', 1000, 2),
+        ])}
+        isStreamingResponse
+      />,
+    )
+
+    expect(screen.getByTestId('message-blank-user')).toBeInTheDocument()
+    expect(screen.getByTestId('message-blank-assistant')).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: /earlier messages/ }),
+    ).not.toBeInTheDocument()
+  })
 })

--- a/tests/components/chat/chat-messages-archive-boundary.test.tsx
+++ b/tests/components/chat/chat-messages-archive-boundary.test.tsx
@@ -135,9 +135,9 @@ describe('ChatMessages archive boundary', () => {
     rerender(<ChatMessages {...props('long-chat', longChat)} />)
 
     expect(screen.queryByTestId('message-long-1')).not.toBeInTheDocument()
-    expect(screen.getByTestId('message-long-2')).toBeInTheDocument()
+    expect(screen.getByTestId('message-long-4')).toBeInTheDocument()
     expect(
-      screen.getByRole('button', { name: 'Show 1 earlier messages' }),
+      screen.getByRole('button', { name: /Show \d+ earlier messages/ }),
     ).toBeInTheDocument()
   })
 
@@ -155,7 +155,10 @@ describe('ChatMessages archive boundary', () => {
     rerender(<ChatMessages {...props('hydrated-chat', longChat)} />)
 
     expect(screen.queryByTestId('message-hydrated-1')).not.toBeInTheDocument()
-    expect(screen.getByTestId('message-hydrated-2')).toBeInTheDocument()
+    expect(screen.getByTestId('message-hydrated-4')).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: /Show \d+ earlier messages/ }),
+    ).toBeInTheDocument()
   })
 
   it('reinitializes the collapsed prefix after the same chat temporarily empties', () => {
@@ -173,9 +176,9 @@ describe('ChatMessages archive boundary', () => {
     rerender(<ChatMessages {...props('same-chat', longChat)} />)
 
     expect(screen.queryByTestId('message-rehydrated-1')).not.toBeInTheDocument()
-    expect(screen.getByTestId('message-rehydrated-2')).toBeInTheDocument()
+    expect(screen.getByTestId('message-rehydrated-4')).toBeInTheDocument()
     expect(
-      screen.getByRole('button', { name: 'Show 1 earlier messages' }),
+      screen.getByRole('button', { name: /Show \d+ earlier messages/ }),
     ).toBeInTheDocument()
   })
 

--- a/tests/components/chat/chat-messages-archive-boundary.test.tsx
+++ b/tests/components/chat/chat-messages-archive-boundary.test.tsx
@@ -1,0 +1,160 @@
+import { ChatMessages } from '@/components/chat/chat-messages'
+import type { Message } from '@/components/chat/types'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/config/models', () => ({
+  findSelectableModel: (_id: string, models: unknown[]) => models[0],
+}))
+
+vi.mock('@/components/chat/renderers/client', () => ({
+  getRendererRegistry: () => ({
+    getMessageRenderer: () => ({
+      render: ({ message }: { message: Message }) => (
+        <div data-testid={`message-${message.turnId}`}>{message.content}</div>
+      ),
+    }),
+  }),
+}))
+
+vi.mock('@/hooks/use-chat-print', () => ({
+  useChatPrint: () => undefined,
+}))
+
+vi.mock('@/components/chat/PrintableChat', () => ({
+  PrintableChat: () => null,
+}))
+
+vi.mock('@/components/chat/WelcomeScreen', () => ({
+  WelcomeScreen: () => null,
+}))
+
+const models = [{ id: 'model-1', contextWindowTokens: 1000 }] as any
+
+function message(
+  role: Message['role'],
+  turnId: string,
+  tokenCount: number,
+  timestamp: number,
+): Message {
+  return {
+    role,
+    turnId,
+    content: 'x'.repeat(tokenCount * 4),
+    timestamp: new Date(timestamp),
+  }
+}
+
+function props(chatId: string, messages: Message[]) {
+  return {
+    chatId,
+    messages,
+    contextWindowTokens: 1000,
+    isDarkMode: false,
+    models,
+    selectedModel: 'model-1',
+  }
+}
+
+describe('ChatMessages archive boundary', () => {
+  it('does not hide visible messages as pending input consumes the budget', () => {
+    const messages = [
+      message('user', 'turn-1-user', 200, 1),
+      message('assistant', 'turn-1-assistant', 200, 2),
+      message('user', 'turn-2-user', 200, 3),
+      message('assistant', 'turn-2-assistant', 200, 4),
+    ]
+    const { rerender } = render(
+      <ChatMessages {...props('chat-1', messages)} pendingContextTokens={0} />,
+    )
+
+    expect(screen.getByTestId('message-turn-1-user')).toBeInTheDocument()
+
+    rerender(
+      <ChatMessages
+        {...props('chat-1', messages)}
+        pendingContextTokens={800}
+      />,
+    )
+
+    expect(screen.getByTestId('message-turn-1-user')).toBeInTheDocument()
+    expect(screen.getByTestId('message-turn-2-assistant')).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: /earlier messages/ }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('keeps the active turn visible as its assistant response grows', () => {
+    const initialMessages = [
+      message('user', 'old-user', 100, 1),
+      message('assistant', 'old-assistant', 100, 2),
+      message('user', 'active-user', 100, 3),
+    ]
+    const { rerender } = render(
+      <ChatMessages
+        {...props('chat-1', initialMessages)}
+        isStreamingResponse
+      />,
+    )
+
+    const streamingMessages = [
+      ...initialMessages,
+      message('assistant', 'active-assistant', 300, 4),
+    ]
+    rerender(
+      <ChatMessages
+        {...props('chat-1', streamingMessages)}
+        isStreamingResponse
+      />,
+    )
+
+    const grownMessages = [
+      ...streamingMessages.slice(0, -1),
+      message('assistant', 'active-assistant', 850, 4),
+    ]
+    rerender(
+      <ChatMessages {...props('chat-1', grownMessages)} isStreamingResponse />,
+    )
+
+    expect(screen.getByTestId('message-active-user')).toBeInTheDocument()
+    expect(screen.getByTestId('message-active-assistant')).toBeInTheDocument()
+  })
+
+  it('initializes a fresh collapsed prefix when the chat changes', () => {
+    const shortChat = [message('user', 'short-message', 100, 1)]
+    const longChat = [
+      message('user', 'long-1', 300, 1),
+      message('assistant', 'long-2', 300, 2),
+      message('user', 'long-3', 300, 3),
+      message('assistant', 'long-4', 300, 4),
+    ]
+    const { rerender } = render(
+      <ChatMessages {...props('short-chat', shortChat)} />,
+    )
+
+    rerender(<ChatMessages {...props('long-chat', longChat)} />)
+
+    expect(screen.queryByTestId('message-long-1')).not.toBeInTheDocument()
+    expect(screen.getByTestId('message-long-2')).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Show 1 earlier messages' }),
+    ).toBeInTheDocument()
+  })
+
+  it('initializes the collapsed prefix when an existing chat hydrates', () => {
+    const longChat = [
+      message('user', 'hydrated-1', 300, 1),
+      message('assistant', 'hydrated-2', 300, 2),
+      message('user', 'hydrated-3', 300, 3),
+      message('assistant', 'hydrated-4', 300, 4),
+    ]
+    const { rerender } = render(
+      <ChatMessages {...props('hydrated-chat', [])} />,
+    )
+
+    rerender(<ChatMessages {...props('hydrated-chat', longChat)} />)
+
+    expect(screen.queryByTestId('message-hydrated-1')).not.toBeInTheDocument()
+    expect(screen.getByTestId('message-hydrated-2')).toBeInTheDocument()
+  })
+})

--- a/tests/components/chat/chat-messages-recovery.test.tsx
+++ b/tests/components/chat/chat-messages-recovery.test.tsx
@@ -138,6 +138,48 @@ describe('ChatMessages recovery indicator', () => {
       screen.queryByRole('button', { name: /earlier messages/ }),
     ).not.toBeInTheDocument()
   })
+
+  it('keeps the archive expanded after an archived recovery completes', () => {
+    mockFindContextStartIndex.mockReturnValue(1)
+    const latestMessage = {
+      role: 'user' as const,
+      turnId: 'turn-2',
+      content: 'Latest',
+      timestamp: new Date('2026-07-21T00:00:01.000Z'),
+    }
+
+    const { rerender } = render(
+      <ChatMessages {...baseProps} messages={[messages[0], latestMessage]} />,
+    )
+
+    expect(screen.getByTestId('message-turn-1')).toBeInTheDocument()
+
+    // Recovery completes: the envelope clears and the recovered assistant
+    // message lands in the archived slice.
+    mockFindContextStartIndex.mockReturnValue(2)
+    rerender(
+      <ChatMessages
+        {...baseProps}
+        messages={[
+          messages[0],
+          {
+            role: 'assistant',
+            turnId: 'turn-1',
+            content: 'Recovered answer',
+            timestamp: new Date('2026-07-21T00:00:00.500Z'),
+          },
+          latestMessage,
+        ]}
+        pendingRecoveries={[]}
+      />,
+    )
+
+    expect(screen.getByText('user: Question')).toBeInTheDocument()
+    expect(screen.getByText('assistant: Recovered answer')).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: /earlier messages/ }),
+    ).not.toBeInTheDocument()
+  })
   it('renders the recovery widget immediately after its user turn', async () => {
     render(<ChatMessages {...baseProps} />)
 

--- a/tests/components/chat/chat-messages-recovery.test.tsx
+++ b/tests/components/chat/chat-messages-recovery.test.tsx
@@ -1,6 +1,8 @@
 import { ChatMessages } from '@/components/chat/chat-messages'
-import { render, screen, waitFor } from '@testing-library/react'
-import { describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockFindContextStartIndex = vi.hoisted(() => vi.fn(() => 0))
 
 vi.mock('@/config/models', () => ({
   findSelectableModel: (_id: string, models: unknown[]) => models[0],
@@ -43,7 +45,7 @@ vi.mock('@/hooks/use-chat-print', () => ({
 }))
 
 vi.mock('@/utils/token-estimation', () => ({
-  findContextStartIndex: () => 0,
+  findContextStartIndex: mockFindContextStartIndex,
   getContextTokenBudget: () => 1000,
   getHistoryTokenBudget: () => 1000,
   resolveContextWindowTokens: () => 1000,
@@ -82,6 +84,32 @@ const baseProps = {
 }
 
 describe('ChatMessages recovery indicator', () => {
+  beforeEach(() => {
+    mockFindContextStartIndex.mockReturnValue(0)
+  })
+
+  it('defers archived message rendering until requested', () => {
+    mockFindContextStartIndex.mockReturnValue(2)
+    const archivedMessages = [
+      { ...messages[0], turnId: 'archived-1', content: 'First' },
+      { ...messages[0], turnId: 'archived-2', content: 'Second' },
+      { ...messages[0], turnId: 'live', content: 'Latest' },
+    ]
+
+    render(
+      <ChatMessages
+        {...baseProps}
+        messages={archivedMessages}
+        pendingRecoveries={[]}
+      />,
+    )
+
+    expect(screen.queryByTestId('message-archived-1')).not.toBeInTheDocument()
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Show 2 earlier messages' }),
+    )
+    expect(screen.getByTestId('message-archived-1')).toBeInTheDocument()
+  })
   it('renders the recovery widget immediately after its user turn', async () => {
     render(<ChatMessages {...baseProps} />)
 

--- a/tests/components/chat/chat-messages-recovery.test.tsx
+++ b/tests/components/chat/chat-messages-recovery.test.tsx
@@ -92,7 +92,12 @@ describe('ChatMessages recovery indicator', () => {
     mockFindContextStartIndex.mockReturnValue(2)
     const archivedMessages = [
       { ...messages[0], turnId: 'archived-1', content: 'First' },
-      { ...messages[0], turnId: 'archived-2', content: 'Second' },
+      {
+        ...messages[0],
+        turnId: 'archived-2',
+        content: 'Second',
+        timestamp: new Date('2026-07-21T00:00:00.001Z'),
+      },
       { ...messages[0], turnId: 'live', content: 'Latest' },
     ]
 
@@ -109,6 +114,29 @@ describe('ChatMessages recovery indicator', () => {
       screen.getByRole('button', { name: 'Show 2 earlier messages' }),
     )
     expect(screen.getByTestId('message-archived-1')).toBeInTheDocument()
+  })
+
+  it('keeps an archived recovering turn visible', () => {
+    mockFindContextStartIndex.mockReturnValue(1)
+    render(
+      <ChatMessages
+        {...baseProps}
+        messages={[
+          messages[0],
+          {
+            role: 'user',
+            turnId: 'turn-2',
+            content: 'Latest',
+            timestamp: new Date('2026-07-21T00:00:01.000Z'),
+          },
+        ]}
+      />,
+    )
+
+    expect(screen.getByTestId('message-turn-1')).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: /earlier messages/ }),
+    ).not.toBeInTheDocument()
   })
   it('renders the recovery widget immediately after its user turn', async () => {
     render(<ChatMessages {...baseProps} />)

--- a/tests/components/chat/chat-messages-recovery.test.tsx
+++ b/tests/components/chat/chat-messages-recovery.test.tsx
@@ -130,6 +130,7 @@ describe('ChatMessages recovery indicator', () => {
             timestamp: new Date('2026-07-21T00:00:01.000Z'),
           },
         ]}
+        activeRecoveryTurnIds={['turn-1']}
       />,
     )
 
@@ -149,7 +150,11 @@ describe('ChatMessages recovery indicator', () => {
     }
 
     const { rerender } = render(
-      <ChatMessages {...baseProps} messages={[messages[0], latestMessage]} />,
+      <ChatMessages
+        {...baseProps}
+        messages={[messages[0], latestMessage]}
+        activeRecoveryTurnIds={['turn-1']}
+      />,
     )
 
     expect(screen.getByTestId('message-turn-1')).toBeInTheDocument()
@@ -180,6 +185,31 @@ describe('ChatMessages recovery indicator', () => {
       screen.queryByRole('button', { name: /earlier messages/ }),
     ).not.toBeInTheDocument()
   })
+
+  it('keeps a never-started archived recovery collapsed', () => {
+    mockFindContextStartIndex.mockReturnValue(1)
+
+    render(
+      <ChatMessages
+        {...baseProps}
+        messages={[
+          messages[0],
+          {
+            role: 'user',
+            turnId: 'turn-2',
+            content: 'Latest',
+            timestamp: new Date('2026-07-21T00:00:01.000Z'),
+          },
+        ]}
+      />,
+    )
+
+    expect(screen.queryByTestId('message-turn-1')).not.toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Show 1 earlier messages' }),
+    ).toBeInTheDocument()
+  })
+
   it('renders the recovery widget immediately after its user turn', async () => {
     render(<ChatMessages {...baseProps} />)
 

--- a/tests/components/chat/streaming/animation-frame-publisher.test.ts
+++ b/tests/components/chat/streaming/animation-frame-publisher.test.ts
@@ -31,6 +31,23 @@ describe('AnimationFramePublisher', () => {
     await vi.waitFor(() => expect(onUpdate).toHaveBeenCalledTimes(2))
   })
 
+  it('materializes only the latest queued frame value', async () => {
+    const onUpdate = vi.fn()
+    const staleFactory = vi.fn(() => 'stale')
+    const latestFactory = vi.fn(() => 'latest')
+    const publisher = new AnimationFramePublisher<string>(onUpdate)
+
+    publisher.publish('leading')
+    publisher.publishLazy(staleFactory)
+    publisher.publishLazy(latestFactory)
+    frames.shift()?.(performance.now())
+    await vi.waitFor(() => expect(onUpdate).toHaveBeenCalledTimes(2))
+
+    expect(staleFactory).not.toHaveBeenCalled()
+    expect(latestFactory).toHaveBeenCalledOnce()
+    expect(onUpdate).toHaveBeenLastCalledWith('latest')
+  })
+
   it('publishes a final undefined value while hidden', async () => {
     vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('hidden')
     const onUpdate = vi.fn()


### PR DESCRIPTION
## Summary
- keep archived transcript turns collapsed until requested while automatically exposing active recoveries
- avoid parsing collapsed thought Markdown while preserving smooth expand/collapse transitions
- materialize only the latest queued streaming snapshot per animation frame

## Testing
- `npx vitest run` (1577 tests)
- `npm run lint`
- `npx tsc --noEmit`