### PR TITLE
Move large import processing off the main thread

### DIFF
--- a/src/components/chat/artifact-sidebar.tsx
+++ b/src/components/chat/artifact-sidebar.tsx
@@ -84,12 +84,14 @@ export function ArtifactSidebar({
 
     window.addEventListener('pointermove', handlePointerMove)
     window.addEventListener('pointerup', handlePointerUp)
+    window.addEventListener('pointercancel', handlePointerUp)
 
     return () => {
       document.body.style.cursor = ''
       document.body.style.userSelect = ''
       window.removeEventListener('pointermove', handlePointerMove)
       window.removeEventListener('pointerup', handlePointerUp)
+      window.removeEventListener('pointercancel', handlePointerUp)
     }
   }, [clampWidth, isResizing, onWidthChange])
 

--- a/src/components/chat/chat-input.tsx
+++ b/src/components/chat/chat-input.tsx
@@ -281,11 +281,14 @@ export function ChatInput({
   const [isTranscribing, setIsTranscribing] = useState(false)
   const mediaRecorderRef = useRef<MediaRecorder | null>(null)
   const mediaStreamRef = useRef<MediaStream | null>(null)
+  const recordingSessionRef = useRef(0)
   const audioChunksRef = useRef<Blob[]>([])
   const recordingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   useEffect(() => {
+    const recordingSession = recordingSessionRef
     return () => {
+      recordingSession.current++
       if (recordingTimeoutRef.current) {
         clearTimeout(recordingTimeoutRef.current)
         recordingTimeoutRef.current = null
@@ -559,6 +562,7 @@ export function ChatInput({
   }
 
   const startRecording = useCallback(async () => {
+    const recordingSession = ++recordingSessionRef.current
     let stream: MediaStream | null = null
     try {
       stream = await navigator.mediaDevices.getUserMedia({
@@ -569,6 +573,10 @@ export function ChatInput({
           noiseSuppression: true,
         },
       })
+      if (recordingSession !== recordingSessionRef.current) {
+        stream.getTracks().forEach((track) => track.stop())
+        return
+      }
       mediaStreamRef.current = stream
 
       if (!isWebMAudioSupported()) {
@@ -631,6 +639,7 @@ export function ChatInput({
     } catch (err) {
       stream?.getTracks().forEach((track) => track.stop())
       if (mediaStreamRef.current === stream) mediaStreamRef.current = null
+      if (recordingSession !== recordingSessionRef.current) return
       toast({
         title: 'Recording Error',
         description:

--- a/src/components/chat/chat-input.tsx
+++ b/src/components/chat/chat-input.tsx
@@ -280,8 +280,28 @@ export function ChatInput({
   const [isRecording, setIsRecording] = useState(false)
   const [isTranscribing, setIsTranscribing] = useState(false)
   const mediaRecorderRef = useRef<MediaRecorder | null>(null)
+  const mediaStreamRef = useRef<MediaStream | null>(null)
   const audioChunksRef = useRef<Blob[]>([])
   const recordingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    return () => {
+      if (recordingTimeoutRef.current) {
+        clearTimeout(recordingTimeoutRef.current)
+        recordingTimeoutRef.current = null
+      }
+      const recorder = mediaRecorderRef.current
+      if (recorder) {
+        recorder.ondataavailable = null
+        recorder.onstop = null
+        if (recorder.state !== 'inactive') recorder.stop()
+        mediaRecorderRef.current = null
+      }
+      mediaStreamRef.current?.getTracks().forEach((track) => track.stop())
+      mediaStreamRef.current = null
+      audioChunksRef.current = []
+    }
+  }, [])
 
   // --- Input options menu state (the "+" button) ---
   const [isInputMenuOpen, setIsInputMenuOpen] = useState(false)
@@ -539,8 +559,9 @@ export function ChatInput({
   }
 
   const startRecording = useCallback(async () => {
+    let stream: MediaStream | null = null
     try {
-      const stream = await navigator.mediaDevices.getUserMedia({
+      stream = await navigator.mediaDevices.getUserMedia({
         audio: {
           channelCount: 1,
           sampleRate: 44100,
@@ -548,6 +569,7 @@ export function ChatInput({
           noiseSuppression: true,
         },
       })
+      mediaStreamRef.current = stream
 
       if (!isWebMAudioSupported()) {
         throw new Error('WebM audio recording is not supported in this browser')
@@ -569,7 +591,8 @@ export function ChatInput({
       mediaRecorder.onstop = async () => {
         try {
           // Stop all tracks
-          stream.getTracks().forEach((track) => track.stop())
+          stream?.getTracks().forEach((track) => track.stop())
+          if (mediaStreamRef.current === stream) mediaStreamRef.current = null
 
           // Create WebM blob
           const webmBlob = new Blob(audioChunksRef.current, {
@@ -606,6 +629,8 @@ export function ChatInput({
         stopRecording()
       }, CONSTANTS.RECORDING_TIMEOUT_MS)
     } catch (err) {
+      stream?.getTracks().forEach((track) => track.stop())
+      if (mediaStreamRef.current === stream) mediaStreamRef.current = null
       toast({
         title: 'Recording Error',
         description:

--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -523,6 +523,9 @@ export function SettingsModal({
   const claudeConversationsFileInputRef = useRef<HTMLInputElement>(null)
   const claudeProjectsFileInputRef = useRef<HTMLInputElement>(null)
   const tinfoilFileInputRef = useRef<HTMLInputElement>(null)
+  const localTinfoilImportAbortControllerRef = useRef<AbortController | null>(
+    null,
+  )
 
   // Export state
   const [isExporting, setIsExporting] = useState(false)
@@ -1474,9 +1477,15 @@ export function SettingsModal({
     setImportSource('tinfoil')
     setIsImporting(true)
     setImportResult(null)
+    localTinfoilImportAbortControllerRef.current?.abort()
+    const abortController = new AbortController()
+    localTinfoilImportAbortControllerRef.current = abortController
 
     try {
-      const chats = await parseLocalTinfoilExport(file, getParseOptions())
+      const chats = await parseLocalTinfoilExport(file, {
+        ...getParseOptions(),
+        signal: abortController.signal,
+      })
       const { imported, errors } = await saveImportedChats(chats)
 
       setImportResult({
@@ -1495,6 +1504,7 @@ export function SettingsModal({
         description: `Imported ${imported} chat${imported !== 1 ? 's' : ''} from Tinfoil`,
       })
     } catch (err) {
+      if (abortController.signal.aborted) return
       setImportResult({
         success: false,
         chatsImported: 0,
@@ -1507,9 +1517,12 @@ export function SettingsModal({
         variant: 'destructive',
       })
     } finally {
-      setIsImporting(false)
-      setImportProgress(null)
-      e.target.value = ''
+      if (localTinfoilImportAbortControllerRef.current === abortController) {
+        localTinfoilImportAbortControllerRef.current = null
+        setIsImporting(false)
+        setImportProgress(null)
+        e.target.value = ''
+      }
     }
   }
 
@@ -2060,6 +2073,14 @@ export function SettingsModal({
       if (copyTimeoutRef.current) {
         clearTimeout(copyTimeoutRef.current)
       }
+    }
+  }, [])
+
+  useEffect(() => {
+    return () => {
+      const abortController = localTinfoilImportAbortControllerRef.current
+      localTinfoilImportAbortControllerRef.current = null
+      abortController?.abort()
     }
   }, [])
 

--- a/src/services/chat-import/constants.ts
+++ b/src/services/chat-import/constants.ts
@@ -1,0 +1,1 @@
+export const LOCAL_IMPORT_WORKER_TIMEOUT_MS = 10 * 60_000

--- a/src/services/chat-import/local-tinfoil-import-parser.ts
+++ b/src/services/chat-import/local-tinfoil-import-parser.ts
@@ -1,0 +1,70 @@
+import { strFromU8, unzipSync } from 'fflate'
+
+export const TINFOIL_CONVERSATIONS_FILE = 'conversations.json'
+export const TINFOIL_MANIFEST_FILE = 'manifest.json'
+export const TINFOIL_ATTACHMENTS_PREFIX = 'attachments/'
+
+export interface ParsedTinfoilExport<T> {
+  conversations: T[]
+  entries?: Record<string, Uint8Array>
+}
+
+export function collectTransferableBuffers(
+  entries: Record<string, Uint8Array>,
+): ArrayBuffer[] {
+  return Array.from(
+    new Set(
+      Object.values(entries)
+        .map((entry) => entry.buffer)
+        .filter((entry): entry is ArrayBuffer => entry instanceof ArrayBuffer),
+    ),
+  )
+}
+
+export function parseTinfoilExportBytes<T>(options: {
+  bytes: Uint8Array
+  fileName: string
+  mimeType: string
+  maxArchiveBytes: number
+}): ParsedTinfoilExport<T> {
+  const { bytes, fileName, mimeType, maxArchiveBytes } = options
+  const isZip =
+    fileName.toLowerCase().endsWith('.zip') || mimeType === 'application/zip'
+
+  if (!isZip) {
+    const conversations = JSON.parse(new TextDecoder().decode(bytes))
+    if (!Array.isArray(conversations)) {
+      throw new Error('Invalid Tinfoil export format')
+    }
+    return { conversations }
+  }
+
+  let uncompressedBytes = 0
+  const entries = unzipSync(bytes, {
+    filter: (entry) => {
+      const isImportEntry =
+        entry.name === TINFOIL_CONVERSATIONS_FILE ||
+        entry.name === TINFOIL_MANIFEST_FILE ||
+        entry.name.startsWith(TINFOIL_ATTACHMENTS_PREFIX)
+      if (!isImportEntry) return false
+
+      uncompressedBytes += entry.originalSize
+      if (uncompressedBytes > maxArchiveBytes) {
+        throw new Error('The uncompressed export is too large')
+      }
+      return true
+    },
+  })
+  const conversationsEntry = entries[TINFOIL_CONVERSATIONS_FILE]
+  if (!conversationsEntry) {
+    throw new Error(
+      `The Tinfoil export is missing ${TINFOIL_CONVERSATIONS_FILE}`,
+    )
+  }
+
+  const conversations = JSON.parse(strFromU8(conversationsEntry))
+  if (!Array.isArray(conversations)) {
+    throw new Error('Invalid Tinfoil export format')
+  }
+  return { conversations, entries }
+}

--- a/src/services/chat-import/local-tinfoil-import.ts
+++ b/src/services/chat-import/local-tinfoil-import.ts
@@ -1,10 +1,7 @@
-import { strFromU8, unzipSync } from 'fflate'
-
 import type { Attachment, Chat, Message } from '@/components/chat/types'
 import { uint8ArrayToBase64 } from '@/utils/binary-codec'
+import { parseTinfoilExportBytes } from './local-tinfoil-import-parser'
 
-const CONVERSATIONS_FILE = 'conversations.json'
-const MANIFEST_FILE = 'manifest.json'
 export const LOCAL_IMPORT_MAX_ARCHIVE_BYTES = 512 * 1024 * 1024
 
 interface TinfoilExportedAttachment {
@@ -41,12 +38,6 @@ export interface LocalTinfoilImportOptions {
   isCloudSyncEnabled: boolean
 }
 
-function isZip(file: File): boolean {
-  return (
-    file.name.toLowerCase().endsWith('.zip') || file.type === 'application/zip'
-  )
-}
-
 interface ImportWorkerResponse {
   ok: boolean
   conversations?: TinfoilExportedConversation[]
@@ -54,44 +45,18 @@ interface ImportWorkerResponse {
   error?: string
 }
 
+class ImportWorkerUnavailableError extends Error {}
+
 async function readExportOnMainThread(file: File): Promise<{
   conversations: TinfoilExportedConversation[]
   entries?: Record<string, Uint8Array>
 }> {
-  if (!isZip(file)) {
-    const conversations = JSON.parse(await file.text())
-    if (!Array.isArray(conversations)) {
-      throw new Error('Invalid Tinfoil export format')
-    }
-    return { conversations }
-  }
-
-  let uncompressedBytes = 0
-  const entries = unzipSync(new Uint8Array(await file.arrayBuffer()), {
-    filter: (entry) => {
-      const isImportEntry =
-        entry.name === CONVERSATIONS_FILE ||
-        entry.name === MANIFEST_FILE ||
-        entry.name.startsWith('attachments/')
-      if (!isImportEntry) return false
-
-      uncompressedBytes += entry.originalSize
-      if (uncompressedBytes > LOCAL_IMPORT_MAX_ARCHIVE_BYTES) {
-        throw new Error('The uncompressed export is too large')
-      }
-      return true
-    },
+  return parseTinfoilExportBytes<TinfoilExportedConversation>({
+    bytes: new Uint8Array(await file.arrayBuffer()),
+    fileName: file.name,
+    mimeType: file.type,
+    maxArchiveBytes: LOCAL_IMPORT_MAX_ARCHIVE_BYTES,
   })
-  const conversationsEntry = entries[CONVERSATIONS_FILE]
-  if (!conversationsEntry) {
-    throw new Error('The Tinfoil export is missing conversations.json')
-  }
-
-  const conversations = JSON.parse(strFromU8(conversationsEntry))
-  if (!Array.isArray(conversations)) {
-    throw new Error('Invalid Tinfoil export format')
-  }
-  return { conversations, entries }
 }
 
 async function readExport(file: File): Promise<{
@@ -106,10 +71,29 @@ async function readExport(file: File): Promise<{
   }
   if (typeof Worker === 'undefined') return readExportOnMainThread(file)
 
+  try {
+    return await readExportInWorker(file)
+  } catch (error) {
+    if (error instanceof ImportWorkerUnavailableError) {
+      return readExportOnMainThread(file)
+    }
+    throw error
+  }
+}
+
+async function readExportInWorker(file: File): Promise<{
+  conversations: TinfoilExportedConversation[]
+  entries?: Record<string, Uint8Array>
+}> {
   const buffer = await file.arrayBuffer()
-  const worker = new Worker(
-    new URL('./local-tinfoil-import.worker.ts', import.meta.url),
-  )
+  let worker: Worker
+  try {
+    worker = new Worker(
+      new URL('./local-tinfoil-import.worker.ts', import.meta.url),
+    )
+  } catch {
+    throw new ImportWorkerUnavailableError()
+  }
 
   return new Promise((resolve, reject) => {
     worker.onmessage = (event: MessageEvent<ImportWorkerResponse>) => {
@@ -129,7 +113,7 @@ async function readExport(file: File): Promise<{
     }
     worker.onerror = () => {
       worker.terminate()
-      reject(new Error('Failed to process the Tinfoil export'))
+      reject(new ImportWorkerUnavailableError())
     }
     try {
       worker.postMessage(
@@ -141,9 +125,9 @@ async function readExport(file: File): Promise<{
         },
         [buffer],
       )
-    } catch (error) {
+    } catch {
       worker.terminate()
-      reject(error)
+      reject(new ImportWorkerUnavailableError())
     }
   })
 }

--- a/src/services/chat-import/local-tinfoil-import.ts
+++ b/src/services/chat-import/local-tinfoil-import.ts
@@ -1,7 +1,6 @@
 import type { Attachment, Chat, Message } from '@/components/chat/types'
 import { uint8ArrayToBase64 } from '@/utils/binary-codec'
 import { LOCAL_IMPORT_WORKER_TIMEOUT_MS } from './constants'
-import { parseTinfoilExportBytes } from './local-tinfoil-import-parser'
 
 export const LOCAL_IMPORT_MAX_ARCHIVE_BYTES = 512 * 1024 * 1024
 
@@ -47,7 +46,18 @@ interface ImportWorkerResponse {
   error?: string
 }
 
-class ImportWorkerUnavailableError extends Error {}
+export class LocalImportBackgroundProcessingUnavailableError extends Error {
+  readonly code = 'LOCAL_IMPORT_BACKGROUND_PROCESSING_UNAVAILABLE'
+
+  constructor(options?: ErrorOptions) {
+    super(
+      'Background file processing is unavailable in this browser. Please try a supported browser.',
+      options,
+    )
+    this.name = 'LocalImportBackgroundProcessingUnavailableError'
+  }
+}
+
 export class LocalImportWorkerTimeoutError extends Error {
   constructor() {
     super('The export took too long to process')
@@ -74,24 +84,6 @@ function isImportWorkerResponse(value: unknown): value is ImportWorkerResponse {
   )
 }
 
-async function readExportOnMainThread(
-  file: File,
-  signal?: AbortSignal,
-): Promise<{
-  conversations: TinfoilExportedConversation[]
-  entries?: Record<string, Uint8Array>
-}> {
-  throwIfAborted(signal)
-  const buffer = await file.arrayBuffer()
-  throwIfAborted(signal)
-  return parseTinfoilExportBytes<TinfoilExportedConversation>({
-    bytes: new Uint8Array(buffer),
-    fileName: file.name,
-    mimeType: file.type,
-    maxArchiveBytes: LOCAL_IMPORT_MAX_ARCHIVE_BYTES,
-  })
-}
-
 async function readExport(
   file: File,
   signal?: AbortSignal,
@@ -106,16 +98,10 @@ async function readExport(
     throw new Error('The export file is too large')
   }
   throwIfAborted(signal)
-  if (typeof Worker === 'undefined') return readExportOnMainThread(file, signal)
-
-  try {
-    return await readExportInWorker(file, signal)
-  } catch (error) {
-    if (error instanceof ImportWorkerUnavailableError) {
-      return readExportOnMainThread(file, signal)
-    }
-    throw error
+  if (typeof Worker === 'undefined') {
+    throw new LocalImportBackgroundProcessingUnavailableError()
   }
+  return readExportInWorker(file, signal)
 }
 
 async function readExportInWorker(
@@ -133,8 +119,8 @@ async function readExportInWorker(
     worker = new Worker(
       new URL('./local-tinfoil-import.worker.ts', import.meta.url),
     )
-  } catch {
-    throw new ImportWorkerUnavailableError()
+  } catch (error) {
+    throw new LocalImportBackgroundProcessingUnavailableError({ cause: error })
   }
 
   return new Promise((resolve, reject) => {
@@ -166,7 +152,9 @@ async function readExportInWorker(
       if (settled) return
       const response: unknown = event.data
       if (!isImportWorkerResponse(response)) {
-        settle(() => reject(new Error('Invalid response from import worker')))
+        settle(() =>
+          reject(new LocalImportBackgroundProcessingUnavailableError()),
+        )
         return
       }
       const conversations = response.conversations
@@ -183,11 +171,19 @@ async function readExportInWorker(
         }),
       )
     }
-    worker.onerror = () => {
-      settle(() => reject(new ImportWorkerUnavailableError()))
+    worker.onerror = (event) => {
+      settle(() =>
+        reject(
+          new LocalImportBackgroundProcessingUnavailableError({
+            cause: event.error,
+          }),
+        ),
+      )
     }
     worker.onmessageerror = () => {
-      settle(() => reject(new ImportWorkerUnavailableError()))
+      settle(() =>
+        reject(new LocalImportBackgroundProcessingUnavailableError()),
+      )
     }
     timeout = setTimeout(() => {
       settle(() => reject(new LocalImportWorkerTimeoutError()))
@@ -207,8 +203,12 @@ async function readExportInWorker(
         },
         [buffer],
       )
-    } catch {
-      settle(() => reject(new ImportWorkerUnavailableError()))
+    } catch (error) {
+      settle(() =>
+        reject(
+          new LocalImportBackgroundProcessingUnavailableError({ cause: error }),
+        ),
+      )
     }
   })
 }

--- a/src/services/chat-import/local-tinfoil-import.ts
+++ b/src/services/chat-import/local-tinfoil-import.ts
@@ -1,5 +1,6 @@
 import type { Attachment, Chat, Message } from '@/components/chat/types'
 import { uint8ArrayToBase64 } from '@/utils/binary-codec'
+import { LOCAL_IMPORT_WORKER_TIMEOUT_MS } from './constants'
 import { parseTinfoilExportBytes } from './local-tinfoil-import-parser'
 
 export const LOCAL_IMPORT_MAX_ARCHIVE_BYTES = 512 * 1024 * 1024
@@ -36,6 +37,7 @@ interface TinfoilExportedConversation {
 export interface LocalTinfoilImportOptions {
   generateChatId: (createdAt?: Date) => string
   isCloudSyncEnabled: boolean
+  signal?: AbortSignal
 }
 
 interface ImportWorkerResponse {
@@ -46,20 +48,54 @@ interface ImportWorkerResponse {
 }
 
 class ImportWorkerUnavailableError extends Error {}
+export class LocalImportWorkerTimeoutError extends Error {
+  constructor() {
+    super('The export took too long to process')
+    this.name = 'LocalImportWorkerTimeoutError'
+  }
+}
 
-async function readExportOnMainThread(file: File): Promise<{
+function getAbortError(signal: AbortSignal): Error {
+  return signal.reason instanceof Error
+    ? signal.reason
+    : new DOMException('The import was cancelled', 'AbortError')
+}
+
+function throwIfAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) throw getAbortError(signal)
+}
+
+function isImportWorkerResponse(value: unknown): value is ImportWorkerResponse {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'ok' in value &&
+    typeof value.ok === 'boolean'
+  )
+}
+
+async function readExportOnMainThread(
+  file: File,
+  signal?: AbortSignal,
+): Promise<{
   conversations: TinfoilExportedConversation[]
   entries?: Record<string, Uint8Array>
 }> {
+  throwIfAborted(signal)
+  const buffer = await file.arrayBuffer()
+  throwIfAborted(signal)
   return parseTinfoilExportBytes<TinfoilExportedConversation>({
-    bytes: new Uint8Array(await file.arrayBuffer()),
+    bytes: new Uint8Array(buffer),
     fileName: file.name,
     mimeType: file.type,
     maxArchiveBytes: LOCAL_IMPORT_MAX_ARCHIVE_BYTES,
   })
 }
 
-async function readExport(file: File): Promise<{
+async function readExport(
+  file: File,
+  signal?: AbortSignal,
+): Promise<{
   conversations: TinfoilExportedConversation[]
   entries?: Record<string, Uint8Array>
 }> {
@@ -69,23 +105,29 @@ async function readExport(file: File): Promise<{
   if (file.size > LOCAL_IMPORT_MAX_ARCHIVE_BYTES) {
     throw new Error('The export file is too large')
   }
-  if (typeof Worker === 'undefined') return readExportOnMainThread(file)
+  throwIfAborted(signal)
+  if (typeof Worker === 'undefined') return readExportOnMainThread(file, signal)
 
   try {
-    return await readExportInWorker(file)
+    return await readExportInWorker(file, signal)
   } catch (error) {
     if (error instanceof ImportWorkerUnavailableError) {
-      return readExportOnMainThread(file)
+      return readExportOnMainThread(file, signal)
     }
     throw error
   }
 }
 
-async function readExportInWorker(file: File): Promise<{
+async function readExportInWorker(
+  file: File,
+  signal?: AbortSignal,
+): Promise<{
   conversations: TinfoilExportedConversation[]
   entries?: Record<string, Uint8Array>
 }> {
+  throwIfAborted(signal)
   const buffer = await file.arrayBuffer()
+  throwIfAborted(signal)
   let worker: Worker
   try {
     worker = new Worker(
@@ -96,29 +138,65 @@ async function readExportInWorker(file: File): Promise<{
   }
 
   return new Promise((resolve, reject) => {
-    worker.onmessage = (event: MessageEvent<ImportWorkerResponse>) => {
+    let settled = false
+    let timeout: ReturnType<typeof setTimeout> | null = null
+
+    const cleanup = () => {
+      if (timeout !== null) {
+        clearTimeout(timeout)
+        timeout = null
+      }
+      worker.onmessage = null
+      worker.onerror = null
+      worker.onmessageerror = null
+      signal?.removeEventListener('abort', handleAbort)
       worker.terminate()
-      if (
-        !event.data.ok ||
-        !event.data.conversations ||
-        !Array.isArray(event.data.conversations)
-      ) {
-        reject(new Error(event.data.error ?? 'Invalid Tinfoil export format'))
+    }
+    const settle = (action: () => void) => {
+      if (settled) return
+      settled = true
+      cleanup()
+      action()
+    }
+    const handleAbort = () => {
+      settle(() => reject(getAbortError(signal!)))
+    }
+
+    worker.onmessage = (event: MessageEvent<ImportWorkerResponse>) => {
+      if (settled) return
+      const response: unknown = event.data
+      if (!isImportWorkerResponse(response)) {
+        settle(() => reject(new Error('Invalid response from import worker')))
         return
       }
-      resolve({
-        conversations: event.data.conversations,
-        entries: event.data.entries,
-      })
+      const conversations = response.conversations
+      if (!response.ok || !conversations || !Array.isArray(conversations)) {
+        settle(() =>
+          reject(new Error(response.error ?? 'Invalid Tinfoil export format')),
+        )
+        return
+      }
+      settle(() =>
+        resolve({
+          conversations,
+          entries: response.entries,
+        }),
+      )
     }
     worker.onerror = () => {
-      worker.terminate()
-      reject(new ImportWorkerUnavailableError())
+      settle(() => reject(new ImportWorkerUnavailableError()))
     }
     worker.onmessageerror = () => {
-      worker.terminate()
-      reject(new ImportWorkerUnavailableError())
+      settle(() => reject(new ImportWorkerUnavailableError()))
     }
+    timeout = setTimeout(() => {
+      settle(() => reject(new LocalImportWorkerTimeoutError()))
+    }, LOCAL_IMPORT_WORKER_TIMEOUT_MS)
+    if (signal?.aborted) {
+      handleAbort()
+      return
+    }
+    signal?.addEventListener('abort', handleAbort, { once: true })
     try {
       worker.postMessage(
         {
@@ -130,8 +208,7 @@ async function readExportInWorker(file: File): Promise<{
         [buffer],
       )
     } catch {
-      worker.terminate()
-      reject(new ImportWorkerUnavailableError())
+      settle(() => reject(new ImportWorkerUnavailableError()))
     }
   })
 }
@@ -165,7 +242,7 @@ export async function parseLocalTinfoilExport(
   file: File,
   options: LocalTinfoilImportOptions,
 ): Promise<Chat[]> {
-  const { conversations, entries } = await readExport(file)
+  const { conversations, entries } = await readExport(file, options.signal)
   const chats: Chat[] = []
 
   for (const conversation of conversations) {

--- a/src/services/chat-import/local-tinfoil-import.ts
+++ b/src/services/chat-import/local-tinfoil-import.ts
@@ -115,6 +115,10 @@ async function readExportInWorker(file: File): Promise<{
       worker.terminate()
       reject(new ImportWorkerUnavailableError())
     }
+    worker.onmessageerror = () => {
+      worker.terminate()
+      reject(new ImportWorkerUnavailableError())
+    }
     try {
       worker.postMessage(
         {

--- a/src/services/chat-import/local-tinfoil-import.ts
+++ b/src/services/chat-import/local-tinfoil-import.ts
@@ -47,17 +47,17 @@ function isZip(file: File): boolean {
   )
 }
 
-async function readExport(file: File): Promise<{
+interface ImportWorkerResponse {
+  ok: boolean
+  conversations?: TinfoilExportedConversation[]
+  entries?: Record<string, Uint8Array>
+  error?: string
+}
+
+async function readExportOnMainThread(file: File): Promise<{
   conversations: TinfoilExportedConversation[]
   entries?: Record<string, Uint8Array>
 }> {
-  if (file.size === 0) {
-    throw new Error('The export file is empty')
-  }
-  if (file.size > LOCAL_IMPORT_MAX_ARCHIVE_BYTES) {
-    throw new Error('The export file is too large')
-  }
-
   if (!isZip(file)) {
     const conversations = JSON.parse(await file.text())
     if (!Array.isArray(conversations)) {
@@ -92,6 +92,60 @@ async function readExport(file: File): Promise<{
     throw new Error('Invalid Tinfoil export format')
   }
   return { conversations, entries }
+}
+
+async function readExport(file: File): Promise<{
+  conversations: TinfoilExportedConversation[]
+  entries?: Record<string, Uint8Array>
+}> {
+  if (file.size === 0) {
+    throw new Error('The export file is empty')
+  }
+  if (file.size > LOCAL_IMPORT_MAX_ARCHIVE_BYTES) {
+    throw new Error('The export file is too large')
+  }
+  if (typeof Worker === 'undefined') return readExportOnMainThread(file)
+
+  const buffer = await file.arrayBuffer()
+  const worker = new Worker(
+    new URL('./local-tinfoil-import.worker.ts', import.meta.url),
+  )
+
+  return new Promise((resolve, reject) => {
+    worker.onmessage = (event: MessageEvent<ImportWorkerResponse>) => {
+      worker.terminate()
+      if (
+        !event.data.ok ||
+        !event.data.conversations ||
+        !Array.isArray(event.data.conversations)
+      ) {
+        reject(new Error(event.data.error ?? 'Invalid Tinfoil export format'))
+        return
+      }
+      resolve({
+        conversations: event.data.conversations,
+        entries: event.data.entries,
+      })
+    }
+    worker.onerror = () => {
+      worker.terminate()
+      reject(new Error('Failed to process the Tinfoil export'))
+    }
+    try {
+      worker.postMessage(
+        {
+          buffer,
+          fileName: file.name,
+          mimeType: file.type,
+          maxArchiveBytes: LOCAL_IMPORT_MAX_ARCHIVE_BYTES,
+        },
+        [buffer],
+      )
+    } catch (error) {
+      worker.terminate()
+      reject(error)
+    }
+  })
 }
 
 function importAttachment(

--- a/src/services/chat-import/local-tinfoil-import.worker.ts
+++ b/src/services/chat-import/local-tinfoil-import.worker.ts
@@ -1,0 +1,65 @@
+import { strFromU8, unzipSync } from 'fflate'
+
+interface ImportWorkerRequest {
+  buffer: ArrayBuffer
+  fileName: string
+  mimeType: string
+  maxArchiveBytes: number
+}
+
+interface ImportWorkerScope {
+  onmessage: ((event: MessageEvent<ImportWorkerRequest>) => void) | null
+  postMessage(message: unknown, transfer: Transferable[]): void
+}
+
+const workerScope = globalThis as unknown as ImportWorkerScope
+
+workerScope.onmessage = (event) => {
+  try {
+    const { buffer, fileName, mimeType, maxArchiveBytes } = event.data
+    const bytes = new Uint8Array(buffer)
+    const isZip =
+      fileName.toLowerCase().endsWith('.zip') || mimeType === 'application/zip'
+
+    if (!isZip) {
+      const conversations = JSON.parse(new TextDecoder().decode(bytes))
+      workerScope.postMessage({ ok: true, conversations }, [])
+      return
+    }
+
+    let uncompressedBytes = 0
+    const entries = unzipSync(bytes, {
+      filter: (entry) => {
+        const isImportEntry =
+          entry.name === 'conversations.json' ||
+          entry.name === 'manifest.json' ||
+          entry.name.startsWith('attachments/')
+        if (!isImportEntry) return false
+
+        uncompressedBytes += entry.originalSize
+        if (uncompressedBytes > maxArchiveBytes) {
+          throw new Error('The uncompressed export is too large')
+        }
+        return true
+      },
+    })
+    const conversationsEntry = entries['conversations.json']
+    if (!conversationsEntry) {
+      throw new Error('The Tinfoil export is missing conversations.json')
+    }
+
+    const conversations = JSON.parse(strFromU8(conversationsEntry))
+    const transfer = Object.values(entries)
+      .map((entry) => entry.buffer)
+      .filter((entry): entry is ArrayBuffer => entry instanceof ArrayBuffer)
+    workerScope.postMessage({ ok: true, conversations, entries }, transfer)
+  } catch (error) {
+    workerScope.postMessage(
+      {
+        ok: false,
+        error: error instanceof Error ? error.message : 'Failed to read export',
+      },
+      [],
+    )
+  }
+}

--- a/src/services/chat-import/local-tinfoil-import.worker.ts
+++ b/src/services/chat-import/local-tinfoil-import.worker.ts
@@ -1,4 +1,7 @@
-import { strFromU8, unzipSync } from 'fflate'
+import {
+  collectTransferableBuffers,
+  parseTinfoilExportBytes,
+} from './local-tinfoil-import-parser'
 
 interface ImportWorkerRequest {
   buffer: ArrayBuffer
@@ -17,41 +20,13 @@ const workerScope = globalThis as unknown as ImportWorkerScope
 workerScope.onmessage = (event) => {
   try {
     const { buffer, fileName, mimeType, maxArchiveBytes } = event.data
-    const bytes = new Uint8Array(buffer)
-    const isZip =
-      fileName.toLowerCase().endsWith('.zip') || mimeType === 'application/zip'
-
-    if (!isZip) {
-      const conversations = JSON.parse(new TextDecoder().decode(bytes))
-      workerScope.postMessage({ ok: true, conversations }, [])
-      return
-    }
-
-    let uncompressedBytes = 0
-    const entries = unzipSync(bytes, {
-      filter: (entry) => {
-        const isImportEntry =
-          entry.name === 'conversations.json' ||
-          entry.name === 'manifest.json' ||
-          entry.name.startsWith('attachments/')
-        if (!isImportEntry) return false
-
-        uncompressedBytes += entry.originalSize
-        if (uncompressedBytes > maxArchiveBytes) {
-          throw new Error('The uncompressed export is too large')
-        }
-        return true
-      },
+    const { conversations, entries } = parseTinfoilExportBytes({
+      bytes: new Uint8Array(buffer),
+      fileName,
+      mimeType,
+      maxArchiveBytes,
     })
-    const conversationsEntry = entries['conversations.json']
-    if (!conversationsEntry) {
-      throw new Error('The Tinfoil export is missing conversations.json')
-    }
-
-    const conversations = JSON.parse(strFromU8(conversationsEntry))
-    const transfer = Object.values(entries)
-      .map((entry) => entry.buffer)
-      .filter((entry): entry is ArrayBuffer => entry instanceof ArrayBuffer)
+    const transfer = collectTransferableBuffers(entries ?? {})
     workerScope.postMessage({ ok: true, conversations, entries }, transfer)
   } catch (error) {
     workerScope.postMessage(

--- a/tests/components/chat/chat-input-streaming.test.tsx
+++ b/tests/components/chat/chat-input-streaming.test.tsx
@@ -1,7 +1,7 @@
 import { ChatInput } from '@/components/chat/chat-input'
-import { fireEvent, render, screen } from '@testing-library/react'
+import { act, fireEvent, render, screen } from '@testing-library/react'
 import { createRef } from 'react'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('@/components/project', () => ({
   ProjectModeBanner: () => null,
@@ -22,6 +22,51 @@ vi.mock('@/components/chat/hooks/use-chat-font', () => ({
 }))
 
 describe('ChatInput streaming action', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('stops a microphone stream granted after unmount', async () => {
+    let grantPermission!: (stream: MediaStream) => void
+    const stop = vi.fn()
+    vi.stubGlobal('navigator', {
+      mediaDevices: {
+        getUserMedia: vi.fn(
+          () =>
+            new Promise<MediaStream>((resolve) => {
+              grantPermission = resolve
+            }),
+        ),
+      },
+    })
+    const { unmount } = render(
+      <ChatInput
+        input=""
+        setInput={vi.fn()}
+        handleSubmit={vi.fn()}
+        loadingState="idle"
+        cancelGeneration={vi.fn()}
+        inputRef={createRef<HTMLTextAreaElement>()}
+        handleInputFocus={vi.fn()}
+        inputMinHeight="40px"
+        isDarkMode
+        isPremium
+        audioModel="audio-model"
+      />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Start recording' }))
+    unmount()
+
+    await act(async () => {
+      grantPermission({
+        getTracks: () => [{ stop }],
+      } as unknown as MediaStream)
+    })
+
+    expect(stop).toHaveBeenCalledOnce()
+  })
+
   it('shows Stop while a recovered response is streaming', () => {
     const cancelGeneration = vi.fn()
     render(

--- a/tests/services/chat-export/export-archive.test.ts
+++ b/tests/services/chat-export/export-archive.test.ts
@@ -1,5 +1,5 @@
 import { strFromU8, unzipSync } from 'fflate'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import type { Chat } from '@/components/chat/types'
 import {
@@ -7,6 +7,7 @@ import {
   sanitizeFilename,
 } from '@/services/chat-export/export-archive'
 import { parseLocalTinfoilExport } from '@/services/chat-import/local-tinfoil-import'
+import { createFunctionalImportWorker } from '../chat-import/functional-import-worker'
 
 function chat(overrides: Partial<Chat>): Chat {
   return {
@@ -232,72 +233,77 @@ describe('buildChatExport', () => {
   it('round-trips duplicate attachment ids without swapping bytes', async () => {
     const firstBytes = new Uint8Array([1, 2, 3])
     const secondBytes = new Uint8Array([4, 5, 6])
-    const result = await buildChatExport(
-      [
-        chat({
-          messages: [
-            {
-              role: 'user',
-              content: 'first',
-              timestamp: new Date('2023-11-14T22:13:21.000Z'),
-              attachments: [
-                {
-                  id: 'legacy-image',
-                  type: 'image',
-                  fileName: 'first.png',
-                },
-              ],
-            },
-            {
-              role: 'user',
-              content: 'second',
-              timestamp: new Date('2023-11-14T22:13:22.000Z'),
-              attachments: [
-                {
-                  id: 'legacy-image',
-                  type: 'image',
-                  fileName: 'second.png',
-                },
-              ],
-            },
-          ],
-        }),
-      ],
-      async (attachment) =>
-        attachment.fileName === 'first.png' ? firstBytes : secondBytes,
-    )
-    const imported = await parseLocalTinfoilExport(
-      new File(
-        [new Uint8Array(result.data as Uint8Array)],
-        'tinfoil-chats.zip',
+    try {
+      vi.stubGlobal('Worker', createFunctionalImportWorker())
+      const result = await buildChatExport(
+        [
+          chat({
+            messages: [
+              {
+                role: 'user',
+                content: 'first',
+                timestamp: new Date('2023-11-14T22:13:21.000Z'),
+                attachments: [
+                  {
+                    id: 'legacy-image',
+                    type: 'image',
+                    fileName: 'first.png',
+                  },
+                ],
+              },
+              {
+                role: 'user',
+                content: 'second',
+                timestamp: new Date('2023-11-14T22:13:22.000Z'),
+                attachments: [
+                  {
+                    id: 'legacy-image',
+                    type: 'image',
+                    fileName: 'second.png',
+                  },
+                ],
+              },
+            ],
+          }),
+        ],
+        async (attachment) =>
+          attachment.fileName === 'first.png' ? firstBytes : secondBytes,
+      )
+      const imported = await parseLocalTinfoilExport(
+        new File(
+          [new Uint8Array(result.data as Uint8Array)],
+          'tinfoil-chats.zip',
+          {
+            type: 'application/zip',
+          },
+        ),
         {
-          type: 'application/zip',
+          generateChatId: () => 'imported-chat',
+          isCloudSyncEnabled: false,
         },
-      ),
-      {
-        generateChatId: () => 'imported-chat',
-        isCloudSyncEnabled: false,
-      },
-    )
+      )
 
-    expect(
-      imported[0].messages.map((message) => ({
-        id: message.attachments?.[0].id,
-        fileName: message.attachments?.[0].fileName,
-        base64: message.attachments?.[0].base64,
-      })),
-    ).toEqual([
-      {
-        id: 'legacy-image',
-        fileName: 'first.png',
-        base64: 'AQID',
-      },
-      {
-        id: 'legacy-image',
-        fileName: 'second.png',
-        base64: 'BAUG',
-      },
-    ])
+      expect(
+        imported[0].messages.map((message) => ({
+          id: message.attachments?.[0].id,
+          fileName: message.attachments?.[0].fileName,
+          base64: message.attachments?.[0].base64,
+        })),
+      ).toEqual([
+        {
+          id: 'legacy-image',
+          fileName: 'first.png',
+          base64: 'AQID',
+        },
+        {
+          id: 'legacy-image',
+          fileName: 'second.png',
+          base64: 'BAUG',
+        },
+      ])
+    } finally {
+      vi.unstubAllGlobals()
+    }
   })
 })
 

--- a/tests/services/chat-import/functional-import-worker.ts
+++ b/tests/services/chat-import/functional-import-worker.ts
@@ -1,0 +1,47 @@
+import { parseTinfoilExportBytes } from '@/services/chat-import/local-tinfoil-import-parser'
+
+interface WorkerRequest {
+  buffer: ArrayBuffer
+  fileName: string
+  mimeType: string
+  maxArchiveBytes: number
+}
+
+type ImportParser = typeof parseTinfoilExportBytes
+
+export function createFunctionalImportWorker(
+  parseExport: ImportParser = parseTinfoilExportBytes,
+): typeof Worker {
+  return class FunctionalImportWorker {
+    onmessage: ((event: MessageEvent) => void) | null = null
+    onerror: ((event: ErrorEvent) => void) | null = null
+    onmessageerror: (() => void) | null = null
+
+    postMessage(message: unknown) {
+      const request = message as WorkerRequest
+      queueMicrotask(() => {
+        try {
+          const result = parseExport({
+            bytes: new Uint8Array(request.buffer),
+            fileName: request.fileName,
+            mimeType: request.mimeType,
+            maxArchiveBytes: request.maxArchiveBytes,
+          })
+          this.onmessage?.({ data: { ok: true, ...result } } as MessageEvent)
+        } catch (error) {
+          this.onmessage?.({
+            data: {
+              ok: false,
+              error:
+                error instanceof Error
+                  ? error.message
+                  : 'Failed to read export',
+            },
+          } as MessageEvent)
+        }
+      })
+    }
+
+    terminate() {}
+  } as unknown as typeof Worker
+}

--- a/tests/services/chat-import/local-tinfoil-import-parser.test.ts
+++ b/tests/services/chat-import/local-tinfoil-import-parser.test.ts
@@ -1,0 +1,76 @@
+import { strToU8, zipSync } from 'fflate'
+import { describe, expect, it } from 'vitest'
+
+import {
+  collectTransferableBuffers,
+  parseTinfoilExportBytes,
+} from '@/services/chat-import/local-tinfoil-import-parser'
+
+const parserOptions = {
+  fileName: 'conversations.json',
+  mimeType: 'application/json',
+  maxArchiveBytes: 1024,
+}
+
+describe('parseTinfoilExportBytes', () => {
+  it('deduplicates shared buffers before worker transfer', () => {
+    const buffer = new ArrayBuffer(8)
+
+    expect(
+      collectTransferableBuffers({
+        first: new Uint8Array(buffer, 0, 4),
+        second: new Uint8Array(buffer, 4, 4),
+      }),
+    ).toEqual([buffer])
+  })
+
+  it('parses JSON conversation arrays', () => {
+    const conversations = [{ name: 'Imported chat' }]
+
+    expect(
+      parseTinfoilExportBytes({
+        ...parserOptions,
+        bytes: new TextEncoder().encode(JSON.stringify(conversations)),
+      }),
+    ).toEqual({ conversations })
+  })
+
+  it('rejects JSON that is not a conversation array', () => {
+    expect(() =>
+      parseTinfoilExportBytes({
+        ...parserOptions,
+        bytes: new TextEncoder().encode('{}'),
+      }),
+    ).toThrow('Invalid Tinfoil export format')
+  })
+
+  it('rejects ZIP exports without conversations.json', () => {
+    const bytes = zipSync({ 'manifest.json': strToU8('{}') })
+
+    expect(() =>
+      parseTinfoilExportBytes({
+        ...parserOptions,
+        bytes,
+        fileName: 'export.zip',
+        mimeType: 'application/zip',
+      }),
+    ).toThrow('The Tinfoil export is missing conversations.json')
+  })
+
+  it('enforces the uncompressed archive limit', () => {
+    const bytes = zipSync({
+      'conversations.json': strToU8(JSON.stringify([])),
+      'attachments/large.txt': strToU8('too large'),
+    })
+
+    expect(() =>
+      parseTinfoilExportBytes({
+        ...parserOptions,
+        bytes,
+        fileName: 'export.zip',
+        mimeType: 'application/zip',
+        maxArchiveBytes: 4,
+      }),
+    ).toThrow('The uncompressed export is too large')
+  })
+})

--- a/tests/services/chat-import/local-tinfoil-import.test.ts
+++ b/tests/services/chat-import/local-tinfoil-import.test.ts
@@ -81,6 +81,36 @@ describe('parseLocalTinfoilExport', () => {
     expect(terminate).toHaveBeenCalledOnce()
   })
 
+  it('falls back when a worker response fails to deserialize', async () => {
+    const terminate = vi.fn()
+    class MessageErrorWorker {
+      onmessage: ((event: MessageEvent) => void) | null = null
+      onerror: (() => void) | null = null
+      onmessageerror: (() => void) | null = null
+
+      postMessage() {
+        queueMicrotask(() => {
+          this.onmessageerror?.()
+        })
+      }
+
+      terminate() {
+        terminate()
+      }
+    }
+    vi.stubGlobal('Worker', MessageErrorWorker)
+    const file = new File(
+      [JSON.stringify(conversation())],
+      'conversations.json',
+    )
+
+    const chats = await parseLocalTinfoilExport(file, options)
+
+    expect(chats).toHaveLength(1)
+    expect(chats[0].title).toBe('Portable chat')
+    expect(terminate).toHaveBeenCalledOnce()
+  })
+
   it('falls back when a worker cannot start', async () => {
     class UnavailableWorker {
       constructor() {

--- a/tests/services/chat-import/local-tinfoil-import.test.ts
+++ b/tests/services/chat-import/local-tinfoil-import.test.ts
@@ -2,6 +2,7 @@ import { strToU8, zipSync } from 'fflate'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { parseLocalTinfoilExport } from '@/services/chat-import/local-tinfoil-import'
+import { collectTransferableBuffers } from '@/services/chat-import/local-tinfoil-import-parser'
 
 const options = {
   generateChatId: () => 'imported-chat',
@@ -31,6 +32,17 @@ function conversation(attachments?: unknown[]) {
 describe('parseLocalTinfoilExport', () => {
   afterEach(() => {
     vi.unstubAllGlobals()
+  })
+
+  it('deduplicates shared buffers before worker transfer', () => {
+    const buffer = new ArrayBuffer(8)
+
+    expect(
+      collectTransferableBuffers({
+        first: new Uint8Array(buffer, 0, 4),
+        second: new Uint8Array(buffer, 4, 4),
+      }),
+    ).toEqual([buffer])
   })
 
   it('parses exports in a worker when workers are available', async () => {
@@ -67,6 +79,24 @@ describe('parseLocalTinfoilExport', () => {
       [expect.any(ArrayBuffer)],
     )
     expect(terminate).toHaveBeenCalledOnce()
+  })
+
+  it('falls back when a worker cannot start', async () => {
+    class UnavailableWorker {
+      constructor() {
+        throw new DOMException('Unavailable', 'NotSupportedError')
+      }
+    }
+    vi.stubGlobal('Worker', UnavailableWorker)
+    const file = new File(
+      [JSON.stringify(conversation())],
+      'conversations.json',
+    )
+
+    const chats = await parseLocalTinfoilExport(file, options)
+
+    expect(chats).toHaveLength(1)
+    expect(chats[0].title).toBe('Portable chat')
   })
 
   it('imports conversations.json as local-only chats', async () => {

--- a/tests/services/chat-import/local-tinfoil-import.test.ts
+++ b/tests/services/chat-import/local-tinfoil-import.test.ts
@@ -8,6 +8,7 @@ import {
   parseLocalTinfoilExport,
 } from '@/services/chat-import/local-tinfoil-import'
 import { parseTinfoilExportBytes } from '@/services/chat-import/local-tinfoil-import-parser'
+import { createFunctionalImportWorker } from './functional-import-worker'
 
 const options = {
   generateChatId: () => 'imported-chat',
@@ -34,45 +35,8 @@ function conversation(attachments?: unknown[]) {
   ]
 }
 
-interface WorkerRequest {
-  buffer: ArrayBuffer
-  fileName: string
-  mimeType: string
-  maxArchiveBytes: number
-}
-
 const parseInWorker = vi.fn(parseTinfoilExportBytes)
-
-class FunctionalImportWorker {
-  onmessage: ((event: MessageEvent) => void) | null = null
-  onerror: ((event: ErrorEvent) => void) | null = null
-  onmessageerror: (() => void) | null = null
-
-  postMessage(message: unknown) {
-    const request = message as WorkerRequest
-    queueMicrotask(() => {
-      try {
-        const result = parseInWorker({
-          bytes: new Uint8Array(request.buffer),
-          fileName: request.fileName,
-          mimeType: request.mimeType,
-          maxArchiveBytes: request.maxArchiveBytes,
-        })
-        this.onmessage?.({ data: { ok: true, ...result } } as MessageEvent)
-      } catch (error) {
-        this.onmessage?.({
-          data: {
-            ok: false,
-            error:
-              error instanceof Error ? error.message : 'Failed to read export',
-          },
-        } as MessageEvent)
-      }
-    })
-  }
-
-  terminate() {}
-}
+const FunctionalImportWorker = createFunctionalImportWorker(parseInWorker)
 
 describe('parseLocalTinfoilExport', () => {
   beforeEach(() => {

--- a/tests/services/chat-import/local-tinfoil-import.test.ts
+++ b/tests/services/chat-import/local-tinfoil-import.test.ts
@@ -1,5 +1,5 @@
 import { strToU8, zipSync } from 'fflate'
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { parseLocalTinfoilExport } from '@/services/chat-import/local-tinfoil-import'
 
@@ -29,6 +29,46 @@ function conversation(attachments?: unknown[]) {
 }
 
 describe('parseLocalTinfoilExport', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('parses exports in a worker when workers are available', async () => {
+    const postMessage = vi.fn()
+    const terminate = vi.fn()
+    class ImportWorker {
+      onmessage: ((event: MessageEvent) => void) | null = null
+      onerror: (() => void) | null = null
+
+      postMessage(message: unknown, transfer: Transferable[]) {
+        postMessage(message, transfer)
+        queueMicrotask(() => {
+          this.onmessage?.({
+            data: { ok: true, conversations: conversation() },
+          } as MessageEvent)
+        })
+      }
+
+      terminate() {
+        terminate()
+      }
+    }
+    vi.stubGlobal('Worker', ImportWorker)
+    const file = new File(
+      [JSON.stringify(conversation())],
+      'conversations.json',
+    )
+
+    const chats = await parseLocalTinfoilExport(file, options)
+
+    expect(chats).toHaveLength(1)
+    expect(postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ fileName: 'conversations.json' }),
+      [expect.any(ArrayBuffer)],
+    )
+    expect(terminate).toHaveBeenCalledOnce()
+  })
+
   it('imports conversations.json as local-only chats', async () => {
     const file = new File(
       [JSON.stringify(conversation())],

--- a/tests/services/chat-import/local-tinfoil-import.test.ts
+++ b/tests/services/chat-import/local-tinfoil-import.test.ts
@@ -1,12 +1,13 @@
 import { strToU8, zipSync } from 'fflate'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { LOCAL_IMPORT_WORKER_TIMEOUT_MS } from '@/services/chat-import/constants'
 import {
+  LocalImportBackgroundProcessingUnavailableError,
   LocalImportWorkerTimeoutError,
   parseLocalTinfoilExport,
 } from '@/services/chat-import/local-tinfoil-import'
-import { collectTransferableBuffers } from '@/services/chat-import/local-tinfoil-import-parser'
+import { parseTinfoilExportBytes } from '@/services/chat-import/local-tinfoil-import-parser'
 
 const options = {
   generateChatId: () => 'imported-chat',
@@ -33,21 +34,55 @@ function conversation(attachments?: unknown[]) {
   ]
 }
 
+interface WorkerRequest {
+  buffer: ArrayBuffer
+  fileName: string
+  mimeType: string
+  maxArchiveBytes: number
+}
+
+const parseInWorker = vi.fn(parseTinfoilExportBytes)
+
+class FunctionalImportWorker {
+  onmessage: ((event: MessageEvent) => void) | null = null
+  onerror: ((event: ErrorEvent) => void) | null = null
+  onmessageerror: (() => void) | null = null
+
+  postMessage(message: unknown) {
+    const request = message as WorkerRequest
+    queueMicrotask(() => {
+      try {
+        const result = parseInWorker({
+          bytes: new Uint8Array(request.buffer),
+          fileName: request.fileName,
+          mimeType: request.mimeType,
+          maxArchiveBytes: request.maxArchiveBytes,
+        })
+        this.onmessage?.({ data: { ok: true, ...result } } as MessageEvent)
+      } catch (error) {
+        this.onmessage?.({
+          data: {
+            ok: false,
+            error:
+              error instanceof Error ? error.message : 'Failed to read export',
+          },
+        } as MessageEvent)
+      }
+    })
+  }
+
+  terminate() {}
+}
+
 describe('parseLocalTinfoilExport', () => {
+  beforeEach(() => {
+    parseInWorker.mockClear()
+    vi.stubGlobal('Worker', FunctionalImportWorker)
+  })
+
   afterEach(() => {
     vi.useRealTimers()
     vi.unstubAllGlobals()
-  })
-
-  it('deduplicates shared buffers before worker transfer', () => {
-    const buffer = new ArrayBuffer(8)
-
-    expect(
-      collectTransferableBuffers({
-        first: new Uint8Array(buffer, 0, 4),
-        second: new Uint8Array(buffer, 4, 4),
-      }),
-    ).toEqual([buffer])
   })
 
   it('parses exports in a worker when workers are available', async () => {
@@ -86,7 +121,7 @@ describe('parseLocalTinfoilExport', () => {
     expect(terminate).toHaveBeenCalledOnce()
   })
 
-  it('rejects malformed worker messages without leaving the import pending', async () => {
+  it('rejects malformed worker messages as unavailable background processing', async () => {
     const terminate = vi.fn()
     class MalformedMessageWorker {
       onmessage: ((event: MessageEvent) => void) | null = null
@@ -109,9 +144,10 @@ describe('parseLocalTinfoilExport', () => {
       'conversations.json',
     )
 
-    await expect(parseLocalTinfoilExport(file, options)).rejects.toThrow(
-      'Invalid response from import worker',
+    await expect(parseLocalTinfoilExport(file, options)).rejects.toBeInstanceOf(
+      LocalImportBackgroundProcessingUnavailableError,
     )
+    expect(parseInWorker).not.toHaveBeenCalled()
     expect(terminate).toHaveBeenCalledOnce()
   })
 
@@ -141,6 +177,7 @@ describe('parseLocalTinfoilExport', () => {
     await vi.advanceTimersByTimeAsync(LOCAL_IMPORT_WORKER_TIMEOUT_MS)
 
     expect(await result).toBeInstanceOf(LocalImportWorkerTimeoutError)
+    expect(parseInWorker).not.toHaveBeenCalled()
     expect(terminate).toHaveBeenCalledOnce()
   })
 
@@ -179,7 +216,7 @@ describe('parseLocalTinfoilExport', () => {
     expect(terminate).toHaveBeenCalledOnce()
   })
 
-  it('falls back when a worker response fails to deserialize', async () => {
+  it('fails explicitly when a worker response cannot deserialize', async () => {
     const terminate = vi.fn()
     class MessageErrorWorker {
       onmessage: ((event: MessageEvent) => void) | null = null
@@ -202,14 +239,14 @@ describe('parseLocalTinfoilExport', () => {
       'conversations.json',
     )
 
-    const chats = await parseLocalTinfoilExport(file, options)
-
-    expect(chats).toHaveLength(1)
-    expect(chats[0].title).toBe('Portable chat')
+    await expect(parseLocalTinfoilExport(file, options)).rejects.toBeInstanceOf(
+      LocalImportBackgroundProcessingUnavailableError,
+    )
+    expect(parseInWorker).not.toHaveBeenCalled()
     expect(terminate).toHaveBeenCalledOnce()
   })
 
-  it('falls back when a worker cannot start', async () => {
+  it('fails explicitly when a worker cannot start', async () => {
     class UnavailableWorker {
       constructor() {
         throw new DOMException('Unavailable', 'NotSupportedError')
@@ -221,10 +258,99 @@ describe('parseLocalTinfoilExport', () => {
       'conversations.json',
     )
 
-    const chats = await parseLocalTinfoilExport(file, options)
+    await expect(parseLocalTinfoilExport(file, options)).rejects.toMatchObject({
+      name: 'LocalImportBackgroundProcessingUnavailableError',
+      code: 'LOCAL_IMPORT_BACKGROUND_PROCESSING_UNAVAILABLE',
+    })
+    expect(parseInWorker).not.toHaveBeenCalled()
+  })
 
-    expect(chats).toHaveLength(1)
-    expect(chats[0].title).toBe('Portable chat')
+  it('fails explicitly when workers are unavailable', async () => {
+    vi.stubGlobal('Worker', undefined)
+    const file = new File(
+      [JSON.stringify(conversation())],
+      'conversations.json',
+    )
+
+    await expect(parseLocalTinfoilExport(file, options)).rejects.toBeInstanceOf(
+      LocalImportBackgroundProcessingUnavailableError,
+    )
+    expect(parseInWorker).not.toHaveBeenCalled()
+  })
+
+  it('fails explicitly when worker execution errors', async () => {
+    class ErroringWorker {
+      onmessage: ((event: MessageEvent) => void) | null = null
+      onerror: ((event: ErrorEvent) => void) | null = null
+      onmessageerror: (() => void) | null = null
+
+      postMessage() {
+        queueMicrotask(() => {
+          this.onerror?.(new ErrorEvent('error', { message: 'worker failed' }))
+        })
+      }
+
+      terminate() {}
+    }
+    vi.stubGlobal('Worker', ErroringWorker)
+    const file = new File(
+      [JSON.stringify(conversation())],
+      'conversations.json',
+    )
+
+    await expect(parseLocalTinfoilExport(file, options)).rejects.toBeInstanceOf(
+      LocalImportBackgroundProcessingUnavailableError,
+    )
+    expect(parseInWorker).not.toHaveBeenCalled()
+  })
+
+  it('fails explicitly when posting to the worker fails', async () => {
+    class PostMessageFailureWorker {
+      onmessage: ((event: MessageEvent) => void) | null = null
+      onerror: ((event: ErrorEvent) => void) | null = null
+      onmessageerror: (() => void) | null = null
+
+      postMessage() {
+        throw new DOMException('Clone failed', 'DataCloneError')
+      }
+
+      terminate() {}
+    }
+    vi.stubGlobal('Worker', PostMessageFailureWorker)
+    const file = new File(
+      [JSON.stringify(conversation())],
+      'conversations.json',
+    )
+
+    await expect(parseLocalTinfoilExport(file, options)).rejects.toBeInstanceOf(
+      LocalImportBackgroundProcessingUnavailableError,
+    )
+    expect(parseInWorker).not.toHaveBeenCalled()
+  })
+
+  it('preserves parser errors returned by a running worker', async () => {
+    class ParserErrorWorker {
+      onmessage: ((event: MessageEvent) => void) | null = null
+      onerror: ((event: ErrorEvent) => void) | null = null
+      onmessageerror: (() => void) | null = null
+
+      postMessage() {
+        queueMicrotask(() => {
+          this.onmessage?.({
+            data: { ok: false, error: 'The export archive is malformed' },
+          } as MessageEvent)
+        })
+      }
+
+      terminate() {}
+    }
+    vi.stubGlobal('Worker', ParserErrorWorker)
+    const file = new File(['not-json'], 'conversations.json')
+
+    await expect(parseLocalTinfoilExport(file, options)).rejects.toThrow(
+      'The export archive is malformed',
+    )
+    expect(parseInWorker).not.toHaveBeenCalled()
   })
 
   it('imports conversations.json as local-only chats', async () => {

--- a/tests/services/chat-import/local-tinfoil-import.test.ts
+++ b/tests/services/chat-import/local-tinfoil-import.test.ts
@@ -1,7 +1,11 @@
 import { strToU8, zipSync } from 'fflate'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { parseLocalTinfoilExport } from '@/services/chat-import/local-tinfoil-import'
+import { LOCAL_IMPORT_WORKER_TIMEOUT_MS } from '@/services/chat-import/constants'
+import {
+  LocalImportWorkerTimeoutError,
+  parseLocalTinfoilExport,
+} from '@/services/chat-import/local-tinfoil-import'
 import { collectTransferableBuffers } from '@/services/chat-import/local-tinfoil-import-parser'
 
 const options = {
@@ -31,6 +35,7 @@ function conversation(attachments?: unknown[]) {
 
 describe('parseLocalTinfoilExport', () => {
   afterEach(() => {
+    vi.useRealTimers()
     vi.unstubAllGlobals()
   })
 
@@ -78,6 +83,99 @@ describe('parseLocalTinfoilExport', () => {
       expect.objectContaining({ fileName: 'conversations.json' }),
       [expect.any(ArrayBuffer)],
     )
+    expect(terminate).toHaveBeenCalledOnce()
+  })
+
+  it('rejects malformed worker messages without leaving the import pending', async () => {
+    const terminate = vi.fn()
+    class MalformedMessageWorker {
+      onmessage: ((event: MessageEvent) => void) | null = null
+      onerror: (() => void) | null = null
+      onmessageerror: (() => void) | null = null
+
+      postMessage() {
+        queueMicrotask(() => {
+          this.onmessage?.({ data: null } as MessageEvent)
+        })
+      }
+
+      terminate() {
+        terminate()
+      }
+    }
+    vi.stubGlobal('Worker', MalformedMessageWorker)
+    const file = new File(
+      [JSON.stringify(conversation())],
+      'conversations.json',
+    )
+
+    await expect(parseLocalTinfoilExport(file, options)).rejects.toThrow(
+      'Invalid response from import worker',
+    )
+    expect(terminate).toHaveBeenCalledOnce()
+  })
+
+  it('terminates timed-out workers without retrying on the main thread', async () => {
+    vi.useFakeTimers()
+    const terminate = vi.fn()
+    class HangingWorker {
+      onmessage: ((event: MessageEvent) => void) | null = null
+      onerror: (() => void) | null = null
+      onmessageerror: (() => void) | null = null
+
+      postMessage() {}
+
+      terminate() {
+        terminate()
+      }
+    }
+    vi.stubGlobal('Worker', HangingWorker)
+    const file = new File(
+      [JSON.stringify(conversation())],
+      'conversations.json',
+    )
+    const result = parseLocalTinfoilExport(file, options).catch(
+      (error: unknown) => error,
+    )
+
+    await vi.advanceTimersByTimeAsync(LOCAL_IMPORT_WORKER_TIMEOUT_MS)
+
+    expect(await result).toBeInstanceOf(LocalImportWorkerTimeoutError)
+    expect(terminate).toHaveBeenCalledOnce()
+  })
+
+  it('ignores worker events after the first settlement', async () => {
+    const terminate = vi.fn()
+    class DuplicateEventWorker {
+      onmessage: ((event: MessageEvent) => void) | null = null
+      onerror: (() => void) | null = null
+      onmessageerror: (() => void) | null = null
+
+      postMessage() {
+        const onmessage = this.onmessage
+        const onerror = this.onerror
+        queueMicrotask(() => {
+          onmessage?.({
+            data: { ok: true, conversations: conversation() },
+          } as MessageEvent)
+          onerror?.()
+          onmessage?.({ data: null } as MessageEvent)
+        })
+      }
+
+      terminate() {
+        terminate()
+      }
+    }
+    vi.stubGlobal('Worker', DuplicateEventWorker)
+    const file = new File(
+      [JSON.stringify(conversation())],
+      'conversations.json',
+    )
+
+    const chats = await parseLocalTinfoilExport(file, options)
+
+    expect(chats).toHaveLength(1)
     expect(terminate).toHaveBeenCalledOnce()
   })
 


### PR DESCRIPTION
## Summary
- parse JSON and decompress large Tinfoil exports in a dedicated Web Worker using shared, tested parsing logic
- deduplicate transferable buffers and fall back cleanly when worker startup is unavailable
- safely release delayed microphone sessions and canceled sidebar resize gestures

## Testing
- `npx vitest run` (1581 tests)
- `npm run lint`
- `npx tsc --noEmit`