### PR TITLE
Fix follow-up messages queueing after responses

### DIFF
--- a/src/components/chat/hooks/use-chat-messaging.ts
+++ b/src/components/chat/hooks/use-chat-messaging.ts
@@ -127,6 +127,7 @@ interface UseChatMessagingReturn {
     systemPromptOverride?: string,
     baseMessages?: Message[],
     quote?: string,
+    onReadyForNextMessage?: () => void,
   ) => Promise<ChatDispatchResult>
   cancelGeneration: (chatId?: string) => Promise<void>
   editMessage: (messageIndex: number, newContent: string) => void
@@ -543,6 +544,7 @@ export function useChatMessaging({
       systemPromptOverride?: string,
       baseMessages?: Message[],
       quote?: string,
+      onReadyForNextMessage?: () => void,
     ) => {
       // Gate on the target chat's own status so a busy background stream
       // never blocks sending in a different chat.
@@ -602,6 +604,12 @@ export function useChatMessaging({
       let recoveryLocalSavePromise: Promise<Chat> | undefined
       let dispatchAccepted = false
       let optimisticTurnApplied = false
+      let readyForNextMessageSignalled = false
+      const signalReadyForNextMessage = () => {
+        if (readyForNextMessageSignalled) return
+        readyForNextMessageSignalled = true
+        onReadyForNextMessage?.()
+      }
 
       const setLoadingStateFor = (s: LoadingState) =>
         patchStatus(streamChatIdRef.current, { loadingState: s })
@@ -1337,6 +1345,7 @@ export function useChatMessaging({
                   : previous,
               )
             }
+            signalReadyForNextMessage()
           }
 
           logInfo('[handleQuery] Streaming completed, processing response', {
@@ -1622,6 +1631,7 @@ export function useChatMessaging({
             isStreaming: false,
             isThinking: false,
           })
+          if (!controller.signal.aborted) signalReadyForNextMessage()
         }
         clearController(streamChatIdRef.current, controller)
         if (

--- a/src/components/chat/hooks/use-chat-state.ts
+++ b/src/components/chat/hooks/use-chat-state.ts
@@ -51,6 +51,7 @@ interface UseChatStateReturn {
     systemPromptOverride?: string,
     baseMessages?: Message[],
     quote?: string,
+    onReadyForNextMessage?: () => void,
   ) => Promise<ChatDispatchResult>
   createNewChat: (isLocalOnly?: boolean, fromUserAction?: boolean) => void
   deleteChat: (chatId: string) => void

--- a/src/components/chat/hooks/use-message-queue.ts
+++ b/src/components/chat/hooks/use-message-queue.ts
@@ -10,6 +10,7 @@ type HandleQuery = (
   systemPromptOverride?: string,
   baseMessages?: Message[],
   quote?: string,
+  onReadyForNextMessage?: () => void,
 ) => void | ChatDispatchResult | Promise<void | ChatDispatchResult>
 
 export type QueueSubmitInput = {
@@ -115,11 +116,10 @@ function writeToStorage(key: string | null, queue: QueuedMessage[]): void {
  *   "my dispatch finished" and fires the next one in parallel.
  *
  *   The pump avoids that race entirely: it owns the dispatch lifecycle
- *   end-to-end. It awaits `handleQuery`'s returned promise — which only
- *   settles when the stream we kicked off truly completes — and only
- *   then loops to the next message. Stale `loadingState` writes from a
- *   previously-cancelled stream can't trigger anything because nothing
- *   observes them.
+ *   end-to-end. It awaits either `handleQuery`'s returned promise or its
+ *   explicit ready-for-next-message signal, emitted after the response is
+ *   fully visible. Stale `loadingState` writes from a previously-cancelled
+ *   stream can't trigger anything because nothing observes them.
  *
  * Cancellation (Stop button):
  *
@@ -319,12 +319,17 @@ export function useMessageQueue({
           setQueueFor(pump.id, rest)
 
           try {
+            let markReadyForNextMessage!: () => void
+            const readyForNextMessage = new Promise<void>((resolve) => {
+              markReadyForNextMessage = resolve
+            })
             const result = handleQueryRef.current(
               next.text,
               next.attachments,
               undefined,
               undefined,
               next.quote,
+              markReadyForNextMessage,
             )
             let dispatchResult: void | ChatDispatchResult = undefined
             if (
@@ -342,6 +347,9 @@ export function useMessageQueue({
                     .catch(() => ({ type: 'error' as const })),
                   cancelWaiter.promise.then(() => ({
                     type: 'cancelled' as const,
+                  })),
+                  readyForNextMessage.then(() => ({
+                    type: 'ready' as const,
                   })),
                 ])
                 if (settled.type === 'result') {

--- a/tests/components/chat/use-chat-messaging.stop-stream.test.tsx
+++ b/tests/components/chat/use-chat-messaging.stop-stream.test.tsx
@@ -1170,6 +1170,7 @@ describe('useChatMessaging stopped streams', () => {
     recoveryAvailableState.available = true
     let finishRecoveryCompletion!: () => void
     const idleWhileFinalizing: boolean[] = []
+    const readyForNextMessage = vi.fn()
     completeLiveChatRecoveryMock.mockImplementationOnce(
       (...args: unknown[]) => {
         idleWhileFinalizing.push(
@@ -1223,7 +1224,14 @@ describe('useChatMessaging stopped streams', () => {
 
     let query!: Promise<unknown>
     act(() => {
-      query = result.current.messaging.handleQuery('Prompt') as Promise<unknown>
+      query = result.current.messaging.handleQuery(
+        'Prompt',
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        readyForNextMessage,
+      ) as Promise<unknown>
     })
     await vi.waitFor(() => expect(sendChatStreamMock).toHaveBeenCalled())
     stream.send({ choices: [{ delta: { content: 'Complete answer' } }] })
@@ -1238,6 +1246,7 @@ describe('useChatMessaging stopped streams', () => {
     // The stop button/spinner must revert as soon as the stream ends, not
     // after the recovery finalization round-trips settle.
     expect(idleWhileFinalizing).toEqual([true])
+    expect(readyForNextMessage).toHaveBeenCalledOnce()
 
     await act(async () => {
       finishRecoveryCompletion()

--- a/tests/components/chat/use-message-queue.concurrency.test.tsx
+++ b/tests/components/chat/use-message-queue.concurrency.test.tsx
@@ -94,6 +94,7 @@ describe('useMessageQueue concurrency', () => {
       undefined,
       undefined,
       undefined,
+      expect.any(Function),
     )
 
     // Chat A is now streaming; switch to a different, idle chat B.
@@ -114,6 +115,7 @@ describe('useMessageQueue concurrency', () => {
       undefined,
       undefined,
       undefined,
+      expect.any(Function),
     )
 
     resolveA?.()
@@ -143,6 +145,7 @@ describe('useMessageQueue concurrency', () => {
       undefined,
       undefined,
       undefined,
+      expect.any(Function),
     )
   })
 
@@ -424,6 +427,7 @@ describe('useMessageQueue concurrency', () => {
       undefined,
       undefined,
       undefined,
+      expect.any(Function),
     )
 
     resolveA?.()
@@ -461,6 +465,7 @@ describe('useMessageQueue concurrency', () => {
       undefined,
       undefined,
       undefined,
+      expect.any(Function),
     )
 
     act(() => {
@@ -475,9 +480,62 @@ describe('useMessageQueue concurrency', () => {
       undefined,
       undefined,
       undefined,
+      expect.any(Function),
     )
 
     resolvers[1]?.()
+  })
+
+  it('dispatches the next message when the completed response becomes interactive', async () => {
+    const resolvers: Array<() => void> = []
+    const readyCallbacks: Array<() => void> = []
+    const handleQuery = vi.fn(
+      (
+        _text: string,
+        _attachments: unknown,
+        _systemPromptOverride: unknown,
+        _baseMessages: unknown,
+        _quote: unknown,
+        onReadyForNextMessage?: () => void,
+      ) => {
+        if (onReadyForNextMessage) readyCallbacks.push(onReadyForNextMessage)
+        return new Promise<void>((resolve) => {
+          resolvers.push(resolve)
+        })
+      },
+    )
+
+    const { result, rerender } = renderHook(
+      ({ loadingState }) =>
+        useMessageQueue({
+          chatId: 'chat-a',
+          loadingState,
+          handleQuery,
+          isRateLimited: () => false,
+        }),
+      { initialProps: { loadingState: 'idle' as LoadingState } },
+    )
+
+    act(() => result.current.submit({ text: 'first' }))
+    await flushMicrotasks()
+    rerender({ loadingState: 'loading' as LoadingState })
+    act(() => result.current.submit({ text: 'second' }))
+    await flushMicrotasks()
+
+    expect(handleQuery).toHaveBeenCalledTimes(1)
+    expect(result.current.queuedMessages.map(({ text }) => text)).toEqual([
+      'second',
+    ])
+
+    rerender({ loadingState: 'idle' as LoadingState })
+    act(() => readyCallbacks[0]?.())
+    await flushMicrotasks()
+
+    expect(handleQuery).toHaveBeenCalledTimes(2)
+    expect(handleQuery.mock.calls[1][0]).toBe('second')
+    expect(result.current.queuedMessages).toEqual([])
+
+    resolvers.forEach((resolve) => resolve())
   })
 
   it('parks a queued message when switching away and resumes on return', async () => {
@@ -521,6 +579,7 @@ describe('useMessageQueue concurrency', () => {
       undefined,
       undefined,
       undefined,
+      expect.any(Function),
     )
   })
 
@@ -560,6 +619,7 @@ describe('useMessageQueue concurrency', () => {
       undefined,
       undefined,
       undefined,
+      expect.any(Function),
     )
   })
 
@@ -601,6 +661,7 @@ describe('useMessageQueue concurrency', () => {
       undefined,
       undefined,
       undefined,
+      expect.any(Function),
     )
   })
 
@@ -715,6 +776,7 @@ describe('useMessageQueue concurrency', () => {
       undefined,
       undefined,
       'quoted',
+      expect.any(Function),
     ])
     expect(handleQuery.mock.calls[2][0]).toBe('C')
     expect(result.current.queuedMessages).toEqual([])
@@ -817,6 +879,7 @@ describe('useMessageQueue concurrency', () => {
       undefined,
       undefined,
       undefined,
+      expect.any(Function),
     )
     expect(result.current.queuedMessages).toEqual([])
   })


### PR DESCRIPTION
## Summary
- release the per-chat message queue when a completed response becomes interactive
- keep background recovery and persistence from delaying follow-up messages
- add regression coverage for follow-up dispatch during background finalization

## Testing
- `npx vitest run tests/components/chat/use-message-queue.concurrency.test.tsx tests/components/chat/use-chat-messaging.stop-stream.test.tsx`
- `npx eslint src/components/chat/hooks/use-chat-messaging.ts src/components/chat/hooks/use-chat-state.ts src/components/chat/hooks/use-message-queue.ts tests/components/chat/use-chat-messaging.stop-stream.test.tsx tests/components/chat/use-message-queue.concurrency.test.tsx`
- `npx prettier --check src/components/chat/hooks/use-chat-messaging.ts src/components/chat/hooks/use-chat-state.ts src/components/chat/hooks/use-message-queue.ts tests/components/chat/use-chat-messaging.stop-stream.test.tsx tests/components/chat/use-message-queue.concurrency.test.tsx`

## Note
- `npx tsc --noEmit` remains blocked by the existing missing generated `out/_next/static/media/local-tinfoil-import-parser` module.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unblocks follow-up messages after a response by signaling readiness when the response becomes interactive. Previously, the queue waited for background finalization; now it dispatches the next message as soon as the UI can accept input.

- Add optional `onReadyForNextMessage` to `useChatMessaging.handleQuery` and plumb it through `useMessageQueue`.
- Update the pump to proceed on the first of: dispatch result, cancellation, or the ready signal; prevents background recovery/persistence from stalling the queue and restores idle state immediately after stream end.
- Add regression tests for stop-stream and concurrency; update expectations to include the callback.
- Migration: none. Callers of `handleQuery` may ignore the new optional parameter.

<sup>Written for commit a0a69799a8ac2793789304c4460327a261fe3f91. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/501?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

