### PR TITLE
Preserve more context headroom for chat responses

### DIFF
--- a/src/utils/token-estimation.ts
+++ b/src/utils/token-estimation.ts
@@ -7,7 +7,7 @@ import {
 
 // Fraction of the model's context window reserved for conversation history;
 // the remainder is headroom for the system prompt and the model's response.
-export const CONTEXT_WINDOW_USAGE_RATIO = 0.9
+export const CONTEXT_WINDOW_USAGE_RATIO = 0.8
 
 export const DEFAULT_CONTEXT_WINDOW_TOKENS = 64000
 

--- a/tests/components/chat/genui/retry.test.ts
+++ b/tests/components/chat/genui/retry.test.ts
@@ -125,7 +125,7 @@ describe('artifact retry', () => {
     const selected = selectArtifactRetryContext(
       [message('user', older), message('assistant', recent)],
       1000,
-      'm'.repeat(3200),
+      'm'.repeat(2800),
     )
 
     expect(selected).toEqual([{ role: 'assistant', content: recent }])
@@ -139,7 +139,7 @@ describe('artifact retry', () => {
     }
 
     expect(
-      selectArtifactRetryContext([contextualMessage], 1000, 'm'.repeat(3200)),
+      selectArtifactRetryContext([contextualMessage], 1000, 'm'.repeat(2800)),
     ).toEqual([{ role: 'assistant', content: 'visible' }])
   })
 

--- a/tests/utils/token-estimation.test.ts
+++ b/tests/utils/token-estimation.test.ts
@@ -97,7 +97,7 @@ describe('getContextTokenBudget', () => {
   })
 
   it('reserves pending input tokens before budgeting persisted history', () => {
-    expect(getHistoryTokenBudget(1000, 250)).toBe(650)
+    expect(getHistoryTokenBudget(1000, 250)).toBe(550)
     expect(getHistoryTokenBudget(1000, 1000)).toBe(0)
   })
 })
@@ -209,7 +209,7 @@ describe('findContextStartIndex', () => {
 
 describe('selectMessagesWithinBudget', () => {
   it('selects the most recent messages that fit the model budget', () => {
-    // 1k-token context window → 900-token budget; each message is 400 tokens
+    // 1k-token context window → 800-token budget; each message is 400 tokens
     const messages = [
       makeMessage('user', 1600),
       makeMessage('assistant', 1600),


### PR DESCRIPTION
## Summary
- archive older conversation messages after 80% of the model context is used
- reserve 20% of the context window for system instructions and new responses
- update context budgeting expectations

## Testing
- `npm run test:unit -- --run tests/utils/token-estimation.test.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves 20% of the model context for system instructions and new responses by reducing the conversation history budget from 90% to 80%. Previously, history could consume 90%, constraining longer replies; now older messages may be archived sooner to keep more headroom.

- Set CONTEXT_WINDOW_USAGE_RATIO to 0.8 in src/utils/token-estimation.ts; e.g., 1k window → 800-token history; getHistoryTokenBudget(1000, 250) → 550.
- Align tests with the 80% budget, including retry context selection thresholds in tests/components/chat/genui/retry.test.ts (3200 → 2800) and updates in tests/utils/token-estimation.test.ts.
- No API or config changes; only budgeting behavior shifts.

<sup>Written for commit b4feed443810020ebb25e3df247c669c5cffc1ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/496?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

