### PR TITLE
Fix stale active chat content after sync

### DIFF
--- a/src/components/chat/hooks/chat-persistence-manager.ts
+++ b/src/components/chat/hooks/chat-persistence-manager.ts
@@ -16,9 +16,18 @@ import { saveChat, updateChatMessages } from './chat-operations'
 export class ChatPersistenceManager {
   private saveQueues = new Map<string, Promise<Chat>>()
   private isSignedIn: boolean
+  private isDisposed = false
 
-  constructor(isSignedIn: boolean) {
+  constructor(
+    isSignedIn: boolean,
+    private readonly accountScope: string,
+    private readonly getAccountScope: () => string,
+  ) {
     this.isSignedIn = isSignedIn
+  }
+
+  activate() {
+    this.isDisposed = false
   }
 
   setSignedIn(isSignedIn: boolean) {
@@ -48,6 +57,9 @@ export class ChatPersistenceManager {
     const savePromise = existingQueue
       .catch(() => undefined)
       .then(async () => {
+        if (this.isDisposed || this.accountScope !== this.getAccountScope()) {
+          return chat
+        }
         try {
           const savedChat = await saveChat(chat, this.isSignedIn, skipCloudSync)
           return savedChat
@@ -77,6 +89,7 @@ export class ChatPersistenceManager {
    * Cleanup on unmount
    */
   cleanup() {
+    this.isDisposed = true
     this.saveQueues.clear()
   }
 }

--- a/src/components/chat/hooks/use-chat-storage.ts
+++ b/src/components/chat/hooks/use-chat-storage.ts
@@ -121,6 +121,8 @@ export function useChatStorage({
   currentChatRef.current = currentChat
   const selectionRequestRef = useRef(0)
   const selectionFallbackRef = useRef<Chat | null>(null)
+  const titleSaveSequenceRef = useRef(0)
+  const titleSaveGenerationRef = useRef(new Map<string, number>())
 
   // Create persistence manager
   const persistenceManager = useMemo(
@@ -221,9 +223,17 @@ export function useChatStorage({
                   existing.pendingSave === true ||
                   streamingTracker.isStreamingOrPending(c.id)
                 ) {
+                  const pendingTitle = existing.pendingSave
+                    ? {
+                        title: existing.title,
+                        titleState: existing.titleState,
+                        updatedAt: existing.updatedAt,
+                      }
+                    : {}
                   chat = {
                     ...existing,
                     ...c,
+                    ...pendingTitle,
                     messages: existing.messages,
                     isMetadataOnly: false,
                   }
@@ -265,21 +275,25 @@ export function useChatStorage({
               // stored copy over the messages the new stream is about to write.
               const isStreaming = streamingTracker.isStreamingOrPending(prev.id)
               const isRecoveryReload = pendingRecoveryIds.includes(prev.id)
+              const pendingCurrentTitle = prev.pendingSave
+                ? {
+                    title: prev.title,
+                    titleState: prev.titleState,
+                    updatedAt: prev.updatedAt,
+                  }
+                : {}
               const existingMessageCount = existingChat.isMetadataOnly
                 ? (existingChat.messageCount ?? 0)
                 : existingChat.messages.length
               const canAdoptRefreshedCurrent =
                 refreshedCurrentChat !== null &&
                 prev === current &&
-                prev.id === current.id &&
-                prev.updatedAt === current.updatedAt &&
-                prev.messages.length === current.messages.length &&
-                !prev.pendingSave &&
                 !isStreaming &&
                 refreshedCurrentChat.updatedAt === existingChat.updatedAt &&
                 refreshedCurrentChat.messages.length === existingMessageCount
               if (canAdoptRefreshedCurrent) {
                 nextCurrent = {
+                  ...prev,
                   ...refreshedCurrentChat,
                   pendingRecoveries: storedRecoveries,
                   pendingSave: prev.pendingSave,
@@ -330,6 +344,7 @@ export function useChatStorage({
                 ) {
                   nextCurrent = {
                     ...existingChat,
+                    ...pendingCurrentTitle,
                     pendingRecoveries: storedRecoveries,
                     pendingSave: prev.pendingSave,
                   }
@@ -345,7 +360,7 @@ export function useChatStorage({
                   nextCurrent = {
                     ...prev,
                     syncedAt: existingChat.syncedAt,
-                    title: existingChat.title,
+                    title: prev.pendingSave ? prev.title : existingChat.title,
                     presetId: existingChat.presetId,
                     pendingRecoveries: storedRecoveries,
                   }
@@ -530,7 +545,12 @@ export function useChatStorage({
   const updateChatTitle = useCallback(
     (chatId: string, newTitle: string) => {
       const updatedAt = new Date().toISOString()
+      const saveGeneration = ++titleSaveSequenceRef.current
+      titleSaveGenerationRef.current.set(chatId, saveGeneration)
       const finishSave = (savedUpdatedAt?: string) => {
+        if (titleSaveGenerationRef.current.get(chatId) !== saveGeneration)
+          return
+        titleSaveGenerationRef.current.delete(chatId)
         setChatCollection((previous) => {
           const finish = (chat: Chat) =>
             chat.id === chatId && chat.updatedAt === updatedAt

--- a/src/components/chat/hooks/use-chat-storage.ts
+++ b/src/components/chat/hooks/use-chat-storage.ts
@@ -103,7 +103,7 @@ export function useChatStorage({
   isLocalChatUrl = false,
   initialNewChatIsLocalOnly = false,
 }: UseChatStorageProps): UseChatStorageReturn {
-  const { isSignedIn } = useAuth()
+  const { isSignedIn, userId } = useAuth()
   const { toast } = useToast()
   const [isInitialLoad, setIsInitialLoad] = useState(true)
   const [hydratingChatId, setHydratingChatId] = useState<string | null>(null)
@@ -133,6 +133,10 @@ export function useChatStorage({
   const selectionFallbackRef = useRef<Chat | null>(null)
   const titleSaveSequenceRef = useRef(0)
   const titleSaveGenerationRef = useRef(new Map<string, number>())
+  const accountKey = `${!!isSignedIn}:${userId ?? ''}`
+  const accountKeyRef = useRef(accountKey)
+  accountKeyRef.current = accountKey
+  const initialLoadAccountKeyRef = useRef(accountKey)
 
   // Create persistence manager
   const persistenceManager = useMemo(
@@ -159,6 +163,7 @@ export function useChatStorage({
 
       recoveryIds?.forEach((id) => pendingRecoveryReloadIdsRef.current.add(id))
       const reloadGeneration = ++reloadGenerationRef.current
+      const reloadAccountKey = accountKeyRef.current
       try {
         const current = currentChatRef.current
         const needsFullReload =
@@ -168,7 +173,10 @@ export function useChatStorage({
           storeHistory && !!isSignedIn,
           !needsFullReload,
         )
-        if (reloadGeneration !== reloadGenerationRef.current) {
+        if (
+          reloadGeneration !== reloadGenerationRef.current ||
+          reloadAccountKey !== accountKeyRef.current
+        ) {
           return
         }
         const currentSummary = loadedChats.find(
@@ -188,14 +196,22 @@ export function useChatStorage({
             ? await chatStorage.getChat(current.id)
             : currentSummary
           : null
-        if (reloadGeneration !== reloadGenerationRef.current) {
+        if (
+          reloadGeneration !== reloadGenerationRef.current ||
+          reloadAccountKey !== accountKeyRef.current
+        ) {
           return
         }
         const pendingRecoveryIds = [...pendingRecoveryReloadIdsRef.current]
         pendingRecoveryReloadIdsRef.current.clear()
 
         setChatCollection((previous) => {
-          if (reloadGeneration !== reloadGenerationRef.current) return previous
+          if (
+            reloadGeneration !== reloadGenerationRef.current ||
+            reloadAccountKey !== accountKeyRef.current
+          ) {
+            return previous
+          }
           const { chats: prevChats, currentChat: prev } = previous
           // Always ensure we have blank chats for both modes
           const cloudBlank =
@@ -249,10 +265,12 @@ export function useChatStorage({
                   }
                 }
               } else if (existing && hasPendingTitle) {
-                chat = {
-                  ...c,
-                  ...pendingTitleFields(existing, true),
-                }
+                chat = existing.pendingSave
+                  ? { ...c, ...existing }
+                  : {
+                      ...c,
+                      ...pendingTitleFields(existing, hasPendingTitle),
+                    }
               }
               return chat.pendingRecoveries?.length
                 ? {
@@ -443,6 +461,10 @@ export function useChatStorage({
   // Initial load
   useEffect(() => {
     let mounted = true
+    const initialAccountKey = accountKey
+    const accountChanged =
+      initialLoadAccountKeyRef.current !== initialAccountKey
+    initialLoadAccountKeyRef.current = initialAccountKey
 
     const loadInitialChats = async () => {
       if (typeof window === 'undefined') return
@@ -453,7 +475,7 @@ export function useChatStorage({
           storeHistory && !!isSignedIn,
         )
 
-        if (!mounted) return
+        if (!mounted || accountKeyRef.current !== initialAccountKey) return
 
         // Always have blank chats for both modes
         const cloudBlank = createBlankChat(false)
@@ -469,9 +491,10 @@ export function useChatStorage({
           // Preserve an explicit blank-mode selection made while storage was
           // loading. Never reset a non-blank chat.
           currentChat:
-            current.isBlankChat &&
-            current.id === '' &&
-            current.isTemporary !== true
+            accountChanged ||
+            (current.isBlankChat &&
+              current.id === '' &&
+              current.isTemporary !== true)
               ? (getBlankChat(finalChats, current.isLocalOnly === true) ??
                 finalChats[0])
               : current,
@@ -492,7 +515,13 @@ export function useChatStorage({
     return () => {
       mounted = false
     }
-  }, [storeHistory, isSignedIn, initialNewChatIsLocalOnly, setChatCollection])
+  }, [
+    storeHistory,
+    isSignedIn,
+    accountKey,
+    initialNewChatIsLocalOnly,
+    setChatCollection,
+  ])
 
   // Create new chat (switch to the appropriate blank chat)
   const createNewChat = useCallback(
@@ -560,12 +589,17 @@ export function useChatStorage({
   const updateChatTitle = useCallback(
     (chatId: string, newTitle: string) => {
       const updatedAt = new Date().toISOString()
+      const titleSnapshot =
+        currentChat?.id === chatId
+          ? currentChat
+          : chats.find((chat) => chat.id === chatId)
       const saveGeneration = storeHistory
         ? ++titleSaveSequenceRef.current
         : null
       if (saveGeneration !== null) {
         titleSaveGenerationRef.current.set(chatId, saveGeneration)
       }
+      const titleAccountKey = accountKeyRef.current
       const clearTitleGenerationIfOwned = () => {
         if (
           saveGeneration === null ||
@@ -577,8 +611,13 @@ export function useChatStorage({
         return true
       }
       const finishSave = (savedUpdatedAt?: string) => {
+        if (accountKeyRef.current !== titleAccountKey) {
+          clearTitleGenerationIfOwned()
+          return
+        }
         if (!clearTitleGenerationIfOwned()) return
         setChatCollection((previous) => {
+          if (accountKeyRef.current !== titleAccountKey) return previous
           const finish = (chat: Chat) =>
             chat.id === chatId && chat.updatedAt === updatedAt
               ? {
@@ -611,8 +650,32 @@ export function useChatStorage({
             .save(chatToUpdate)
             .then((saved) => finishSave(saved.updatedAt))
             .catch((error) => {
-              if (clearTitleGenerationIfOwned()) {
-                reloadGenerationRef.current += 1
+              if (
+                accountKeyRef.current === titleAccountKey &&
+                clearTitleGenerationIfOwned()
+              ) {
+                if (titleSnapshot) {
+                  setChatCollection((previous) => {
+                    if (accountKeyRef.current !== titleAccountKey)
+                      return previous
+                    const rollback = (chat: Chat) =>
+                      chat.id === chatId && chat.updatedAt === updatedAt
+                        ? {
+                            ...chat,
+                            title: titleSnapshot.title,
+                            titleState: titleSnapshot.titleState,
+                            updatedAt: titleSnapshot.updatedAt,
+                          }
+                        : chat
+                    return {
+                      chats: previous.chats.map(rollback),
+                      currentChat: rollback(previous.currentChat),
+                    }
+                  })
+                }
+                void reloadChats()
+              } else {
+                clearTitleGenerationIfOwned()
               }
               logError('Failed to save chat title update', error, {
                 component: 'useChatStorage',
@@ -637,7 +700,8 @@ export function useChatStorage({
     },
     [
       storeHistory,
-      currentChat?.id,
+      chats,
+      currentChat,
       persistenceManager,
       reloadChats,
       setChats,

--- a/src/components/chat/hooks/use-chat-storage.ts
+++ b/src/components/chat/hooks/use-chat-storage.ts
@@ -31,6 +31,9 @@ import {
 import { ChatPersistenceManager } from './chat-persistence-manager'
 import { useChatCollection } from './use-chat-collection'
 
+const useIsomorphicLayoutEffect =
+  typeof window === 'undefined' ? useEffect : useLayoutEffect
+
 interface UseChatStorageProps {
   storeHistory: boolean
   scrollToBottom?: () => void
@@ -146,7 +149,7 @@ export function useChatStorage({
   const previousAccountKeyRef = useRef(accountKey)
   const committedAccountKeyRef = useRef(accountKey)
   const accountGenerationRef = useRef(0)
-  useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     if (previousAccountKeyRef.current !== accountKey) {
       previousAccountKeyRef.current = accountKey
       accountGenerationRef.current += 1
@@ -172,7 +175,7 @@ export function useChatStorage({
   }, [isSignedIn, persistenceManager])
 
   // Cleanup on unmount
-  useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     persistenceManager.activate()
     return () => {
       persistenceManager.cleanup()

--- a/src/components/chat/hooks/use-chat-storage.ts
+++ b/src/components/chat/hooks/use-chat-storage.ts
@@ -159,6 +159,26 @@ export function useChatStorage({
         if (reloadGeneration !== reloadGenerationRef.current) {
           return
         }
+        const currentSummary = loadedChats.find(
+          (chat) => chat.id === current.id,
+        )
+        const currentContentChanged =
+          !current.isBlankChat &&
+          !current.isMetadataOnly &&
+          !current.pendingSave &&
+          !streamingTracker.isStreamingOrPending(current.id) &&
+          currentSummary !== undefined &&
+          currentSummary.updatedAt !== undefined &&
+          (current.updatedAt === undefined ||
+            currentSummary.updatedAt > current.updatedAt)
+        const refreshedCurrentChat = currentContentChanged
+          ? currentSummary.isMetadataOnly
+            ? await chatStorage.getChat(current.id)
+            : currentSummary
+          : null
+        if (reloadGeneration !== reloadGenerationRef.current) {
+          return
+        }
         const pendingRecoveryIds = [...pendingRecoveryReloadIdsRef.current]
         pendingRecoveryReloadIdsRef.current.clear()
 
@@ -245,7 +265,26 @@ export function useChatStorage({
               // stored copy over the messages the new stream is about to write.
               const isStreaming = streamingTracker.isStreamingOrPending(prev.id)
               const isRecoveryReload = pendingRecoveryIds.includes(prev.id)
-              if (isRecoveryReload && isStreaming) {
+              const existingMessageCount = existingChat.isMetadataOnly
+                ? (existingChat.messageCount ?? 0)
+                : existingChat.messages.length
+              const canAdoptRefreshedCurrent =
+                refreshedCurrentChat !== null &&
+                prev === current &&
+                prev.id === current.id &&
+                prev.updatedAt === current.updatedAt &&
+                prev.messages.length === current.messages.length &&
+                !prev.pendingSave &&
+                !isStreaming &&
+                refreshedCurrentChat.updatedAt === existingChat.updatedAt &&
+                refreshedCurrentChat.messages.length === existingMessageCount
+              if (canAdoptRefreshedCurrent) {
+                nextCurrent = {
+                  ...refreshedCurrentChat,
+                  pendingRecoveries: storedRecoveries,
+                  pendingSave: prev.pendingSave,
+                }
+              } else if (isRecoveryReload && isStreaming) {
                 nextCurrent = {
                   ...prev,
                   pendingRecoveries: storedRecoveries,
@@ -490,21 +529,48 @@ export function useChatStorage({
   // Update chat title
   const updateChatTitle = useCallback(
     (chatId: string, newTitle: string) => {
+      const updatedAt = new Date().toISOString()
+      const finishSave = (savedUpdatedAt?: string) => {
+        setChatCollection((previous) => {
+          const finish = (chat: Chat) =>
+            chat.id === chatId && chat.updatedAt === updatedAt
+              ? {
+                  ...chat,
+                  updatedAt: savedUpdatedAt ?? chat.updatedAt,
+                  pendingSave: false,
+                }
+              : chat
+          return {
+            chats: previous.chats.map(finish),
+            currentChat: finish(previous.currentChat),
+          }
+        })
+      }
       setChats((prevChats) => {
         const updatedChats = prevChats.map((chat) =>
           chat.id === chatId
-            ? { ...chat, title: newTitle, titleState: 'manual' as const }
+            ? {
+                ...chat,
+                title: newTitle,
+                titleState: 'manual' as const,
+                updatedAt,
+                pendingSave: storeHistory && !chat.isTemporary,
+              }
             : chat,
         )
 
         const chatToUpdate = updatedChats.find((c) => c.id === chatId)
         if (chatToUpdate && !chatToUpdate.isTemporary && storeHistory) {
-          persistenceManager.save(chatToUpdate).catch((error) => {
-            logError('Failed to save chat title update', error, {
-              component: 'useChatStorage',
-              metadata: { chatId },
+          persistenceManager
+            .save(chatToUpdate)
+            .then((saved) => finishSave(saved.updatedAt))
+            .catch((error) => {
+              finishSave()
+              logError('Failed to save chat title update', error, {
+                component: 'useChatStorage',
+                metadata: { chatId },
+              })
             })
-          })
         }
 
         return updatedChats
@@ -515,6 +581,8 @@ export function useChatStorage({
           ...prev,
           title: newTitle,
           titleState: 'manual' as const,
+          updatedAt,
+          pendingSave: storeHistory && !prev.isTemporary,
         }))
       }
     },
@@ -523,6 +591,7 @@ export function useChatStorage({
       currentChat?.id,
       persistenceManager,
       setChats,
+      setChatCollection,
       setCurrentChat,
     ],
   )

--- a/src/components/chat/hooks/use-chat-storage.ts
+++ b/src/components/chat/hooks/use-chat-storage.ts
@@ -168,6 +168,7 @@ export function useChatStorage({
           !current.isBlankChat &&
           !current.isMetadataOnly &&
           !current.pendingSave &&
+          !titleSaveGenerationRef.current.has(current.id) &&
           !streamingTracker.isStreamingOrPending(current.id) &&
           currentSummary !== undefined &&
           currentSummary.updatedAt !== undefined &&
@@ -221,15 +222,18 @@ export function useChatStorage({
                 if (
                   hydratedMatchesStorage ||
                   existing.pendingSave === true ||
+                  titleSaveGenerationRef.current.has(c.id) ||
                   streamingTracker.isStreamingOrPending(c.id)
                 ) {
-                  const pendingTitle = existing.pendingSave
-                    ? {
-                        title: existing.title,
-                        titleState: existing.titleState,
-                        updatedAt: existing.updatedAt,
-                      }
-                    : {}
+                  const pendingTitle =
+                    existing.pendingSave ||
+                    titleSaveGenerationRef.current.has(c.id)
+                      ? {
+                          title: existing.title,
+                          titleState: existing.titleState,
+                          updatedAt: existing.updatedAt,
+                        }
+                      : {}
                   chat = {
                     ...existing,
                     ...c,
@@ -275,7 +279,9 @@ export function useChatStorage({
               // stored copy over the messages the new stream is about to write.
               const isStreaming = streamingTracker.isStreamingOrPending(prev.id)
               const isRecoveryReload = pendingRecoveryIds.includes(prev.id)
-              const pendingCurrentTitle = prev.pendingSave
+              const hasPendingTitle =
+                prev.pendingSave || titleSaveGenerationRef.current.has(prev.id)
+              const pendingCurrentTitle = hasPendingTitle
                 ? {
                     title: prev.title,
                     titleState: prev.titleState,
@@ -360,7 +366,7 @@ export function useChatStorage({
                   nextCurrent = {
                     ...prev,
                     syncedAt: existingChat.syncedAt,
-                    title: prev.pendingSave ? prev.title : existingChat.title,
+                    title: hasPendingTitle ? prev.title : existingChat.title,
                     presetId: existingChat.presetId,
                     pendingRecoveries: storedRecoveries,
                   }
@@ -545,9 +551,14 @@ export function useChatStorage({
   const updateChatTitle = useCallback(
     (chatId: string, newTitle: string) => {
       const updatedAt = new Date().toISOString()
-      const saveGeneration = ++titleSaveSequenceRef.current
-      titleSaveGenerationRef.current.set(chatId, saveGeneration)
+      const saveGeneration = storeHistory
+        ? ++titleSaveSequenceRef.current
+        : null
+      if (saveGeneration !== null) {
+        titleSaveGenerationRef.current.set(chatId, saveGeneration)
+      }
       const finishSave = (savedUpdatedAt?: string) => {
+        if (saveGeneration === null) return
         if (titleSaveGenerationRef.current.get(chatId) !== saveGeneration)
           return
         titleSaveGenerationRef.current.delete(chatId)
@@ -591,6 +602,11 @@ export function useChatStorage({
                 metadata: { chatId },
               })
             })
+        } else if (
+          saveGeneration !== null &&
+          titleSaveGenerationRef.current.get(chatId) === saveGeneration
+        ) {
+          titleSaveGenerationRef.current.delete(chatId)
         }
 
         return updatedChats

--- a/src/components/chat/hooks/use-chat-storage.ts
+++ b/src/components/chat/hooks/use-chat-storage.ts
@@ -87,6 +87,16 @@ function withoutCancelledRecoveries(
   return remaining.length > 0 ? remaining : undefined
 }
 
+function pendingTitleFields(chat: Chat, isPending: boolean): Partial<Chat> {
+  return isPending
+    ? {
+        title: chat.title,
+        titleState: chat.titleState,
+        updatedAt: chat.updatedAt,
+      }
+    : {}
+}
+
 export function useChatStorage({
   storeHistory,
   initialChatId,
@@ -168,7 +178,6 @@ export function useChatStorage({
           !current.isBlankChat &&
           !current.isMetadataOnly &&
           !current.pendingSave &&
-          !titleSaveGenerationRef.current.has(current.id) &&
           !streamingTracker.isStreamingOrPending(current.id) &&
           currentSummary !== undefined &&
           currentSummary.updatedAt !== undefined &&
@@ -185,7 +194,9 @@ export function useChatStorage({
         const pendingRecoveryIds = [...pendingRecoveryReloadIdsRef.current]
         pendingRecoveryReloadIdsRef.current.clear()
 
-        setChatCollection(({ chats: prevChats, currentChat: prev }) => {
+        setChatCollection((previous) => {
+          if (reloadGeneration !== reloadGenerationRef.current) return previous
+          const { chats: prevChats, currentChat: prev } = previous
           // Always ensure we have blank chats for both modes
           const cloudBlank =
             getBlankChat(prevChats, false) || createBlankChat(false)
@@ -208,6 +219,10 @@ export function useChatStorage({
             .map((c) => {
               const existing = previousById.get(c.id)
               let chat = c
+              const hasPendingTitle =
+                existing !== undefined &&
+                (existing.pendingSave === true ||
+                  titleSaveGenerationRef.current.has(c.id))
               if (c.isMetadataOnly && existing && !existing.isMetadataOnly) {
                 // A hydrated copy keeps its messages only while it still
                 // mirrors storage. When the stored chat has newer content
@@ -225,22 +240,18 @@ export function useChatStorage({
                   titleSaveGenerationRef.current.has(c.id) ||
                   streamingTracker.isStreamingOrPending(c.id)
                 ) {
-                  const pendingTitle =
-                    existing.pendingSave ||
-                    titleSaveGenerationRef.current.has(c.id)
-                      ? {
-                          title: existing.title,
-                          titleState: existing.titleState,
-                          updatedAt: existing.updatedAt,
-                        }
-                      : {}
                   chat = {
                     ...existing,
                     ...c,
-                    ...pendingTitle,
+                    ...pendingTitleFields(existing, hasPendingTitle),
                     messages: existing.messages,
                     isMetadataOnly: false,
                   }
+                }
+              } else if (existing && hasPendingTitle) {
+                chat = {
+                  ...c,
+                  ...pendingTitleFields(existing, true),
                 }
               }
               return chat.pendingRecoveries?.length
@@ -281,13 +292,10 @@ export function useChatStorage({
               const isRecoveryReload = pendingRecoveryIds.includes(prev.id)
               const hasPendingTitle =
                 prev.pendingSave || titleSaveGenerationRef.current.has(prev.id)
-              const pendingCurrentTitle = hasPendingTitle
-                ? {
-                    title: prev.title,
-                    titleState: prev.titleState,
-                    updatedAt: prev.updatedAt,
-                  }
-                : {}
+              const pendingCurrentTitle = pendingTitleFields(
+                prev,
+                hasPendingTitle,
+              )
               const existingMessageCount = existingChat.isMetadataOnly
                 ? (existingChat.messageCount ?? 0)
                 : existingChat.messages.length
@@ -301,6 +309,7 @@ export function useChatStorage({
                 nextCurrent = {
                   ...prev,
                   ...refreshedCurrentChat,
+                  ...pendingCurrentTitle,
                   pendingRecoveries: storedRecoveries,
                   pendingSave: prev.pendingSave,
                 }
@@ -557,18 +566,24 @@ export function useChatStorage({
       if (saveGeneration !== null) {
         titleSaveGenerationRef.current.set(chatId, saveGeneration)
       }
-      const finishSave = (savedUpdatedAt?: string) => {
-        if (saveGeneration === null) return
-        if (titleSaveGenerationRef.current.get(chatId) !== saveGeneration)
-          return
+      const clearTitleGenerationIfOwned = () => {
+        if (
+          saveGeneration === null ||
+          titleSaveGenerationRef.current.get(chatId) !== saveGeneration
+        ) {
+          return false
+        }
         titleSaveGenerationRef.current.delete(chatId)
+        return true
+      }
+      const finishSave = (savedUpdatedAt?: string) => {
+        if (!clearTitleGenerationIfOwned()) return
         setChatCollection((previous) => {
           const finish = (chat: Chat) =>
             chat.id === chatId && chat.updatedAt === updatedAt
               ? {
                   ...chat,
                   updatedAt: savedUpdatedAt ?? chat.updatedAt,
-                  pendingSave: false,
                 }
               : chat
           return {
@@ -576,6 +591,7 @@ export function useChatStorage({
             currentChat: finish(previous.currentChat),
           }
         })
+        void reloadChats()
       }
       setChats((prevChats) => {
         const updatedChats = prevChats.map((chat) =>
@@ -585,7 +601,6 @@ export function useChatStorage({
                 title: newTitle,
                 titleState: 'manual' as const,
                 updatedAt,
-                pendingSave: storeHistory && !chat.isTemporary,
               }
             : chat,
         )
@@ -596,17 +611,16 @@ export function useChatStorage({
             .save(chatToUpdate)
             .then((saved) => finishSave(saved.updatedAt))
             .catch((error) => {
-              finishSave()
+              if (clearTitleGenerationIfOwned()) {
+                reloadGenerationRef.current += 1
+              }
               logError('Failed to save chat title update', error, {
                 component: 'useChatStorage',
                 metadata: { chatId },
               })
             })
-        } else if (
-          saveGeneration !== null &&
-          titleSaveGenerationRef.current.get(chatId) === saveGeneration
-        ) {
-          titleSaveGenerationRef.current.delete(chatId)
+        } else {
+          clearTitleGenerationIfOwned()
         }
 
         return updatedChats
@@ -618,7 +632,6 @@ export function useChatStorage({
           title: newTitle,
           titleState: 'manual' as const,
           updatedAt,
-          pendingSave: storeHistory && !prev.isTemporary,
         }))
       }
     },
@@ -626,6 +639,7 @@ export function useChatStorage({
       storeHistory,
       currentChat?.id,
       persistenceManager,
+      reloadChats,
       setChats,
       setChatCollection,
       setCurrentChat,

--- a/src/components/chat/hooks/use-chat-storage.ts
+++ b/src/components/chat/hooks/use-chat-storage.ts
@@ -10,7 +10,14 @@ import { indexedDBStorage } from '@/services/storage/indexed-db'
 import { samePendingRecoveryEnvelope } from '@/types/chat-recovery'
 import { logError, logInfo } from '@/utils/error-handling'
 import { useAuth } from '@clerk/nextjs'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
 import { BLANK_LOCAL_QUEUE_ID, isBlankQueueId } from '../message-queue-identity'
 import type { Chat, PendingRecoveryEnvelope } from '../types'
 import {
@@ -137,17 +144,26 @@ export function useChatStorage({
   const titleSaveGenerationRef = useRef(new Map<string, number>())
   const accountKey = `${!!isSignedIn}:${userId ?? ''}`
   const previousAccountKeyRef = useRef(accountKey)
+  const committedAccountKeyRef = useRef(accountKey)
   const accountGenerationRef = useRef(0)
-  if (previousAccountKeyRef.current !== accountKey) {
-    previousAccountKeyRef.current = accountKey
-    accountGenerationRef.current += 1
-  }
+  useLayoutEffect(() => {
+    if (previousAccountKeyRef.current !== accountKey) {
+      previousAccountKeyRef.current = accountKey
+      accountGenerationRef.current += 1
+    }
+    committedAccountKeyRef.current = accountKey
+  }, [accountKey])
   const initialLoadAccountKeyRef = useRef(accountKey)
 
   // Create persistence manager
   const persistenceManager = useMemo(
-    () => new ChatPersistenceManager(!!isSignedIn),
-    [isSignedIn],
+    () =>
+      new ChatPersistenceManager(
+        !!isSignedIn,
+        accountKey,
+        () => committedAccountKeyRef.current,
+      ),
+    [isSignedIn, accountKey],
   )
 
   // Update persistence manager when auth changes
@@ -156,7 +172,8 @@ export function useChatStorage({
   }, [isSignedIn, persistenceManager])
 
   // Cleanup on unmount
-  useEffect(() => {
+  useLayoutEffect(() => {
+    persistenceManager.activate()
     return () => {
       persistenceManager.cleanup()
     }

--- a/src/components/chat/hooks/use-chat-storage.ts
+++ b/src/components/chat/hooks/use-chat-storage.ts
@@ -129,13 +129,19 @@ export function useChatStorage({
     })
   const currentChatRef = useRef(currentChat)
   currentChatRef.current = currentChat
+  const chatsRef = useRef(chats)
+  chatsRef.current = chats
   const selectionRequestRef = useRef(0)
   const selectionFallbackRef = useRef<Chat | null>(null)
   const titleSaveSequenceRef = useRef(0)
   const titleSaveGenerationRef = useRef(new Map<string, number>())
   const accountKey = `${!!isSignedIn}:${userId ?? ''}`
-  const accountKeyRef = useRef(accountKey)
-  accountKeyRef.current = accountKey
+  const previousAccountKeyRef = useRef(accountKey)
+  const accountGenerationRef = useRef(0)
+  if (previousAccountKeyRef.current !== accountKey) {
+    previousAccountKeyRef.current = accountKey
+    accountGenerationRef.current += 1
+  }
   const initialLoadAccountKeyRef = useRef(accountKey)
 
   // Create persistence manager
@@ -163,7 +169,7 @@ export function useChatStorage({
 
       recoveryIds?.forEach((id) => pendingRecoveryReloadIdsRef.current.add(id))
       const reloadGeneration = ++reloadGenerationRef.current
-      const reloadAccountKey = accountKeyRef.current
+      const reloadAccountGeneration = accountGenerationRef.current
       try {
         const current = currentChatRef.current
         const needsFullReload =
@@ -175,7 +181,7 @@ export function useChatStorage({
         )
         if (
           reloadGeneration !== reloadGenerationRef.current ||
-          reloadAccountKey !== accountKeyRef.current
+          reloadAccountGeneration !== accountGenerationRef.current
         ) {
           return
         }
@@ -198,7 +204,7 @@ export function useChatStorage({
           : null
         if (
           reloadGeneration !== reloadGenerationRef.current ||
-          reloadAccountKey !== accountKeyRef.current
+          reloadAccountGeneration !== accountGenerationRef.current
         ) {
           return
         }
@@ -208,7 +214,7 @@ export function useChatStorage({
         setChatCollection((previous) => {
           if (
             reloadGeneration !== reloadGenerationRef.current ||
-            reloadAccountKey !== accountKeyRef.current
+            reloadAccountGeneration !== accountGenerationRef.current
           ) {
             return previous
           }
@@ -462,6 +468,7 @@ export function useChatStorage({
   useEffect(() => {
     let mounted = true
     const initialAccountKey = accountKey
+    const initialAccountGeneration = accountGenerationRef.current
     const accountChanged =
       initialLoadAccountKeyRef.current !== initialAccountKey
     initialLoadAccountKeyRef.current = initialAccountKey
@@ -475,7 +482,12 @@ export function useChatStorage({
           storeHistory && !!isSignedIn,
         )
 
-        if (!mounted || accountKeyRef.current !== initialAccountKey) return
+        if (
+          !mounted ||
+          accountGenerationRef.current !== initialAccountGeneration
+        ) {
+          return
+        }
 
         // Always have blank chats for both modes
         const cloudBlank = createBlankChat(false)
@@ -589,17 +601,18 @@ export function useChatStorage({
   const updateChatTitle = useCallback(
     (chatId: string, newTitle: string) => {
       const updatedAt = new Date().toISOString()
+      const current = currentChatRef.current
       const titleSnapshot =
-        currentChat?.id === chatId
-          ? currentChat
-          : chats.find((chat) => chat.id === chatId)
+        current.id === chatId
+          ? current
+          : chatsRef.current.find((chat) => chat.id === chatId)
       const saveGeneration = storeHistory
         ? ++titleSaveSequenceRef.current
         : null
       if (saveGeneration !== null) {
         titleSaveGenerationRef.current.set(chatId, saveGeneration)
       }
-      const titleAccountKey = accountKeyRef.current
+      const titleAccountGeneration = accountGenerationRef.current
       const clearTitleGenerationIfOwned = () => {
         if (
           saveGeneration === null ||
@@ -611,13 +624,15 @@ export function useChatStorage({
         return true
       }
       const finishSave = (savedUpdatedAt?: string) => {
-        if (accountKeyRef.current !== titleAccountKey) {
+        if (accountGenerationRef.current !== titleAccountGeneration) {
           clearTitleGenerationIfOwned()
           return
         }
         if (!clearTitleGenerationIfOwned()) return
         setChatCollection((previous) => {
-          if (accountKeyRef.current !== titleAccountKey) return previous
+          if (accountGenerationRef.current !== titleAccountGeneration) {
+            return previous
+          }
           const finish = (chat: Chat) =>
             chat.id === chatId && chat.updatedAt === updatedAt
               ? {
@@ -650,14 +665,18 @@ export function useChatStorage({
             .save(chatToUpdate)
             .then((saved) => finishSave(saved.updatedAt))
             .catch((error) => {
+              const clearedTitleGeneration = clearTitleGenerationIfOwned()
               if (
-                accountKeyRef.current === titleAccountKey &&
-                clearTitleGenerationIfOwned()
+                accountGenerationRef.current === titleAccountGeneration &&
+                clearedTitleGeneration
               ) {
                 if (titleSnapshot) {
                   setChatCollection((previous) => {
-                    if (accountKeyRef.current !== titleAccountKey)
+                    if (
+                      accountGenerationRef.current !== titleAccountGeneration
+                    ) {
                       return previous
+                    }
                     const rollback = (chat: Chat) =>
                       chat.id === chatId && chat.updatedAt === updatedAt
                         ? {
@@ -674,8 +693,6 @@ export function useChatStorage({
                   })
                 }
                 void reloadChats()
-              } else {
-                clearTitleGenerationIfOwned()
               }
               logError('Failed to save chat title update', error, {
                 component: 'useChatStorage',
@@ -689,7 +706,7 @@ export function useChatStorage({
         return updatedChats
       })
 
-      if (currentChat?.id === chatId) {
+      if (current.id === chatId) {
         setCurrentChat((prev) => ({
           ...prev,
           title: newTitle,
@@ -700,8 +717,6 @@ export function useChatStorage({
     },
     [
       storeHistory,
-      chats,
-      currentChat,
       persistenceManager,
       reloadChats,
       setChats,

--- a/tests/components/chat/use-chat-storage.reloadChats.test.tsx
+++ b/tests/components/chat/use-chat-storage.reloadChats.test.tsx
@@ -417,7 +417,7 @@ describe('useChatStorage.reloadChats', () => {
     )
   })
 
-  it('never blanks the displayed chat when a newer summary arrives', async () => {
+  it('refreshes the displayed chat when a newer summary arrives', async () => {
     const summary = {
       id: 'chat-1',
       title: 'Chat',
@@ -441,7 +441,8 @@ describe('useChatStorage.reloadChats', () => {
       isMetadataOnly: false,
     }
     mockLoadChats.mockResolvedValueOnce([summary])
-    vi.spyOn(chatStorage, 'getChat').mockResolvedValue(hydrated)
+    const getChat = vi.spyOn(chatStorage, 'getChat')
+    getChat.mockResolvedValueOnce(hydrated)
 
     const { result } = renderHook(() => useChatStorage({ storeHistory: true }))
     await waitFor(() => expect(result.current.isInitialLoad).toBe(false))
@@ -450,21 +451,36 @@ describe('useChatStorage.reloadChats', () => {
       expect(result.current.currentChat.messages).toHaveLength(1),
     )
 
-    // Storage reports newer content while this chat is on screen. The
-    // current chat only merges metadata (never adopts the summary's empty
-    // messages), so the visible conversation is preserved.
+    // Storage reports newer content while this chat is on screen.
     const newerSummary = {
       ...summary,
       title: 'Renamed elsewhere',
       messageCount: 2,
       updatedAt: '2026-08-12T01:00:00.000Z',
     }
+    const refreshed = {
+      ...hydrated,
+      title: newerSummary.title,
+      updatedAt: newerSummary.updatedAt,
+      messages: [
+        ...hydrated.messages,
+        {
+          role: 'assistant' as const,
+          content: 'Synced answer',
+          timestamp: new Date('2026-08-12T01:00:00.000Z'),
+        },
+      ],
+    }
+    getChat.mockResolvedValueOnce(refreshed)
     mockLoadChats.mockResolvedValue([newerSummary])
     await act(async () => {
       await result.current.reloadChats()
     })
 
-    expect(result.current.currentChat.messages).toHaveLength(1)
+    expect(result.current.currentChat.messages).toHaveLength(2)
+    expect(result.current.currentChat.messages[1]?.content).toBe(
+      'Synced answer',
+    )
     expect(result.current.currentChat.title).toBe('Renamed elsewhere')
     expect(result.current.currentChat.isMetadataOnly).toBeFalsy()
   })


### PR DESCRIPTION
## Summary
- hydrate newer active-chat content instead of merging only its title
- fence refreshes against concurrent edits, streams, and pending saves
- track title saves so reloads cannot overwrite in-flight local changes

## Testing
- `npx eslint src/components/chat/hooks/use-chat-storage.ts tests/components/chat/use-chat-storage.reloadChats.test.tsx`
- `npm run test:unit -- --run tests/components/chat/use-chat-storage.reloadChats.test.tsx`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes the active chat from storage after sync and isolates saves/reloads by account and SSR lifecycle. Previously we only merged title updates, which could leave stale messages and allow cross-account writes; now we hydrate and adopt refreshed messages when safe, preserve local edits, and reject stale saves.

- Refresh active chat safely: detect newer storage content; hydrate via `chatStorage.getChat`; adopt refreshed messages/title when not streaming and message counts/updatedAt align; otherwise keep the on-screen conversation.
- Preserve local title edits: stamp `updatedAt`; track per-chat title save generations; keep local titles during in-flight saves; roll back on failure; reload after completion without clobbering edits.
- Isolate by account and lifecycle: derive an account key from `isSignedIn`/`userId`; bump an account generation on changes; cancel mid-flight initial loads, reloads, and title saves; re-select the correct blank chat on account switch. `ChatPersistenceManager` is now account-scoped and refuses saves when disposed or the scope mismatches; added `activate()` and SSR-safe `useIsomorphicLayoutEffect` to support chat lifecycle during server rendering.

<sup>Written for commit e59f389c0661989dae57987977ff55b4915512c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/504?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

