### PR TITLE
fix: update chat location immediately after moving

### DIFF
--- a/src/components/chat/hooks/use-chat-storage.ts
+++ b/src/components/chat/hooks/use-chat-storage.ts
@@ -266,6 +266,17 @@ export function useChatStorage({
                   }
                 }
               }
+
+              if (
+                nextCurrent.isLocalOnly !== existingChat.isLocalOnly ||
+                nextCurrent.projectId !== existingChat.projectId
+              ) {
+                nextCurrent = {
+                  ...nextCurrent,
+                  isLocalOnly: existingChat.isLocalOnly,
+                  projectId: existingChat.projectId,
+                }
+              }
             }
           }
 

--- a/tests/components/chat/use-chat-storage.reloadChats.test.tsx
+++ b/tests/components/chat/use-chat-storage.reloadChats.test.tsx
@@ -190,6 +190,134 @@ describe('useChatStorage.reloadChats', () => {
     expect(result.current.currentChat.isBlankChat).toBe(false)
   })
 
+  it('moves the selected local chat into the cloud collection after reload', async () => {
+    const { result } = renderHook(() =>
+      useChatStorage({
+        storeHistory: true,
+      }),
+    )
+
+    await waitFor(() => {
+      expect(result.current.isInitialLoad).toBe(false)
+    })
+
+    const current = {
+      id: 'chat-1',
+      title: 'Moved chat',
+      messages: [
+        { role: 'user', content: 'Current message', timestamp: new Date() },
+      ],
+      createdAt: new Date(),
+      isBlankChat: false,
+      isLocalOnly: true,
+    }
+    await act(async () => {
+      result.current.setCurrentChat(current as any)
+    })
+    mockLoadChats.mockResolvedValue([
+      {
+        ...current,
+        messages: [],
+        isLocalOnly: false,
+      },
+    ])
+
+    await act(async () => {
+      await result.current.reloadChats()
+    })
+
+    expect(result.current.currentChat.isLocalOnly).toBe(false)
+    expect(result.current.currentChat.messages).toEqual(current.messages)
+    expect(result.current.chats.find((chat) => chat.id === current.id)).toBe(
+      result.current.currentChat,
+    )
+  })
+
+  it('moves the selected cloud chat into the local collection after reload', async () => {
+    const { result } = renderHook(() =>
+      useChatStorage({
+        storeHistory: true,
+      }),
+    )
+
+    await waitFor(() => {
+      expect(result.current.isInitialLoad).toBe(false)
+    })
+
+    const current = {
+      id: 'chat-1',
+      title: 'Moved chat',
+      messages: [],
+      createdAt: new Date(),
+      isBlankChat: false,
+      isLocalOnly: false,
+      projectId: 'project-1',
+    }
+    await act(async () => {
+      result.current.setCurrentChat(current as any)
+    })
+    mockLoadChats.mockResolvedValue([
+      {
+        ...current,
+        isLocalOnly: true,
+        projectId: undefined,
+      },
+    ])
+
+    await act(async () => {
+      await result.current.reloadChats()
+    })
+
+    expect(result.current.currentChat.isLocalOnly).toBe(true)
+    expect(result.current.currentChat.projectId).toBeUndefined()
+    expect(result.current.chats.find((chat) => chat.id === current.id)).toBe(
+      result.current.currentChat,
+    )
+  })
+
+  it('updates the selected chat location during a streaming recovery reload', async () => {
+    const { result } = renderHook(() =>
+      useChatStorage({
+        storeHistory: true,
+      }),
+    )
+
+    await waitFor(() => {
+      expect(result.current.isInitialLoad).toBe(false)
+    })
+
+    const current = {
+      id: 'chat-1',
+      title: 'Moved chat',
+      messages: [
+        { role: 'user', content: 'Streaming message', timestamp: new Date() },
+      ],
+      createdAt: new Date(),
+      isBlankChat: false,
+      isLocalOnly: true,
+    }
+    await act(async () => {
+      result.current.setCurrentChat(current as any)
+    })
+    mockIsStreaming.mockReturnValue(true)
+    mockLoadChats.mockResolvedValue([
+      {
+        ...current,
+        messages: [],
+        isLocalOnly: false,
+      },
+    ])
+
+    act(() => {
+      chatEvents.emit({ reason: 'recovery', ids: [current.id] })
+    })
+
+    await waitFor(() => {
+      expect(result.current.currentChat.isLocalOnly).toBe(false)
+    })
+    expect(result.current.currentChat.messages).toEqual(current.messages)
+  })
+
   it('applies idChanges to currentChat before reloading', async () => {
     const { result } = renderHook(() =>
       useChatStorage({


### PR DESCRIPTION
## Summary
- reconcile selected-chat storage metadata after local/cloud moves
- keep the sidebar collection and active chat location in sync without refresh
- cover both move directions and streaming recovery reloads

## Tests
- `npm run test:unit -- --run tests/components/chat/use-chat-storage.reloadChats.test.tsx`
- `npx eslint src/components/chat/hooks/use-chat-storage.ts tests/components/chat/use-chat-storage.reloadChats.test.tsx`
- `npx tsc --noEmit`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update selected chat location immediately after moving between local and cloud to keep UI state consistent. Previously the active chat kept stale `isLocalOnly`/`projectId` until a full reload; now it updates in place and preserves messages, including during streaming recovery.

- During reload, when the current chat matches by id, copy `isLocalOnly` and `projectId` from the persisted chat into the current chat.
- Handle both directions: local → cloud and cloud → local.
- On streaming recovery reloads, update location while keeping the in-progress message list.
- Adds unit tests for both move directions and recovery; no migrations or API changes.

<sup>Written for commit a454b7a7062df8eea99cc5c16d9278d5315f4894. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/495?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

