### PR TITLE
Bound attachment payload reads during sync

### DIFF
--- a/src/services/cloud/chat-codec.ts
+++ b/src/services/cloud/chat-codec.ts
@@ -10,7 +10,7 @@
 import { DEFAULT_CHAT_TITLE } from '@/constants/chat'
 import { ensureValidISODate } from '@/utils/chat-timestamps'
 import { logInfo } from '@/utils/error-handling'
-import type { StoredChat } from '../storage/indexed-db'
+import type { ChatSyncMetadata, StoredChat } from '../storage/indexed-db'
 import { observe } from './edit-clock'
 import { RemoteChatPlaintextSchema } from './schemas'
 
@@ -34,7 +34,7 @@ export interface ProcessedChatResult {
 }
 
 export interface ProcessRemoteChatOptions {
-  localChat?: StoredChat | null
+  localChat?: Pick<ChatSyncMetadata, 'projectId'> | null
   projectId?: string
 }
 
@@ -157,7 +157,7 @@ function createPlaceholderChat(options: PlaceholderOptions): StoredChat {
 
 export async function processRemoteChats(
   remoteChats: RemoteChatData[],
-  localChatMap: Map<string, StoredChat>,
+  localChatMap: Map<string, ChatSyncMetadata>,
 ): Promise<ProcessedChatResult[]> {
   const results: ProcessedChatResult[] = []
 

--- a/src/services/cloud/chat-ingestion.ts
+++ b/src/services/cloud/chat-ingestion.ts
@@ -9,7 +9,7 @@
 import { logError } from '@/utils/error-handling'
 import { chatEvents, type ChatChangeReason } from '../storage/chat-events'
 import { deletedChatsTracker } from '../storage/deleted-chats-tracker'
-import { indexedDBStorage, type StoredChat } from '../storage/indexed-db'
+import { indexedDBStorage, type ChatSyncMetadata } from '../storage/indexed-db'
 import {
   processRemoteChat,
   type ProcessRemoteChatOptions,
@@ -41,7 +41,7 @@ export interface RemoteChatEntry {
 
 export interface IngestOptions {
   /** Pre-built map of local chats by ID. If omitted, each chat is fetched individually. */
-  localChatMap?: Map<string, StoredChat>
+  localChatMap?: Map<string, ChatSyncMetadata>
   /** Project ID to associate with ingested chats */
   projectId?: string
   /** When true, call shouldIngestRemoteChat to skip chats that are already up-to-date locally */

--- a/src/services/cloud/cloud-sync.ts
+++ b/src/services/cloud/cloud-sync.ts
@@ -1179,7 +1179,7 @@ export class CloudSyncService {
     if (!this.isCurrentGeneration(generation)) return result
 
     try {
-      const unsyncedChats = await indexedDBStorage.getUnsyncedChats()
+      const unsyncedChats = await indexedDBStorage.getUnsyncedChatMetadata()
       if (!this.isCurrentGeneration(generation)) return result
 
       // Debug logging
@@ -1387,7 +1387,7 @@ export class CloudSyncService {
         },
       })
 
-      const localChats = await indexedDBStorage.getAllChats()
+      const localChats = await indexedDBStorage.getChatSyncMetadata()
 
       const localChatMap = new Map(localChats.map((c) => [c.id, c]))
 
@@ -2063,7 +2063,7 @@ export class CloudSyncService {
     }
 
     try {
-      const localChats = await indexedDBStorage.getAllChats()
+      const localChats = await indexedDBStorage.getChatSyncMetadata()
       const localChatMap = new Map(localChats.map((c) => [c.id, c]))
 
       let hasMore = true
@@ -2182,7 +2182,7 @@ export class CloudSyncService {
 
     try {
       // First, backup any unsynced local project chats
-      const unsyncedChats = await indexedDBStorage.getUnsyncedChats()
+      const unsyncedChats = await indexedDBStorage.getUnsyncedChatMetadata()
       if (!this.isCurrentGeneration(generation)) return result
       const projectChatsToSync = unsyncedChats.filter(
         (chat) =>

--- a/src/services/cloud/sync-predicates.ts
+++ b/src/services/cloud/sync-predicates.ts
@@ -6,7 +6,10 @@
  * can be uploaded, downloaded, or retried for decryption.
  */
 
-import type { StoredChat } from '@/services/storage/indexed-db'
+import type {
+  ChatSyncMetadata,
+  StoredChat,
+} from '@/services/storage/indexed-db'
 import type { EditClock } from './edit-clock'
 
 export function trustedChatClock(
@@ -46,7 +49,10 @@ export function trustedChatClock(
  * @returns true if the chat can be uploaded
  */
 export function isUploadableChat(
-  chat: StoredChat,
+  chat: Pick<
+    ChatSyncMetadata,
+    'id' | 'isLocalOnly' | 'isBlankChat' | 'decryptionFailed'
+  >,
   isStreaming?: (chatId: string) => boolean,
 ): boolean {
   if (chat.isLocalOnly === true) {
@@ -82,7 +88,13 @@ export function isUploadableChat(
  */
 export function shouldIngestRemoteChat(
   remote: { id: string; updatedAt?: string | null },
-  local: StoredChat | null | undefined,
+  local:
+    | Pick<
+        ChatSyncMetadata,
+        'decryptionFailed' | 'locallyModified' | 'syncedAt'
+      >
+    | null
+    | undefined,
 ): boolean {
   // If no local chat exists, always ingest
   if (!local) {

--- a/src/services/cloud/sync-predicates.ts
+++ b/src/services/cloud/sync-predicates.ts
@@ -42,7 +42,7 @@ export function trustedChatClock(
  * - isLocalOnly === true (user explicitly chose local storage)
  * - isBlankChat === true (empty placeholder chat)
  * - decryptionFailed === true (would overwrite server data with placeholder)
- * - no messages (nothing to upload)
+ * - no messages (malformed or stale persisted chat, not an intentional blank)
  * - currently streaming (incomplete data)
  *
  * @param chat The chat to check
@@ -78,7 +78,7 @@ export function isUploadableChat(
   }
 
   const messageCount =
-    'messageCount' in chat ? chat.messageCount : chat.messages.length
+    'messages' in chat ? chat.messages.length : chat.messageCount
   if (messageCount === 0) {
     return false
   }

--- a/src/services/cloud/sync-predicates.ts
+++ b/src/services/cloud/sync-predicates.ts
@@ -42,6 +42,7 @@ export function trustedChatClock(
  * - isLocalOnly === true (user explicitly chose local storage)
  * - isBlankChat === true (empty placeholder chat)
  * - decryptionFailed === true (would overwrite server data with placeholder)
+ * - no messages (nothing to upload)
  * - currently streaming (incomplete data)
  *
  * @param chat The chat to check
@@ -49,10 +50,19 @@ export function trustedChatClock(
  * @returns true if the chat can be uploaded
  */
 export function isUploadableChat(
-  chat: Pick<
-    ChatSyncMetadata,
-    'id' | 'isLocalOnly' | 'isBlankChat' | 'decryptionFailed'
-  >,
+  chat:
+    | Pick<
+        ChatSyncMetadata,
+        | 'id'
+        | 'messageCount'
+        | 'isLocalOnly'
+        | 'isBlankChat'
+        | 'decryptionFailed'
+      >
+    | Pick<
+        StoredChat,
+        'id' | 'messages' | 'isLocalOnly' | 'isBlankChat' | 'decryptionFailed'
+      >,
   isStreaming?: (chatId: string) => boolean,
 ): boolean {
   if (chat.isLocalOnly === true) {
@@ -64,6 +74,12 @@ export function isUploadableChat(
   }
 
   if (chat.decryptionFailed === true) {
+    return false
+  }
+
+  const messageCount =
+    'messageCount' in chat ? chat.messageCount : chat.messages.length
+  if (messageCount === 0) {
     return false
   }
 

--- a/src/services/storage/indexed-db.ts
+++ b/src/services/storage/indexed-db.ts
@@ -42,6 +42,17 @@ export interface StoredChat extends Chat {
   clockVersion?: number
 }
 
+export interface ChatSyncMetadata {
+  id: string
+  projectId?: string
+  decryptionFailed?: boolean
+  locallyModified?: boolean
+  syncedAt?: number
+  updatedAt: string
+  isLocalOnly?: boolean
+  isBlankChat?: boolean
+}
+
 export interface SaveChatResult {
   saved: boolean
   isLocalOnly: boolean
@@ -157,6 +168,19 @@ function deserializeStoredChat(chat: StoredChat): StoredChat {
       timestamp: message.timestamp ? new Date(message.timestamp) : new Date(),
     })),
   } as StoredChat
+}
+
+function toChatSyncMetadata(chat: StoredChat): ChatSyncMetadata {
+  return {
+    id: chat.id,
+    projectId: chat.projectId,
+    decryptionFailed: chat.decryptionFailed,
+    locallyModified: chat.locallyModified,
+    syncedAt: chat.syncedAt,
+    updatedAt: chat.updatedAt,
+    isLocalOnly: chat.isLocalOnly,
+    isBlankChat: chat.isBlankChat,
+  }
 }
 
 /**
@@ -1743,49 +1767,67 @@ export class IndexedDBStorage {
         const request = store.openCursor(null, 'next') // Ascending order on reverse timestamp = most recent first
 
         const chats: StoredChat[] = []
-        let payloads: StoredAttachmentPayload[] = []
-        const payloadRequest = transaction
+        const payloadIndex = transaction
           .objectStore(ATTACHMENT_PAYLOADS_STORE)
-          .getAll()
-        payloadRequest.onsuccess = () => {
-          payloads = payloadRequest.result as StoredAttachmentPayload[]
-        }
-        payloadRequest.onerror = () =>
-          reject(new Error('Failed to get attachment payloads'))
+          .index(ATTACHMENT_PAYLOADS_CHAT_INDEX)
 
         request.onsuccess = (event) => {
-          const cursor = (event.target as IDBRequest).result
-          if (cursor) {
+          const cursor = (event.target as IDBRequest<IDBCursorWithValue | null>)
+            .result
+          if (!cursor) return
+
+          const rawChat = cursor.value as StoredChat
+          const payloadRequest = payloadIndex.getAll(
+            IDBKeyRange.only(rawChat.id),
+          )
+          payloadRequest.onsuccess = () => {
             try {
-              chats.push(deserializeStoredChat(cursor.value as StoredChat))
+              const chat = deserializeStoredChat(rawChat)
+              chats.push(
+                hydrateAttachmentPayloads(
+                  chat,
+                  payloadRequest.result as StoredAttachmentPayload[],
+                ),
+              )
               cursor.continue()
             } catch (error) {
               reject(error)
             }
           }
+          payloadRequest.onerror = () =>
+            reject(new Error('Failed to get attachment payloads'))
         }
 
         request.onerror = () => reject(new Error('Failed to get all chats'))
-        transaction.oncomplete = () => {
-          try {
-            const payloadsByChat = new Map<string, StoredAttachmentPayload[]>()
-            for (const payload of payloads) {
-              const chatPayloads = payloadsByChat.get(payload.chatId)
-              if (chatPayloads) chatPayloads.push(payload)
-              else payloadsByChat.set(payload.chatId, [payload])
-            }
-            resolve(
-              chats.map((chat) =>
-                hydrateAttachmentPayloads(
-                  chat,
-                  payloadsByChat.get(chat.id) ?? [],
-                ),
-              ),
-            )
-          } catch (error) {
-            reject(error)
+        transaction.oncomplete = () => resolve(chats)
+        transaction.onerror = () => reject(new Error('Failed to get all chats'))
+        transaction.onabort = () =>
+          reject(new Error('Get all chats transaction aborted'))
+      }),
+    )
+  }
+
+  async getChatSyncMetadata(): Promise<ChatSyncMetadata[]> {
+    await this.waitForSaveQueue()
+    const db = await this.ensureDB()
+
+    return this.protectRead(
+      new Promise((resolve, reject) => {
+        const transaction = db.transaction([CHATS_STORE], 'readonly')
+        const request = transaction.objectStore(CHATS_STORE).openCursor()
+        const metadata: ChatSyncMetadata[] = []
+
+        request.onsuccess = () => {
+          const cursor = request.result
+          if (!cursor) {
+            resolve(metadata)
+            return
           }
+          metadata.push(toChatSyncMetadata(cursor.value as StoredChat))
+          cursor.continue()
         }
+        request.onerror = () =>
+          reject(new Error('Failed to get chat sync metadata'))
       }),
     )
   }
@@ -1946,7 +1988,7 @@ export class IndexedDBStorage {
     return hydrated.filter((chat): chat is StoredChat => chat !== null)
   }
 
-  async getUnsyncedChatMetadata(): Promise<StoredChat[]> {
+  async getUnsyncedChatMetadata(): Promise<ChatSyncMetadata[]> {
     await this.ensureSyncPendingIndex()
     await this.waitForSaveQueue()
     const db = await this.ensureDB()
@@ -1955,14 +1997,19 @@ export class IndexedDBStorage {
       new Promise((resolve, reject) => {
         const transaction = db.transaction([CHATS_STORE], 'readonly')
         const store = transaction.objectStore(CHATS_STORE)
-        const request = store.index(CHATS_SYNC_PENDING_INDEX).getAll(1)
+        const request = store
+          .index(CHATS_SYNC_PENDING_INDEX)
+          .openCursor(IDBKeyRange.only(1))
+        const metadata: ChatSyncMetadata[] = []
 
         request.onsuccess = () => {
-          try {
-            resolve((request.result as StoredChat[]).map(deserializeStoredChat))
-          } catch (error) {
-            reject(error)
+          const cursor = request.result
+          if (!cursor) {
+            resolve(metadata)
+            return
           }
+          metadata.push(toChatSyncMetadata(cursor.value as StoredChat))
+          cursor.continue()
         }
         request.onerror = () =>
           reject(new Error('Failed to get unsynced chats'))

--- a/src/services/storage/indexed-db.ts
+++ b/src/services/storage/indexed-db.ts
@@ -44,6 +44,7 @@ export interface StoredChat extends Chat {
 
 export interface ChatSyncMetadata {
   id: string
+  messageCount: number
   projectId?: string
   decryptionFailed?: boolean
   locallyModified?: boolean
@@ -145,6 +146,12 @@ const ACCOUNT_CHANGE_RESET_TIMEOUT_MS = 10_000
 const ACCOUNT_CHANGE_READ_ERROR = 'IndexedDB read superseded by account change'
 const ACCOUNT_CHANGE_WRITE_ERROR =
   'IndexedDB write superseded by account change'
+const CHAT_SYNC_BOOLEAN_FIELDS = [
+  'decryptionFailed',
+  'locallyModified',
+  'isLocalOnly',
+  'isBlankChat',
+] as const
 let isUpgradeBlocked = false
 const textEncoder = new TextEncoder()
 
@@ -170,16 +177,52 @@ function deserializeStoredChat(chat: StoredChat): StoredChat {
   } as StoredChat
 }
 
-function toChatSyncMetadata(chat: StoredChat): ChatSyncMetadata {
+function toChatSyncMetadata(chat: unknown): ChatSyncMetadata {
+  if (!chat || typeof chat !== 'object') {
+    throw new Error('Stored chat has invalid sync metadata')
+  }
+
+  const rawChat = chat as Record<string, unknown>
+  if (typeof rawChat.id !== 'string' || rawChat.id.trim().length === 0) {
+    throw new Error('Stored chat has invalid sync metadata: id')
+  }
+  if (!Array.isArray(rawChat.messages)) {
+    throw new Error('Stored chat has invalid sync metadata: messages')
+  }
+  if (
+    typeof rawChat.updatedAt !== 'string' ||
+    rawChat.updatedAt.trim().length === 0
+  ) {
+    throw new Error('Stored chat has invalid sync metadata: updatedAt')
+  }
+  if (
+    rawChat.projectId !== undefined &&
+    typeof rawChat.projectId !== 'string'
+  ) {
+    throw new Error('Stored chat has invalid sync metadata: projectId')
+  }
+  if (
+    rawChat.syncedAt !== undefined &&
+    (typeof rawChat.syncedAt !== 'number' || !Number.isFinite(rawChat.syncedAt))
+  ) {
+    throw new Error('Stored chat has invalid sync metadata: syncedAt')
+  }
+  for (const field of CHAT_SYNC_BOOLEAN_FIELDS) {
+    if (rawChat[field] !== undefined && typeof rawChat[field] !== 'boolean') {
+      throw new Error(`Stored chat has invalid sync metadata: ${field}`)
+    }
+  }
+
   return {
-    id: chat.id,
-    projectId: chat.projectId,
-    decryptionFailed: chat.decryptionFailed,
-    locallyModified: chat.locallyModified,
-    syncedAt: chat.syncedAt,
-    updatedAt: chat.updatedAt,
-    isLocalOnly: chat.isLocalOnly,
-    isBlankChat: chat.isBlankChat,
+    id: rawChat.id,
+    messageCount: rawChat.messages.length,
+    projectId: rawChat.projectId as string | undefined,
+    decryptionFailed: rawChat.decryptionFailed as boolean | undefined,
+    locallyModified: rawChat.locallyModified as boolean | undefined,
+    syncedAt: rawChat.syncedAt as number | undefined,
+    updatedAt: rawChat.updatedAt,
+    isLocalOnly: rawChat.isLocalOnly as boolean | undefined,
+    isBlankChat: rawChat.isBlankChat as boolean | undefined,
   }
 }
 
@@ -1818,13 +1861,17 @@ export class IndexedDBStorage {
         const metadata: ChatSyncMetadata[] = []
 
         request.onsuccess = () => {
-          const cursor = request.result
-          if (!cursor) {
-            resolve(metadata)
-            return
+          try {
+            const cursor = request.result
+            if (!cursor) {
+              resolve(metadata)
+              return
+            }
+            metadata.push(toChatSyncMetadata(cursor.value))
+            cursor.continue()
+          } catch (error) {
+            reject(error)
           }
-          metadata.push(toChatSyncMetadata(cursor.value as StoredChat))
-          cursor.continue()
         }
         request.onerror = () =>
           reject(new Error('Failed to get chat sync metadata'))
@@ -2003,13 +2050,17 @@ export class IndexedDBStorage {
         const metadata: ChatSyncMetadata[] = []
 
         request.onsuccess = () => {
-          const cursor = request.result
-          if (!cursor) {
-            resolve(metadata)
-            return
+          try {
+            const cursor = request.result
+            if (!cursor) {
+              resolve(metadata)
+              return
+            }
+            metadata.push(toChatSyncMetadata(cursor.value))
+            cursor.continue()
+          } catch (error) {
+            reject(error)
           }
-          metadata.push(toChatSyncMetadata(cursor.value as StoredChat))
-          cursor.continue()
         }
         request.onerror = () =>
           reject(new Error('Failed to get unsynced chats'))

--- a/tests/services/cloud/chat-codec.test.ts
+++ b/tests/services/cloud/chat-codec.test.ts
@@ -177,7 +177,11 @@ describe('Chat Codec - processRemoteChat', () => {
       const localChat = {
         id: 'remote-chat-1',
         projectId: 'local-project',
-      } as any
+        decryptionFailed: false,
+        locallyModified: false,
+        syncedAt: 0,
+        updatedAt: '2024-01-01T00:00:00.000Z',
+      }
 
       const result = await processRemoteChat(baseRemoteChat, { localChat })
 

--- a/tests/services/cloud/cloud-sync.test.ts
+++ b/tests/services/cloud/cloud-sync.test.ts
@@ -15,8 +15,6 @@ const mockGetAllChats = vi.fn()
 const mockGetCloudChatCount = vi.fn()
 const mockGetProjectChatCount = vi.fn()
 const mockIsChatHistoryAuthoritative = vi.fn()
-const mockGetUnsyncedChats = vi.fn()
-const mockGetUnsyncedFullChats = vi.fn()
 const mockGetUnsyncedChatMetadata = vi.fn()
 const mockGetChatSyncMetadata = vi.fn()
 const mockGetChat = vi.fn()
@@ -88,7 +86,6 @@ vi.mock('@/services/storage/indexed-db', () => ({
     getProjectChatCount: (...args: any[]) => mockGetProjectChatCount(...args),
     isChatHistoryAuthoritative: (...args: any[]) =>
       mockIsChatHistoryAuthoritative(...args),
-    getUnsyncedChats: (...args: any[]) => mockGetUnsyncedFullChats(...args),
     getUnsyncedChatMetadata: (...args: any[]) =>
       mockGetUnsyncedChatMetadata(...args),
     saveChat: (...args: any[]) => mockSaveChat(...args),
@@ -230,9 +227,7 @@ describe('CloudSyncService', () => {
     mockRebaseSyncVersion.mockResolvedValue(undefined)
     mockResetSyncMetadataForAllChats.mockResolvedValue(undefined)
     mockDeleteChat.mockResolvedValue(undefined)
-    mockGetUnsyncedChatMetadata.mockImplementation((...args) =>
-      mockGetUnsyncedChats(...args),
-    )
+    mockGetUnsyncedChatMetadata.mockResolvedValue([])
     mockGetChatSyncMetadata.mockResolvedValue([])
     mockGetKey.mockReturnValue(null)
     mockIsChatHistoryAuthoritative.mockResolvedValue(true)
@@ -583,10 +578,11 @@ describe('CloudSyncService', () => {
         isBlankChat: false,
         isLocalOnly: false,
         decryptionFailed: false,
+        messageCount: 1,
         syncVersion: 3,
       }
 
-      mockGetUnsyncedChats.mockResolvedValue([
+      mockGetUnsyncedChatMetadata.mockResolvedValue([
         { ...good, id: 'local-only', isLocalOnly: true },
         { ...good, id: 'blank', isBlankChat: true },
         { ...good, id: 'failed', decryptionFailed: true },
@@ -606,14 +602,32 @@ describe('CloudSyncService', () => {
 
       expect(mockUploadChat).toHaveBeenCalledTimes(1)
       expect(mockGetUnsyncedChatMetadata).toHaveBeenCalledOnce()
-      expect(mockGetUnsyncedChats).toHaveBeenCalledOnce()
-      expect(mockGetUnsyncedFullChats).not.toHaveBeenCalled()
       expect(mockGetChat).toHaveBeenCalledTimes(1)
       expect(mockUploadChat.mock.calls[0]?.[0]?.id).toBe('cloud-1')
       expect(mockFinalizeUpload).toHaveBeenCalledWith(
         expect.objectContaining({ chatId: 'cloud-1', syncVersion: 4 }),
       )
       expect(result.uploaded).toBe(1)
+      expect(result.errors).toEqual([])
+    })
+
+    it('does not enqueue an empty metadata chat for upload', async () => {
+      mockGetUnsyncedChatMetadata.mockResolvedValue([
+        {
+          id: 'empty-chat',
+          messageCount: 0,
+          updatedAt: '2024-01-01T00:00:00.000Z',
+          isBlankChat: false,
+          isLocalOnly: false,
+          decryptionFailed: false,
+        },
+      ])
+
+      const result = await new CloudSyncService().backupUnsyncedChats()
+
+      expect(mockGetChat).not.toHaveBeenCalled()
+      expect(mockUploadChat).not.toHaveBeenCalled()
+      expect(result.uploaded).toBe(0)
       expect(result.errors).toEqual([])
     })
 
@@ -627,9 +641,10 @@ describe('CloudSyncService', () => {
         isBlankChat: false,
         isLocalOnly: false,
         locallyModified: true,
+        messageCount: 1,
         syncVersion: 1,
       }
-      mockGetUnsyncedChats.mockResolvedValue([chat])
+      mockGetUnsyncedChatMetadata.mockResolvedValue([chat])
       mockGetChat.mockResolvedValue(chat)
       mockUploadChat.mockRejectedValue(
         new SyncEnclaveError('missing', 404, 'NOT_FOUND'),
@@ -657,9 +672,10 @@ describe('CloudSyncService', () => {
         isBlankChat: false,
         isLocalOnly: false,
         locallyModified: true,
+        messageCount: 1,
         syncVersion: 1,
       }
-      mockGetUnsyncedChats.mockResolvedValue([chat])
+      mockGetUnsyncedChatMetadata.mockResolvedValue([chat])
       mockGetChat.mockResolvedValue(chat)
       mockUploadChat.mockRejectedValue(
         new SyncEnclaveError('forbidden', 403, 'FORBIDDEN'),
@@ -681,15 +697,35 @@ describe('CloudSyncService', () => {
       const status = await service.checkSyncStatus()
 
       expect(status).toEqual({ needsSync: false, reason: 'no_changes' })
-      expect(mockGetUnsyncedChats).not.toHaveBeenCalled()
+      expect(mockGetUnsyncedChatMetadata).not.toHaveBeenCalled()
     })
 
     it('returns local_changes when there are unsynced non-local chats', async () => {
-      mockGetUnsyncedChats.mockResolvedValue([
-        { id: 'local-only', isLocalOnly: true, isBlankChat: false },
-        { id: 'blank', isLocalOnly: false, isBlankChat: true },
-        { id: 'streaming', isLocalOnly: false, isBlankChat: false },
-        { id: 'good', isLocalOnly: false, isBlankChat: false },
+      mockGetUnsyncedChatMetadata.mockResolvedValue([
+        {
+          id: 'local-only',
+          messageCount: 1,
+          isLocalOnly: true,
+          isBlankChat: false,
+        },
+        {
+          id: 'blank',
+          messageCount: 1,
+          isLocalOnly: false,
+          isBlankChat: true,
+        },
+        {
+          id: 'streaming',
+          messageCount: 1,
+          isLocalOnly: false,
+          isBlankChat: false,
+        },
+        {
+          id: 'good',
+          messageCount: 1,
+          isLocalOnly: false,
+          isBlankChat: false,
+        },
       ])
       mockIsStreaming.mockImplementation((id: string) => id === 'streaming')
 
@@ -701,7 +737,7 @@ describe('CloudSyncService', () => {
     })
 
     it('returns count_changed when there is no cached status', async () => {
-      mockGetUnsyncedChats.mockResolvedValue([])
+      mockGetUnsyncedChatMetadata.mockResolvedValue([])
       mockGetChatSyncStatus.mockResolvedValue({
         count: 5,
         lastUpdated: '2024-01-01T00:00:00.000Z',
@@ -717,7 +753,7 @@ describe('CloudSyncService', () => {
     })
 
     it('returns no_changes when cached status matches remote status and there are no local changes', async () => {
-      mockGetUnsyncedChats.mockResolvedValue([])
+      mockGetUnsyncedChatMetadata.mockResolvedValue([])
       mockGetChatSyncStatus.mockResolvedValue({
         count: 5,
         lastUpdated: '2024-01-01T00:00:00.000Z',
@@ -741,7 +777,7 @@ describe('CloudSyncService', () => {
     })
 
     it('forces a full pull when the live local chat count has dropped below the cached snapshot', async () => {
-      mockGetUnsyncedChats.mockResolvedValue([])
+      mockGetUnsyncedChatMetadata.mockResolvedValue([])
       mockGetChatSyncStatus.mockResolvedValue({
         count: 1873,
         lastUpdated: '2026-05-25T18:04:30.182Z',
@@ -766,7 +802,7 @@ describe('CloudSyncService', () => {
     })
 
     it('stays at no_changes when remote and live local counts both match the cached snapshot', async () => {
-      mockGetUnsyncedChats.mockResolvedValue([])
+      mockGetUnsyncedChatMetadata.mockResolvedValue([])
       mockGetChatSyncStatus.mockResolvedValue({
         count: 1873,
         lastUpdated: '2026-05-25T18:04:30.182Z',
@@ -790,7 +826,7 @@ describe('CloudSyncService', () => {
     })
 
     it('falls back to remote-only comparison when the snapshot predates the localCount field', async () => {
-      mockGetUnsyncedChats.mockResolvedValue([])
+      mockGetUnsyncedChatMetadata.mockResolvedValue([])
       mockGetChatSyncStatus.mockResolvedValue({
         count: 12,
         lastUpdated: '2024-01-01T00:00:00.000Z',
@@ -814,7 +850,7 @@ describe('CloudSyncService', () => {
 
     it('restores missing cached project chats when remote status is unchanged', async () => {
       const projectId = 'project-with-missing-chat'
-      mockGetUnsyncedChats.mockResolvedValue([])
+      mockGetUnsyncedChatMetadata.mockResolvedValue([])
       mockGetProjectChatsSyncStatus.mockResolvedValue({
         count: 3,
         lastUpdated: '2026-08-11T12:00:00.000Z',
@@ -840,9 +876,10 @@ describe('CloudSyncService', () => {
     })
 
     it('filters out project chats when checking non-project sync status', async () => {
-      mockGetUnsyncedChats.mockResolvedValue([
+      mockGetUnsyncedChatMetadata.mockResolvedValue([
         {
           id: 'project-chat',
+          messageCount: 1,
           projectId: 'proj-123',
           isLocalOnly: false,
           isBlankChat: false,
@@ -857,14 +894,20 @@ describe('CloudSyncService', () => {
     })
 
     it('only considers project chats when projectId is provided', async () => {
-      mockGetUnsyncedChats.mockResolvedValue([
+      mockGetUnsyncedChatMetadata.mockResolvedValue([
         {
           id: 'project-chat',
+          messageCount: 1,
           projectId: 'proj-123',
           isLocalOnly: false,
           isBlankChat: false,
         },
-        { id: 'regular-chat', isLocalOnly: false, isBlankChat: false },
+        {
+          id: 'regular-chat',
+          messageCount: 1,
+          isLocalOnly: false,
+          isBlankChat: false,
+        },
       ])
 
       const service = new CloudSyncService()
@@ -875,7 +918,7 @@ describe('CloudSyncService', () => {
     })
 
     it('returns error when getChatSyncStatus throws', async () => {
-      mockGetUnsyncedChats.mockResolvedValue([])
+      mockGetUnsyncedChatMetadata.mockResolvedValue([])
       mockGetChatSyncStatus.mockRejectedValue(new Error('Network error'))
 
       const service = new CloudSyncService()
@@ -888,7 +931,7 @@ describe('CloudSyncService', () => {
   describe('smartSync recovery history finalization', () => {
     it('deep-syncs every remote chat before marking history ready', async () => {
       mockNeedsRecoveryHistorySync.mockReturnValue(true)
-      mockGetUnsyncedChats.mockResolvedValue([])
+      mockGetUnsyncedChatMetadata.mockResolvedValue([])
       mockGetAllChats.mockResolvedValue([])
       mockGetChatSyncStatus.mockResolvedValue({
         count: 2,
@@ -919,7 +962,7 @@ describe('CloudSyncService', () => {
 
     it('does not mark history ready when the remote snapshot changes', async () => {
       mockNeedsRecoveryHistorySync.mockReturnValue(true)
-      mockGetUnsyncedChats.mockResolvedValue([])
+      mockGetUnsyncedChatMetadata.mockResolvedValue([])
       mockGetAllChats.mockResolvedValue([])
       mockGetChatSyncStatus
         .mockResolvedValueOnce({
@@ -944,7 +987,7 @@ describe('CloudSyncService', () => {
     it('does not mark recovery history ready after an account reset', async () => {
       let resolveAuthoritative: ((value: boolean) => void) | undefined
       mockNeedsRecoveryHistorySync.mockReturnValue(true)
-      mockGetUnsyncedChats.mockResolvedValue([])
+      mockGetUnsyncedChatMetadata.mockResolvedValue([])
       mockGetAllChats.mockResolvedValue([])
       mockIsChatHistoryAuthoritative.mockReturnValue(
         new Promise<boolean>((resolve) => {
@@ -975,7 +1018,7 @@ describe('CloudSyncService', () => {
         syncedAt: Date.parse('2026-01-01T00:00:00.000Z'),
         updatedAt: '2026-01-01T00:00:00.000Z',
       }
-      mockGetUnsyncedChats.mockResolvedValue([])
+      mockGetUnsyncedChatMetadata.mockResolvedValue([])
       mockGetChatSyncMetadata.mockResolvedValue([metadata])
       mockListChats.mockResolvedValue({
         conversations: [{ id: 'local-chat' }],
@@ -995,7 +1038,7 @@ describe('CloudSyncService', () => {
     })
 
     it('runs the deletion reconciliation pass even without cached sync status', async () => {
-      mockGetUnsyncedChats.mockResolvedValue([])
+      mockGetUnsyncedChatMetadata.mockResolvedValue([])
       mockGetAllChats.mockResolvedValue([])
       mockListChats.mockResolvedValue({ conversations: [], hasMore: false })
 
@@ -1022,7 +1065,7 @@ describe('CloudSyncService', () => {
       // Uploading before deletions reconcile could resurrect chats that
       // were deleted on another device, so the upload leg is skipped
       // while downloads still proceed.
-      expect(mockGetUnsyncedChats).not.toHaveBeenCalled()
+      expect(mockGetUnsyncedChatMetadata).not.toHaveBeenCalled()
       expect(mockUploadChat).not.toHaveBeenCalled()
       expect(mockListChats).toHaveBeenCalled()
       expect(result.uploaded).toBe(0)
@@ -1062,7 +1105,7 @@ describe('CloudSyncService', () => {
     })
 
     it('retries listing remote chats before succeeding', async () => {
-      mockGetUnsyncedChats.mockResolvedValue([])
+      mockGetUnsyncedChatMetadata.mockResolvedValue([])
       mockGetAllChats.mockResolvedValue([])
       mockListChats
         .mockRejectedValueOnce(new SyncNetworkError())
@@ -1079,7 +1122,7 @@ describe('CloudSyncService', () => {
     })
 
     it('throws when remote chat listing still fails after retry', async () => {
-      mockGetUnsyncedChats.mockResolvedValue([])
+      mockGetUnsyncedChatMetadata.mockResolvedValue([])
       mockListChats.mockRejectedValue(new SyncNetworkError())
 
       const service = new CloudSyncService()
@@ -1092,7 +1135,7 @@ describe('CloudSyncService', () => {
 
     it('fetches only the first page for a default (non-deep) full sync', async () => {
       mockNeedsRecoveryHistorySync.mockReturnValue(true)
-      mockGetUnsyncedChats.mockResolvedValue([])
+      mockGetUnsyncedChatMetadata.mockResolvedValue([])
       mockGetAllChats.mockResolvedValue([])
       mockListChats.mockResolvedValue({
         conversations: [{ id: 'c1' }],
@@ -1112,7 +1155,7 @@ describe('CloudSyncService', () => {
     })
 
     it('pages through every remote chat when a deep sync is requested', async () => {
-      mockGetUnsyncedChats.mockResolvedValue([])
+      mockGetUnsyncedChatMetadata.mockResolvedValue([])
       mockGetAllChats.mockResolvedValue([])
       mockListChats
         .mockResolvedValueOnce({
@@ -1150,7 +1193,7 @@ describe('CloudSyncService', () => {
     })
 
     it('stops deep paging when a page returns no continuation token', async () => {
-      mockGetUnsyncedChats.mockResolvedValue([])
+      mockGetUnsyncedChatMetadata.mockResolvedValue([])
       mockGetAllChats.mockResolvedValue([])
       mockListChats.mockResolvedValue({
         conversations: [{ id: 'only' }],
@@ -1164,7 +1207,7 @@ describe('CloudSyncService', () => {
     })
 
     it('does not repopulate sync status after an account change', async () => {
-      mockGetUnsyncedChats.mockResolvedValue([])
+      mockGetUnsyncedChatMetadata.mockResolvedValue([])
       mockGetAllChats.mockResolvedValue([])
       mockListChats.mockResolvedValue({ conversations: [], hasMore: false })
       mockGetChatSyncStatus.mockResolvedValue({
@@ -1193,7 +1236,7 @@ describe('CloudSyncService', () => {
     })
 
     it('does not report a stale sync as healthy', async () => {
-      mockGetUnsyncedChats.mockResolvedValue([])
+      mockGetUnsyncedChatMetadata.mockResolvedValue([])
       mockGetAllChats.mockResolvedValue([])
       mockListChats.mockResolvedValue({ conversations: [], hasMore: false })
       mockGetCloudChatCount.mockResolvedValue(0)
@@ -1219,7 +1262,7 @@ describe('CloudSyncService', () => {
     })
 
     it('defers the legacy blob migration until the local key is the registered current key', async () => {
-      mockGetUnsyncedChats.mockResolvedValue([])
+      mockGetUnsyncedChatMetadata.mockResolvedValue([])
       mockGetAllChats.mockResolvedValue([])
       mockListChats.mockResolvedValue({
         conversations: [],
@@ -1271,7 +1314,7 @@ describe('CloudSyncService', () => {
     })
 
     it('does not finalize a previous account migration', async () => {
-      mockGetUnsyncedChats.mockResolvedValue([])
+      mockGetUnsyncedChatMetadata.mockResolvedValue([])
       mockGetAllChats.mockResolvedValue([])
       mockListChats.mockResolvedValue({ conversations: [], hasMore: false })
       mockGetKey.mockReturnValue('key_local')
@@ -1313,7 +1356,7 @@ describe('CloudSyncService', () => {
     })
 
     it('adopts the local key so legacy data can migrate without a passkey', async () => {
-      mockGetUnsyncedChats.mockResolvedValue([])
+      mockGetUnsyncedChatMetadata.mockResolvedValue([])
       mockGetAllChats.mockResolvedValue([])
       mockListChats.mockResolvedValue({ conversations: [], hasMore: false })
       const flush = () => new Promise((resolve) => setTimeout(resolve, 0))
@@ -1346,7 +1389,7 @@ describe('CloudSyncService', () => {
     })
 
     it('adopts the local key even when remote rows are sealed under another key', async () => {
-      mockGetUnsyncedChats.mockResolvedValue([])
+      mockGetUnsyncedChatMetadata.mockResolvedValue([])
       mockGetAllChats.mockResolvedValue([])
       mockListChats.mockResolvedValue({ conversations: [], hasMore: false })
       const flush = () => new Promise((resolve) => setTimeout(resolve, 0))
@@ -1374,7 +1417,7 @@ describe('CloudSyncService', () => {
     })
 
     it('attaches an initial bundle when a cached PRF matches a stored credential', async () => {
-      mockGetUnsyncedChats.mockResolvedValue([])
+      mockGetUnsyncedChatMetadata.mockResolvedValue([])
       mockGetAllChats.mockResolvedValue([])
       mockListChats.mockResolvedValue({ conversations: [], hasMore: false })
       const flush = () => new Promise((resolve) => setTimeout(resolve, 0))
@@ -1415,7 +1458,7 @@ describe('CloudSyncService', () => {
     })
 
     it('adopts bundleless when the cached PRF credential is not on the account', async () => {
-      mockGetUnsyncedChats.mockResolvedValue([])
+      mockGetUnsyncedChatMetadata.mockResolvedValue([])
       mockGetAllChats.mockResolvedValue([])
       mockListChats.mockResolvedValue({ conversations: [], hasMore: false })
       const flush = () => new Promise((resolve) => setTimeout(resolve, 0))
@@ -1448,7 +1491,7 @@ describe('CloudSyncService', () => {
     })
 
     it('still adopts the key when bundle building fails', async () => {
-      mockGetUnsyncedChats.mockResolvedValue([])
+      mockGetUnsyncedChatMetadata.mockResolvedValue([])
       mockGetAllChats.mockResolvedValue([])
       mockListChats.mockResolvedValue({ conversations: [], hasMore: false })
       const flush = () => new Promise((resolve) => setTimeout(resolve, 0))
@@ -1478,7 +1521,7 @@ describe('CloudSyncService', () => {
     })
 
     it('does not adopt the local key when the server reports no legacy data', async () => {
-      mockGetUnsyncedChats.mockResolvedValue([])
+      mockGetUnsyncedChatMetadata.mockResolvedValue([])
       mockGetAllChats.mockResolvedValue([])
       mockListChats.mockResolvedValue({ conversations: [], hasMore: false })
       const flush = () => new Promise((resolve) => setTimeout(resolve, 0))
@@ -1950,19 +1993,26 @@ describe('CloudSyncService', () => {
       isBlankChat: false,
       isLocalOnly: false,
       decryptionFailed: false,
+      messageCount: 1,
       syncVersion: 1,
     }
 
     describe('backupUnsyncedChats filtering', () => {
       it('uploads only eligible chats from a mixed batch', async () => {
-        mockGetUnsyncedChats.mockResolvedValue([
+        mockGetUnsyncedChatMetadata.mockResolvedValue([
           // Eligible
           { ...uploadableChat, id: 'eligible-1' },
           { ...uploadableChat, id: 'eligible-2' },
 
           // Not eligible - various reasons
           { ...uploadableChat, id: 'local-only', isLocalOnly: true },
-          { ...uploadableChat, id: 'blank', isBlankChat: true, messages: [] },
+          {
+            ...uploadableChat,
+            id: 'blank',
+            isBlankChat: true,
+            messageCount: 0,
+            messages: [],
+          },
           { ...uploadableChat, id: 'decrypt-failed', decryptionFailed: true },
           { ...uploadableChat, id: 'streaming' },
         ])
@@ -1977,7 +2027,7 @@ describe('CloudSyncService', () => {
       })
 
       it('handles empty unsynced chats list', async () => {
-        mockGetUnsyncedChats.mockResolvedValue([])
+        mockGetUnsyncedChatMetadata.mockResolvedValue([])
 
         const service = new CloudSyncService()
         const result = await service.backupUnsyncedChats()
@@ -1987,7 +2037,7 @@ describe('CloudSyncService', () => {
       })
 
       it('handles all chats being ineligible', async () => {
-        mockGetUnsyncedChats.mockResolvedValue([
+        mockGetUnsyncedChatMetadata.mockResolvedValue([
           { ...uploadableChat, id: 'local-1', isLocalOnly: true },
           { ...uploadableChat, id: 'local-2', isLocalOnly: true },
           { ...uploadableChat, id: 'blank-1', isBlankChat: true },
@@ -2003,7 +2053,7 @@ describe('CloudSyncService', () => {
 
     describe('Project chat filtering', () => {
       it('filters by projectId when checking project sync status', async () => {
-        mockGetUnsyncedChats.mockResolvedValue([
+        mockGetUnsyncedChatMetadata.mockResolvedValue([
           { ...uploadableChat, id: 'project-a-chat', projectId: 'project-a' },
           { ...uploadableChat, id: 'project-b-chat', projectId: 'project-b' },
           { ...uploadableChat, id: 'no-project-chat' },
@@ -2022,7 +2072,7 @@ describe('CloudSyncService', () => {
       })
 
       it('excludes project chats when checking regular sync status', async () => {
-        mockGetUnsyncedChats.mockResolvedValue([
+        mockGetUnsyncedChatMetadata.mockResolvedValue([
           { ...uploadableChat, id: 'project-chat', projectId: 'some-project' },
         ])
 

--- a/tests/services/cloud/cloud-sync.test.ts
+++ b/tests/services/cloud/cloud-sync.test.ts
@@ -16,6 +16,9 @@ const mockGetCloudChatCount = vi.fn()
 const mockGetProjectChatCount = vi.fn()
 const mockIsChatHistoryAuthoritative = vi.fn()
 const mockGetUnsyncedChats = vi.fn()
+const mockGetUnsyncedFullChats = vi.fn()
+const mockGetUnsyncedChatMetadata = vi.fn()
+const mockGetChatSyncMetadata = vi.fn()
 const mockGetChat = vi.fn()
 const mockSaveChat = vi.fn()
 const mockSaveExistingChat = vi.fn()
@@ -80,12 +83,14 @@ vi.mock('@/services/storage/indexed-db', () => ({
   chatContentFingerprint: (chat: unknown) => JSON.stringify(chat),
   indexedDBStorage: {
     getAllChats: (...args: any[]) => mockGetAllChats(...args),
+    getChatSyncMetadata: (...args: any[]) => mockGetChatSyncMetadata(...args),
     getCloudChatCount: (...args: any[]) => mockGetCloudChatCount(...args),
     getProjectChatCount: (...args: any[]) => mockGetProjectChatCount(...args),
     isChatHistoryAuthoritative: (...args: any[]) =>
       mockIsChatHistoryAuthoritative(...args),
-    getUnsyncedChats: (...args: any[]) => mockGetUnsyncedChats(...args),
-    getUnsyncedChatMetadata: (...args: any[]) => mockGetUnsyncedChats(...args),
+    getUnsyncedChats: (...args: any[]) => mockGetUnsyncedFullChats(...args),
+    getUnsyncedChatMetadata: (...args: any[]) =>
+      mockGetUnsyncedChatMetadata(...args),
     saveChat: (...args: any[]) => mockSaveChat(...args),
     saveExistingChat: (...args: any[]) => mockSaveExistingChat(...args),
     markAsSynced: (...args: any[]) => mockMarkAsSynced(...args),
@@ -225,6 +230,10 @@ describe('CloudSyncService', () => {
     mockRebaseSyncVersion.mockResolvedValue(undefined)
     mockResetSyncMetadataForAllChats.mockResolvedValue(undefined)
     mockDeleteChat.mockResolvedValue(undefined)
+    mockGetUnsyncedChatMetadata.mockImplementation((...args) =>
+      mockGetUnsyncedChats(...args),
+    )
+    mockGetChatSyncMetadata.mockResolvedValue([])
     mockGetKey.mockReturnValue(null)
     mockIsChatHistoryAuthoritative.mockResolvedValue(true)
     mockKeyCurrent.mockResolvedValue({ key_id: null })
@@ -596,6 +605,10 @@ describe('CloudSyncService', () => {
       const result = await service.backupUnsyncedChats()
 
       expect(mockUploadChat).toHaveBeenCalledTimes(1)
+      expect(mockGetUnsyncedChatMetadata).toHaveBeenCalledOnce()
+      expect(mockGetUnsyncedChats).toHaveBeenCalledOnce()
+      expect(mockGetUnsyncedFullChats).not.toHaveBeenCalled()
+      expect(mockGetChat).toHaveBeenCalledTimes(1)
       expect(mockUploadChat.mock.calls[0]?.[0]?.id).toBe('cloud-1')
       expect(mockFinalizeUpload).toHaveBeenCalledWith(
         expect.objectContaining({ chatId: 'cloud-1', syncVersion: 4 }),
@@ -953,6 +966,34 @@ describe('CloudSyncService', () => {
   })
 
   describe('syncAllChats', () => {
+    it('builds the ingest map from lightweight sync metadata', async () => {
+      const metadata = {
+        id: 'local-chat',
+        projectId: 'project-1',
+        decryptionFailed: false,
+        locallyModified: false,
+        syncedAt: Date.parse('2026-01-01T00:00:00.000Z'),
+        updatedAt: '2026-01-01T00:00:00.000Z',
+      }
+      mockGetUnsyncedChats.mockResolvedValue([])
+      mockGetChatSyncMetadata.mockResolvedValue([metadata])
+      mockListChats.mockResolvedValue({
+        conversations: [{ id: 'local-chat' }],
+        hasMore: false,
+      })
+
+      await new CloudSyncService().syncAllChats()
+
+      expect(mockGetChatSyncMetadata).toHaveBeenCalledOnce()
+      expect(mockGetAllChats).not.toHaveBeenCalled()
+      expect(mockIngestRemoteChats).toHaveBeenCalledWith(
+        [{ id: 'local-chat' }],
+        expect.objectContaining({
+          localChatMap: new Map([['local-chat', metadata]]),
+        }),
+      )
+    })
+
     it('runs the deletion reconciliation pass even without cached sync status', async () => {
       mockGetUnsyncedChats.mockResolvedValue([])
       mockGetAllChats.mockResolvedValue([])
@@ -1460,6 +1501,33 @@ describe('CloudSyncService', () => {
   })
 
   describe('syncProjectChats', () => {
+    it('preserves project scope from lightweight local metadata', async () => {
+      const metadata = {
+        id: 'project-chat',
+        projectId: 'project-1',
+        decryptionFailed: false,
+        locallyModified: false,
+        syncedAt: 0,
+        updatedAt: '2026-01-01T00:00:00.000Z',
+      }
+      mockGetChatSyncMetadata.mockResolvedValue([metadata])
+      mockListProjectChats.mockResolvedValue({
+        chats: [{ id: 'project-chat' }],
+        hasMore: false,
+      })
+
+      await new CloudSyncService().syncProjectChats('project-1')
+
+      expect(mockGetAllChats).not.toHaveBeenCalled()
+      expect(mockIngestRemoteChats).toHaveBeenCalledWith(
+        [{ id: 'project-chat' }],
+        expect.objectContaining({
+          localChatMap: new Map([['project-chat', metadata]]),
+          projectId: 'project-1',
+        }),
+      )
+    })
+
     it('retries listing project chats before succeeding', async () => {
       mockNeedsRecoveryHistorySync.mockReturnValue(true)
       mockGetAllChats.mockResolvedValue([])

--- a/tests/services/cloud/sync-predicates.test.ts
+++ b/tests/services/cloud/sync-predicates.test.ts
@@ -7,6 +7,7 @@
  * - isLocalOnly !== true
  * - isBlankChat !== true
  * - decryptionFailed !== true
+ * - has at least one message
  * - not currently streaming
  */
 
@@ -71,7 +72,7 @@ describe('Sync Predicates', () => {
       expect(isUploadableChat(baseChat, isStreaming)).toBe(true)
     })
 
-    it('handles undefined/missing optional fields', () => {
+    it('returns false for full chats without messages', () => {
       const minimalChat = {
         id: 'minimal',
         title: 'Minimal',
@@ -81,7 +82,19 @@ describe('Sync Predicates', () => {
         lastAccessedAt: Date.now(),
         // No optional fields set
       } as StoredChat
-      expect(isUploadableChat(minimalChat)).toBe(true)
+      expect(isUploadableChat(minimalChat)).toBe(false)
+    })
+
+    it('returns false for metadata with no messages', () => {
+      expect(
+        isUploadableChat({
+          id: 'empty-metadata',
+          messageCount: 0,
+          isLocalOnly: false,
+          isBlankChat: false,
+          decryptionFailed: false,
+        }),
+      ).toBe(false)
     })
 
     it('handles false vs undefined for boolean flags', () => {

--- a/tests/services/cloud/sync-predicates.test.ts
+++ b/tests/services/cloud/sync-predicates.test.ts
@@ -85,6 +85,16 @@ describe('Sync Predicates', () => {
       expect(isUploadableChat(minimalChat)).toBe(false)
     })
 
+    it('uses full chat messages instead of an incidental message count', () => {
+      const staleFullChat = {
+        ...baseChat,
+        messages: [],
+        messageCount: 4,
+      }
+
+      expect(isUploadableChat(staleFullChat)).toBe(false)
+    })
+
     it('returns false for metadata with no messages', () => {
       expect(
         isUploadableChat({

--- a/tests/services/cloud/sync-predicates.test.ts
+++ b/tests/services/cloud/sync-predicates.test.ts
@@ -100,6 +100,23 @@ describe('Sync Predicates', () => {
     // (not local.updatedAt) because syncedAt represents when we last
     // got data from the server
 
+    it('makes the same decision from lightweight sync metadata', () => {
+      const remote = {
+        id: 'test-chat-1',
+        updatedAt: '2024-01-02T00:00:00.000Z',
+      }
+      const metadata = {
+        id: 'test-chat-1',
+        projectId: 'project-1',
+        decryptionFailed: false,
+        locallyModified: false,
+        syncedAt: new Date('2024-01-01T00:00:00.000Z').getTime(),
+        updatedAt: '2024-01-01T00:00:00.000Z',
+      }
+
+      expect(shouldIngestRemoteChat(remote, metadata)).toBe(true)
+    })
+
     it('returns true when no local chat exists', () => {
       const remote = {
         id: 'new-chat',

--- a/tests/services/storage/indexed-db-account-reset.test.ts
+++ b/tests/services/storage/indexed-db-account-reset.test.ts
@@ -302,6 +302,7 @@ describe('IndexedDBStorage account reset', () => {
   })
 
   it('rejects malformed stored chats instead of leaving reads pending', async () => {
+    vi.stubGlobal('IDBKeyRange', { only: (key: IDBValidKey) => key })
     const storage = new IndexedDBStorage()
     const cursorRequest = {
       onsuccess: null,
@@ -311,13 +312,21 @@ describe('IndexedDBStorage account reset', () => {
       onerror: (() => void) | null
     }
     const openCursor = vi.fn(() => cursorRequest)
-    const payloadRequest = { onsuccess: null, onerror: null, result: [] }
+    const payloadRequest = {
+      onsuccess: null,
+      onerror: null,
+      result: [],
+    } as {
+      onsuccess: (() => void) | null
+      onerror: (() => void) | null
+      result: unknown[]
+    }
     const transaction = {
       oncomplete: null,
       objectStore: (storeName: string) =>
         storeName === 'chats'
           ? { openCursor }
-          : { getAll: () => payloadRequest },
+          : { index: () => ({ getAll: () => payloadRequest }) },
     }
     vi.spyOn(storage as any, 'ensureDB').mockResolvedValue({
       transaction: () => transaction,
@@ -334,6 +343,8 @@ describe('IndexedDBStorage account reset', () => {
         },
       },
     })
+    await vi.waitFor(() => expect(payloadRequest.onsuccess).not.toBeNull())
+    payloadRequest.onsuccess?.()
 
     await expect(chats).rejects.toThrow('Stored chat has invalid messages')
   })

--- a/tests/services/storage/indexed-db-account-reset.test.ts
+++ b/tests/services/storage/indexed-db-account-reset.test.ts
@@ -57,6 +57,7 @@ describe('IndexedDBStorage account reset', () => {
   afterEach(() => {
     vi.useRealTimers()
     vi.restoreAllMocks()
+    vi.unstubAllGlobals()
   })
 
   it('bypasses a stalled write queue and closes the old connection', async () => {

--- a/tests/services/storage/indexed-db-sync-index.test.ts
+++ b/tests/services/storage/indexed-db-sync-index.test.ts
@@ -431,6 +431,68 @@ describe('IndexedDB pending sync index', () => {
     expect(chats.map((chat) => chat.id)).toEqual(['chat-a', 'chat-b', 'chat-c'])
   })
 
+  it('derives sync message counts without copying messages into metadata', async () => {
+    const storage = new IndexedDBStorage()
+    await storage.initialize()
+    await storage.saveChat(
+      storedChat('metadata-count', {
+        messages: [
+          {
+            role: 'user',
+            content: 'Count me',
+            timestamp: new Date('2026-08-12T00:00:00.000Z'),
+          },
+        ],
+      }),
+    )
+
+    const metadata = await storage.getChatSyncMetadata()
+
+    expect(metadata).toEqual([
+      expect.objectContaining({ id: 'metadata-count', messageCount: 1 }),
+    ])
+    expect(metadata[0]).not.toHaveProperty('messages')
+  })
+
+  it('rejects malformed all-chat sync metadata', async () => {
+    const storage = new IndexedDBStorage()
+    await storage.initialize()
+    const db = (storage as any).db as IDBDatabase
+    await new Promise<void>((resolve, reject) => {
+      const transaction = db.transaction('chats', 'readwrite')
+      transaction.objectStore('chats').put({
+        ...storedChat('invalid-project'),
+        projectId: 42,
+      })
+      transaction.oncomplete = () => resolve()
+      transaction.onerror = () => reject(transaction.error)
+    })
+
+    await expect(storage.getChatSyncMetadata()).rejects.toThrow(
+      'Stored chat has invalid sync metadata: projectId',
+    )
+  })
+
+  it('rejects malformed unsynced sync metadata', async () => {
+    const storage = new IndexedDBStorage()
+    await storage.initialize()
+    const db = (storage as any).db as IDBDatabase
+    await new Promise<void>((resolve, reject) => {
+      const transaction = db.transaction('chats', 'readwrite')
+      transaction.objectStore('chats').put({
+        ...storedChat('invalid-messages'),
+        messages: null,
+        syncPending: 1,
+      })
+      transaction.oncomplete = () => resolve()
+      transaction.onerror = () => reject(transaction.error)
+    })
+
+    await expect(storage.getUnsyncedChatMetadata()).rejects.toThrow(
+      'Stored chat has invalid sync metadata: messages',
+    )
+  })
+
   it('fails reads when a local attachment payload row is missing', async () => {
     const storage = new IndexedDBStorage()
     await storage.initialize()

--- a/tests/services/storage/indexed-db-sync-index.test.ts
+++ b/tests/services/storage/indexed-db-sync-index.test.ts
@@ -119,6 +119,7 @@ function blockChatTransaction(
 
 describe('IndexedDB pending sync index', () => {
   afterEach(() => {
+    vi.restoreAllMocks()
     vi.unstubAllGlobals()
   })
 
@@ -323,6 +324,111 @@ describe('IndexedDB pending sync index', () => {
     })
     expect(payloadCount).toBe(0)
     db.close()
+  })
+
+  it('hydrates all chats in key order with chat-scoped payload reads', async () => {
+    const storage = new IndexedDBStorage()
+    await storage.initialize()
+    for (const id of ['chat-b', 'chat-a']) {
+      await storage.saveChat(
+        storedChat(id, {
+          messages: [
+            {
+              role: 'user',
+              content: id,
+              timestamp: new Date('2026-08-12T00:00:00.000Z'),
+              attachments: [
+                {
+                  id: `${id}-attachment`,
+                  type: 'document',
+                  fileName: `${id}.txt`,
+                  textContent: `${id}-payload`,
+                },
+              ],
+            },
+          ],
+        }),
+      )
+    }
+
+    const db = (storage as any).db as IDBDatabase
+    const transaction = db.transaction('attachmentPayloads')
+    const payloadStore = transaction.objectStore('attachmentPayloads')
+    const storeGetAll = vi.spyOn(Object.getPrototypeOf(payloadStore), 'getAll')
+    const payloadIndex = payloadStore.index('chatId')
+    const indexGetAll = vi.spyOn(Object.getPrototypeOf(payloadIndex), 'getAll')
+
+    const chats = await storage.getAllChats()
+
+    expect(storeGetAll).not.toHaveBeenCalled()
+    expect(indexGetAll).toHaveBeenCalledTimes(2)
+    expect(
+      indexGetAll.mock.calls.map(([range]) => (range as IDBKeyRange).lower),
+    ).toEqual(['chat-a', 'chat-b'])
+    expect(chats.map((chat) => chat.id)).toEqual(['chat-a', 'chat-b'])
+    expect(
+      chats.map((chat) => chat.messages[0].attachments?.[0].textContent),
+    ).toEqual(['chat-a-payload', 'chat-b-payload'])
+  })
+
+  it('requests each chat payload only after the previous read resolves', async () => {
+    const storage = new IndexedDBStorage()
+    await storage.initialize()
+    const payloadText = 'payload'.repeat(8_000)
+    for (const id of ['chat-a', 'chat-b', 'chat-c']) {
+      await storage.saveChat(
+        storedChat(id, {
+          messages: [
+            {
+              role: 'user',
+              content: id,
+              timestamp: new Date('2026-08-12T00:00:00.000Z'),
+              attachments: [
+                {
+                  id: `${id}-attachment`,
+                  type: 'document',
+                  fileName: `${id}.txt`,
+                  textContent: `${id}-${payloadText}`,
+                },
+              ],
+            },
+          ],
+        }),
+      )
+    }
+
+    const db = (storage as any).db as IDBDatabase
+    const payloadIndex = db
+      .transaction('attachmentPayloads')
+      .objectStore('attachmentPayloads')
+      .index('chatId')
+    const events: string[] = []
+    const originalGetAll = Object.getPrototypeOf(payloadIndex).getAll
+    const getAllSpy = vi
+      .spyOn(Object.getPrototypeOf(payloadIndex), 'getAll')
+      .mockImplementation(function (this: IDBIndex, ...args: unknown[]) {
+        const query = args[0] as IDBValidKey | IDBKeyRange
+        const chatId = (query as IDBKeyRange).lower as string
+        events.push(`requested:${chatId}`)
+        const request = originalGetAll.call(this, query)
+        request.addEventListener('success', () => {
+          events.push(`resolved:${chatId}`)
+        })
+        return request
+      })
+
+    const chats = await storage.getAllChats()
+
+    expect(getAllSpy).toHaveBeenCalledTimes(3)
+    expect(events).toEqual([
+      'requested:chat-a',
+      'resolved:chat-a',
+      'requested:chat-b',
+      'resolved:chat-b',
+      'requested:chat-c',
+      'resolved:chat-c',
+    ])
+    expect(chats.map((chat) => chat.id)).toEqual(['chat-a', 'chat-b', 'chat-c'])
   })
 
   it('fails reads when a local attachment payload row is missing', async () => {


### PR DESCRIPTION
## Summary
- read normalized attachment payloads one chat at a time instead of cloning the complete payload store into the renderer
- use lightweight typed metadata for sync eligibility and local ingest maps
- keep authoritative full chat hydration at the point where an upload actually starts

## Why
PR #488 can overlap full startup and sync reads. A single unbounded IndexedDB `getAll()` over every attachment payload creates high renderer memory pressure and can make Brave report an unresponsive page or terminate the renderer.

## Testing
- `npx vitest run` (1617 tests)
- `npx tsc --noEmit`
- `npm run lint`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds attachment payload reads during sync and validates lightweight chat sync metadata to prevent renderer memory spikes and bad or empty uploads. Old behavior loaded all payloads with a store‑wide IndexedDB getAll; new behavior reads per chat via the `attachmentPayloads/chatId` index, defers full hydration until an upload starts, and trusts full chat message lists when checking upload eligibility.

- Storage: `getAllChats` hydrates chats sequentially with per‑chat payload reads; new `getChatSyncMetadata` and `getUnsyncedChatMetadata` return validated `ChatSyncMetadata` with `messageCount` derived without copying messages.
- Sync: ingest maps and backup filtering use `getChatSyncMetadata`/`getUnsyncedChatMetadata` instead of full chats.
- Predicates: `isUploadableChat` accepts metadata or full chats, uses full chat `messages.length` when available, and now rejects zero‑message chats; `shouldIngestRemoteChat` accepts minimal metadata fields.
- Tests: add coverage for chat‑scoped payload reads, sequential payload fetches, metadata validation, and metadata‑driven ingest and backup.

**Migration**
- Pass `ChatSyncMetadata` to `processRemoteChat` (`options.localChat`) and `processRemoteChats` (`IngestOptions.localChatMap`).
- Use `indexedDBStorage.getUnsyncedChatMetadata` when full chats are not required, and `indexedDBStorage.getChatSyncMetadata` to build ingest maps.
- Treat zero‑message chats as ineligible for upload.

<sup>Written for commit 14598a58fd38491ce45bc8c6fcc3841c156db921. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/499?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

