### PR TITLE
Fix project file duplication and arbitrary sign-outs

### DIFF
--- a/src/components/chat/cloud-sync-health-card.tsx
+++ b/src/components/chat/cloud-sync-health-card.tsx
@@ -61,7 +61,9 @@ function describeStatus(health: SyncHealthSnapshot): {
       detail:
         health.gate.reason === 'attestation'
           ? "The sync server couldn't be verified. Retrying automatically."
-          : 'Having trouble reaching the cloud. Retrying automatically.',
+          : health.gate.reason === 'auth'
+            ? 'The sync server is not accepting your session right now. Retrying automatically.'
+            : 'Having trouble reaching the cloud. Retrying automatically.',
       cta: null,
     }
   }

--- a/src/hooks/use-cloud-sync.ts
+++ b/src/hooks/use-cloud-sync.ts
@@ -22,7 +22,7 @@ import {
 } from '@/utils/cloud-sync-settings'
 import { logError, logInfo } from '@/utils/error-handling'
 import { hasPasskeyBackup } from '@/utils/signout-cleanup'
-import { useAuth, useClerk } from '@clerk/nextjs'
+import { useAuth } from '@clerk/nextjs'
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 export interface CloudSyncState {
@@ -47,7 +47,6 @@ type CloudKeyActivationMode = 'recoverExisting' | 'explicitStartFresh'
 
 export function useCloudSync(options?: UseCloudSyncOptions) {
   const { getToken, isSignedIn } = useAuth()
-  const { signOut } = useClerk()
   const [state, setState] = useState<CloudSyncState>({
     syncing: false,
     lastSyncTime: null,
@@ -71,11 +70,6 @@ export function useCloudSync(options?: UseCloudSyncOptions) {
       isMountedRef.current = false
     }
   }, [])
-
-  useEffect(
-    () => authTokenManager.registerPersistentAuthHandler(() => signOut()),
-    [signOut],
-  )
 
   // Listen for fallback key additions and trigger retry decryption
   useEffect(() => {

--- a/src/services/auth/auth-token-manager.ts
+++ b/src/services/auth/auth-token-manager.ts
@@ -1,5 +1,3 @@
-import { logError } from '@/utils/error-handling'
-
 interface TokenReadOptions {
   skipCache?: boolean
 }
@@ -32,8 +30,6 @@ export class AuthTokenManager {
   private getToken: TokenGetter | null = null
   private initResolvers: Array<() => void> = []
   private refreshByRejectedToken = new Map<string, Promise<string>>()
-  private persistentAuthHandler: (() => Promise<void>) | null = null
-  private persistentAuthHandlerPromise: Promise<void> | null = null
   private generation = 0
 
   initialize(getToken: TokenGetter) {
@@ -109,40 +105,6 @@ export class AuthTokenManager {
     })
     this.refreshByRejectedToken.set(rejectedToken, refresh)
     return refresh
-  }
-
-  registerPersistentAuthHandler(handler: () => Promise<void>): () => void {
-    this.persistentAuthHandler = handler
-    return () => {
-      if (this.persistentAuthHandler === handler) {
-        this.persistentAuthHandler = null
-      }
-    }
-  }
-
-  handlePersistentAuthFailure(): Promise<void> {
-    if (this.persistentAuthHandlerPromise)
-      return this.persistentAuthHandlerPromise
-    if (!this.persistentAuthHandler) return Promise.resolve()
-
-    const handler = this.persistentAuthHandler
-    const promise = Promise.resolve()
-      .then(handler)
-      .catch((error) => {
-        logError(
-          'Failed to sign out after persistent authentication failure',
-          error,
-          {
-            component: 'AuthTokenManager',
-            action: 'handlePersistentAuthFailure',
-          },
-        )
-      })
-      .finally(() => {
-        this.persistentAuthHandlerPromise = null
-      })
-    this.persistentAuthHandlerPromise = promise
-    return promise
   }
 
   reset(): void {

--- a/src/services/cloud/project-storage.ts
+++ b/src/services/cloud/project-storage.ts
@@ -809,7 +809,12 @@ export class ProjectStorageService {
       }
       cursor = status.next_cursor
     } while (cursor)
-    return { documents: Array.from(documentsById.values()) }
+    // Replacing a Map value keeps its original insertion position, so
+    // re-sort to preserve the updated_at ordering of the walk.
+    const documents = Array.from(documentsById.values()).sort((a, b) =>
+      a.updatedAt < b.updatedAt ? -1 : a.updatedAt > b.updatedAt ? 1 : 0,
+    )
+    return { documents }
   }
 
   async getDocumentSyncStatus(

--- a/src/services/cloud/project-storage.ts
+++ b/src/services/cloud/project-storage.ts
@@ -784,7 +784,14 @@ export class ProjectStorageService {
     projectId: string,
     _options?: { includeContent?: boolean },
   ): Promise<ProjectDocumentListResponse> {
-    const documents: ProjectDocumentListResponse['documents'] = []
+    // Deduplicate by id: list-status walks the whole scope ordered by
+    // updated_at, so a row whose updated_at is bumped mid-walk (e.g.
+    // the enclave's rewrap-on-pull) or that straddles a page boundary
+    // can be returned twice. Keep the freshest copy of each row.
+    const documentsById = new Map<
+      string,
+      ProjectDocumentListResponse['documents'][number]
+    >()
     let cursor: string | undefined
     do {
       const status = await enclaveListStatus({
@@ -792,14 +799,17 @@ export class ProjectStorageService {
         cursor,
         limit: 500,
       })
-      documents.push(
-        ...status.updates
-          .filter((update) => update.id.startsWith(`${projectId}/`))
-          .map(projectDocumentListItemFromStatus),
-      )
+      for (const update of status.updates) {
+        if (!update.id.startsWith(`${projectId}/`)) continue
+        const document = projectDocumentListItemFromStatus(update)
+        const existing = documentsById.get(document.id)
+        if (!existing || document.updatedAt >= existing.updatedAt) {
+          documentsById.set(document.id, document)
+        }
+      }
       cursor = status.next_cursor
     } while (cursor)
-    return { documents }
+    return { documents: Array.from(documentsById.values()) }
   }
 
   async getDocumentSyncStatus(

--- a/src/services/cloud/sync-health.ts
+++ b/src/services/cloud/sync-health.ts
@@ -12,8 +12,8 @@
  * State model:
  *  - `gate` is the account-wide condition. `action-required` (key
  *    problems, blocked account) outranks `paused` (attestation /
- *    network trouble that retries itself); a paused report never
- *    downgrades an action-required gate.
+ *    network / auth trouble that retries itself); a paused report
+ *    never downgrades an action-required gate.
  *  - `failedChats` tracks per-chat terminal upload failures; an
  *    entry clears when that chat finally uploads or is deleted.
  *  - `lastSyncedAt` is the wall-clock time of the last completed

--- a/src/services/cloud/sync-health.ts
+++ b/src/services/cloud/sync-health.ts
@@ -23,7 +23,7 @@
  * so React consumers can use `useSyncExternalStore`.
  */
 
-export type SyncPausedReason = 'attestation' | 'network'
+export type SyncPausedReason = 'attestation' | 'network' | 'auth'
 
 export type SyncActionReason =
   'key-recovery' | 'key-mismatch' | 'key-conflict' | 'account-blocked'

--- a/src/services/sync-enclave/sync-enclave-client.ts
+++ b/src/services/sync-enclave/sync-enclave-client.ts
@@ -1,5 +1,6 @@
 import { SYNC_ENCLAVE_REPO, SYNC_ENCLAVE_URL } from '@/config'
 import { authTokenManager } from '@/services/auth'
+import { reportSyncPaused } from '@/services/cloud/sync-health'
 import { logError, logInfo } from '@/utils/error-handling'
 import { SecureClient } from 'tinfoil'
 
@@ -138,7 +139,14 @@ export class SyncEnclaveClient {
       token = await authTokenManager.refreshToken(token as string)
       resp = await send(token)
       if (resp.status === 401) {
-        authTokenManager.handlePersistentAuthFailure()
+        // A 401 that survives a token refresh is usually a server-side
+        // condition (enclave JWKS staleness after a signing-key
+        // rotation, clock skew) rather than a revoked session, so it
+        // must never force a sign-out. Pause sync and surface it; the
+        // periodic sync retries and clears the gate on success. A
+        // genuinely ended Clerk session is detected by Clerk itself
+        // and handled by the sign-out cleanup path.
+        reportSyncPaused('auth')
         throw new SyncPersistentAuthError()
       }
     }

--- a/tests/services/auth/auth-token-manager.test.ts
+++ b/tests/services/auth/auth-token-manager.test.ts
@@ -94,26 +94,4 @@ describe('AuthTokenManager', () => {
 
     await expect(read).rejects.toBeInstanceOf(AuthTokenUnavailableError)
   })
-
-  it('keeps persistent auth handling single-flight across resets', async () => {
-    let resolveHandler!: () => void
-    const handler = vi.fn(
-      () => new Promise<void>((resolve) => (resolveHandler = resolve)),
-    )
-    const manager = new AuthTokenManager()
-    manager.registerPersistentAuthHandler(handler)
-
-    const firstHandling = manager.handlePersistentAuthFailure()
-    manager.handlePersistentAuthFailure()
-    await vi.waitFor(() => expect(handler).toHaveBeenCalledOnce())
-
-    manager.reset()
-    manager.handlePersistentAuthFailure()
-    resolveHandler()
-    await firstHandling
-    expect(handler).toHaveBeenCalledOnce()
-
-    manager.handlePersistentAuthFailure()
-    await vi.waitFor(() => expect(handler).toHaveBeenCalledTimes(2))
-  })
 })

--- a/tests/services/cloud/project-storage.documents.test.ts
+++ b/tests/services/cloud/project-storage.documents.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const mocks = vi.hoisted(() => ({
   enclavePull: vi.fn(),
   enclavePush: vi.fn(),
+  enclaveListStatus: vi.fn(),
   pullItemPlaintext: vi.fn(),
 }))
 
@@ -22,7 +23,7 @@ vi.mock('@/services/cloud/cek-encoding', () => ({
 
 vi.mock('@/services/sync-enclave/sync-api', () => ({
   deleteRow: vi.fn(),
-  listStatus: vi.fn(),
+  listStatus: mocks.enclaveListStatus,
   pull: mocks.enclavePull,
   push: mocks.enclavePush,
   newIdempotencyKey: () => 'idempotency-key',
@@ -89,6 +90,79 @@ describe('ProjectStorageService documents', () => {
     expect(documents.get('doc-1')?.sizeBytes).toBe(
       new TextEncoder().encode(content).length,
     )
+  })
+
+  it('deduplicates documents listed on multiple pages', async () => {
+    const storage = new ProjectStorageService()
+    // Simulates a row whose updated_at was bumped mid-walk (enclave
+    // rewrap-on-pull), so the same id appears on two pages.
+    mocks.enclaveListStatus
+      .mockResolvedValueOnce({
+        updates: [
+          {
+            id: 'project-1/doc-1',
+            etag: '1',
+            updated_at: '2026-01-01T00:00:00.000Z',
+          },
+          {
+            id: 'project-1/doc-2',
+            etag: '1',
+            updated_at: '2026-01-01T00:00:01.000Z',
+          },
+        ],
+        next_cursor: 'page-2',
+      })
+      .mockResolvedValueOnce({
+        updates: [
+          {
+            id: 'project-1/doc-1',
+            etag: '2',
+            updated_at: '2026-01-01T00:00:02.000Z',
+          },
+          {
+            id: 'project-1/doc-2',
+            etag: '2',
+            updated_at: '2026-01-01T00:00:03.000Z',
+          },
+        ],
+        next_cursor: undefined,
+      })
+
+    const { documents } = await storage.listDocuments('project-1')
+
+    expect(documents).toHaveLength(2)
+    expect(documents.map((doc) => doc.id).sort()).toEqual(['doc-1', 'doc-2'])
+    // The freshest copy of each row wins.
+    expect(documents.find((doc) => doc.id === 'doc-1')?.updatedAt).toBe(
+      '2026-01-01T00:00:02.000Z',
+    )
+    expect(documents.find((doc) => doc.id === 'doc-2')?.updatedAt).toBe(
+      '2026-01-01T00:00:03.000Z',
+    )
+  })
+
+  it('excludes other projects\u2019 documents from the listing', async () => {
+    const storage = new ProjectStorageService()
+    mocks.enclaveListStatus.mockResolvedValueOnce({
+      updates: [
+        {
+          id: 'project-1/doc-1',
+          etag: '1',
+          updated_at: '2026-01-01T00:00:00.000Z',
+        },
+        {
+          id: 'project-2/doc-9',
+          etag: '1',
+          updated_at: '2026-01-01T00:00:01.000Z',
+        },
+      ],
+      next_cursor: undefined,
+    })
+
+    const { documents } = await storage.listDocuments('project-1')
+
+    expect(documents).toHaveLength(1)
+    expect(documents[0]).toMatchObject({ id: 'doc-1', projectId: 'project-1' })
   })
 
   it('marks failed pulls as unavailable documents', async () => {

--- a/tests/services/cloud/project-storage.documents.test.ts
+++ b/tests/services/cloud/project-storage.documents.test.ts
@@ -119,10 +119,12 @@ describe('ProjectStorageService documents', () => {
             etag: '2',
             updated_at: '2026-01-01T00:00:02.000Z',
           },
+          // Stale copy arriving after the fresher page-1 row: the
+          // freshest copy must win, not the last occurrence.
           {
             id: 'project-1/doc-2',
-            etag: '2',
-            updated_at: '2026-01-01T00:00:03.000Z',
+            etag: '0',
+            updated_at: '2025-12-31T00:00:00.000Z',
           },
         ],
         next_cursor: undefined,
@@ -130,15 +132,13 @@ describe('ProjectStorageService documents', () => {
 
     const { documents } = await storage.listDocuments('project-1')
 
-    expect(documents).toHaveLength(2)
-    expect(documents.map((doc) => doc.id).sort()).toEqual(['doc-1', 'doc-2'])
-    // The freshest copy of each row wins.
-    expect(documents.find((doc) => doc.id === 'doc-1')?.updatedAt).toBe(
-      '2026-01-01T00:00:02.000Z',
-    )
-    expect(documents.find((doc) => doc.id === 'doc-2')?.updatedAt).toBe(
-      '2026-01-01T00:00:03.000Z',
-    )
+    // The freshest copy of each row wins, ordered by updated_at.
+    expect(
+      documents.map((doc) => ({ id: doc.id, updatedAt: doc.updatedAt })),
+    ).toEqual([
+      { id: 'doc-2', updatedAt: '2026-01-01T00:00:01.000Z' },
+      { id: 'doc-1', updatedAt: '2026-01-01T00:00:02.000Z' },
+    ])
   })
 
   it('excludes other projects\u2019 documents from the listing', async () => {

--- a/tests/services/sync-enclave/sync-enclave-client.test.ts
+++ b/tests/services/sync-enclave/sync-enclave-client.test.ts
@@ -14,7 +14,7 @@ const {
   mockGetVerificationDocument,
   mockGetValidToken,
   mockRefreshToken,
-  mockHandlePersistentAuthFailure,
+  mockReportSyncPaused,
 } = vi.hoisted(() => ({
   mockSecureClientConstructor: vi.fn(),
   mockReady: vi.fn(),
@@ -26,7 +26,7 @@ const {
   }),
   mockGetValidToken: vi.fn().mockResolvedValue('test-jwt'),
   mockRefreshToken: vi.fn().mockResolvedValue('fresh-jwt'),
-  mockHandlePersistentAuthFailure: vi.fn(),
+  mockReportSyncPaused: vi.fn(),
 }))
 
 vi.mock('tinfoil', () => ({
@@ -46,8 +46,11 @@ vi.mock('@/services/auth', () => ({
   authTokenManager: {
     getValidToken: mockGetValidToken,
     refreshToken: mockRefreshToken,
-    handlePersistentAuthFailure: mockHandlePersistentAuthFailure,
   },
+}))
+
+vi.mock('@/services/cloud/sync-health', () => ({
+  reportSyncPaused: mockReportSyncPaused,
 }))
 
 function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
@@ -66,7 +69,7 @@ describe('SyncEnclaveClient', () => {
     mockFetch.mockReset()
     mockGetValidToken.mockReset().mockResolvedValue('test-jwt')
     mockRefreshToken.mockReset().mockResolvedValue('fresh-jwt')
-    mockHandlePersistentAuthFailure.mockReset()
+    mockReportSyncPaused.mockReset()
   })
 
   afterEach(() => {
@@ -190,7 +193,7 @@ describe('SyncEnclaveClient', () => {
     )
   })
 
-  it('throws persistent authentication after a replayed 401', async () => {
+  it('pauses sync instead of signing out after a replayed 401', async () => {
     const { getSyncEnclaveClient } =
       await import('@/services/sync-enclave/sync-enclave-client')
     mockFetch.mockResolvedValue(jsonResponse({ code: 'AUTH' }, { status: 401 }))
@@ -202,10 +205,10 @@ describe('SyncEnclaveClient', () => {
       status: 401,
     })
     expect(mockFetch).toHaveBeenCalledTimes(2)
-    expect(mockHandlePersistentAuthFailure).toHaveBeenCalledOnce()
+    expect(mockReportSyncPaused).toHaveBeenCalledWith('auth')
   })
 
-  it('does not sign out when forced refresh fails before replay', async () => {
+  it('does not pause sync when forced refresh fails before replay', async () => {
     const { getSyncEnclaveClient } =
       await import('@/services/sync-enclave/sync-enclave-client')
     mockFetch.mockResolvedValueOnce(
@@ -218,7 +221,7 @@ describe('SyncEnclaveClient', () => {
       'refresh failed',
     )
     expect(mockFetch).toHaveBeenCalledOnce()
-    expect(mockHandlePersistentAuthFailure).not.toHaveBeenCalled()
+    expect(mockReportSyncPaused).not.toHaveBeenCalled()
   })
 
   it('parses non-2xx responses into SyncEnclaveError with code + details', async () => {


### PR DESCRIPTION
## Summary

Fixes two user-reported bugs:

### Project context files duplicating on reload
Users reported that reloading a project page duplicated the file list (2 files became 4), and deleting one of a pair "deleted" its twin. The duplicates share the same document id: `listDocuments` pages through the `project_document` scope with no deduplication, so a row whose `updated_at` is bumped mid-walk (e.g. the enclave's rewrap-on-pull) or that straddles a page boundary is returned twice. Downstream, hydration maps the list 1:1 and the sidebar renders per array element, so one record shows up twice — and since deletion filters by id, both rendered rows vanish together. Duplicated documents were also injected into the system prompt twice, which could blow past model context limits ("some models won't answer").

Fix: deduplicate by id in `listDocuments`, keeping the freshest copy of each row. This also corrects the inflated count in `getDocumentSyncStatus`.

### Arbitrary sign-outs (and older chats disappearing)
Any sync-enclave request that received a 401, refreshed the token, and got a second 401 immediately forced a Clerk `signOut()`. Two consecutive 401s are frequently a transient server-side condition (enclave JWKS staleness after a Clerk signing-key rotation, clock skew, or Clerk returning an equivalent cached token), not a revoked session. Because background sync runs every 20 seconds, a brief window of enclave-side auth trouble logged users out mid-session — and the sign-out cleanup then wiped all local data, after which only the first page of chats re-synced, explaining "older chats aren't appearing".

Fix: a replayed 401 now pauses sync (surfaced via the existing sync-health store with a new `auth` paused reason and settings copy) instead of signing the user out. The periodic sync keeps retrying and clears the gate on success. A genuinely ended session is still detected by Clerk itself and handled by the existing sign-out cleanup path. The now-unused persistent-auth-handler machinery is removed from `AuthTokenManager`.

## Test plan
- Added tests: `listDocuments` dedupes rows repeated across pages (keeping the freshest) and filters other projects' documents
- Updated tests: replayed 401 pauses sync and does not invoke any sign-out path
- Full suite passes (135 files, 1550 tests), typecheck and lint clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents duplicate project files after reload and stops arbitrary sign-outs by pausing sync on repeated 401s. Previously, reloads could duplicate files and deleting one removed both; repeated 401s forced sign-out and wiped local data, hiding older chats. Now we dedupe and preserve ordering, and pause sync with automatic retry.

- Project files: `ProjectStorageService.listDocuments` dedupes by document id across pages and mid-walk updates, keeping the newest `updatedAt`, then re-sorts to maintain `updated_at` order. Fixes sidebar duplication, linked deletions, double system-prompt injection that could exceed model context, and inflated counts in `getDocumentSyncStatus`. Tests cover cross-page dedupe, cross-project filtering, and ordering.
- Sync auth: On a 401 that persists after token refresh, we call `reportSyncPaused('auth')` instead of signing out. UI shows an auth-specific pause message; periodic sync retries and unpauses on success. Removed the persistent-auth handler from `AuthTokenManager` and its registration in `use-cloud-sync`. Tests updated to assert pause behavior.

<sup>Written for commit 72ebd8fbd271ef5793e93e27eace44777511b470. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/493?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

