### PR TITLE
Show upload progress for every file added to a project

### DIFF
--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -2491,10 +2491,16 @@ export function ChatInterface({
       setShowAddToProjectModal(false)
 
       // Then process uploads (UI will show upload progress)
-      for (const file of filesToUpload) {
-        if (addToProject) {
-          await addFileToProjectContext(file)
-        } else {
+      if (addToProject) {
+        // Start all uploads before awaiting so every file registers its
+        // "Uploading..." placeholder immediately, mirroring the sidebar's
+        // own upload path. A sequential loop would surface one row at a
+        // time as each upload finishes.
+        await Promise.all(
+          filesToUpload.map((file) => addFileToProjectContext(file)),
+        )
+      } else {
+        for (const file of filesToUpload) {
           await processFileForChat(file)
         }
       }


### PR DESCRIPTION
## Summary
- When multiple files were dropped into the chat and confirmed into a project, only one "Uploading..." row appeared in the Documents sidebar at a time. The confirm handler awaited each file sequentially, and the placeholder is registered inside each upload, so the next file's row only appeared after the previous upload finished.
- The confirm path now starts all project uploads before awaiting (`Promise.all`), so every file registers its placeholder immediately — matching the sidebar's own multi-file upload path, which already uploads in parallel through the same hook and provider.
- Chat-attachment uploads (the "don't add to project" branch) keep their sequential behavior.

## Test plan
- Full suite passes (135 files, 1550 tests), typecheck and lint clean
- Manual: drop several files into a chat with an active project, confirm "Add to project" — all files show "Uploading..." rows at once

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows upload progress for every file added to a project from chat. Previously the confirm flow uploaded sequentially and showed one “Uploading…” row at a time; now it starts all project uploads in parallel so each file’s placeholder appears immediately. Chat-only uploads remain sequential.

- Changes are limited to the confirm handler in src/components/chat/chat-interface.tsx.
- For “Add to project,” a `Promise.all` starts all `addFileToProjectContext(file)` calls in parallel.
- The “Don’t add to project” path keeps a sequential loop over `processFileForChat(file)`.
- Expect concurrent project uploads; completion order may change but each file should show progress independently.

<sup>Written for commit 650f327ba1e183384d4ad5fd89e76b849c77e1ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/494?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

