### PR TITLE
Stop saved chats from exhausting browser memory

### DIFF
--- a/src/services/inference/chat-recovery.ts
+++ b/src/services/inference/chat-recovery.ts
@@ -893,10 +893,10 @@ export function scanPendingChatRecoveries(
   const controller = new AbortController()
   const promise = (async () => {
     try {
-      const chats = await indexedDBStorage.getAllChats()
+      const chats = await indexedDBStorage.getPendingChatRecoveries()
       if (generation !== recoveryScanGeneration) return
       const pending = chats.flatMap((chat) =>
-        (chat.pendingRecoveries ?? []).map((envelope) => ({
+        chat.pendingRecoveries.map((envelope) => ({
           chatId: chat.id,
           envelope,
         })),

--- a/src/services/storage/indexed-db.ts
+++ b/src/services/storage/indexed-db.ts
@@ -2,6 +2,7 @@ import type {
   Attachment,
   Chat as ChatType,
   Message,
+  PendingRecoveryEnvelope,
 } from '@/components/chat/types'
 import { ACCOUNT_RESET_FAILED_EVENT } from '@/constants/auth-events'
 import {
@@ -57,6 +58,11 @@ export interface ChatSyncMetadata {
 export interface SaveChatResult {
   saved: boolean
   isLocalOnly: boolean
+}
+
+export interface ChatRecoverySummary {
+  id: string
+  pendingRecoveries: PendingRecoveryEnvelope[]
 }
 
 interface StoredProject {
@@ -1745,13 +1751,14 @@ export class IndexedDBStorage {
   // local-only rows). Cheaper than getAllChats when the caller only
   // needs the total — avoids deserializing every stored message.
   async getCloudChatCount(): Promise<number> {
+    await this.ensureChatSummaries()
     await this.waitForSaveQueue()
     const db = await this.ensureDB()
 
     return this.protectRead(
       new Promise((resolve, reject) => {
-        const transaction = db.transaction([CHATS_STORE], 'readonly')
-        const store = transaction.objectStore(CHATS_STORE)
+        const transaction = db.transaction([CHAT_SUMMARIES_STORE], 'readonly')
+        const store = transaction.objectStore(CHAT_SUMMARIES_STORE)
         const request = store.openCursor()
         let count = 0
 
@@ -1774,16 +1781,15 @@ export class IndexedDBStorage {
   }
 
   async getProjectChatCount(projectId: string): Promise<number> {
+    await this.ensureChatSummaries()
     await this.waitForSaveQueue()
     const db = await this.ensureDB()
 
     return this.protectRead(
       new Promise((resolve, reject) => {
-        const transaction = db.transaction([CHATS_STORE], 'readonly')
-        const store = transaction.objectStore(CHATS_STORE)
-        const request = store
-          .index(CHATS_PROJECT_INDEX)
-          .openCursor(IDBKeyRange.only(projectId))
+        const transaction = db.transaction([CHAT_SUMMARIES_STORE], 'readonly')
+        const store = transaction.objectStore(CHAT_SUMMARIES_STORE)
+        const request = store.openCursor()
         let count = 0
 
         request.onsuccess = () => {
@@ -1793,7 +1799,7 @@ export class IndexedDBStorage {
             return
           }
           const chat = cursor.value as StoredChat
-          if (!chat.isLocalOnly) {
+          if (chat.projectId === projectId && !chat.isLocalOnly) {
             count += 1
           }
           cursor.continue()
@@ -1805,13 +1811,14 @@ export class IndexedDBStorage {
   }
 
   async hasPendingChatRecoveries(): Promise<boolean> {
+    await this.ensureChatSummaries()
     await this.waitForSaveQueue()
     const db = await this.ensureDB()
 
     return this.protectRead(
       new Promise((resolve, reject) => {
-        const transaction = db.transaction([CHATS_STORE], 'readonly')
-        const store = transaction.objectStore(CHATS_STORE)
+        const transaction = db.transaction([CHAT_SUMMARIES_STORE], 'readonly')
+        const store = transaction.objectStore(CHAT_SUMMARIES_STORE)
         const request = store.openCursor()
 
         request.onsuccess = (event) => {
@@ -1831,6 +1838,39 @@ export class IndexedDBStorage {
 
         request.onerror = () =>
           reject(new Error('Failed to inspect pending chat recoveries'))
+      }),
+    )
+  }
+
+  async getPendingChatRecoveries(): Promise<ChatRecoverySummary[]> {
+    await this.ensureChatSummaries()
+    await this.waitForSaveQueue()
+    const db = await this.ensureDB()
+
+    return this.protectRead(
+      new Promise((resolve, reject) => {
+        const transaction = db.transaction([CHAT_SUMMARIES_STORE], 'readonly')
+        const store = transaction.objectStore(CHAT_SUMMARIES_STORE)
+        const request = store.openCursor()
+        const chats: ChatRecoverySummary[] = []
+
+        request.onsuccess = () => {
+          const cursor = request.result
+          if (!cursor) {
+            resolve(chats)
+            return
+          }
+          const chat = cursor.value as StoredChat
+          if (chat.pendingRecoveries?.length) {
+            chats.push({
+              id: chat.id,
+              pendingRecoveries: chat.pendingRecoveries,
+            })
+          }
+          cursor.continue()
+        }
+        request.onerror = () =>
+          reject(new Error('Failed to get pending chat recoveries'))
       }),
     )
   }

--- a/tests/services/inference/chat-recovery.test.ts
+++ b/tests/services/inference/chat-recovery.test.ts
@@ -21,7 +21,7 @@ const setChatRecoveryDraft = vi.fn()
 const retryDeferredAlternativesFinalization = vi.fn()
 const parseRichStreamingResponse = vi.fn()
 const generateTitle = vi.fn()
-const getAllChats = vi.fn()
+const getPendingChatRecoveries = vi.fn()
 const getChat = vi.fn()
 let storedAlternatives: string[] = []
 let cloudSyncEnabled = true
@@ -106,7 +106,7 @@ vi.mock('@/services/encryption/encryption-service', () => ({
 
 vi.mock('@/services/storage/indexed-db', () => ({
   indexedDBStorage: {
-    getAllChats: () => getAllChats(),
+    getPendingChatRecoveries: () => getPendingChatRecoveries(),
     getChat: (...args: unknown[]) => getChat(...args),
   },
 }))
@@ -355,7 +355,7 @@ describe('chat recovery lifecycle', () => {
   })
 
   it('streams a processing session and persists only after completion', async () => {
-    getAllChats.mockResolvedValue([
+    getPendingChatRecoveries.mockResolvedValue([
       { id: 'chat-1', pendingRecoveries: [envelope] },
     ])
     decryptRecoveryEnvelope.mockResolvedValue({
@@ -429,7 +429,7 @@ describe('chat recovery lifecycle', () => {
   })
 
   it('generates a title when the first response is recovered', async () => {
-    getAllChats.mockResolvedValue([
+    getPendingChatRecoveries.mockResolvedValue([
       { id: 'chat-1', pendingRecoveries: [envelope] },
     ])
     getChat.mockResolvedValue({
@@ -489,7 +489,7 @@ describe('chat recovery lifecycle', () => {
   })
 
   it('releases recovery activity before deleting the completed session', async () => {
-    getAllChats.mockResolvedValue([
+    getPendingChatRecoveries.mockResolvedValue([
       { id: 'chat-1', pendingRecoveries: [envelope] },
     ])
     decryptRecoveryEnvelope.mockResolvedValue({
@@ -531,7 +531,7 @@ describe('chat recovery lifecycle', () => {
   })
 
   it('ignores a stream update after recovery cancellation', async () => {
-    getAllChats.mockResolvedValue([
+    getPendingChatRecoveries.mockResolvedValue([
       { id: 'chat-1', pendingRecoveries: [envelope] },
     ])
     decryptRecoveryEnvelope.mockResolvedValue({
@@ -581,7 +581,7 @@ describe('chat recovery lifecycle', () => {
   })
 
   it('publishes the recovered replay from its first visible update', async () => {
-    getAllChats.mockResolvedValue([
+    getPendingChatRecoveries.mockResolvedValue([
       { id: 'chat-1', pendingRecoveries: [envelope] },
     ])
     decryptRecoveryEnvelope.mockResolvedValue({
@@ -628,7 +628,7 @@ describe('chat recovery lifecycle', () => {
   })
 
   it('releases recovery activity when checkpoint loading fails', async () => {
-    getAllChats.mockResolvedValue([
+    getPendingChatRecoveries.mockResolvedValue([
       { id: 'chat-1', pendingRecoveries: [envelope] },
     ])
     getChat.mockRejectedValueOnce(new Error('IndexedDB unavailable'))
@@ -651,7 +651,7 @@ describe('chat recovery lifecycle', () => {
   })
 
   it('preserves the partial response when recovery returns an upstream error', async () => {
-    getAllChats.mockResolvedValue([
+    getPendingChatRecoveries.mockResolvedValue([
       { id: 'chat-1', pendingRecoveries: [envelope] },
     ])
     decryptRecoveryEnvelope.mockResolvedValue({
@@ -680,7 +680,7 @@ describe('chat recovery lifecycle', () => {
   })
 
   it('keeps recovery active through repeated processing reconnects', async () => {
-    getAllChats.mockResolvedValue([
+    getPendingChatRecoveries.mockResolvedValue([
       { id: 'chat-1', pendingRecoveries: [envelope] },
     ])
     decryptRecoveryEnvelope.mockResolvedValue({
@@ -732,7 +732,7 @@ describe('chat recovery lifecycle', () => {
   })
 
   it('keeps streaming when a recovered response ends while processing', async () => {
-    getAllChats.mockResolvedValue([
+    getPendingChatRecoveries.mockResolvedValue([
       { id: 'chat-1', pendingRecoveries: [envelope] },
     ])
     decryptRecoveryEnvelope.mockResolvedValue({
@@ -779,7 +779,7 @@ describe('chat recovery lifecycle', () => {
   })
 
   it('reconnects when a recovered response transport terminates', async () => {
-    getAllChats.mockResolvedValue([
+    getPendingChatRecoveries.mockResolvedValue([
       { id: 'chat-1', pendingRecoveries: [envelope] },
     ])
     decryptRecoveryEnvelope.mockResolvedValue({
@@ -826,7 +826,7 @@ describe('chat recovery lifecycle', () => {
   })
 
   it('replays from zero when a completed response is truncated', async () => {
-    getAllChats.mockResolvedValue([
+    getPendingChatRecoveries.mockResolvedValue([
       { id: 'chat-1', pendingRecoveries: [envelope] },
     ])
     decryptRecoveryEnvelope.mockResolvedValue({
@@ -895,7 +895,7 @@ describe('chat recovery lifecycle', () => {
   })
 
   it('does not regress the visible draft while replaying after reconnect', async () => {
-    getAllChats.mockResolvedValue([
+    getPendingChatRecoveries.mockResolvedValue([
       { id: 'chat-1', pendingRecoveries: [envelope] },
     ])
     decryptRecoveryEnvelope.mockResolvedValue({
@@ -974,7 +974,7 @@ describe('chat recovery lifecycle', () => {
   })
 
   it('ignores a presentation checkpoint from a replaced session', async () => {
-    getAllChats.mockResolvedValue([
+    getPendingChatRecoveries.mockResolvedValue([
       { id: 'chat-1', pendingRecoveries: [envelope] },
     ])
     decryptRecoveryEnvelope.mockResolvedValue({
@@ -1025,7 +1025,7 @@ describe('chat recovery lifecycle', () => {
   })
 
   it('keeps a persisted partial visible until replay catches up', async () => {
-    getAllChats.mockResolvedValue([
+    getPendingChatRecoveries.mockResolvedValue([
       { id: 'chat-1', pendingRecoveries: [envelope] },
     ])
     getChat.mockResolvedValue({
@@ -1090,7 +1090,7 @@ describe('chat recovery lifecycle', () => {
   })
 
   it('reuses an in-flight recovery scan instead of restarting its stream', async () => {
-    getAllChats.mockResolvedValue([
+    getPendingChatRecoveries.mockResolvedValue([
       { id: 'chat-1', pendingRecoveries: [envelope] },
     ])
     decryptRecoveryEnvelope.mockResolvedValue({
@@ -1133,7 +1133,7 @@ describe('chat recovery lifecycle', () => {
   })
 
   it('queues refreshed discovery without restarting the active stream', async () => {
-    getAllChats
+    getPendingChatRecoveries
       .mockResolvedValueOnce([{ id: 'chat-1', pendingRecoveries: [envelope] }])
       .mockResolvedValueOnce([])
     decryptRecoveryEnvelope.mockResolvedValue({
@@ -1169,11 +1169,13 @@ describe('chat recovery lifecycle', () => {
       timestamp: new Date().toISOString(),
     })
     await activeScan
-    await vi.waitFor(() => expect(getAllChats).toHaveBeenCalledTimes(2))
+    await vi.waitFor(() =>
+      expect(getPendingChatRecoveries).toHaveBeenCalledTimes(2),
+    )
   })
 
   it('saves the visible draft when cancelling a resumed recovery stream', async () => {
-    getAllChats.mockResolvedValue([
+    getPendingChatRecoveries.mockResolvedValue([
       { id: 'chat-1', pendingRecoveries: [envelope] },
     ])
     decryptRecoveryEnvelope.mockResolvedValue({
@@ -1280,7 +1282,7 @@ describe('chat recovery lifecycle', () => {
   })
 
   it('replays a completed response through progressive drafts', async () => {
-    getAllChats.mockResolvedValue([
+    getPendingChatRecoveries.mockResolvedValue([
       { id: 'chat-1', pendingRecoveries: [envelope] },
     ])
     decryptRecoveryEnvelope.mockResolvedValue({
@@ -1324,7 +1326,7 @@ describe('chat recovery lifecycle', () => {
   })
 
   it('recovers a device-local token directly from IndexedDB', async () => {
-    getAllChats.mockResolvedValue([
+    getPendingChatRecoveries.mockResolvedValue([
       {
         id: 'chat-1',
         isLocalOnly: true,
@@ -1367,7 +1369,7 @@ describe('chat recovery lifecycle', () => {
 
   it('stops an old account scan when recovery state is reset', async () => {
     let resolveChats: ((chats: unknown[]) => void) | undefined
-    getAllChats.mockReturnValueOnce(
+    getPendingChatRecoveries.mockReturnValueOnce(
       new Promise<unknown[]>((resolve) => {
         resolveChats = resolve
       }),
@@ -1379,14 +1381,14 @@ describe('chat recovery lifecycle', () => {
     await oldScan
 
     expect(decryptRecoveryEnvelope).not.toHaveBeenCalled()
-    getAllChats.mockResolvedValueOnce([])
+    getPendingChatRecoveries.mockResolvedValueOnce([])
     await expect(scanPendingChatRecoveries('new-user')).resolves.toBeUndefined()
   })
 
   it('aborts an aged scan before starting its replacement', async () => {
     let now = 1_000
     const dateNow = vi.spyOn(Date, 'now').mockImplementation(() => now)
-    getAllChats.mockResolvedValue([
+    getPendingChatRecoveries.mockResolvedValue([
       { id: 'chat-1', pendingRecoveries: [envelope] },
     ])
     decryptRecoveryEnvelope.mockResolvedValue({
@@ -1440,7 +1442,7 @@ describe('chat recovery lifecycle', () => {
   it('replaces reconnects that report no forward progress', async () => {
     let now = 1_000
     const dateNow = vi.spyOn(Date, 'now').mockImplementation(() => now)
-    getAllChats.mockResolvedValue([
+    getPendingChatRecoveries.mockResolvedValue([
       { id: 'chat-1', pendingRecoveries: [envelope] },
     ])
     decryptRecoveryEnvelope.mockResolvedValue({
@@ -1491,7 +1493,7 @@ describe('chat recovery lifecycle', () => {
   it('retains stale recovery ownership when replacement discovery fails', async () => {
     let now = 1_000
     const dateNow = vi.spyOn(Date, 'now').mockImplementation(() => now)
-    getAllChats
+    getPendingChatRecoveries
       .mockResolvedValueOnce([{ id: 'chat-1', pendingRecoveries: [envelope] }])
       .mockRejectedValueOnce(new Error('IndexedDB unavailable'))
       .mockResolvedValueOnce([])
@@ -1550,7 +1552,7 @@ describe('chat recovery lifecycle', () => {
   })
 
   it('does not invalidate a live attempt when a recovery scan starts', async () => {
-    getAllChats.mockResolvedValue([])
+    getPendingChatRecoveries.mockResolvedValue([])
     encryptRecoveryEnvelope.mockResolvedValue(envelope)
     startChatRecoveryAttempt('chat-1', 'turn-1', SESSION_ID)
 
@@ -1649,7 +1651,7 @@ describe('chat recovery lifecycle', () => {
   })
 
   it('removes a failed envelope before deleting its server session', async () => {
-    getAllChats.mockResolvedValue([
+    getPendingChatRecoveries.mockResolvedValue([
       { id: 'chat-1', pendingRecoveries: [envelope] },
     ])
     decryptRecoveryEnvelope.mockResolvedValue({
@@ -1686,7 +1688,7 @@ describe('chat recovery lifecycle', () => {
 
   it('rewraps an envelope opened with a historical CEK', async () => {
     storedAlternatives = ['historical-key']
-    getAllChats.mockResolvedValue([
+    getPendingChatRecoveries.mockResolvedValue([
       { id: 'chat-1', pendingRecoveries: [envelope] },
     ])
     decryptRecoveryEnvelope

--- a/tests/services/storage/indexed-db-sync-index.test.ts
+++ b/tests/services/storage/indexed-db-sync-index.test.ts
@@ -494,20 +494,22 @@ describe('IndexedDB pending sync index', () => {
       }),
     )
 
+    await storage.getChatSummaries()
     const db = (storage as any).db as IDBDatabase
-    await new Promise<void>((resolve, reject) => {
-      const transaction = db.transaction('chats', 'readwrite')
-      const store = transaction.objectStore('chats')
-      const request = store.get('pending-recovery')
-      request.onsuccess = () => {
-        store.put({
-          ...(request.result as StoredChat),
-          messages: undefined,
-        })
-      }
-      request.onerror = () => reject(request.error)
-      transaction.oncomplete = () => resolve()
-      transaction.onerror = () => reject(transaction.error)
+    const chatStore = db.transaction('chats').objectStore('chats')
+    const storePrototype = Object.getPrototypeOf(chatStore)
+    const originalOpenCursor = storePrototype.openCursor
+    const cursorStoreNames: string[] = []
+    vi.spyOn(storePrototype, 'openCursor').mockImplementation(function (
+      this: IDBObjectStore,
+      ...args: unknown[]
+    ) {
+      cursorStoreNames.push(this.name)
+      const [query, direction] = args as [
+        IDBValidKey | IDBKeyRange | null | undefined,
+        IDBCursorDirection | undefined,
+      ]
+      return originalOpenCursor.call(this, query, direction)
     })
 
     await expect(storage.getPendingChatRecoveries()).resolves.toEqual([
@@ -519,6 +521,12 @@ describe('IndexedDB pending sync index', () => {
     await expect(storage.hasPendingChatRecoveries()).resolves.toBe(true)
     await expect(storage.getCloudChatCount()).resolves.toBe(1)
     await expect(storage.getProjectChatCount('project-1')).resolves.toBe(1)
+    expect(cursorStoreNames).toEqual([
+      'chatSummaries',
+      'chatSummaries',
+      'chatSummaries',
+      'chatSummaries',
+    ])
   })
 
   it('rejects malformed all-chat sync metadata', async () => {

--- a/tests/services/storage/indexed-db-sync-index.test.ts
+++ b/tests/services/storage/indexed-db-sync-index.test.ts
@@ -462,6 +462,65 @@ describe('IndexedDB pending sync index', () => {
     expect(metadata[0]).not.toHaveProperty('messages')
   })
 
+  it('serves recurring metadata reads without hydrating full chat rows', async () => {
+    const storage = new IndexedDBStorage()
+    await storage.initialize()
+    const pendingRecovery = {
+      v: 1 as const,
+      turnId: 'turn-1',
+      keyId: '0123456789abcdef0123456789abcdef',
+      createdAt: '2026-08-12T00:00:00.000Z',
+      expiresAt: '2026-08-12T01:00:00.000Z',
+      nonce: 'AAAAAAAAAAAAAAAA',
+      ciphertext: 'AAAAAAAAAAAAAAAAAAAAAAAA',
+    }
+    await storage.saveChat(
+      storedChat('pending-recovery', {
+        projectId: 'project-1',
+        pendingRecoveries: [pendingRecovery],
+        messages: [
+          {
+            role: 'user',
+            content: 'Do not hydrate me',
+            timestamp: new Date('2026-08-12T00:00:00.000Z'),
+          },
+        ],
+      }),
+    )
+    await storage.saveChat(
+      storedChat('local-only', {
+        isLocalOnly: true,
+        projectId: 'project-1',
+      }),
+    )
+
+    const db = (storage as any).db as IDBDatabase
+    await new Promise<void>((resolve, reject) => {
+      const transaction = db.transaction('chats', 'readwrite')
+      const store = transaction.objectStore('chats')
+      const request = store.get('pending-recovery')
+      request.onsuccess = () => {
+        store.put({
+          ...(request.result as StoredChat),
+          messages: undefined,
+        })
+      }
+      request.onerror = () => reject(request.error)
+      transaction.oncomplete = () => resolve()
+      transaction.onerror = () => reject(transaction.error)
+    })
+
+    await expect(storage.getPendingChatRecoveries()).resolves.toEqual([
+      {
+        id: 'pending-recovery',
+        pendingRecoveries: [pendingRecovery],
+      },
+    ])
+    await expect(storage.hasPendingChatRecoveries()).resolves.toBe(true)
+    await expect(storage.getCloudChatCount()).resolves.toBe(1)
+    await expect(storage.getProjectChatCount('project-1')).resolves.toBe(1)
+  })
+
   it('rejects malformed all-chat sync metadata', async () => {
     const storage = new IndexedDBStorage()
     await storage.initialize()


### PR DESCRIPTION
## Summary
- read pending recoveries from lightweight chat summaries instead of hydrating every saved message and attachment every 10 seconds
- use the same summary records for recurring cloud and project chat counts
- add a regression test proving these periodic reads do not touch full chat rows

## Validation
- `npx vitest run` (146 files, 1,711 tests)
- `npm run lint`
- `npm run build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop periodic chat scans from hydrating full chat rows, preventing browser memory growth. Previously the recovery poll and chat count reads loaded every message and attachment; now they read lightweight chat summaries only, with no user-visible changes.

- Switch recovery scanning to getPendingChatRecoveries() instead of getAllChats().
- Serve getCloudChatCount(), getProjectChatCount(), and hasPendingChatRecoveries() from a chat summaries store, initialized via ensureChatSummaries().
- Add getPendingChatRecoveries() returning { id, pendingRecoveries } for chats with work to resume.
- Add a storage-layer regression test that these recurring reads only touch the chatSummaries store; update recovery tests to mock getPendingChatRecoveries().

<sup>Written for commit 54fb275a98f00b68ef3041f8c49952792ca95b0f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/500?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

