### PR TITLE
Add synced chat favorites

### DIFF
--- a/src/components/auth-cleanup-handler.tsx
+++ b/src/components/auth-cleanup-handler.tsx
@@ -1,5 +1,8 @@
 import { SignoutConfirmationModal } from '@/components/modals/signout-confirmation-modal'
-import { ACCOUNT_RESET_FAILED_EVENT } from '@/constants/auth-events'
+import {
+  ACCOUNT_RESET_FAILED_EVENT,
+  AUTH_ACTIVE_USER_CHANGED_EVENT,
+} from '@/constants/auth-events'
 import {
   AUTH_ACCOUNT_RESET_FAILED,
   AUTH_ACTIVE_USER_ID,
@@ -174,6 +177,7 @@ export function AuthCleanupHandler() {
 
       // Same user or fresh sign-in — persist the active user ID
       localStorage.setItem(AUTH_ACTIVE_USER_ID, user.id)
+      window.dispatchEvent(new Event(AUTH_ACTIVE_USER_CHANGED_EVENT))
     }
 
     // Check if user just signed out (stored user ID exists but no longer signed in)

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -82,6 +82,7 @@ import { cloudSync, SyncInProgressError } from '@/services/cloud/cloud-sync'
 import { encryptionService } from '@/services/encryption/encryption-service'
 import { generateCodeExecutionAccessToken } from '@/services/exec-snapshot/access-token'
 import { isPrfSupported, PrfNotSupportedError } from '@/services/passkey'
+import { chatEvents } from '@/services/storage/chat-events'
 import { chatStorage } from '@/services/storage/chat-storage'
 import {
   INDEXED_DB_UPGRADE_BLOCKED_EVENT,
@@ -995,7 +996,8 @@ export function ChatInterface({
     [invalidateFavoriteNavigation, loadChatByIdWithoutNavigationInvalidation],
   )
 
-  const { pinnedChatIds, pinChat, unpinChat, unpinChats } = usePinnedChats()
+  const { pinnedChatIds, pinChat, unpinChat, unpinChats } =
+    usePinnedChats(authUserId)
   const favoriteHydrationGenerationRef = useRef(0)
   const favoriteHydrationAccountRef = useRef(authUserId)
   const currentFavoriteAccountRef = useRef(authUserId)
@@ -1003,6 +1005,17 @@ export function ChatInterface({
   const favoriteHydrationCloudSyncRef = useRef(cloudSyncSettingEnabled)
   const favoriteHydrationMountedRef = useRef(false)
   const attemptedFavoriteHydrationsRef = useRef(new Set<string>())
+  const unavailableFavoriteHydrationsRef = useRef(new Set<string>())
+  const [favoriteHydrationRetryVersion, setFavoriteHydrationRetryVersion] =
+    useState(0)
+  const retryUnavailableFavoriteHydrations = useCallback(() => {
+    if (unavailableFavoriteHydrationsRef.current.size === 0) return
+    for (const chatId of unavailableFavoriteHydrationsRef.current) {
+      attemptedFavoriteHydrationsRef.current.delete(chatId)
+    }
+    unavailableFavoriteHydrationsRef.current.clear()
+    setFavoriteHydrationRetryVersion((version) => version + 1)
+  }, [])
   const missingPinnedChatIds = useMemo(() => {
     const loadedIds = new Set(chats.map((chat) => chat.id))
     return pinnedChatIds.filter((chatId) => !loadedIds.has(chatId))
@@ -1027,7 +1040,33 @@ export function ChatInterface({
     favoriteHydrationCloudSyncRef.current = cloudSyncSettingEnabled
     favoriteHydrationGenerationRef.current += 1
     attemptedFavoriteHydrationsRef.current.clear()
+    unavailableFavoriteHydrationsRef.current.clear()
   }, [authUserId, cloudSyncSettingEnabled])
+
+  useEffect(() => {
+    const unsubscribeChats = chatEvents.on((event) => {
+      if (
+        event.reason === 'sync' ||
+        event.reason === 'pagination' ||
+        event.reason === 'recovery'
+      ) {
+        retryUnavailableFavoriteHydrations()
+      }
+    })
+    window.addEventListener('online', retryUnavailableFavoriteHydrations)
+    window.addEventListener(
+      ENCRYPTION_KEY_CHANGED_EVENT,
+      retryUnavailableFavoriteHydrations,
+    )
+    return () => {
+      unsubscribeChats()
+      window.removeEventListener('online', retryUnavailableFavoriteHydrations)
+      window.removeEventListener(
+        ENCRYPTION_KEY_CHANGED_EVENT,
+        retryUnavailableFavoriteHydrations,
+      )
+    }
+  }, [retryUnavailableFavoriteHydrations])
 
   useEffect(() => {
     const pinnedIds = new Set(pinnedChatIds)
@@ -1035,6 +1074,7 @@ export function ChatInterface({
     for (const attemptedId of attemptedFavoriteHydrationsRef.current) {
       if (!pinnedIds.has(attemptedId) || loadedIds.has(attemptedId)) {
         attemptedFavoriteHydrationsRef.current.delete(attemptedId)
+        unavailableFavoriteHydrationsRef.current.delete(attemptedId)
       }
     }
     const invalidLoadedFavoriteIds = chats
@@ -1087,6 +1127,11 @@ export function ChatInterface({
         .filter(({ result }) => result.status === 'invalid')
         .map(({ chatId }) => chatId)
       if (idsToPrune.length > 0) unpinChats(idsToPrune)
+      for (const { chatId, result } of results) {
+        if (result.status === 'unavailable') {
+          unavailableFavoriteHydrationsRef.current.add(chatId)
+        }
+      }
 
       const hydratedChats = results.flatMap(({ result }) =>
         result.status === 'ready' ? [result.chat] : [],
@@ -1107,6 +1152,7 @@ export function ChatInterface({
     authUserId,
     chats,
     cloudSyncSettingEnabled,
+    favoriteHydrationRetryVersion,
     isSignedIn,
     missingPinnedChatIds,
     missingPinnedChatIdsKey,
@@ -3703,6 +3749,7 @@ export function ChatInterface({
                   pinnedChatIds={pinnedChatIds}
                   onToggleFavorite={handleToggleFavorite}
                   onOpenFavorite={handleOpenFavorite}
+                  cloudSyncEnabled={cloudSyncSettingEnabled}
                   windowWidth={windowWidth}
                 />
               ) : (
@@ -3745,6 +3792,7 @@ export function ChatInterface({
                   pinnedChatIds={pinnedChatIds}
                   onToggleFavorite={handleToggleFavorite}
                   onOpenFavorite={handleOpenFavorite}
+                  cloudSyncEnabled={cloudSyncSettingEnabled}
                   windowWidth={windowWidth}
                 />
               )}

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -69,8 +69,14 @@ import { cn } from '@/components/ui/utils'
 import { CLOUD_SYNC } from '@/config'
 import { useCloudSync } from '@/hooks/use-cloud-sync'
 import { usePasskeyBackup } from '@/hooks/use-passkey-backup'
+import { usePinnedChats } from '@/hooks/use-pinned-chats'
 import { useProfileSync } from '@/hooks/use-profile-sync'
 import { ENCRYPTION_KEY_CHANGED_EVENT } from '@/services/encryption/encryption-service'
+import { hydratePinnedChatById } from '@/services/storage/pinned-chat-hydration'
+import {
+  canRequestChatPin,
+  isResolvedFavoriteChat,
+} from '@/services/storage/pinned-chats'
 
 import { cloudSync, SyncInProgressError } from '@/services/cloud/cloud-sync'
 import { encryptionService } from '@/services/encryption/encryption-service'
@@ -117,6 +123,7 @@ import { CONSTANTS } from './constants'
 import { getDocumentTextContent } from './document-content'
 import { useDocumentUploader } from './document-uploader'
 import { DragProvider } from './drag-context'
+import { openFavoriteChat } from './favorite-navigation'
 import {
   resolveProjectUploadTarget,
   routeChatFileUpload,
@@ -906,9 +913,9 @@ export function ChatInterface({
 
     // Actions
     handleQuery,
-    createNewChat,
+    createNewChat: createNewChatWithoutNavigationInvalidation,
     deleteChat,
-    handleChatSelect,
+    handleChatSelect: handleChatSelectWithoutNavigationInvalidation,
     toggleTheme,
     setThemeMode,
     openAndExpandVerifier,
@@ -928,7 +935,7 @@ export function ChatInterface({
     initialChatLoadFailed,
     cloudChatNotFound,
     retryInitialChatLoad,
-    loadChatById,
+    loadChatById: loadChatByIdWithoutNavigationInvalidation,
   } = useChatState({
     systemPrompt: finalSystemPrompt,
     rules: processedRules,
@@ -949,6 +956,164 @@ export function ChatInterface({
     piiCheckEnabled,
     genUIEnabled,
   })
+
+  const favoriteNavigationGenerationRef = useRef(0)
+  const invalidateFavoriteNavigation = useCallback(() => {
+    favoriteNavigationGenerationRef.current += 1
+  }, [])
+  useEffect(
+    () => () => {
+      invalidateFavoriteNavigation()
+    },
+    [invalidateFavoriteNavigation],
+  )
+  useEffect(() => {
+    invalidateFavoriteNavigation()
+  }, [authUserId, invalidateFavoriteNavigation])
+  const createNewChat = useCallback(
+    (isLocalOnly?: boolean, fromUserAction?: boolean) => {
+      invalidateFavoriteNavigation()
+      createNewChatWithoutNavigationInvalidation(isLocalOnly, fromUserAction)
+    },
+    [createNewChatWithoutNavigationInvalidation, invalidateFavoriteNavigation],
+  )
+  const handleChatSelect = useCallback(
+    (chatId: string) => {
+      invalidateFavoriteNavigation()
+      handleChatSelectWithoutNavigationInvalidation(chatId)
+    },
+    [
+      handleChatSelectWithoutNavigationInvalidation,
+      invalidateFavoriteNavigation,
+    ],
+  )
+  const loadChatById = useCallback(
+    async (chatId: string, isLocalUrl: boolean) => {
+      invalidateFavoriteNavigation()
+      await loadChatByIdWithoutNavigationInvalidation(chatId, isLocalUrl)
+    },
+    [invalidateFavoriteNavigation, loadChatByIdWithoutNavigationInvalidation],
+  )
+
+  const { pinnedChatIds, pinChat, unpinChat, unpinChats } = usePinnedChats()
+  const favoriteHydrationGenerationRef = useRef(0)
+  const favoriteHydrationAccountRef = useRef(authUserId)
+  const currentFavoriteAccountRef = useRef(authUserId)
+  currentFavoriteAccountRef.current = authUserId
+  const favoriteHydrationCloudSyncRef = useRef(cloudSyncSettingEnabled)
+  const favoriteHydrationMountedRef = useRef(false)
+  const attemptedFavoriteHydrationsRef = useRef(new Set<string>())
+  const missingPinnedChatIds = useMemo(() => {
+    const loadedIds = new Set(chats.map((chat) => chat.id))
+    return pinnedChatIds.filter((chatId) => !loadedIds.has(chatId))
+  }, [chats, pinnedChatIds])
+  const missingPinnedChatIdsKey = missingPinnedChatIds.join('\u0000')
+
+  useEffect(() => {
+    favoriteHydrationMountedRef.current = true
+    return () => {
+      favoriteHydrationMountedRef.current = false
+    }
+  }, [])
+
+  useEffect(() => {
+    if (
+      favoriteHydrationAccountRef.current === authUserId &&
+      favoriteHydrationCloudSyncRef.current === cloudSyncSettingEnabled
+    ) {
+      return
+    }
+    favoriteHydrationAccountRef.current = authUserId
+    favoriteHydrationCloudSyncRef.current = cloudSyncSettingEnabled
+    favoriteHydrationGenerationRef.current += 1
+    attemptedFavoriteHydrationsRef.current.clear()
+  }, [authUserId, cloudSyncSettingEnabled])
+
+  useEffect(() => {
+    const pinnedIds = new Set(pinnedChatIds)
+    const loadedIds = new Set(chats.map((chat) => chat.id))
+    for (const attemptedId of attemptedFavoriteHydrationsRef.current) {
+      if (!pinnedIds.has(attemptedId) || loadedIds.has(attemptedId)) {
+        attemptedFavoriteHydrationsRef.current.delete(attemptedId)
+      }
+    }
+    const invalidLoadedFavoriteIds = chats
+      .filter(
+        (chat) =>
+          pinnedIds.has(chat.id) &&
+          (chat.isBlankChat || chat.isTemporary || chat.dataCorrupted),
+      )
+      .map((chat) => chat.id)
+    if (invalidLoadedFavoriteIds.length > 0) {
+      unpinChats(invalidLoadedFavoriteIds)
+    }
+    if (!isSignedIn || !cloudSyncSettingEnabled || !missingPinnedChatIdsKey)
+      return
+
+    const chatIds = missingPinnedChatIds.filter(
+      (chatId) => !attemptedFavoriteHydrationsRef.current.has(chatId),
+    )
+    if (chatIds.length === 0) return
+    chatIds.forEach((chatId) =>
+      attemptedFavoriteHydrationsRef.current.add(chatId),
+    )
+    const generation = favoriteHydrationGenerationRef.current
+    const accountId = authUserId
+
+    const hydrateFavorites = async () => {
+      const results = await Promise.all(
+        chatIds.map(async (chatId) => {
+          try {
+            return { chatId, result: await hydratePinnedChatById(chatId) }
+          } catch (error) {
+            logError('Failed to hydrate favorite', error, {
+              component: 'ChatInterface',
+              action: 'hydrateFavorites',
+              metadata: { chatId },
+            })
+            return { chatId, result: { status: 'unavailable' } as const }
+          }
+        }),
+      )
+      if (
+        !favoriteHydrationMountedRef.current ||
+        currentFavoriteAccountRef.current !== accountId ||
+        favoriteHydrationGenerationRef.current !== generation
+      ) {
+        return
+      }
+
+      const idsToPrune = results
+        .filter(({ result }) => result.status === 'invalid')
+        .map(({ chatId }) => chatId)
+      if (idsToPrune.length > 0) unpinChats(idsToPrune)
+
+      const hydratedChats = results.flatMap(({ result }) =>
+        result.status === 'ready' ? [result.chat] : [],
+      )
+      if (hydratedChats.length === 0) return
+      setChats((current) => {
+        let updated = current
+        for (const hydrated of hydratedChats) {
+          if (updated.some((chat) => chat.id === hydrated.id)) continue
+          updated = upsertChatById(updated, hydrated)
+        }
+        return updated
+      })
+    }
+
+    void hydrateFavorites()
+  }, [
+    authUserId,
+    chats,
+    cloudSyncSettingEnabled,
+    isSignedIn,
+    missingPinnedChatIds,
+    missingPinnedChatIdsKey,
+    pinnedChatIds,
+    setChats,
+    unpinChats,
+  ])
 
   const isTemporaryMode = currentChat?.isTemporary === true
   const currentChatId = currentChat?.id
@@ -1996,6 +2161,7 @@ export function ChatInterface({
   }, [passkeyActive, setupPasskey])
 
   const handleCreateProject = useCallback(async () => {
+    invalidateFavoriteNavigation()
     try {
       const name = `My Project #${projects.length + 1}`
       const project = await createProject({ name, description: '' })
@@ -2011,7 +2177,13 @@ export function ChatInterface({
         variant: 'destructive',
       })
     }
-  }, [createProject, enterProjectMode, projects.length, toast])
+  }, [
+    createProject,
+    enterProjectMode,
+    invalidateFavoriteNavigation,
+    projects.length,
+    toast,
+  ])
 
   // Handler for exiting project mode - creates a new chat and exits
   const handleExitProject = useCallback(() => {
@@ -2022,6 +2194,7 @@ export function ChatInterface({
   }, [createNewChat, exitProjectMode])
 
   const handleToggleTemporaryMode = useCallback(() => {
+    invalidateFavoriteNavigation()
     if (!canToggleTemporaryChat(currentChat)) return
 
     const hasMessages = (currentChat?.messages?.length ?? 0) > 0
@@ -2129,7 +2302,15 @@ export function ChatInterface({
       isLocalOnly: currentChat?.isLocalOnly,
     })
     setCurrentChat(tempChat)
-  }, [chats, createNewChat, currentChat, isSignedIn, setChats, setCurrentChat])
+  }, [
+    chats,
+    createNewChat,
+    currentChat,
+    invalidateFavoriteNavigation,
+    isSignedIn,
+    setChats,
+    setCurrentChat,
+  ])
 
   useEffect(() => {
     if (!isTemporaryMode && previousChatRef.current !== null) {
@@ -2140,10 +2321,11 @@ export function ChatInterface({
   // Handler for exiting project mode while dragging - does NOT create a new chat
   // so the drag operation can continue and drop into cloud/local tabs
   const handleExitProjectWhileDragging = useCallback(() => {
+    invalidateFavoriteNavigation()
     setPendingProjectUpload(null)
     setShowAddToProjectModal(false)
     exitProjectMode()
-  }, [exitProjectMode])
+  }, [exitProjectMode, invalidateFavoriteNavigation])
 
   // Handler for moving a chat to a project via drag and drop
   const handleMoveChatToProject = useCallback(
@@ -2226,7 +2408,9 @@ export function ChatInterface({
   const handleDeleteProjectChats = useCallback(
     async (projectId: string): Promise<void> => {
       try {
-        await chatStorage.deleteChatsByProject(projectId)
+        const deletedChatIds =
+          await chatStorage.deleteChatsByProjectWithIds(projectId)
+        unpinChats(deletedChatIds)
         await reloadChats()
       } catch (error) {
         logError('Failed to delete project chats', error, {
@@ -2241,12 +2425,12 @@ export function ChatInterface({
         throw error
       }
     },
-    [reloadChats],
+    [reloadChats, unpinChats],
   )
 
   // Handler for converting a local-only chat to cloud chat via drag and drop
   const handleConvertChatToCloud = useCallback(
-    async (chatId: string): Promise<void> => {
+    async (chatId: string): Promise<boolean> => {
       try {
         await chatStorage.convertChatToCloud(chatId)
         await reloadChats()
@@ -2255,6 +2439,7 @@ export function ChatInterface({
           title: 'Chat moved to cloud',
           description: 'The chat will now sync across your devices.',
         })
+        return true
       } catch (error) {
         logError('Failed to convert chat to cloud', error, {
           component: 'ChatInterface',
@@ -2267,16 +2452,107 @@ export function ChatInterface({
           description: 'Please try again.',
           variant: 'destructive',
         })
+        return false
       }
     },
     [reloadChats, toast],
   )
+
+  const handleToggleFavorite = useCallback(
+    async (favorite: Pick<Chat, 'id' | 'isLocalOnly'>) => {
+      if (pinnedChatIds.includes(favorite.id)) {
+        unpinChat(favorite.id)
+        return
+      }
+
+      const accountId = authUserId
+      const hydrationGeneration = favoriteHydrationGenerationRef.current
+      let chat = chats.find((candidate) => candidate.id === favorite.id)
+      if (!chat) {
+        try {
+          const hydration = await hydratePinnedChatById(favorite.id)
+          if (
+            hydration.status !== 'ready' ||
+            currentFavoriteAccountRef.current !== accountId ||
+            favoriteHydrationGenerationRef.current !== hydrationGeneration
+          ) {
+            return
+          }
+          chat = hydration.chat
+          const loadedChat = chat
+          setChats((current) => upsertChatById(current, loadedChat))
+        } catch (error) {
+          logError('Failed to load chat before pinning', error, {
+            component: 'ChatInterface',
+            action: 'handleToggleFavorite',
+            metadata: { chatId: favorite.id },
+          })
+          return
+        }
+      }
+      if (!canRequestChatPin(chat)) {
+        return
+      }
+      if (chat.isLocalOnly && !(await handleConvertChatToCloud(chat.id))) return
+      if (
+        currentFavoriteAccountRef.current !== accountId ||
+        favoriteHydrationGenerationRef.current !== hydrationGeneration
+      ) {
+        return
+      }
+      pinChat(chat.id)
+    },
+    [
+      chats,
+      authUserId,
+      handleConvertChatToCloud,
+      pinChat,
+      pinnedChatIds,
+      setChats,
+      unpinChat,
+    ],
+  )
+
+  const handleOpenFavorite = useCallback(
+    async (favorite: Pick<Chat, 'id' | 'projectId'>) => {
+      const generation = favoriteNavigationGenerationRef.current + 1
+      favoriteNavigationGenerationRef.current = generation
+      await openFavoriteChat({
+        favorite,
+        activeProjectId: activeProject?.id,
+        isProjectMode,
+        enterProjectMode: (projectId, isCurrent) =>
+          enterProjectMode(projectId, undefined, { isCurrent }),
+        exitProjectMode,
+        openChat: (chatId) =>
+          loadChatByIdWithoutNavigationInvalidation(chatId, false),
+        isCurrent: () => favoriteNavigationGenerationRef.current === generation,
+      })
+    },
+    [
+      activeProject?.id,
+      enterProjectMode,
+      exitProjectMode,
+      isProjectMode,
+      loadChatByIdWithoutNavigationInvalidation,
+    ],
+  )
+
+  const favoriteChats = useMemo(() => {
+    const chatsById = new Map(chats.map((chat) => [chat.id, chat]))
+    return pinnedChatIds
+      .map((chatId) => chatsById.get(chatId))
+      .filter((chat): chat is Chat =>
+        Boolean(chat && isResolvedFavoriteChat(chat)),
+      )
+  }, [chats, pinnedChatIds])
 
   // Handler for converting a cloud chat to local-only via drag and drop
   const handleConvertChatToLocal = useCallback(
     async (chatId: string): Promise<void> => {
       try {
         await chatStorage.convertChatToLocal(chatId)
+        unpinChat(chatId)
         await reloadChats()
 
         toast({
@@ -2297,7 +2573,7 @@ export function ChatInterface({
         })
       }
     },
-    [reloadChats, toast],
+    [reloadChats, toast, unpinChat],
   )
 
   // Helper to process file and add to chat attachments
@@ -3402,6 +3678,10 @@ export function ChatInterface({
                       updatedAt: c.updatedAt,
                       projectId: c.projectId,
                       isBlankChat: c.isBlankChat,
+                      decryptionFailed: c.decryptionFailed,
+                      dataCorrupted: c.dataCorrupted,
+                      isTemporary: c.isTemporary,
+                      pendingSave: c.pendingSave,
                     }))}
                   deleteChat={deleteChat}
                   updateChatTitle={updateChatTitle}
@@ -3419,6 +3699,10 @@ export function ChatInterface({
                     name: p.name,
                   }))}
                   onSettingsClick={handleOpenSettingsModal}
+                  favoriteChats={favoriteChats}
+                  pinnedChatIds={pinnedChatIds}
+                  onToggleFavorite={handleToggleFavorite}
+                  onOpenFavorite={handleOpenFavorite}
                   windowWidth={windowWidth}
                 />
               ) : (
@@ -3449,10 +3733,18 @@ export function ChatInterface({
                       updatedAt: c.updatedAt,
                       projectId: c.projectId,
                       isBlankChat: c.isBlankChat,
+                      decryptionFailed: c.decryptionFailed,
+                      dataCorrupted: c.dataCorrupted,
+                      isTemporary: c.isTemporary,
+                      pendingSave: c.pendingSave,
                     }))}
                   deleteChat={deleteChat}
                   updateChatTitle={updateChatTitle}
                   onSettingsClick={handleOpenSettingsModal}
+                  favoriteChats={favoriteChats}
+                  pinnedChatIds={pinnedChatIds}
+                  onToggleFavorite={handleToggleFavorite}
+                  onOpenFavorite={handleOpenFavorite}
                   windowWidth={windowWidth}
                 />
               )}
@@ -3522,6 +3814,9 @@ export function ChatInterface({
                 onConvertChatToCloud={handleConvertChatToCloud}
                 onConvertChatToLocal={handleConvertChatToLocal}
                 onSettingsClick={handleOpenSettingsModal}
+                pinnedChatIds={pinnedChatIds}
+                onToggleFavorite={handleToggleFavorite}
+                onOpenFavorite={handleOpenFavorite}
                 windowWidth={windowWidth}
                 chatDecryptionProgress={decryptionProgress}
               />

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -1006,9 +1006,11 @@ export function ChatInterface({
   const favoriteHydrationMountedRef = useRef(false)
   const attemptedFavoriteHydrationsRef = useRef(new Set<string>())
   const unavailableFavoriteHydrationsRef = useRef(new Set<string>())
+  const favoriteHydrationRetrySignalRef = useRef(0)
   const [favoriteHydrationRetryVersion, setFavoriteHydrationRetryVersion] =
     useState(0)
   const retryUnavailableFavoriteHydrations = useCallback(() => {
+    favoriteHydrationRetrySignalRef.current += 1
     if (unavailableFavoriteHydrationsRef.current.size === 0) return
     for (const chatId of unavailableFavoriteHydrationsRef.current) {
       attemptedFavoriteHydrationsRef.current.delete(chatId)
@@ -1098,6 +1100,7 @@ export function ChatInterface({
       attemptedFavoriteHydrationsRef.current.add(chatId),
     )
     const generation = favoriteHydrationGenerationRef.current
+    const retrySignal = favoriteHydrationRetrySignalRef.current
     const accountId = authUserId
 
     const hydrateFavorites = async () => {
@@ -1127,10 +1130,19 @@ export function ChatInterface({
         .filter(({ result }) => result.status === 'invalid')
         .map(({ chatId }) => chatId)
       if (idsToPrune.length > 0) unpinChats(idsToPrune)
+      let shouldRetry = false
       for (const { chatId, result } of results) {
         if (result.status === 'unavailable') {
-          unavailableFavoriteHydrationsRef.current.add(chatId)
+          if (favoriteHydrationRetrySignalRef.current !== retrySignal) {
+            attemptedFavoriteHydrationsRef.current.delete(chatId)
+            shouldRetry = true
+          } else {
+            unavailableFavoriteHydrationsRef.current.add(chatId)
+          }
         }
+      }
+      if (shouldRetry) {
+        setFavoriteHydrationRetryVersion((version) => version + 1)
       }
 
       const hydratedChats = results.flatMap(({ result }) =>

--- a/src/components/chat/chat-list-item.tsx
+++ b/src/components/chat/chat-list-item.tsx
@@ -324,7 +324,7 @@ export function ChatListItem({
       document.activeElement.blur()
     }
     setIsDragging(true)
-    e.dataTransfer.effectAllowed = 'move'
+    e.dataTransfer.effectAllowed = 'copyMove'
     e.dataTransfer.setData('text/plain', chat.id)
     e.dataTransfer.setData('application/x-chat-id', chat.id)
     onDragStart?.(chat.id)

--- a/src/components/chat/chat-list-item.tsx
+++ b/src/components/chat/chat-list-item.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { DEFAULT_CHAT_TITLE } from '@/constants/chat'
+import { canRequestChatPin } from '@/services/storage/pinned-chats'
 import { isPlainPrimaryClick } from '@/utils/navigation'
 import {
   CheckIcon,
@@ -17,6 +18,7 @@ import Link from 'next/link'
 import { useEffect, useId, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { CiFloppyDisk } from 'react-icons/ci'
+import { PiPushPin, PiPushPinFill } from 'react-icons/pi'
 import { FaLock } from '../icons/lazy-icons'
 import { RedactedText } from '../ui/redacted-text'
 import { cn } from '../ui/utils'
@@ -38,7 +40,13 @@ export interface ChatItemData {
   decryptionFailed?: boolean
   dataCorrupted?: boolean
   isLocalOnly?: boolean
+  isTemporary?: boolean
   pendingSave?: boolean
+  projectId?: string
+}
+
+export function canPinChat(chat: ChatItemData): boolean {
+  return canRequestChatPin(chat)
 }
 
 /**
@@ -106,6 +114,8 @@ interface ChatListItemProps {
   onConvertToCloud?: () => void
   onConvertToLocal?: () => void
   onRemoveFromProject?: () => void
+  isPinned?: boolean
+  onTogglePin?: () => void | Promise<void>
 }
 
 function ChatSelectionControl({
@@ -182,6 +192,8 @@ export function ChatListItem({
   onConvertToCloud,
   onConvertToLocal,
   onRemoveFromProject,
+  isPinned = false,
+  onTogglePin,
 }: ChatListItemProps) {
   const [displayTitle, setDisplayTitle] = useState(chat.title)
   const [isAnimating, setIsAnimating] = useState(false)
@@ -464,6 +476,13 @@ export function ChatListItem({
                   />
                 )
               )}
+              {isPinned && !isStreaming && (
+                <PiPushPinFill
+                  className="h-3.5 w-3.5 flex-shrink-0 text-content-muted"
+                  title="Pinned to Favorites"
+                  aria-label="Pinned to Favorites"
+                />
+              )}
             </span>
             {(chat.decryptionFailed ||
               (messageCount > 0 && timestamp) ||
@@ -538,6 +557,34 @@ export function ChatListItem({
       {!isEditing && (
         <div className="flex flex-shrink-0 items-center gap-1.5">
           <div className="pointer-events-none hidden items-center opacity-0 transition-opacity md:flex md:group-focus-within:pointer-events-auto md:group-focus-within:opacity-100 md:group-hover:pointer-events-auto md:group-hover:opacity-100">
+            {canPinChat(chat) && onTogglePin && (
+              <button
+                type="button"
+                className={cn(
+                  'mr-1 rounded p-1 transition-colors',
+                  isPinned
+                    ? 'text-content-primary'
+                    : 'text-content-muted hover:text-content-secondary',
+                  isDarkMode
+                    ? 'hover:bg-surface-chat hover:text-white'
+                    : 'hover:bg-surface-sidebar',
+                )}
+                onClick={(event) => {
+                  event.stopPropagation()
+                  void onTogglePin()
+                }}
+                aria-label={
+                  isPinned ? 'Remove from Favorites' : 'Pin to Favorites'
+                }
+                title={isPinned ? 'Remove from Favorites' : 'Pin to Favorites'}
+              >
+                {isPinned ? (
+                  <PiPushPinFill className="h-4 w-4" aria-hidden="true" />
+                ) : (
+                  <PiPushPin className="h-4 w-4" aria-hidden="true" />
+                )}
+              </button>
+            )}
             {hasRealTitle && (
               <button
                 type="button"
@@ -651,6 +698,40 @@ export function ChatListItem({
                               aria-hidden="true"
                             />
                             Rename
+                          </button>
+                        )}
+
+                        {canPinChat(chat) && onTogglePin && (
+                          <button
+                            type="button"
+                            role="menuitem"
+                            className={cn(
+                              'flex w-full items-center gap-3 px-3 py-2.5 text-left text-sm transition-colors',
+                              isDarkMode
+                                ? 'text-content-secondary hover:bg-surface-sidebar'
+                                : 'text-content-secondary hover:bg-gray-100',
+                            )}
+                            onClick={(event) => {
+                              event.stopPropagation()
+                              setIsMobileMenuOpen(false)
+                              setMobileMenuView('main')
+                              void onTogglePin()
+                            }}
+                          >
+                            {isPinned ? (
+                              <PiPushPinFill
+                                className="h-4 w-4"
+                                aria-hidden="true"
+                              />
+                            ) : (
+                              <PiPushPin
+                                className="h-4 w-4"
+                                aria-hidden="true"
+                              />
+                            )}
+                            {isPinned
+                              ? 'Remove from Favorites'
+                              : 'Pin to Favorites'}
                           </button>
                         )}
 

--- a/src/components/chat/chat-list-item.tsx
+++ b/src/components/chat/chat-list-item.tsx
@@ -557,7 +557,7 @@ export function ChatListItem({
       {!isEditing && (
         <div className="flex flex-shrink-0 items-center gap-1.5">
           <div className="pointer-events-none hidden items-center opacity-0 transition-opacity md:flex md:group-focus-within:pointer-events-auto md:group-focus-within:opacity-100 md:group-hover:pointer-events-auto md:group-hover:opacity-100">
-            {canPinChat(chat) && onTogglePin && (
+            {(isPinned || canPinChat(chat)) && onTogglePin && (
               <button
                 type="button"
                 className={cn(
@@ -701,7 +701,7 @@ export function ChatListItem({
                           </button>
                         )}
 
-                        {canPinChat(chat) && onTogglePin && (
+                        {(isPinned || canPinChat(chat)) && onTogglePin && (
                           <button
                             type="button"
                             role="menuitem"

--- a/src/components/chat/chat-list-item.tsx
+++ b/src/components/chat/chat-list-item.tsx
@@ -116,6 +116,7 @@ interface ChatListItemProps {
   onRemoveFromProject?: () => void
   isPinned?: boolean
   showPinnedIndicator?: boolean
+  showDesktopPinAction?: boolean
   onTogglePin?: () => void | Promise<void>
 }
 
@@ -195,6 +196,7 @@ export function ChatListItem({
   onRemoveFromProject,
   isPinned = false,
   showPinnedIndicator = true,
+  showDesktopPinAction = true,
   onTogglePin,
 }: ChatListItemProps) {
   const [displayTitle, setDisplayTitle] = useState(chat.title)
@@ -559,34 +561,38 @@ export function ChatListItem({
       {!isEditing && (
         <div className="flex flex-shrink-0 items-center gap-1.5">
           <div className="pointer-events-none hidden items-center opacity-0 transition-opacity md:flex md:group-focus-within:pointer-events-auto md:group-focus-within:opacity-100 md:group-hover:pointer-events-auto md:group-hover:opacity-100">
-            {(isPinned || canPinChat(chat)) && onTogglePin && (
-              <button
-                type="button"
-                className={cn(
-                  'mr-1 rounded p-1 transition-colors',
-                  isPinned
-                    ? 'text-content-primary'
-                    : 'text-content-muted hover:text-content-secondary',
-                  isDarkMode
-                    ? 'hover:bg-surface-chat hover:text-white'
-                    : 'hover:bg-surface-sidebar',
-                )}
-                onClick={(event) => {
-                  event.stopPropagation()
-                  void onTogglePin()
-                }}
-                aria-label={
-                  isPinned ? 'Remove from Favorites' : 'Pin to Favorites'
-                }
-                title={isPinned ? 'Remove from Favorites' : 'Pin to Favorites'}
-              >
-                {isPinned ? (
-                  <PiPushPinFill className="h-4 w-4" aria-hidden="true" />
-                ) : (
-                  <PiPushPin className="h-4 w-4" aria-hidden="true" />
-                )}
-              </button>
-            )}
+            {showDesktopPinAction &&
+              (isPinned || canPinChat(chat)) &&
+              onTogglePin && (
+                <button
+                  type="button"
+                  className={cn(
+                    'mr-1 rounded p-1 transition-colors',
+                    isPinned
+                      ? 'text-content-primary'
+                      : 'text-content-muted hover:text-content-secondary',
+                    isDarkMode
+                      ? 'hover:bg-surface-chat hover:text-white'
+                      : 'hover:bg-surface-sidebar',
+                  )}
+                  onClick={(event) => {
+                    event.stopPropagation()
+                    void onTogglePin()
+                  }}
+                  aria-label={
+                    isPinned ? 'Remove from Favorites' : 'Pin to Favorites'
+                  }
+                  title={
+                    isPinned ? 'Remove from Favorites' : 'Pin to Favorites'
+                  }
+                >
+                  {isPinned ? (
+                    <PiPushPinFill className="h-4 w-4" aria-hidden="true" />
+                  ) : (
+                    <PiPushPin className="h-4 w-4" aria-hidden="true" />
+                  )}
+                </button>
+              )}
             {hasRealTitle && (
               <button
                 type="button"

--- a/src/components/chat/chat-list-item.tsx
+++ b/src/components/chat/chat-list-item.tsx
@@ -115,6 +115,7 @@ interface ChatListItemProps {
   onConvertToLocal?: () => void
   onRemoveFromProject?: () => void
   isPinned?: boolean
+  showPinnedIndicator?: boolean
   onTogglePin?: () => void | Promise<void>
 }
 
@@ -193,6 +194,7 @@ export function ChatListItem({
   onConvertToLocal,
   onRemoveFromProject,
   isPinned = false,
+  showPinnedIndicator = true,
   onTogglePin,
 }: ChatListItemProps) {
   const [displayTitle, setDisplayTitle] = useState(chat.title)
@@ -476,7 +478,7 @@ export function ChatListItem({
                   />
                 )
               )}
-              {isPinned && !isStreaming && (
+              {isPinned && showPinnedIndicator && !isStreaming && (
                 <PiPushPinFill
                   className="h-3.5 w-3.5 flex-shrink-0 text-content-muted"
                   title="Pinned to Favorites"

--- a/src/components/chat/chat-list.tsx
+++ b/src/components/chat/chat-list.tsx
@@ -49,6 +49,7 @@ interface ChatListProps {
   onConvertToLocal?: (chatId: string) => void
   onRemoveFromProject?: (chatId: string) => void
   pinnedChatIds?: readonly string[]
+  showPinnedIndicators?: boolean
   onTogglePin?: (chat: ChatItemData) => void | Promise<void>
   loadMoreButton?: React.ReactNode
   emptyState?: React.ReactNode
@@ -88,6 +89,7 @@ export function ChatList({
   onConvertToLocal,
   onRemoveFromProject,
   pinnedChatIds = [],
+  showPinnedIndicators = true,
   onTogglePin,
   loadMoreButton,
   emptyState,
@@ -258,6 +260,7 @@ export function ChatList({
                     : undefined
                 }
                 isPinned={pinnedChatIds.includes(chat.id)}
+                showPinnedIndicator={showPinnedIndicators}
                 onTogglePin={onTogglePin ? () => onTogglePin(chat) : undefined}
               />
               {deletingChatId === chat.id && (

--- a/src/components/chat/chat-list.tsx
+++ b/src/components/chat/chat-list.tsx
@@ -48,6 +48,8 @@ interface ChatListProps {
   onConvertToCloud?: (chatId: string) => void
   onConvertToLocal?: (chatId: string) => void
   onRemoveFromProject?: (chatId: string) => void
+  pinnedChatIds?: readonly string[]
+  onTogglePin?: (chat: ChatItemData) => void | Promise<void>
   loadMoreButton?: React.ReactNode
   emptyState?: React.ReactNode
   /**
@@ -85,6 +87,8 @@ export function ChatList({
   onConvertToCloud,
   onConvertToLocal,
   onRemoveFromProject,
+  pinnedChatIds = [],
+  onTogglePin,
   loadMoreButton,
   emptyState,
   loadingIndicator,
@@ -253,6 +257,8 @@ export function ChatList({
                     ? () => onRemoveFromProject(chat.id)
                     : undefined
                 }
+                isPinned={pinnedChatIds.includes(chat.id)}
+                onTogglePin={onTogglePin ? () => onTogglePin(chat) : undefined}
               />
               {deletingChatId === chat.id && (
                 <DeleteConfirmation

--- a/src/components/chat/chat-list.tsx
+++ b/src/components/chat/chat-list.tsx
@@ -50,6 +50,7 @@ interface ChatListProps {
   onRemoveFromProject?: (chatId: string) => void
   pinnedChatIds?: readonly string[]
   showPinnedIndicators?: boolean
+  showDesktopPinActions?: boolean
   onTogglePin?: (chat: ChatItemData) => void | Promise<void>
   loadMoreButton?: React.ReactNode
   emptyState?: React.ReactNode
@@ -90,6 +91,7 @@ export function ChatList({
   onRemoveFromProject,
   pinnedChatIds = [],
   showPinnedIndicators = true,
+  showDesktopPinActions = true,
   onTogglePin,
   loadMoreButton,
   emptyState,
@@ -261,6 +263,7 @@ export function ChatList({
                 }
                 isPinned={pinnedChatIds.includes(chat.id)}
                 showPinnedIndicator={showPinnedIndicators}
+                showDesktopPinAction={showDesktopPinActions}
                 onTogglePin={onTogglePin ? () => onTogglePin(chat) : undefined}
               />
               {deletingChatId === chat.id && (

--- a/src/components/chat/chat-sidebar.tsx
+++ b/src/components/chat/chat-sidebar.tsx
@@ -5,6 +5,7 @@ import {
   UI_SIDEBAR_ACTIVE_TAB,
   UI_SIDEBAR_CHAT_HISTORY_EXPANDED,
   UI_SIDEBAR_EXPAND_SECTION,
+  UI_SIDEBAR_FAVORITES_EXPANDED,
   UI_SIDEBAR_PROJECTS_EXPANDED,
   USER_PREFS_NATIVE_APP_DISMISSED,
 } from '@/constants/storage-keys'
@@ -80,6 +81,8 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Link } from '../link'
 import { Logo } from '../logo'
 import type { Chat } from './types'
+
+const FAVORITES_PANEL_ID = 'sidebar-favorites-panel'
 
 // Utility function to detect iOS devices
 function isIOSDevice() {
@@ -236,6 +239,10 @@ export function ChatSidebar({
     return false
   })
   const [isCreatingProject, setIsCreatingProject] = useState(false)
+  const [isFavoritesExpanded, setIsFavoritesExpanded] = useState(() => {
+    if (typeof window === 'undefined') return true
+    return sessionStorage.getItem(UI_SIDEBAR_FAVORITES_EXPANDED) !== 'false'
+  })
   const [isChatHistoryExpanded, setIsChatHistoryExpanded] = useState(() => {
     if (typeof window !== 'undefined') {
       const shouldExpandProjects = sessionStorage.getItem(
@@ -397,6 +404,13 @@ export function ChatSidebar({
       isChatHistoryExpanded ? 'true' : 'false',
     )
   }, [isChatHistoryExpanded])
+
+  useEffect(() => {
+    sessionStorage.setItem(
+      UI_SIDEBAR_FAVORITES_EXPANDED,
+      isFavoritesExpanded ? 'true' : 'false',
+    )
+  }, [isFavoritesExpanded])
 
   // Listen for cloud sync setting changes
   useEffect(() => {
@@ -630,6 +644,10 @@ export function ChatSidebar({
       pinnedChatIds,
       draggingChatId,
       onToggleFavorite,
+      onActivate: () => {
+        if (!isFavoritesExpanded) hideScrollbarWhileSectionsAnimate()
+        setIsFavoritesExpanded(true)
+      },
       clearDragState,
     })
 
@@ -904,6 +922,7 @@ export function ChatSidebar({
                 <div className="group relative" {...favoriteDropTargetProps}>
                   <button
                     onClick={() => {
+                      setIsFavoritesExpanded(true)
                       setIsOpen(true)
                       requestAnimationFrame(() =>
                         favoritesSectionRef.current?.scrollIntoView({
@@ -1282,37 +1301,75 @@ export function ChatSidebar({
                   (isDarkMode ? 'bg-white/10' : 'bg-gray-200/50'),
               )}
             >
-              <div className="flex items-center gap-2 px-4 py-3 text-sm text-content-secondary">
-                <PiPushPin className="h-4 w-4" aria-hidden="true" />
-                <h2 className="font-aeonik font-medium">Favorites</h2>
-              </div>
-              {favoriteChats.length > 0 ? (
-                <ChatList
-                  chats={favoriteChats}
-                  currentChatId={currentChat?.id}
-                  isDarkMode={isDarkMode}
-                  pixelateSidebarChatTitles={pixelateSidebarChatTitles}
-                  showSyncStatus={true}
-                  getChatHref={(chat) =>
-                    getChatPath(chat.id, { projectId: chat.projectId })
-                  }
-                  onSelectChat={(chatId) => {
-                    const favorite = favoriteChats.find(
-                      (chat) => chat.id === chatId,
-                    )
-                    if (favorite) void onOpenFavorite?.(favorite)
-                  }}
-                  onUpdateTitle={updateChatTitle}
-                  onDeleteChat={deleteChat}
-                  pinnedChatIds={pinnedChatIds}
-                  showPinnedIndicators={false}
-                  onTogglePin={onToggleFavorite}
-                />
-              ) : (
-                <p className="px-4 pb-3 font-aeonik-fono text-xs text-content-muted">
-                  Pin chats for quick access.
-                </p>
-              )}
+              <button
+                type="button"
+                aria-expanded={isFavoritesExpanded}
+                aria-controls={FAVORITES_PANEL_ID}
+                onClick={() => {
+                  hideScrollbarWhileSectionsAnimate()
+                  setIsFavoritesExpanded((expanded) => !expanded)
+                }}
+                className="flex w-full items-center justify-between px-4 py-3 text-sm text-content-secondary transition-colors hover:text-content-primary"
+              >
+                <span className="flex items-center gap-2">
+                  <PiPushPin className="h-4 w-4" aria-hidden="true" />
+                  <span
+                    role="heading"
+                    aria-level={2}
+                    className="font-aeonik font-medium"
+                  >
+                    Favorites
+                  </span>
+                </span>
+                {isFavoritesExpanded ? (
+                  <ChevronDownIcon className="h-4 w-4" />
+                ) : (
+                  <ChevronRightIcon className="h-4 w-4" />
+                )}
+              </button>
+              <AnimatePresence initial={false}>
+                {isFavoritesExpanded && (
+                  <motion.div
+                    id={FAVORITES_PANEL_ID}
+                    initial={{ height: 0, opacity: 0 }}
+                    animate={{ height: 'auto', opacity: 1 }}
+                    exit={{ height: 0, opacity: 0 }}
+                    transition={{
+                      duration: CONSTANTS.SIDEBAR_SECTION_ANIMATION_S,
+                      ease: 'easeInOut',
+                    }}
+                    className="overflow-hidden"
+                  >
+                    {favoriteChats.length > 0 ? (
+                      <ChatList
+                        chats={favoriteChats}
+                        currentChatId={currentChat?.id}
+                        isDarkMode={isDarkMode}
+                        pixelateSidebarChatTitles={pixelateSidebarChatTitles}
+                        showSyncStatus={true}
+                        getChatHref={(chat) =>
+                          getChatPath(chat.id, { projectId: chat.projectId })
+                        }
+                        onSelectChat={(chatId) => {
+                          const favorite = favoriteChats.find(
+                            (chat) => chat.id === chatId,
+                          )
+                          if (favorite) void onOpenFavorite?.(favorite)
+                        }}
+                        onUpdateTitle={updateChatTitle}
+                        onDeleteChat={deleteChat}
+                        pinnedChatIds={pinnedChatIds}
+                        showPinnedIndicators={false}
+                        onTogglePin={onToggleFavorite}
+                      />
+                    ) : (
+                      <p className="px-4 pb-3 font-aeonik-fono text-xs text-content-muted">
+                        Pin chats for quick access.
+                      </p>
+                    )}
+                  </motion.div>
+                )}
+              </AnimatePresence>
             </section>
           )}
 

--- a/src/components/chat/chat-sidebar.tsx
+++ b/src/components/chat/chat-sidebar.tsx
@@ -299,7 +299,8 @@ export function ChatSidebar({
   const [localOnlyModeEnabled, setLocalOnlyModeEnabled] = useState(
     isLocalOnlyModeEnabled(),
   )
-  const { isSignedIn } = useAuth()
+  const { isLoaded: isAuthLoaded, isSignedIn } = useAuth()
+  const favoritesAvailable = Boolean(isSignedIn && cloudSyncEnabled)
   const { user } = useUser()
 
   const {
@@ -424,6 +425,18 @@ export function ChatSidebar({
       isFavoritesExpanded ? 'true' : 'false',
     )
   }, [isFavoritesExpanded, isProjectsExpanded])
+
+  useEffect(() => {
+    if (isAuthLoaded && !favoritesAvailable && isFavoritesExpanded) {
+      setIsFavoritesExpanded(false)
+      if (!isProjectsExpanded) setIsChatHistoryExpanded(true)
+    }
+  }, [
+    favoritesAvailable,
+    isAuthLoaded,
+    isFavoritesExpanded,
+    isProjectsExpanded,
+  ])
 
   // Listen for cloud sync setting changes
   useEffect(() => {
@@ -574,11 +587,12 @@ export function ChatSidebar({
   // premium session) would otherwise leave a signed-out/non-premium user
   // with no Projects section AND a collapsed chat list — an empty sidebar.
   useEffect(() => {
-    if (!hasPinnedProjectsHeader && isProjectsExpanded) {
+    if (isAuthLoaded && !hasPinnedProjectsHeader && isProjectsExpanded) {
       setIsProjectsExpanded(false)
-      if (!isFavoritesExpanded) setIsChatHistoryExpanded(true)
+      setIsFavoritesExpanded(false)
+      setIsChatHistoryExpanded(true)
     }
-  }, [hasPinnedProjectsHeader, isFavoritesExpanded, isProjectsExpanded])
+  }, [hasPinnedProjectsHeader, isAuthLoaded, isProjectsExpanded])
 
   const hideScrollbarWhileSectionsAnimate = useCallback(() => {
     setHideScrollbarDuringAnimation(true)

--- a/src/components/chat/chat-sidebar.tsx
+++ b/src/components/chat/chat-sidebar.tsx
@@ -262,6 +262,7 @@ export function ChatSidebar({
     return true
   })
   const sidebarScrollRef = useRef<HTMLDivElement>(null)
+  const favoritesSectionRef = useRef<HTMLElement>(null)
   // Hides the sidebar scrollbar while a section expand/collapse animates;
   // the scroll height changes every frame and the scrollbar would flicker.
   const [hideScrollbarDuringAnimation, setHideScrollbarDuringAnimation] =
@@ -889,6 +890,31 @@ export function ChatSidebar({
                 </span>
               </div>
 
+              {isSignedIn && cloudSyncEnabled && (
+                <div className="group relative">
+                  <button
+                    onClick={() => {
+                      setIsOpen(true)
+                      requestAnimationFrame(() =>
+                        favoritesSectionRef.current?.scrollIntoView({
+                          block: 'start',
+                        }),
+                      )
+                    }}
+                    className={cn(
+                      'flex h-10 w-10 items-center justify-center rounded-lg transition-colors',
+                      'text-content-secondary hover:bg-surface-chat hover:text-content-primary',
+                    )}
+                    aria-label="Favorites"
+                  >
+                    <PiPushPin className="h-5 w-5" />
+                  </button>
+                  <span className="pointer-events-none absolute left-full top-1/2 z-50 ml-2 -translate-y-1/2 whitespace-nowrap rounded border border-border-subtle bg-surface-chat-background px-2 py-1 text-xs text-content-primary opacity-0 shadow-sm transition-opacity group-hover:opacity-100">
+                    Favorites
+                  </span>
+                </div>
+              )}
+
               {/* Projects button - only for premium users */}
               {isSignedIn && isPremium && (
                 <div className="group relative">
@@ -1237,7 +1263,10 @@ export function ChatSidebar({
               wrapper) so the sticky header pins to the scroll area itself
               and stays visible for the rest of the scroll. */}
           {isSignedIn && cloudSyncEnabled && (
-            <section className="relative z-10 flex-none border-t border-border-subtle">
+            <section
+              ref={favoritesSectionRef}
+              className="relative z-10 flex-none border-t border-border-subtle"
+            >
               <div className="flex items-center gap-2 px-4 py-3 text-sm text-content-secondary">
                 <PiPushPin className="h-4 w-4" aria-hidden="true" />
                 <h2 className="font-aeonik font-medium">Favorites</h2>

--- a/src/components/chat/chat-sidebar.tsx
+++ b/src/components/chat/chat-sidebar.tsx
@@ -239,10 +239,8 @@ export function ChatSidebar({
     return false
   })
   const [isCreatingProject, setIsCreatingProject] = useState(false)
-  const [isFavoritesExpanded, setIsFavoritesExpanded] = useState(() => {
-    if (typeof window === 'undefined') return true
-    return sessionStorage.getItem(UI_SIDEBAR_FAVORITES_EXPANDED) !== 'false'
-  })
+  const [isFavoritesExpanded, setIsFavoritesExpanded] = useState(true)
+  const hasLoadedFavoritesExpandedRef = useRef(false)
   const [isChatHistoryExpanded, setIsChatHistoryExpanded] = useState(() => {
     if (typeof window !== 'undefined') {
       const shouldExpandProjects = sessionStorage.getItem(
@@ -406,11 +404,26 @@ export function ChatSidebar({
   }, [isChatHistoryExpanded])
 
   useEffect(() => {
+    if (!hasLoadedFavoritesExpandedRef.current) {
+      hasLoadedFavoritesExpandedRef.current = true
+      const stored = sessionStorage.getItem(UI_SIDEBAR_FAVORITES_EXPANDED)
+      const requestedSection = sessionStorage.getItem(UI_SIDEBAR_EXPAND_SECTION)
+      const shouldExpand =
+        stored !== 'false' &&
+        !isProjectsExpanded &&
+        requestedSection !== 'chats'
+      setIsFavoritesExpanded(shouldExpand)
+      if (shouldExpand) {
+        setIsProjectsExpanded(false)
+        setIsChatHistoryExpanded(false)
+      }
+      return
+    }
     sessionStorage.setItem(
       UI_SIDEBAR_FAVORITES_EXPANDED,
       isFavoritesExpanded ? 'true' : 'false',
     )
-  }, [isFavoritesExpanded])
+  }, [isFavoritesExpanded, isProjectsExpanded])
 
   // Listen for cloud sync setting changes
   useEffect(() => {
@@ -527,10 +540,12 @@ export function ChatSidebar({
       if (expandSection === 'projects') {
         setIsProjectsExpanded(true)
         setIsChatHistoryExpanded(false)
+        setIsFavoritesExpanded(false)
         refreshProjects()
       } else if (expandSection === 'chats') {
         setIsProjectsExpanded(false)
         setIsChatHistoryExpanded(true)
+        setIsFavoritesExpanded(false)
       }
       sessionStorage.removeItem(UI_SIDEBAR_EXPAND_SECTION)
     }
@@ -561,9 +576,9 @@ export function ChatSidebar({
   useEffect(() => {
     if (!hasPinnedProjectsHeader && isProjectsExpanded) {
       setIsProjectsExpanded(false)
-      setIsChatHistoryExpanded(true)
+      if (!isFavoritesExpanded) setIsChatHistoryExpanded(true)
     }
-  }, [hasPinnedProjectsHeader, isProjectsExpanded])
+  }, [hasPinnedProjectsHeader, isFavoritesExpanded, isProjectsExpanded])
 
   const hideScrollbarWhileSectionsAnimate = useCallback(() => {
     setHideScrollbarDuringAnimation(true)
@@ -585,16 +600,17 @@ export function ChatSidebar({
     [],
   )
 
-  // Projects and Chats behave as an accordion: expanding one collapses the
-  // other. This keeps the newly opened section at the top of the scroll
-  // area (expanding a section while scrolled deep into the other would
-  // otherwise appear to do nothing, since the new content renders at its
+  // Favorites, Projects, and Chats behave as an accordion: expanding one
+  // collapses the others. This keeps the newly opened section at the top
+  // of the scroll area. Expanding while scrolled deep into another section
+  // would otherwise appear to do nothing, since the new content renders at its
   // flow position far above the viewport) and resets the scroll so the
   // opened section's content is immediately visible.
   const expandProjectsSection = useCallback(() => {
     hideScrollbarWhileSectionsAnimate()
     setIsProjectsExpanded(true)
     setIsChatHistoryExpanded(false)
+    setIsFavoritesExpanded(false)
     sidebarScrollRef.current?.scrollTo({ top: 0 })
     if (projects.length === 0) {
       refreshProjects()
@@ -605,7 +621,15 @@ export function ChatSidebar({
     hideScrollbarWhileSectionsAnimate()
     setIsChatHistoryExpanded(true)
     setIsProjectsExpanded(false)
+    setIsFavoritesExpanded(false)
     sidebarScrollRef.current?.scrollTo({ top: 0 })
+  }, [hideScrollbarWhileSectionsAnimate])
+
+  const expandFavoritesSection = useCallback(() => {
+    hideScrollbarWhileSectionsAnimate()
+    setIsFavoritesExpanded(true)
+    setIsProjectsExpanded(false)
+    setIsChatHistoryExpanded(false)
   }, [hideScrollbarWhileSectionsAnimate])
 
   const filteredChats = useMemo(() => {
@@ -644,10 +668,7 @@ export function ChatSidebar({
       pinnedChatIds,
       draggingChatId,
       onToggleFavorite,
-      onActivate: () => {
-        if (!isFavoritesExpanded) hideScrollbarWhileSectionsAnimate()
-        setIsFavoritesExpanded(true)
-      },
+      onActivate: expandFavoritesSection,
       clearDragState,
     })
 
@@ -922,7 +943,7 @@ export function ChatSidebar({
                 <div className="group relative" {...favoriteDropTargetProps}>
                   <button
                     onClick={() => {
-                      setIsFavoritesExpanded(true)
+                      expandFavoritesSection()
                       setIsOpen(true)
                       requestAnimationFrame(() =>
                         favoritesSectionRef.current?.scrollIntoView({
@@ -957,8 +978,7 @@ export function ChatSidebar({
                         UI_SIDEBAR_EXPAND_SECTION,
                         'projects',
                       )
-                      setIsProjectsExpanded(true)
-                      setIsChatHistoryExpanded(false)
+                      expandProjectsSection()
                       setIsOpen(true)
                     }}
                     className={cn(
@@ -980,8 +1000,7 @@ export function ChatSidebar({
                 <button
                   onClick={() => {
                     sessionStorage.setItem(UI_SIDEBAR_EXPAND_SECTION, 'chats')
-                    setIsChatHistoryExpanded(true)
-                    setIsProjectsExpanded(false)
+                    expandChatsSection()
                     setIsOpen(true)
                   }}
                   className={cn(
@@ -1306,8 +1325,12 @@ export function ChatSidebar({
                 aria-expanded={isFavoritesExpanded}
                 aria-controls={FAVORITES_PANEL_ID}
                 onClick={() => {
-                  hideScrollbarWhileSectionsAnimate()
-                  setIsFavoritesExpanded((expanded) => !expanded)
+                  if (isFavoritesExpanded) {
+                    hideScrollbarWhileSectionsAnimate()
+                    setIsFavoritesExpanded(false)
+                  } else {
+                    expandFavoritesSection()
+                  }
                 }}
                 className="flex w-full items-center justify-between px-4 py-3 text-sm text-content-secondary transition-colors hover:text-content-primary"
               >

--- a/src/components/chat/chat-sidebar.tsx
+++ b/src/components/chat/chat-sidebar.tsx
@@ -239,7 +239,7 @@ export function ChatSidebar({
     return false
   })
   const [isCreatingProject, setIsCreatingProject] = useState(false)
-  const [isFavoritesExpanded, setIsFavoritesExpanded] = useState(true)
+  const [isFavoritesExpanded, setIsFavoritesExpanded] = useState(false)
   const hasLoadedFavoritesExpandedRef = useRef(false)
   const [isChatHistoryExpanded, setIsChatHistoryExpanded] = useState(() => {
     if (typeof window !== 'undefined') {
@@ -410,9 +410,7 @@ export function ChatSidebar({
       const stored = sessionStorage.getItem(UI_SIDEBAR_FAVORITES_EXPANDED)
       const requestedSection = sessionStorage.getItem(UI_SIDEBAR_EXPAND_SECTION)
       const shouldExpand =
-        stored !== 'false' &&
-        !isProjectsExpanded &&
-        requestedSection !== 'chats'
+        stored === 'true' && !isProjectsExpanded && requestedSection !== 'chats'
       setIsFavoritesExpanded(shouldExpand)
       if (shouldExpand) {
         setIsProjectsExpanded(false)

--- a/src/components/chat/chat-sidebar.tsx
+++ b/src/components/chat/chat-sidebar.tsx
@@ -14,6 +14,7 @@ import { toast } from '@/hooks/use-toast'
 import { useUpgradeToPro } from '@/hooks/use-upgrade-to-pro'
 import { encryptionService } from '@/services/encryption/encryption-service'
 import { chatStorage } from '@/services/storage/chat-storage'
+import { isResolvedFavoriteChat } from '@/services/storage/pinned-chats'
 import {
   CLOUD_SYNC_SETTING_CHANGED_EVENT,
   hasUserSetLocalOnlyPreference,
@@ -45,6 +46,7 @@ import {
   PiFolder,
   PiMicrophone,
   PiNotePencilLight,
+  PiPushPin,
   PiSparkle,
   PiSpinner,
 } from 'react-icons/pi'
@@ -131,9 +133,12 @@ type ChatSidebarProps = {
   onCreateProject?: () => Promise<void>
   onMoveChatToProject?: (chatId: string, projectId: string) => Promise<void>
   onRemoveChatFromProject?: (chatId: string) => Promise<void>
-  onConvertChatToCloud?: (chatId: string) => Promise<void>
+  onConvertChatToCloud?: (chatId: string) => Promise<boolean>
   onConvertChatToLocal?: (chatId: string) => Promise<void>
   onSettingsClick?: () => void
+  pinnedChatIds?: readonly string[]
+  onToggleFavorite?: (chat: ChatItemData) => void | Promise<void>
+  onOpenFavorite?: (chat: ChatItemData) => void | Promise<void>
   windowWidth: number
   /**
    * Progress of the post-unlock background chat decryption. When
@@ -204,6 +209,9 @@ export function ChatSidebar({
   onConvertChatToCloud,
   onConvertChatToLocal,
   onSettingsClick,
+  pinnedChatIds = [],
+  onToggleFavorite,
+  onOpenFavorite,
   windowWidth,
   chatDecryptionProgress,
 }: ChatSidebarProps) {
@@ -604,6 +612,15 @@ export function ChatSidebar({
         (chat as any).isLocalOnly && !chat.projectId && !chat.isBlankChat,
     )
   }, [chats, activeTab, isSignedIn, cloudSyncEnabled, localOnlyModeEnabled])
+
+  const favoriteChats = useMemo(() => {
+    const chatsById = new Map(chats.map((chat) => [chat.id, chat]))
+    return pinnedChatIds
+      .map((chatId) => chatsById.get(chatId))
+      .filter((chat): chat is Chat =>
+        Boolean(chat && isResolvedFavoriteChat(chat)),
+      )
+  }, [chats, pinnedChatIds])
 
   const paginatesCloudChats =
     isSignedIn &&
@@ -1219,6 +1236,41 @@ export function ChatSidebar({
               list are direct children of the scroll container (no section
               wrapper) so the sticky header pins to the scroll area itself
               and stays visible for the rest of the scroll. */}
+          {isSignedIn && cloudSyncEnabled && (
+            <section className="relative z-10 flex-none border-t border-border-subtle">
+              <div className="flex items-center gap-2 px-4 py-3 text-sm text-content-secondary">
+                <PiPushPin className="h-4 w-4" aria-hidden="true" />
+                <h2 className="font-aeonik font-medium">Favorites</h2>
+              </div>
+              {favoriteChats.length > 0 ? (
+                <ChatList
+                  chats={favoriteChats}
+                  currentChatId={currentChat?.id}
+                  isDarkMode={isDarkMode}
+                  pixelateSidebarChatTitles={pixelateSidebarChatTitles}
+                  showSyncStatus={true}
+                  getChatHref={(chat) =>
+                    getChatPath(chat.id, { projectId: chat.projectId })
+                  }
+                  onSelectChat={(chatId) => {
+                    const favorite = favoriteChats.find(
+                      (chat) => chat.id === chatId,
+                    )
+                    if (favorite) void onOpenFavorite?.(favorite)
+                  }}
+                  onUpdateTitle={updateChatTitle}
+                  onDeleteChat={deleteChat}
+                  pinnedChatIds={pinnedChatIds}
+                  onTogglePin={onToggleFavorite}
+                />
+              ) : (
+                <p className="px-4 pb-3 font-aeonik-fono text-xs text-content-muted">
+                  Pin chats for quick access.
+                </p>
+              )}
+            </section>
+          )}
+
           {hasPinnedProjectsHeader && (
             <>
               <button
@@ -2159,6 +2211,8 @@ export function ChatSidebar({
                         }
                         onConvertToCloud={onConvertChatToCloud}
                         onConvertToLocal={onConvertChatToLocal}
+                        pinnedChatIds={pinnedChatIds}
+                        onTogglePin={onToggleFavorite}
                         emptyState={
                           isSearchActive ? (
                             <div className="rounded-lg border border-border-subtle bg-surface-sidebar p-4 text-center">

--- a/src/components/chat/chat-sidebar.tsx
+++ b/src/components/chat/chat-sidebar.tsx
@@ -1360,6 +1360,7 @@ export function ChatSidebar({
                         onDeleteChat={deleteChat}
                         pinnedChatIds={pinnedChatIds}
                         showPinnedIndicators={false}
+                        showDesktopPinActions={false}
                         onTogglePin={onToggleFavorite}
                       />
                     ) : (

--- a/src/components/chat/chat-sidebar.tsx
+++ b/src/components/chat/chat-sidebar.tsx
@@ -54,6 +54,7 @@ import { ChatList, type ChatItemData } from './chat-list'
 import { formatRelativeTime } from './chat-list-utils'
 import { CONSTANTS } from './constants'
 import { useDrag } from './drag-context'
+import { useFavoriteDropTarget } from './use-favorite-drop-target'
 
 import { useProject } from '@/components/project/project-context'
 import {
@@ -623,6 +624,15 @@ export function ChatSidebar({
       )
   }, [chats, pinnedChatIds])
 
+  const { isFavoriteDropTarget, favoriteDropTargetProps } =
+    useFavoriteDropTarget({
+      chats,
+      pinnedChatIds,
+      draggingChatId,
+      onToggleFavorite,
+      clearDragState,
+    })
+
   const paginatesCloudChats =
     isSignedIn &&
     cloudSyncEnabled &&
@@ -891,7 +901,7 @@ export function ChatSidebar({
               </div>
 
               {isSignedIn && cloudSyncEnabled && (
-                <div className="group relative">
+                <div className="group relative" {...favoriteDropTargetProps}>
                   <button
                     onClick={() => {
                       setIsOpen(true)
@@ -904,6 +914,10 @@ export function ChatSidebar({
                     className={cn(
                       'flex h-10 w-10 items-center justify-center rounded-lg transition-colors',
                       'text-content-secondary hover:bg-surface-chat hover:text-content-primary',
+                      isFavoriteDropTarget &&
+                        (isDarkMode
+                          ? 'border border-white/30 bg-white/10'
+                          : 'border border-gray-400 bg-gray-200/30'),
                     )}
                     aria-label="Favorites"
                   >
@@ -1265,7 +1279,12 @@ export function ChatSidebar({
           {isSignedIn && cloudSyncEnabled && (
             <section
               ref={favoritesSectionRef}
-              className="relative z-10 flex-none border-t border-border-subtle"
+              {...favoriteDropTargetProps}
+              className={cn(
+                'relative z-10 flex-none border-t border-border-subtle transition-colors',
+                isFavoriteDropTarget &&
+                  (isDarkMode ? 'bg-white/10' : 'bg-gray-200/50'),
+              )}
             >
               <div className="flex items-center gap-2 px-4 py-3 text-sm text-content-secondary">
                 <PiPushPin className="h-4 w-4" aria-hidden="true" />

--- a/src/components/chat/chat-sidebar.tsx
+++ b/src/components/chat/chat-sidebar.tsx
@@ -1272,10 +1272,6 @@ export function ChatSidebar({
             </Link>
           </div>
 
-          {/* Projects dropdown - show for premium users. The header and
-              list are direct children of the scroll container (no section
-              wrapper) so the sticky header pins to the scroll area itself
-              and stays visible for the rest of the scroll. */}
           {isSignedIn && cloudSyncEnabled && (
             <section
               ref={favoritesSectionRef}
@@ -1309,6 +1305,7 @@ export function ChatSidebar({
                   onUpdateTitle={updateChatTitle}
                   onDeleteChat={deleteChat}
                   pinnedChatIds={pinnedChatIds}
+                  showPinnedIndicators={false}
                   onTogglePin={onToggleFavorite}
                 />
               ) : (
@@ -1319,6 +1316,10 @@ export function ChatSidebar({
             </section>
           )}
 
+          {/* Projects dropdown - show for premium users. The header and
+              list are direct children of the scroll container (no section
+              wrapper) so the sticky header pins to the scroll area itself
+              and stays visible for the rest of the scroll. */}
           {hasPinnedProjectsHeader && (
             <>
               <button

--- a/src/components/chat/favorite-navigation.ts
+++ b/src/components/chat/favorite-navigation.ts
@@ -1,0 +1,41 @@
+export interface FavoriteDestination {
+  id: string
+  projectId?: string
+}
+
+interface OpenFavoriteChatOptions {
+  favorite: FavoriteDestination
+  activeProjectId?: string
+  isProjectMode: boolean
+  enterProjectMode: (
+    projectId: string,
+    isCurrent: () => boolean,
+  ) => Promise<boolean>
+  exitProjectMode: () => void
+  openChat: (chatId: string) => Promise<void>
+  isCurrent: () => boolean
+}
+
+export async function openFavoriteChat({
+  favorite,
+  activeProjectId,
+  isProjectMode,
+  enterProjectMode,
+  exitProjectMode,
+  openChat,
+  isCurrent,
+}: OpenFavoriteChatOptions): Promise<boolean> {
+  if (
+    favorite.projectId &&
+    (!isProjectMode || activeProjectId !== favorite.projectId)
+  ) {
+    const entered = await enterProjectMode(favorite.projectId, isCurrent)
+    if (!entered || !isCurrent()) return false
+  } else if (!favorite.projectId && isProjectMode) {
+    exitProjectMode()
+  }
+
+  if (!isCurrent()) return false
+  await openChat(favorite.id)
+  return isCurrent()
+}

--- a/src/components/chat/types.ts
+++ b/src/components/chat/types.ts
@@ -185,6 +185,7 @@ export type Chat = {
   syncedAt?: number
   locallyModified?: boolean
   decryptionFailed?: boolean
+  dataCorrupted?: boolean
   // Blank chat flag - true for new chats that haven't been used yet
   isBlankChat?: boolean
   // Local-only flag - true for chats that should never sync to cloud

--- a/src/components/chat/use-favorite-drop-target.ts
+++ b/src/components/chat/use-favorite-drop-target.ts
@@ -1,5 +1,12 @@
+import { canRequestChatPin } from '@/services/storage/pinned-chats'
 import { logError } from '@/utils/error-handling'
-import { useCallback, useEffect, useState, type DragEventHandler } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type DragEventHandler,
+} from 'react'
 import type { ChatItemData } from './chat-list-item'
 
 interface FavoriteDropTargetOptions {
@@ -18,24 +25,35 @@ export function useFavoriteDropTarget({
   clearDragState,
 }: FavoriteDropTargetOptions) {
   const [isFavoriteDropTarget, setIsFavoriteDropTarget] = useState(false)
+  const draggedChat = useMemo(
+    () => chats.find((chat) => chat.id === draggingChatId),
+    [chats, draggingChatId],
+  )
+  const canAcceptDraggedChat = Boolean(
+    draggedChat &&
+    onToggleFavorite &&
+    !pinnedChatIds.includes(draggedChat.id) &&
+    canRequestChatPin(draggedChat),
+  )
 
   useEffect(() => {
-    if (!draggingChatId) setIsFavoriteDropTarget(false)
-  }, [draggingChatId])
+    if (!canAcceptDraggedChat) setIsFavoriteDropTarget(false)
+  }, [canAcceptDraggedChat])
 
-  const onDragOver = useCallback<DragEventHandler<HTMLElement>>((event) => {
-    if (!event.dataTransfer.types.includes('application/x-chat-id')) return
-    event.preventDefault()
-    event.dataTransfer.dropEffect = 'copy'
-    setIsFavoriteDropTarget(true)
-  }, [])
-
-  const onDragEnter = useCallback<DragEventHandler<HTMLElement>>((event) => {
-    if (!event.dataTransfer.types.includes('application/x-chat-id')) return
-    event.preventDefault()
-    event.dataTransfer.dropEffect = 'copy'
-    setIsFavoriteDropTarget(true)
-  }, [])
+  const activateDropTarget = useCallback<DragEventHandler<HTMLElement>>(
+    (event) => {
+      if (
+        !canAcceptDraggedChat ||
+        !event.dataTransfer.types.includes('application/x-chat-id')
+      ) {
+        return
+      }
+      event.preventDefault()
+      event.dataTransfer.dropEffect = 'copy'
+      setIsFavoriteDropTarget(true)
+    },
+    [canAcceptDraggedChat],
+  )
 
   const onDragLeave = useCallback<DragEventHandler<HTMLElement>>((event) => {
     const nextTarget = event.relatedTarget
@@ -55,7 +73,12 @@ export function useFavoriteDropTarget({
       setIsFavoriteDropTarget(false)
       const chatId = event.dataTransfer.getData('application/x-chat-id')
       const chat = chats.find((candidate) => candidate.id === chatId)
-      if (!chat || pinnedChatIds.includes(chatId) || !onToggleFavorite) {
+      if (
+        !chat ||
+        !canRequestChatPin(chat) ||
+        pinnedChatIds.includes(chatId) ||
+        !onToggleFavorite
+      ) {
         clearDragState()
         return
       }
@@ -79,8 +102,8 @@ export function useFavoriteDropTarget({
   return {
     isFavoriteDropTarget,
     favoriteDropTargetProps: {
-      onDragOver,
-      onDragEnter,
+      onDragOver: activateDropTarget,
+      onDragEnter: activateDropTarget,
       onDragLeave,
       onDrop,
     },

--- a/src/components/chat/use-favorite-drop-target.ts
+++ b/src/components/chat/use-favorite-drop-target.ts
@@ -14,6 +14,7 @@ interface FavoriteDropTargetOptions {
   pinnedChatIds: readonly string[]
   draggingChatId: string | null
   onToggleFavorite?: (chat: ChatItemData) => void | Promise<void>
+  onActivate?: () => void
   clearDragState: () => void
 }
 
@@ -22,6 +23,7 @@ export function useFavoriteDropTarget({
   pinnedChatIds,
   draggingChatId,
   onToggleFavorite,
+  onActivate,
   clearDragState,
 }: FavoriteDropTargetOptions) {
   const [isFavoriteDropTarget, setIsFavoriteDropTarget] = useState(false)
@@ -51,8 +53,9 @@ export function useFavoriteDropTarget({
       event.preventDefault()
       event.dataTransfer.dropEffect = 'copy'
       setIsFavoriteDropTarget(true)
+      onActivate?.()
     },
-    [canAcceptDraggedChat],
+    [canAcceptDraggedChat, onActivate],
   )
 
   const onDragLeave = useCallback<DragEventHandler<HTMLElement>>((event) => {

--- a/src/components/chat/use-favorite-drop-target.ts
+++ b/src/components/chat/use-favorite-drop-target.ts
@@ -1,0 +1,88 @@
+import { logError } from '@/utils/error-handling'
+import { useCallback, useEffect, useState, type DragEventHandler } from 'react'
+import type { ChatItemData } from './chat-list-item'
+
+interface FavoriteDropTargetOptions {
+  chats: readonly ChatItemData[]
+  pinnedChatIds: readonly string[]
+  draggingChatId: string | null
+  onToggleFavorite?: (chat: ChatItemData) => void | Promise<void>
+  clearDragState: () => void
+}
+
+export function useFavoriteDropTarget({
+  chats,
+  pinnedChatIds,
+  draggingChatId,
+  onToggleFavorite,
+  clearDragState,
+}: FavoriteDropTargetOptions) {
+  const [isFavoriteDropTarget, setIsFavoriteDropTarget] = useState(false)
+
+  useEffect(() => {
+    if (!draggingChatId) setIsFavoriteDropTarget(false)
+  }, [draggingChatId])
+
+  const onDragOver = useCallback<DragEventHandler<HTMLElement>>((event) => {
+    if (!event.dataTransfer.types.includes('application/x-chat-id')) return
+    event.preventDefault()
+    event.dataTransfer.dropEffect = 'copy'
+    setIsFavoriteDropTarget(true)
+  }, [])
+
+  const onDragEnter = useCallback<DragEventHandler<HTMLElement>>((event) => {
+    if (!event.dataTransfer.types.includes('application/x-chat-id')) return
+    event.preventDefault()
+    event.dataTransfer.dropEffect = 'copy'
+    setIsFavoriteDropTarget(true)
+  }, [])
+
+  const onDragLeave = useCallback<DragEventHandler<HTMLElement>>((event) => {
+    const nextTarget = event.relatedTarget
+    if (
+      nextTarget instanceof Node &&
+      event.currentTarget.contains(nextTarget)
+    ) {
+      return
+    }
+    setIsFavoriteDropTarget(false)
+  }, [])
+
+  const onDrop = useCallback<DragEventHandler<HTMLElement>>(
+    (event) => {
+      event.preventDefault()
+      event.stopPropagation()
+      setIsFavoriteDropTarget(false)
+      const chatId = event.dataTransfer.getData('application/x-chat-id')
+      const chat = chats.find((candidate) => candidate.id === chatId)
+      if (!chat || pinnedChatIds.includes(chatId) || !onToggleFavorite) {
+        clearDragState()
+        return
+      }
+      clearDragState()
+      const toggleFavorite = async () => {
+        try {
+          await onToggleFavorite(chat)
+        } catch (error) {
+          logError('Failed to pin dropped chat', error, {
+            component: 'FavoriteDropTarget',
+            action: 'dropChat',
+            metadata: { chatId },
+          })
+        }
+      }
+      void toggleFavorite()
+    },
+    [chats, clearDragState, onToggleFavorite, pinnedChatIds],
+  )
+
+  return {
+    isFavoriteDropTarget,
+    favoriteDropTargetProps: {
+      onDragOver,
+      onDragEnter,
+      onDragLeave,
+      onDrop,
+    },
+  }
+}

--- a/src/components/chat/use-favorite-drop-target.ts
+++ b/src/components/chat/use-favorite-drop-target.ts
@@ -52,10 +52,10 @@ export function useFavoriteDropTarget({
       }
       event.preventDefault()
       event.dataTransfer.dropEffect = 'copy'
+      if (!isFavoriteDropTarget) onActivate?.()
       setIsFavoriteDropTarget(true)
-      onActivate?.()
     },
-    [canAcceptDraggedChat, onActivate],
+    [canAcceptDraggedChat, isFavoriteDropTarget, onActivate],
   )
 
   const onDragLeave = useCallback<DragEventHandler<HTMLElement>>((event) => {

--- a/src/components/project/project-context.tsx
+++ b/src/components/project/project-context.tsx
@@ -21,6 +21,10 @@ export interface UploadingFile {
   size: number
 }
 
+export interface EnterProjectModeOptions {
+  isCurrent?: () => boolean
+}
+
 export interface ProjectContextValue {
   activeProject: Project | null
   isProjectMode: boolean
@@ -33,6 +37,7 @@ export interface ProjectContextValue {
   enterProjectMode: (
     projectId: string,
     projectName?: string,
+    options?: EnterProjectModeOptions,
   ) => Promise<boolean>
   exitProjectMode: () => void
   createProject: (data: CreateProjectData) => Promise<Project>

--- a/src/components/project/project-load-validity.ts
+++ b/src/components/project/project-load-validity.ts
@@ -1,0 +1,13 @@
+export function canCommitProjectLoad(
+  generation: number,
+  currentGeneration: number,
+  projectId: string,
+  pendingProjectId: string | null,
+  isCurrent: () => boolean = () => true,
+): boolean {
+  return (
+    generation === currentGeneration &&
+    projectId === pendingProjectId &&
+    isCurrent()
+  )
+}

--- a/src/components/project/project-provider.tsx
+++ b/src/components/project/project-provider.tsx
@@ -19,12 +19,14 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
   buildProjectContext,
   estimateTokenCount,
-  type LoadingProject,
   ProjectContext,
+  type EnterProjectModeOptions,
+  type LoadingProject,
   type ProjectContextValue,
   type UploadingFile,
 } from './project-context'
 import { hydrateProjectDocuments } from './project-document-hydration'
+import { canCommitProjectLoad } from './project-load-validity'
 
 interface ProjectProviderProps {
   children: React.ReactNode
@@ -161,7 +163,11 @@ export function ProjectProvider({
   }, [activeProject, processMessages])
 
   const enterProjectMode = useCallback(
-    async (projectId: string, projectName?: string): Promise<boolean> => {
+    async (
+      projectId: string,
+      projectName?: string,
+      options?: EnterProjectModeOptions,
+    ): Promise<boolean> => {
       const generation = projectLoadGenerationRef.current + 1
       const cacheGeneration = projectCache.captureGeneration()
       projectLoadGenerationRef.current = generation
@@ -223,8 +229,13 @@ export function ProjectProvider({
         )
 
         if (
-          projectLoadGenerationRef.current !== generation ||
-          pendingProjectIdRef.current !== projectId
+          !canCommitProjectLoad(
+            generation,
+            projectLoadGenerationRef.current,
+            projectId,
+            pendingProjectIdRef.current,
+            options?.isCurrent,
+          )
         ) {
           return false
         }

--- a/src/components/project/project-provider.tsx
+++ b/src/components/project/project-provider.tsx
@@ -237,6 +237,9 @@ export function ProjectProvider({
             options?.isCurrent,
           )
         ) {
+          if (projectLoadGenerationRef.current === generation) {
+            pendingProjectIdRef.current = committedProjectIdRef.current
+          }
           return false
         }
 
@@ -253,6 +256,7 @@ export function ProjectProvider({
       } catch (err) {
         if (projectLoadGenerationRef.current !== generation) return false
         pendingProjectIdRef.current = committedProjectIdRef.current
+        if (options?.isCurrent && !options.isCurrent()) return false
         const message =
           err instanceof Error ? err.message : 'Failed to load project'
         setError(message)

--- a/src/components/project/project-sidebar.tsx
+++ b/src/components/project/project-sidebar.tsx
@@ -1088,12 +1088,13 @@ export function ProjectSidebar({
                     )
                     if (favorite) {
                       void onOpenFavorite?.(favorite)
-                      if (windowWidth < MOBILE_BREAKPOINT) setIsOpen(false)
+                      if (isMobile) setIsOpen(false)
                     }
                   }}
                   onUpdateTitle={updateChatTitle}
                   onDeleteChat={handleDeleteChat}
                   pinnedChatIds={pinnedChatIds}
+                  showPinnedIndicators={false}
                   onTogglePin={onToggleFavorite}
                 />
               ) : (

--- a/src/components/project/project-sidebar.tsx
+++ b/src/components/project/project-sidebar.tsx
@@ -6,6 +6,7 @@ import { getDocumentTextContent } from '@/components/chat/document-content'
 import { useDocumentUploader } from '@/components/chat/document-uploader'
 import { useDrag } from '@/components/chat/drag-context'
 import { TypingAnimation } from '@/components/chat/typing-animation'
+import { useFavoriteDropTarget } from '@/components/chat/use-favorite-drop-target'
 import { PiSpinnerThin } from '@/components/icons/lazy-icons'
 import { Link } from '@/components/link'
 import { Logo } from '@/components/logo'
@@ -307,7 +308,7 @@ export function ProjectSidebar({
   windowWidth,
 }: ProjectSidebarProps) {
   const { isSignedIn } = useAuth()
-  const { setDraggingChat, clearDragState } = useDrag()
+  const { draggingChatId, setDraggingChat, clearDragState } = useDrag()
   const {
     projectDocuments,
     uploadDocument,
@@ -710,6 +711,16 @@ export function ProjectSidebar({
 
   const resolvedFavoriteChats = favoriteChats.filter(isResolvedFavoriteChat)
 
+  const favoriteDropChats = [...projectChats, ...resolvedFavoriteChats]
+  const { isFavoriteDropTarget, favoriteDropTargetProps } =
+    useFavoriteDropTarget({
+      chats: favoriteDropChats,
+      pinnedChatIds,
+      draggingChatId,
+      onToggleFavorite,
+      clearDragState,
+    })
+
   const isMobile = windowWidth < MOBILE_BREAKPOINT
 
   const sidebarTintColor = getProjectColor(project?.color)
@@ -793,7 +804,7 @@ export function ProjectSidebar({
               </div>
 
               {isSignedIn && cloudSyncEnabled && (
-                <div className="group relative">
+                <div className="group relative" {...favoriteDropTargetProps}>
                   <button
                     onClick={() => {
                       setIsOpen(true)
@@ -806,6 +817,10 @@ export function ProjectSidebar({
                     className={cn(
                       'flex h-10 w-10 items-center justify-center rounded-lg transition-colors',
                       'text-content-secondary hover:bg-surface-chat hover:text-content-primary',
+                      isFavoriteDropTarget &&
+                        (isDarkMode
+                          ? 'border border-white/30 bg-white/10'
+                          : 'border border-gray-400 bg-gray-200/30'),
                     )}
                     aria-label="Favorites"
                   >
@@ -1047,7 +1062,12 @@ export function ProjectSidebar({
           {isSignedIn && cloudSyncEnabled && (
             <section
               ref={favoritesSectionRef}
-              className="relative z-10 flex-none border-y border-border-subtle"
+              {...favoriteDropTargetProps}
+              className={cn(
+                'relative z-10 flex-none border-y border-border-subtle transition-colors',
+                isFavoriteDropTarget &&
+                  (isDarkMode ? 'bg-white/10' : 'bg-gray-200/50'),
+              )}
             >
               <div className="flex items-center gap-2 px-4 py-3 text-sm text-content-secondary">
                 <PiPushPin className="h-4 w-4" aria-hidden="true" />

--- a/src/components/project/project-sidebar.tsx
+++ b/src/components/project/project-sidebar.tsx
@@ -128,6 +128,7 @@ interface ProjectSidebarProps {
   pinnedChatIds?: readonly string[]
   onToggleFavorite?: (chat: ChatItemData) => void | Promise<void>
   onOpenFavorite?: (chat: ChatItemData) => void | Promise<void>
+  cloudSyncEnabled: boolean
   windowWidth: number
 }
 
@@ -302,6 +303,7 @@ export function ProjectSidebar({
   pinnedChatIds = [],
   onToggleFavorite,
   onOpenFavorite,
+  cloudSyncEnabled,
   windowWidth,
 }: ProjectSidebarProps) {
   const { isSignedIn } = useAuth()
@@ -1016,37 +1018,42 @@ export function ProjectSidebar({
             </Link>
           </div>
 
-          <section className="relative z-10 flex-none border-y border-border-subtle">
-            <div className="flex items-center gap-2 px-4 py-3 text-sm text-content-secondary">
-              <PiPushPin className="h-4 w-4" aria-hidden="true" />
-              <h2 className="font-aeonik font-medium">Favorites</h2>
-            </div>
-            {resolvedFavoriteChats.length > 0 ? (
-              <ChatList
-                chats={resolvedFavoriteChats}
-                currentChatId={currentChatId}
-                isDarkMode={isDarkMode}
-                pixelateSidebarChatTitles={pixelateSidebarChatTitles}
-                getChatHref={(chat) =>
-                  getChatPath(chat.id, { projectId: chat.projectId })
-                }
-                onSelectChat={(chatId) => {
-                  const favorite = resolvedFavoriteChats.find(
-                    (chat) => chat.id === chatId,
-                  )
-                  if (favorite) void onOpenFavorite?.(favorite)
-                }}
-                onUpdateTitle={updateChatTitle}
-                onDeleteChat={handleDeleteChat}
-                pinnedChatIds={pinnedChatIds}
-                onTogglePin={onToggleFavorite}
-              />
-            ) : (
-              <p className="px-4 pb-3 font-aeonik-fono text-xs text-content-muted">
-                Pin chats for quick access.
-              </p>
-            )}
-          </section>
+          {isSignedIn && cloudSyncEnabled && (
+            <section className="relative z-10 flex-none border-y border-border-subtle">
+              <div className="flex items-center gap-2 px-4 py-3 text-sm text-content-secondary">
+                <PiPushPin className="h-4 w-4" aria-hidden="true" />
+                <h2 className="font-aeonik font-medium">Favorites</h2>
+              </div>
+              {resolvedFavoriteChats.length > 0 ? (
+                <ChatList
+                  chats={resolvedFavoriteChats}
+                  currentChatId={currentChatId}
+                  isDarkMode={isDarkMode}
+                  pixelateSidebarChatTitles={pixelateSidebarChatTitles}
+                  getChatHref={(chat) =>
+                    getChatPath(chat.id, { projectId: chat.projectId })
+                  }
+                  onSelectChat={(chatId) => {
+                    const favorite = resolvedFavoriteChats.find(
+                      (chat) => chat.id === chatId,
+                    )
+                    if (favorite) {
+                      void onOpenFavorite?.(favorite)
+                      if (windowWidth < MOBILE_BREAKPOINT) setIsOpen(false)
+                    }
+                  }}
+                  onUpdateTitle={updateChatTitle}
+                  onDeleteChat={handleDeleteChat}
+                  pinnedChatIds={pinnedChatIds}
+                  onTogglePin={onToggleFavorite}
+                />
+              ) : (
+                <p className="px-4 pb-3 font-aeonik-fono text-xs text-content-muted">
+                  Pin chats for quick access.
+                </p>
+              )}
+            </section>
+          )}
 
           {/* Project Settings Dropdown */}
           <div className="relative z-10 flex-none border-y border-border-subtle">

--- a/src/components/project/project-sidebar.tsx
+++ b/src/components/project/project-sidebar.tsx
@@ -21,7 +21,10 @@ import {
   PROJECT_COLORS,
   projectColorTintLayer,
 } from '@/constants/project-colors'
-import { UI_EXPAND_PROJECT_DOCUMENTS } from '@/constants/storage-keys'
+import {
+  UI_EXPAND_PROJECT_DOCUMENTS,
+  UI_SIDEBAR_FAVORITES_EXPANDED,
+} from '@/constants/storage-keys'
 import { toast } from '@/hooks/use-toast'
 import { isResolvedFavoriteChat } from '@/services/storage/pinned-chats'
 import type { Fact } from '@/types/memory'
@@ -80,6 +83,7 @@ import { CONSTANTS } from '../chat/constants'
 import { useProject } from './project-context'
 
 const MOBILE_BREAKPOINT = 1024
+const FAVORITES_PANEL_ID = 'project-sidebar-favorites-panel'
 
 interface ProjectChat {
   id: string
@@ -325,6 +329,10 @@ export function ProjectSidebar({
   const { handleDocumentUpload: processDocument, isDocumentUploading } =
     useDocumentUploader()
   const [settingsExpanded, setSettingsExpanded] = useState(false)
+  const [isFavoritesExpanded, setIsFavoritesExpanded] = useState(() => {
+    if (typeof window === 'undefined') return true
+    return sessionStorage.getItem(UI_SIDEBAR_FAVORITES_EXPANDED) !== 'false'
+  })
   const [documentsExpanded, setDocumentsExpanded] = useState(false)
   const [memoryExpanded, setMemoryExpanded] = useState(false)
   const [memoryText, setMemoryText] = useState('')
@@ -402,6 +410,13 @@ export function ProjectSidebar({
   }, [refreshDocuments])
 
   // Expand documents section when signal is set (from file upload to project context)
+  useEffect(() => {
+    sessionStorage.setItem(
+      UI_SIDEBAR_FAVORITES_EXPANDED,
+      isFavoritesExpanded ? 'true' : 'false',
+    )
+  }, [isFavoritesExpanded])
+
   useEffect(() => {
     if (isOpen) {
       const shouldExpandDocs = sessionStorage.getItem(
@@ -718,6 +733,7 @@ export function ProjectSidebar({
       pinnedChatIds,
       draggingChatId,
       onToggleFavorite,
+      onActivate: () => setIsFavoritesExpanded(true),
       clearDragState,
     })
 
@@ -807,6 +823,7 @@ export function ProjectSidebar({
                 <div className="group relative" {...favoriteDropTargetProps}>
                   <button
                     onClick={() => {
+                      setIsFavoritesExpanded(true)
                       setIsOpen(true)
                       requestAnimationFrame(() =>
                         favoritesSectionRef.current?.scrollIntoView({
@@ -1069,39 +1086,71 @@ export function ProjectSidebar({
                   (isDarkMode ? 'bg-white/10' : 'bg-gray-200/50'),
               )}
             >
-              <div className="flex items-center gap-2 px-4 py-3 text-sm text-content-secondary">
-                <PiPushPin className="h-4 w-4" aria-hidden="true" />
-                <h2 className="font-aeonik font-medium">Favorites</h2>
-              </div>
-              {resolvedFavoriteChats.length > 0 ? (
-                <ChatList
-                  chats={resolvedFavoriteChats}
-                  currentChatId={currentChatId}
-                  isDarkMode={isDarkMode}
-                  pixelateSidebarChatTitles={pixelateSidebarChatTitles}
-                  getChatHref={(chat) =>
-                    getChatPath(chat.id, { projectId: chat.projectId })
-                  }
-                  onSelectChat={(chatId) => {
-                    const favorite = resolvedFavoriteChats.find(
-                      (chat) => chat.id === chatId,
-                    )
-                    if (favorite) {
-                      void onOpenFavorite?.(favorite)
-                      if (isMobile) setIsOpen(false)
-                    }
-                  }}
-                  onUpdateTitle={updateChatTitle}
-                  onDeleteChat={handleDeleteChat}
-                  pinnedChatIds={pinnedChatIds}
-                  showPinnedIndicators={false}
-                  onTogglePin={onToggleFavorite}
-                />
-              ) : (
-                <p className="px-4 pb-3 font-aeonik-fono text-xs text-content-muted">
-                  Pin chats for quick access.
-                </p>
-              )}
+              <button
+                type="button"
+                aria-expanded={isFavoritesExpanded}
+                aria-controls={FAVORITES_PANEL_ID}
+                onClick={() => setIsFavoritesExpanded((expanded) => !expanded)}
+                className="flex w-full items-center justify-between px-4 py-3 text-sm text-content-secondary transition-colors hover:text-content-primary"
+              >
+                <span className="flex items-center gap-2">
+                  <PiPushPin className="h-4 w-4" aria-hidden="true" />
+                  <span
+                    role="heading"
+                    aria-level={2}
+                    className="font-aeonik font-medium"
+                  >
+                    Favorites
+                  </span>
+                </span>
+                {isFavoritesExpanded ? (
+                  <ChevronUpIcon className="h-4 w-4" />
+                ) : (
+                  <ChevronDownIcon className="h-4 w-4" />
+                )}
+              </button>
+              <AnimatePresence initial={false}>
+                {isFavoritesExpanded && (
+                  <motion.div
+                    id={FAVORITES_PANEL_ID}
+                    initial={{ height: 0, opacity: 0 }}
+                    animate={{ height: 'auto', opacity: 1 }}
+                    exit={{ height: 0, opacity: 0 }}
+                    transition={{ duration: 0.2, ease: 'easeInOut' }}
+                    className="overflow-hidden"
+                  >
+                    {resolvedFavoriteChats.length > 0 ? (
+                      <ChatList
+                        chats={resolvedFavoriteChats}
+                        currentChatId={currentChatId}
+                        isDarkMode={isDarkMode}
+                        pixelateSidebarChatTitles={pixelateSidebarChatTitles}
+                        getChatHref={(chat) =>
+                          getChatPath(chat.id, { projectId: chat.projectId })
+                        }
+                        onSelectChat={(chatId) => {
+                          const favorite = resolvedFavoriteChats.find(
+                            (chat) => chat.id === chatId,
+                          )
+                          if (favorite) {
+                            void onOpenFavorite?.(favorite)
+                            if (isMobile) setIsOpen(false)
+                          }
+                        }}
+                        onUpdateTitle={updateChatTitle}
+                        onDeleteChat={handleDeleteChat}
+                        pinnedChatIds={pinnedChatIds}
+                        showPinnedIndicators={false}
+                        onTogglePin={onToggleFavorite}
+                      />
+                    ) : (
+                      <p className="px-4 pb-3 font-aeonik-fono text-xs text-content-muted">
+                        Pin chats for quick access.
+                      </p>
+                    )}
+                  </motion.div>
+                )}
+              </AnimatePresence>
             </section>
           )}
 

--- a/src/components/project/project-sidebar.tsx
+++ b/src/components/project/project-sidebar.tsx
@@ -22,6 +22,7 @@ import {
 } from '@/constants/project-colors'
 import { UI_EXPAND_PROJECT_DOCUMENTS } from '@/constants/storage-keys'
 import { toast } from '@/hooks/use-toast'
+import { isResolvedFavoriteChat } from '@/services/storage/pinned-chats'
 import type { Fact } from '@/types/memory'
 import type { Project } from '@/types/project'
 import {
@@ -73,7 +74,7 @@ import {
   BsFiletypeXml,
 } from 'react-icons/bs'
 import { GoSidebarCollapse, GoSidebarExpand } from 'react-icons/go'
-import { PiNotePencilLight } from 'react-icons/pi'
+import { PiNotePencilLight, PiPushPin } from 'react-icons/pi'
 import { CONSTANTS } from '../chat/constants'
 import { useProject } from './project-context'
 
@@ -87,6 +88,10 @@ interface ProjectChat {
   updatedAt?: string
   projectId?: string
   isBlankChat?: boolean
+  decryptionFailed?: boolean
+  dataCorrupted?: boolean
+  isTemporary?: boolean
+  pendingSave?: boolean
 }
 
 interface ProjectOption {
@@ -119,6 +124,10 @@ interface ProjectSidebarProps {
   onMoveChatToProject?: (chatId: string, projectId: string) => Promise<void>
   projects?: ProjectOption[]
   onSettingsClick?: () => void
+  favoriteChats?: ChatItemData[]
+  pinnedChatIds?: readonly string[]
+  onToggleFavorite?: (chat: ChatItemData) => void | Promise<void>
+  onOpenFavorite?: (chat: ChatItemData) => void | Promise<void>
   windowWidth: number
 }
 
@@ -289,6 +298,10 @@ export function ProjectSidebar({
   onMoveChatToProject,
   projects = [],
   onSettingsClick,
+  favoriteChats = [],
+  pinnedChatIds = [],
+  onToggleFavorite,
+  onOpenFavorite,
   windowWidth,
 }: ProjectSidebarProps) {
   const { isSignedIn } = useAuth()
@@ -681,11 +694,18 @@ export function ProjectSidebar({
         (c.createdAt instanceof Date
           ? c.createdAt.toISOString()
           : new Date(c.createdAt).toISOString()),
+      projectId: c.projectId,
+      decryptionFailed: c.decryptionFailed,
+      dataCorrupted: c.dataCorrupted,
+      isTemporary: c.isTemporary,
+      pendingSave: c.pendingSave,
     }))
     .sort(
       (a, b) =>
         new Date(b.updatedAt!).getTime() - new Date(a.updatedAt!).getTime(),
     )
+
+  const resolvedFavoriteChats = favoriteChats.filter(isResolvedFavoriteChat)
 
   const isMobile = windowWidth < MOBILE_BREAKPOINT
 
@@ -995,6 +1015,38 @@ export function ProjectSidebar({
               </span>
             </Link>
           </div>
+
+          <section className="relative z-10 flex-none border-y border-border-subtle">
+            <div className="flex items-center gap-2 px-4 py-3 text-sm text-content-secondary">
+              <PiPushPin className="h-4 w-4" aria-hidden="true" />
+              <h2 className="font-aeonik font-medium">Favorites</h2>
+            </div>
+            {resolvedFavoriteChats.length > 0 ? (
+              <ChatList
+                chats={resolvedFavoriteChats}
+                currentChatId={currentChatId}
+                isDarkMode={isDarkMode}
+                pixelateSidebarChatTitles={pixelateSidebarChatTitles}
+                getChatHref={(chat) =>
+                  getChatPath(chat.id, { projectId: chat.projectId })
+                }
+                onSelectChat={(chatId) => {
+                  const favorite = resolvedFavoriteChats.find(
+                    (chat) => chat.id === chatId,
+                  )
+                  if (favorite) void onOpenFavorite?.(favorite)
+                }}
+                onUpdateTitle={updateChatTitle}
+                onDeleteChat={handleDeleteChat}
+                pinnedChatIds={pinnedChatIds}
+                onTogglePin={onToggleFavorite}
+              />
+            ) : (
+              <p className="px-4 pb-3 font-aeonik-fono text-xs text-content-muted">
+                Pin chats for quick access.
+              </p>
+            )}
+          </section>
 
           {/* Project Settings Dropdown */}
           <div className="relative z-10 flex-none border-y border-border-subtle">
@@ -1464,6 +1516,8 @@ export function ProjectSidebar({
               onDragEnd={() => clearDragState()}
               onMoveToProject={onMoveChatToProject}
               onRemoveFromProject={onRemoveChatFromProject}
+              pinnedChatIds={pinnedChatIds}
+              onTogglePin={onToggleFavorite}
             />
           </div>
         </div>

--- a/src/components/project/project-sidebar.tsx
+++ b/src/components/project/project-sidebar.tsx
@@ -329,7 +329,7 @@ export function ProjectSidebar({
   const { handleDocumentUpload: processDocument, isDocumentUploading } =
     useDocumentUploader()
   const [settingsExpanded, setSettingsExpanded] = useState(false)
-  const [isFavoritesExpanded, setIsFavoritesExpanded] = useState(true)
+  const [isFavoritesExpanded, setIsFavoritesExpanded] = useState(false)
   const hasLoadedFavoritesExpandedRef = useRef(false)
   const [documentsExpanded, setDocumentsExpanded] = useState(false)
   const [memoryExpanded, setMemoryExpanded] = useState(false)

--- a/src/components/project/project-sidebar.tsx
+++ b/src/components/project/project-sidebar.tsx
@@ -360,6 +360,7 @@ export function ProjectSidebar({
   const skipNextAnimationRef = useRef(false)
 
   const fileInputRef = useRef<HTMLInputElement>(null)
+  const favoritesSectionRef = useRef<HTMLElement>(null)
   const exitHoverTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const [isExitButtonDragHover, setIsExitButtonDragHover] = useState(false)
   const [isDropTargetChatList, setIsDropTargetChatList] = useState(false)
@@ -790,6 +791,31 @@ export function ProjectSidebar({
                   </span>
                 </span>
               </div>
+
+              {isSignedIn && cloudSyncEnabled && (
+                <div className="group relative">
+                  <button
+                    onClick={() => {
+                      setIsOpen(true)
+                      requestAnimationFrame(() =>
+                        favoritesSectionRef.current?.scrollIntoView({
+                          block: 'start',
+                        }),
+                      )
+                    }}
+                    className={cn(
+                      'flex h-10 w-10 items-center justify-center rounded-lg transition-colors',
+                      'text-content-secondary hover:bg-surface-chat hover:text-content-primary',
+                    )}
+                    aria-label="Favorites"
+                  >
+                    <PiPushPin className="h-5 w-5" />
+                  </button>
+                  <span className="pointer-events-none absolute left-full top-1/2 z-50 ml-2 -translate-y-1/2 whitespace-nowrap rounded border border-border-subtle bg-surface-chat-background px-2 py-1 text-xs text-content-primary opacity-0 shadow-sm transition-opacity group-hover:opacity-100">
+                    Favorites
+                  </span>
+                </div>
+              )}
             </div>
           </motion.div>
         )}
@@ -1019,7 +1045,10 @@ export function ProjectSidebar({
           </div>
 
           {isSignedIn && cloudSyncEnabled && (
-            <section className="relative z-10 flex-none border-y border-border-subtle">
+            <section
+              ref={favoritesSectionRef}
+              className="relative z-10 flex-none border-y border-border-subtle"
+            >
               <div className="flex items-center gap-2 px-4 py-3 text-sm text-content-secondary">
                 <PiPushPin className="h-4 w-4" aria-hidden="true" />
                 <h2 className="font-aeonik font-medium">Favorites</h2>

--- a/src/components/project/project-sidebar.tsx
+++ b/src/components/project/project-sidebar.tsx
@@ -329,10 +329,8 @@ export function ProjectSidebar({
   const { handleDocumentUpload: processDocument, isDocumentUploading } =
     useDocumentUploader()
   const [settingsExpanded, setSettingsExpanded] = useState(false)
-  const [isFavoritesExpanded, setIsFavoritesExpanded] = useState(() => {
-    if (typeof window === 'undefined') return true
-    return sessionStorage.getItem(UI_SIDEBAR_FAVORITES_EXPANDED) !== 'false'
-  })
+  const [isFavoritesExpanded, setIsFavoritesExpanded] = useState(true)
+  const hasLoadedFavoritesExpandedRef = useRef(false)
   const [documentsExpanded, setDocumentsExpanded] = useState(false)
   const [memoryExpanded, setMemoryExpanded] = useState(false)
   const [memoryText, setMemoryText] = useState('')
@@ -411,6 +409,12 @@ export function ProjectSidebar({
 
   // Expand documents section when signal is set (from file upload to project context)
   useEffect(() => {
+    if (!hasLoadedFavoritesExpandedRef.current) {
+      hasLoadedFavoritesExpandedRef.current = true
+      const stored = sessionStorage.getItem(UI_SIDEBAR_FAVORITES_EXPANDED)
+      if (stored !== null) setIsFavoritesExpanded(stored === 'true')
+      return
+    }
     sessionStorage.setItem(
       UI_SIDEBAR_FAVORITES_EXPANDED,
       isFavoritesExpanded ? 'true' : 'false',

--- a/src/components/project/project-sidebar.tsx
+++ b/src/components/project/project-sidebar.tsx
@@ -1141,6 +1141,7 @@ export function ProjectSidebar({
                         onDeleteChat={handleDeleteChat}
                         pinnedChatIds={pinnedChatIds}
                         showPinnedIndicators={false}
+                        showDesktopPinActions={false}
                         onTogglePin={onToggleFavorite}
                       />
                     ) : (

--- a/src/constants/auth-events.ts
+++ b/src/constants/auth-events.ts
@@ -1,1 +1,2 @@
 export const ACCOUNT_RESET_FAILED_EVENT = 'tinfoil:account-reset-failed'
+export const AUTH_ACTIVE_USER_CHANGED_EVENT = 'tinfoil:active-user-changed'

--- a/src/constants/settings-events.ts
+++ b/src/constants/settings-events.ts
@@ -1,2 +1,3 @@
 export const PIXELATE_SIDEBAR_CHAT_TITLES_CHANGED_EVENT =
   'pixelateSidebarChatTitlesChanged'
+export const PINNED_CHAT_IDS_CHANGED_EVENT = 'pinnedChatIdsChanged'

--- a/src/constants/storage-keys.ts
+++ b/src/constants/storage-keys.ts
@@ -171,6 +171,8 @@ export const UI_SIDEBAR_PROJECTS_EXPANDED =
   'tinfoil-ui-sidebar-projects-expanded'
 export const UI_SIDEBAR_CHAT_HISTORY_EXPANDED =
   'tinfoil-ui-sidebar-chat-history-expanded'
+export const UI_SIDEBAR_FAVORITES_EXPANDED =
+  'tinfoil-ui-sidebar-favorites-expanded'
 export const UI_SIDEBAR_EXPAND_SECTION = 'tinfoil-ui-sidebar-expand-section'
 export const UI_EXPAND_PROJECTS_ON_MOUNT = 'tinfoil-ui-expand-projects-on-mount'
 export const UI_EXPAND_PROJECT_DOCUMENTS = 'tinfoil-ui-expand-project-documents'

--- a/src/constants/storage-keys.ts
+++ b/src/constants/storage-keys.ts
@@ -115,6 +115,7 @@ export const USER_PREFS_CUSTOM_PROMPT_PRESETS =
   'tinfoil-user-prefs-custom-prompt-presets'
 export const USER_PREFS_FAVORITE_PROMPT_PRESETS =
   'tinfoil-user-prefs-favorite-prompt-presets'
+export const USER_PREFS_PINNED_CHAT_IDS = 'tinfoil-user-prefs-pinned-chat-ids'
 export const USER_PREFS_NATIVE_APP_DISMISSED =
   'tinfoil-user-prefs-native-app-dismissed'
 

--- a/src/hooks/use-lossless-profile-sync.ts
+++ b/src/hooks/use-lossless-profile-sync.ts
@@ -1,5 +1,8 @@
 import { CLOUD_SYNC } from '@/config'
-import { PIXELATE_SIDEBAR_CHAT_TITLES_CHANGED_EVENT } from '@/constants/settings-events'
+import {
+  PINNED_CHAT_IDS_CHANGED_EVENT,
+  PIXELATE_SIDEBAR_CHAT_TITLES_CHANGED_EVENT,
+} from '@/constants/settings-events'
 import {
   SYNC_PROFILE_CHANGED_AT,
   SYNC_PROFILE_DIRTY,
@@ -181,7 +184,14 @@ export function useProfileSync() {
             saveLocalProfileMetadata(userId, remoteBaseline)
             saveProfileBaseline(userId, remoteBaseline)
             baseline = remoteBaseline
-            clearLocalProfileChanged()
+            if (
+              remoteBaseline.pinnedChatIds === undefined &&
+              loadLocalSettings().pinnedChatIds !== undefined
+            ) {
+              markLocalProfileChanged()
+            } else {
+              clearLocalProfileChanged()
+            }
           }
         } else {
           const remoteStatus = await profileSync.getSyncStatus()
@@ -346,6 +356,7 @@ export function useProfileSync() {
       'languageChanged',
       'customSystemPromptChanged',
       'promptLibraryChanged',
+      PINNED_CHAT_IDS_CHANGED_EVENT,
       'reasoningSettingsChanged',
       'webSearchEnabledChanged',
       'webSearchAvailableChanged',

--- a/src/hooks/use-lossless-profile-sync.ts
+++ b/src/hooks/use-lossless-profile-sync.ts
@@ -4,6 +4,7 @@ import {
   PIXELATE_SIDEBAR_CHAT_TITLES_CHANGED_EVENT,
 } from '@/constants/settings-events'
 import {
+  AUTH_ACTIVE_USER_ID,
   SYNC_PROFILE_CHANGED_AT,
   SYNC_PROFILE_DIRTY,
 } from '@/constants/storage-keys'
@@ -13,6 +14,7 @@ import {
   changedProfileFields,
   isProfilePopulated,
   mergeProfilesThreeWay,
+  overlayProfileChanges,
 } from '@/services/cloud/profile-merge'
 import {
   applySettingsToLocal,
@@ -30,6 +32,7 @@ import {
   saveLocalProfileMetadata,
   saveProfileBaseline,
 } from '@/services/cloud/profile-sync-state'
+import { normalizePinnedChatIds } from '@/services/storage/pinned-chats'
 import {
   CLOUD_SYNC_SETTING_CHANGED_EVENT,
   isCloudSyncEnabled,
@@ -43,14 +46,21 @@ function clocksEqual(a?: EditClock, b?: EditClock): boolean {
 }
 
 function normalizeRemoteBaseline(profile: ProfileData): ProfileData {
-  if (profile.isDarkMode !== undefined || !profile.themeMode) {
-    return profile
+  let normalized = profile
+  if (profile.pinnedChatIds !== undefined) {
+    normalized = {
+      ...normalized,
+      pinnedChatIds: normalizePinnedChatIds(profile.pinnedChatIds),
+    }
   }
-  const isDarkMode =
-    profile.themeMode === 'system'
-      ? window.matchMedia('(prefers-color-scheme: dark)').matches
-      : profile.themeMode === 'dark'
-  return { ...profile, isDarkMode }
+  if (profile.isDarkMode === undefined && profile.themeMode) {
+    const isDarkMode =
+      profile.themeMode === 'system'
+        ? window.matchMedia('(prefers-color-scheme: dark)').matches
+        : profile.themeMode === 'dark'
+    normalized = { ...normalized, isDarkMode }
+  }
+  return normalized
 }
 
 export function useProfileSync() {
@@ -130,6 +140,8 @@ export function useProfileSync() {
 
   const runFullSync = useCallback(async () => {
     if (!isSignedIn || !userId || !isCloudSyncEnabled()) return
+    const activeUserId = localStorage.getItem(AUTH_ACTIVE_USER_ID)
+    if (activeUserId !== null && activeUserId !== userId) return
 
     await runSerializedProfileSync(userId, async (isCurrent) => {
       if (!isCurrent() || !isCloudSyncEnabled()) return
@@ -139,19 +151,31 @@ export function useProfileSync() {
         if (!isCurrent() || !authorizationMode) return
 
         let baseline = loadProfileBaseline(userId)
+        const wasDirtyBeforeFetch = hasLocalProfileChanges()
+        const localBeforeFetch = loadLocalSettings()
+        const remote = await profileSync.fetchProfile()
+        if (!isCurrent()) return
+        const currentActiveUserId = localStorage.getItem(AUTH_ACTIVE_USER_ID)
+        if (currentActiveUserId !== null && currentActiveUserId !== userId)
+          return
+
+        const localAfterFetch = loadLocalSettings()
+        const changesDuringFetch = changedProfileFields(
+          localAfterFetch,
+          localBeforeFetch,
+        )
+        if (changesDuringFetch.length > 0) markLocalProfileChanged()
+
         const storedMetadata = loadLocalProfileMetadata(userId)
         const local = hasLocalProfileChanges()
           ? prepareLocalProfile(userId, baseline)
           : {
-              ...loadLocalSettings(),
+              ...localAfterFetch,
               version: storedMetadata?.version,
               updatedAt: storedMetadata?.updatedAt,
               fieldClocks: storedMetadata?.fieldClocks,
               clockVersion: storedMetadata?.clockVersion,
             }
-
-        const remote = await profileSync.fetchProfile()
-        if (!isCurrent()) return
 
         if (remote) {
           const remoteBaseline = normalizeRemoteBaseline(remote)
@@ -175,10 +199,21 @@ export function useProfileSync() {
             } else {
               clearLocalProfileChanged()
             }
-          } else if (hasLocalProfileChanges()) {
+          } else if (wasDirtyBeforeFetch) {
             throw new Error(
               'Profile has unsynced changes but no safe merge baseline.',
             )
+          } else if (changesDuringFetch.length > 0) {
+            const overlaid = overlayProfileChanges(
+              remoteBaseline,
+              localBeforeFetch,
+              localAfterFetch,
+            ).profile
+            saveProfileBaseline(userId, remoteBaseline)
+            applyProfile(overlaid)
+            saveLocalProfileMetadata(userId, overlaid)
+            markLocalProfileChanged()
+            return
           } else {
             applyProfile(remoteBaseline)
             saveLocalProfileMetadata(userId, remoteBaseline)

--- a/src/hooks/use-lossless-profile-sync.ts
+++ b/src/hooks/use-lossless-profile-sync.ts
@@ -1,4 +1,5 @@
 import { CLOUD_SYNC } from '@/config'
+import { AUTH_ACTIVE_USER_CHANGED_EVENT } from '@/constants/auth-events'
 import {
   PINNED_CHAT_IDS_CHANGED_EVENT,
   PIXELATE_SIDEBAR_CHAT_TITLES_CHANGED_EVENT,
@@ -413,6 +414,22 @@ export function useProfileSync() {
       }
     }
   }, [isSignedIn, markLocalProfileChanged, syncToCloud])
+
+  useEffect(() => {
+    const handleActiveUserChange = () => {
+      void runFullSync()
+    }
+    window.addEventListener(
+      AUTH_ACTIVE_USER_CHANGED_EVENT,
+      handleActiveUserChange,
+    )
+    return () => {
+      window.removeEventListener(
+        AUTH_ACTIVE_USER_CHANGED_EVENT,
+        handleActiveUserChange,
+      )
+    }
+  }, [runFullSync])
 
   return {
     syncFromCloud: runFullSync,

--- a/src/hooks/use-pinned-chats.ts
+++ b/src/hooks/use-pinned-chats.ts
@@ -1,3 +1,4 @@
+import { AUTH_ACTIVE_USER_CHANGED_EVENT } from '@/constants/auth-events'
 import { PINNED_CHAT_IDS_CHANGED_EVENT } from '@/constants/settings-events'
 import {
   AUTH_ACTIVE_USER_ID,
@@ -21,7 +22,7 @@ export function usePinnedChats(accountId?: string | null) {
     if (!accountId) return true
     if (typeof window === 'undefined') return false
     const activeAccountId = localStorage.getItem(AUTH_ACTIVE_USER_ID)
-    return activeAccountId === null || activeAccountId === accountId
+    return activeAccountId === accountId
   }, [accountId])
 
   useEffect(() => {
@@ -33,8 +34,8 @@ export function usePinnedChats(accountId?: string | null) {
     const unsubscribeChats = chatEvents.on((event) => {
       if (!isCurrentAccount()) return
       if (event.reason === 'delete-all') {
-        const current = loadPinnedChatIds()
-        if (current?.length === 0) return
+        const current = loadPinnedChatIds() ?? []
+        if (current.length === 0) return
         savePinnedChatIds([])
         return
       }
@@ -45,11 +46,13 @@ export function usePinnedChats(accountId?: string | null) {
     })
 
     window.addEventListener(PINNED_CHAT_IDS_CHANGED_EVENT, refresh)
+    window.addEventListener(AUTH_ACTIVE_USER_CHANGED_EVENT, refresh)
     window.addEventListener('storage', handleStorage)
     refresh()
     return () => {
       unsubscribeChats()
       window.removeEventListener(PINNED_CHAT_IDS_CHANGED_EVENT, refresh)
+      window.removeEventListener(AUTH_ACTIVE_USER_CHANGED_EVENT, refresh)
       window.removeEventListener('storage', handleStorage)
     }
   }, [isCurrentAccount])

--- a/src/hooks/use-pinned-chats.ts
+++ b/src/hooks/use-pinned-chats.ts
@@ -1,5 +1,8 @@
 import { PINNED_CHAT_IDS_CHANGED_EVENT } from '@/constants/settings-events'
-import { USER_PREFS_PINNED_CHAT_IDS } from '@/constants/storage-keys'
+import {
+  AUTH_ACTIVE_USER_ID,
+  USER_PREFS_PINNED_CHAT_IDS,
+} from '@/constants/storage-keys'
 import { chatEvents } from '@/services/storage/chat-events'
 import {
   addPinnedChatId,
@@ -9,18 +12,29 @@ import {
 } from '@/services/storage/pinned-chats'
 import { useCallback, useEffect, useState } from 'react'
 
-export function usePinnedChats() {
+export function usePinnedChats(accountId?: string | null) {
   const [pinnedChatIds, setPinnedChatIds] = useState<string[]>(
     () => loadPinnedChatIds() ?? [],
   )
 
+  const isCurrentAccount = useCallback(() => {
+    if (!accountId) return true
+    if (typeof window === 'undefined') return false
+    const activeAccountId = localStorage.getItem(AUTH_ACTIVE_USER_ID)
+    return activeAccountId === null || activeAccountId === accountId
+  }, [accountId])
+
   useEffect(() => {
-    const refresh = () => setPinnedChatIds(loadPinnedChatIds() ?? [])
+    const refresh = () =>
+      setPinnedChatIds(isCurrentAccount() ? (loadPinnedChatIds() ?? []) : [])
     const handleStorage = (event: StorageEvent) => {
       if (event.key === USER_PREFS_PINNED_CHAT_IDS) refresh()
     }
     const unsubscribeChats = chatEvents.on((event) => {
+      if (!isCurrentAccount()) return
       if (event.reason === 'delete-all') {
+        const current = loadPinnedChatIds()
+        if (current?.length === 0) return
         savePinnedChatIds([])
         return
       }
@@ -32,28 +46,47 @@ export function usePinnedChats() {
 
     window.addEventListener(PINNED_CHAT_IDS_CHANGED_EVENT, refresh)
     window.addEventListener('storage', handleStorage)
+    refresh()
     return () => {
       unsubscribeChats()
       window.removeEventListener(PINNED_CHAT_IDS_CHANGED_EVENT, refresh)
       window.removeEventListener('storage', handleStorage)
     }
-  }, [])
+  }, [isCurrentAccount])
 
-  const pinChat = useCallback((chatId: string) => {
-    const current = loadPinnedChatIds() ?? []
-    savePinnedChatIds(addPinnedChatId(current, chatId))
-  }, [])
+  const pinChat = useCallback(
+    (chatId: string) => {
+      if (!isCurrentAccount()) return
+      const current = loadPinnedChatIds() ?? []
+      savePinnedChatIds(addPinnedChatId(current, chatId))
+    },
+    [isCurrentAccount],
+  )
 
-  const unpinChat = useCallback((chatId: string) => {
-    const current = loadPinnedChatIds() ?? []
-    savePinnedChatIds(removePinnedChatIds(current, [chatId]))
-  }, [])
+  const unpinChat = useCallback(
+    (chatId: string) => {
+      if (!isCurrentAccount()) return
+      const current = loadPinnedChatIds() ?? []
+      const next = removePinnedChatIds(current, [chatId])
+      if (next.length !== current.length) savePinnedChatIds(next)
+    },
+    [isCurrentAccount],
+  )
 
-  const unpinChats = useCallback((chatIds: readonly string[]) => {
-    const current = loadPinnedChatIds() ?? []
-    const next = removePinnedChatIds(current, chatIds)
-    if (next.length !== current.length) savePinnedChatIds(next)
-  }, [])
+  const unpinChats = useCallback(
+    (chatIds: readonly string[]) => {
+      if (!isCurrentAccount()) return
+      const current = loadPinnedChatIds() ?? []
+      const next = removePinnedChatIds(current, chatIds)
+      if (next.length !== current.length) savePinnedChatIds(next)
+    },
+    [isCurrentAccount],
+  )
 
-  return { pinnedChatIds, pinChat, unpinChat, unpinChats }
+  return {
+    pinnedChatIds: isCurrentAccount() ? pinnedChatIds : [],
+    pinChat,
+    unpinChat,
+    unpinChats,
+  }
 }

--- a/src/hooks/use-pinned-chats.ts
+++ b/src/hooks/use-pinned-chats.ts
@@ -1,0 +1,59 @@
+import { PINNED_CHAT_IDS_CHANGED_EVENT } from '@/constants/settings-events'
+import { USER_PREFS_PINNED_CHAT_IDS } from '@/constants/storage-keys'
+import { chatEvents } from '@/services/storage/chat-events'
+import {
+  addPinnedChatId,
+  loadPinnedChatIds,
+  removePinnedChatIds,
+  savePinnedChatIds,
+} from '@/services/storage/pinned-chats'
+import { useCallback, useEffect, useState } from 'react'
+
+export function usePinnedChats() {
+  const [pinnedChatIds, setPinnedChatIds] = useState<string[]>(
+    () => loadPinnedChatIds() ?? [],
+  )
+
+  useEffect(() => {
+    const refresh = () => setPinnedChatIds(loadPinnedChatIds() ?? [])
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key === USER_PREFS_PINNED_CHAT_IDS) refresh()
+    }
+    const unsubscribeChats = chatEvents.on((event) => {
+      if (event.reason === 'delete-all') {
+        savePinnedChatIds([])
+        return
+      }
+      if (event.reason !== 'delete' || !event.ids?.length) return
+      const current = loadPinnedChatIds() ?? []
+      const next = removePinnedChatIds(current, event.ids)
+      if (next.length !== current.length) savePinnedChatIds(next)
+    })
+
+    window.addEventListener(PINNED_CHAT_IDS_CHANGED_EVENT, refresh)
+    window.addEventListener('storage', handleStorage)
+    return () => {
+      unsubscribeChats()
+      window.removeEventListener(PINNED_CHAT_IDS_CHANGED_EVENT, refresh)
+      window.removeEventListener('storage', handleStorage)
+    }
+  }, [])
+
+  const pinChat = useCallback((chatId: string) => {
+    const current = loadPinnedChatIds() ?? []
+    savePinnedChatIds(addPinnedChatId(current, chatId))
+  }, [])
+
+  const unpinChat = useCallback((chatId: string) => {
+    const current = loadPinnedChatIds() ?? []
+    savePinnedChatIds(removePinnedChatIds(current, [chatId]))
+  }, [])
+
+  const unpinChats = useCallback((chatIds: readonly string[]) => {
+    const current = loadPinnedChatIds() ?? []
+    const next = removePinnedChatIds(current, chatIds)
+    if (next.length !== current.length) savePinnedChatIds(next)
+  }, [])
+
+  return { pinnedChatIds, pinChat, unpinChat, unpinChats }
+}

--- a/src/services/cloud/profile-merge.ts
+++ b/src/services/cloud/profile-merge.ts
@@ -73,6 +73,25 @@ export function changedProfileFields(
   return changed
 }
 
+export function overlayProfileChanges(
+  remote: ProfileData,
+  before: ProfileData,
+  after: ProfileData,
+): { profile: ProfileData; changedFields: string[] } {
+  const profile = { ...remote }
+  const changedFields = changedProfileFields(after, before)
+  for (const field of changedFields) {
+    if (Object.prototype.hasOwnProperty.call(after, field)) {
+      ;(profile as Record<string, unknown>)[field] = (
+        after as Record<string, unknown>
+      )[field]
+    } else {
+      delete (profile as Record<string, unknown>)[field]
+    }
+  }
+  return { profile, changedFields }
+}
+
 function nonEmptyString(value: unknown): boolean {
   return typeof value === 'string' && value.trim().length > 0
 }
@@ -149,6 +168,14 @@ export function mergeProfilesThreeWay(args: {
     const remoteValue = (remote as Record<string, unknown>)[field]
     const lc = fieldClock(local, field, localTrusted)
     const rc = fieldClock(remote, field, remoteTrusted)
+
+    if (
+      !Object.prototype.hasOwnProperty.call(remote, field) &&
+      PRESERVE_LOCAL_WHEN_REMOTE_OMITS.has(field)
+    ) {
+      if (lc) mergedClocks[field] = lc
+      continue
+    }
 
     if (valuesEqual(localValue, baselineValue)) {
       if (Object.prototype.hasOwnProperty.call(remote, field)) {

--- a/src/services/cloud/profile-merge.ts
+++ b/src/services/cloud/profile-merge.ts
@@ -20,6 +20,7 @@ export const PROFILE_MERGE_FIELDS = [
   'customSystemPrompt',
   'customPromptPresets',
   'favoritePromptPresetIds',
+  'pinnedChatIds',
   'reasoningEffort',
   'thinkingEnabled',
   'webSearchEnabled',
@@ -34,7 +35,7 @@ export const PROFILE_MERGE_FIELDS = [
 // Older clients omit this field, while the setting itself has no unset state.
 const PRESERVE_LOCAL_WHEN_REMOTE_OMITS = new Set<
   (typeof PROFILE_MERGE_FIELDS)[number]
->(['pixelateSidebarChatTitlesEnabled'])
+>(['pixelateSidebarChatTitlesEnabled', 'pinnedChatIds'])
 
 // A blob's field clocks are trustworthy only when they were maintained
 // at the row's current server version. If a clock-unaware client wrote
@@ -94,7 +95,8 @@ export function isProfilePopulated(p: ProfileData | null | undefined): boolean {
     nonEmptyString(p.customSystemPrompt) ||
     nonEmptyArray(p.traits) ||
     nonEmptyArray(p.customPromptPresets) ||
-    nonEmptyArray(p.favoritePromptPresetIds)
+    nonEmptyArray(p.favoritePromptPresetIds) ||
+    nonEmptyArray(p.pinnedChatIds)
   )
 }
 

--- a/src/services/cloud/profile-merge.ts
+++ b/src/services/cloud/profile-merge.ts
@@ -182,8 +182,6 @@ export function mergeProfilesThreeWay(args: {
         ;(merged as Record<string, unknown>)[field] = remoteValue
         if (rc) mergedClocks[field] = rc
         adoptedRemote ||= !valuesEqual(localValue, remoteValue)
-      } else if (PRESERVE_LOCAL_WHEN_REMOTE_OMITS.has(field)) {
-        if (lc) mergedClocks[field] = lc
       } else {
         delete (merged as Record<string, unknown>)[field]
       }

--- a/src/services/cloud/profile-settings-serializer.ts
+++ b/src/services/cloud/profile-settings-serializer.ts
@@ -1,4 +1,7 @@
-import { PIXELATE_SIDEBAR_CHAT_TITLES_CHANGED_EVENT } from '@/constants/settings-events'
+import {
+  PINNED_CHAT_IDS_CHANGED_EVENT,
+  PIXELATE_SIDEBAR_CHAT_TITLES_CHANGED_EVENT,
+} from '@/constants/settings-events'
 import {
   SETTINGS_CHAT_FONT,
   SETTINGS_CODE_EXECUTION_ENABLED,
@@ -19,6 +22,7 @@ import {
   USER_PREFS_LANGUAGE,
   USER_PREFS_NICKNAME,
   USER_PREFS_PERSONALIZATION_ENABLED,
+  USER_PREFS_PINNED_CHAT_IDS,
   USER_PREFS_PROFESSION,
   USER_PREFS_TRAITS,
 } from '@/constants/storage-keys'
@@ -27,6 +31,10 @@ import type {
   ProfilePromptPreset,
 } from '@/services/cloud/profile-sync'
 import { logWarning } from '@/utils/error-handling'
+import {
+  loadPinnedChatIds,
+  normalizePinnedChatIds,
+} from '../storage/pinned-chats'
 import { ProfileDataSchema } from './schemas'
 
 const DEFAULT_PROFILE_LANGUAGE = 'English'
@@ -87,6 +95,8 @@ export function hasProfileChanged(
       JSON.stringify(profile2.customPromptPresets) ||
     JSON.stringify(profile1.favoritePromptPresetIds) !==
       JSON.stringify(profile2.favoritePromptPresetIds) ||
+    JSON.stringify(profile1.pinnedChatIds) !==
+      JSON.stringify(profile2.pinnedChatIds) ||
     profile1.reasoningEffort !== profile2.reasoningEffort ||
     profile1.thinkingEnabled !== profile2.thinkingEnabled ||
     profile1.webSearchEnabled !== profile2.webSearchEnabled ||
@@ -182,6 +192,14 @@ export function loadLocalSettings(): ProfileData {
     )
   }
 
+  const pinnedChatIds = localStorage.getItem(USER_PREFS_PINNED_CHAT_IDS)
+  if (pinnedChatIds !== null) {
+    const loadedPinnedChatIds = loadPinnedChatIds()
+    if (loadedPinnedChatIds !== undefined) {
+      settings.pinnedChatIds = loadedPinnedChatIds
+    }
+  }
+
   const reasoningEffort = localStorage.getItem(SETTINGS_REASONING_EFFORT)
   if (
     reasoningEffort === 'low' ||
@@ -256,6 +274,7 @@ export function resetSettingsToLocalDefaults(): ProfileData {
     customSystemPrompt: '',
     customPromptPresets: [],
     favoritePromptPresetIds: [],
+    pinnedChatIds: [],
     reasoningEffort: 'medium',
     thinkingEnabled: true,
     webSearchEnabled: true,
@@ -390,6 +409,20 @@ export function applySettingsToLocal(settings: ProfileData): void {
       JSON.stringify(settings.favoritePromptPresetIds),
     )
     window.dispatchEvent(new CustomEvent('promptLibraryChanged'))
+  }
+
+  const validatedPinnedChatIds = validation.data.pinnedChatIds
+  if (validatedPinnedChatIds !== undefined) {
+    const pinnedChatIds = normalizePinnedChatIds(validatedPinnedChatIds)
+    localStorage.setItem(
+      USER_PREFS_PINNED_CHAT_IDS,
+      JSON.stringify(pinnedChatIds),
+    )
+    window.dispatchEvent(
+      new CustomEvent(PINNED_CHAT_IDS_CHANGED_EVENT, {
+        detail: { pinnedChatIds },
+      }),
+    )
   }
 
   const shouldApplyReasoning =

--- a/src/services/cloud/profile-sync.ts
+++ b/src/services/cloud/profile-sync.ts
@@ -73,6 +73,8 @@ export interface ProfileData {
   customPromptPresets?: ProfilePromptPreset[]
   // Ordered preset ids pinned as homescreen favorites (built-in or custom)
   favoritePromptPresetIds?: string[]
+  // Ordered durable chat ids pinned as favorites, newest first
+  pinnedChatIds?: string[]
 
   // Shared chat defaults
   reasoningEffort?: 'low' | 'medium' | 'high'

--- a/src/services/cloud/schemas.ts
+++ b/src/services/cloud/schemas.ts
@@ -143,6 +143,7 @@ export const ProfileDataSchema = z
       )
       .optional(),
     favoritePromptPresetIds: z.array(z.string()).optional(),
+    pinnedChatIds: z.array(z.string()).optional().catch(undefined),
     reasoningEffort: z.enum(['low', 'medium', 'high']).optional(),
     thinkingEnabled: z.boolean().optional(),
     webSearchEnabled: z.boolean().optional(),

--- a/src/services/storage/chat-events.ts
+++ b/src/services/storage/chat-events.ts
@@ -1,7 +1,7 @@
 import { logError } from '@/utils/error-handling'
 
 export type ChatChangeReason =
-  'save' | 'delete' | 'sync' | 'pagination' | 'recovery'
+  'save' | 'delete' | 'delete-all' | 'sync' | 'pagination' | 'recovery'
 
 export interface ChatIdChange {
   from: string

--- a/src/services/storage/chat-storage.ts
+++ b/src/services/storage/chat-storage.ts
@@ -174,11 +174,12 @@ export class ChatStorageService {
             id,
             idempotencyKey,
             userId,
-            // A never-synced chat with an in-flight create push still
-            // needs a durable delete intent: the push can commit after
-            // the local row is gone, and without the intent the chat
-            // would resurrect on the next event replay.
-            { forceQueue: cloudSync.hasPendingUpload(id) },
+            // Memory-only remote chats have no local row, while a create
+            // push can outlive its row. Both need a durable delete intent
+            // so event replay cannot resurrect them.
+            {
+              forceQueue: !existingChat || cloudSync.hasPendingUpload(id),
+            },
           )
         : false
     if (!idempotencyKey) {
@@ -200,6 +201,10 @@ export class ChatStorageService {
   }
 
   async deleteChatsByProject(projectId: string): Promise<number> {
+    return (await this.deleteChatsByProjectWithIds(projectId)).length
+  }
+
+  async deleteChatsByProjectWithIds(projectId: string): Promise<string[]> {
     const guard = cloudSync.createAccountOperationGuard()
     const userId = guard.userId
     if (!userId) {
@@ -256,7 +261,7 @@ export class ChatStorageService {
         metadata: { projectId, count: deletedIds.length },
       })
 
-      return deletedIds.length
+      return deletedIds
     })
   }
 
@@ -326,7 +331,7 @@ export class ChatStorageService {
     }
 
     const localDeleted = await indexedDBStorage.deleteAllChats()
-    chatEvents.emit({ reason: 'delete', ids: [] })
+    chatEvents.emit({ reason: 'delete-all' })
 
     logInfo('Deleted all chats', {
       component: 'ChatStorageService',

--- a/src/services/storage/indexed-db.ts
+++ b/src/services/storage/indexed-db.ts
@@ -3218,11 +3218,9 @@ export class IndexedDBStorage {
     userId: string,
     options: {
       /**
-       * Queue the delete intent even for a never-synced chat. Used
-       * when an upload for this chat is in flight: the create push
-       * may commit after the local row is gone, so the remote delete
-       * must still run (after the upload settles) or the chat would
-       * resurrect on the next event replay.
+       * Queue the delete intent even when the local row cannot prove
+       * remote durability. Used for in-flight uploads and memory-only
+       * remote chats so deletion still runs after any upload settles.
        */
       forceQueue?: boolean
     } = {},
@@ -3252,10 +3250,11 @@ export class IndexedDBStorage {
             id,
           )
           if (
-            chat &&
-            !chat.isLocalOnly &&
-            chat.syncUserId === userId &&
-            (options.forceQueue === true || chatKnownToServer(chat))
+            (chat === undefined && options.forceQueue === true) ||
+            (chat !== undefined &&
+              !chat.isLocalOnly &&
+              chat.syncUserId === userId &&
+              (options.forceQueue === true || chatKnownToServer(chat)))
           ) {
             outbox.put(syncDeleteOutboxEntry(id, userId, idempotencyKey))
             queued = true

--- a/src/services/storage/pinned-chat-hydration.ts
+++ b/src/services/storage/pinned-chat-hydration.ts
@@ -1,0 +1,49 @@
+import type { Chat } from '@/components/chat/types'
+import { cloudStorage } from '@/services/cloud/cloud-storage'
+import type { StoredChat } from './indexed-db'
+
+export type PinnedChatHydrationResult =
+  { status: 'ready'; chat: Chat } | { status: 'invalid' | 'unavailable' }
+
+interface PinnedChatHydrationDependencies {
+  downloadChat: (chatId: string) => Promise<StoredChat | null>
+}
+
+const defaultDependencies: PinnedChatHydrationDependencies = {
+  downloadChat: (chatId) => cloudStorage.downloadChat(chatId),
+}
+
+function isInvalidFavoriteChat(
+  chat: Pick<
+    Chat,
+    'isBlankChat' | 'isTemporary' | 'isLocalOnly' | 'dataCorrupted'
+  >,
+): boolean {
+  return Boolean(
+    chat.isBlankChat ||
+    chat.isTemporary ||
+    chat.isLocalOnly ||
+    chat.dataCorrupted,
+  )
+}
+
+function downloadedToChat(chat: StoredChat): Chat {
+  return { ...chat, createdAt: new Date(chat.createdAt) }
+}
+
+function classifyDownloadedChat(chat: StoredChat): PinnedChatHydrationResult {
+  if (isInvalidFavoriteChat(chat)) {
+    return { status: 'invalid' }
+  }
+  if (chat.decryptionFailed) return { status: 'unavailable' }
+  return { status: 'ready', chat: downloadedToChat(chat) }
+}
+
+export async function hydratePinnedChatById(
+  chatId: string,
+  dependencies: PinnedChatHydrationDependencies = defaultDependencies,
+): Promise<PinnedChatHydrationResult> {
+  const downloaded = await dependencies.downloadChat(chatId)
+  if (!downloaded) return { status: 'unavailable' }
+  return classifyDownloadedChat(downloaded)
+}

--- a/src/services/storage/pinned-chats.ts
+++ b/src/services/storage/pinned-chats.ts
@@ -1,0 +1,94 @@
+import { PINNED_CHAT_IDS_CHANGED_EVENT } from '@/constants/settings-events'
+import { USER_PREFS_PINNED_CHAT_IDS } from '@/constants/storage-keys'
+
+export const MAX_PINNED_CHATS = 20
+
+interface FavoriteChatState {
+  id: string
+  isBlankChat?: boolean
+  isTemporary?: boolean
+  isLocalOnly?: boolean
+  decryptionFailed?: boolean
+  dataCorrupted?: boolean
+  pendingSave?: boolean
+}
+
+export function canRequestChatPin(chat: FavoriteChatState): boolean {
+  return Boolean(
+    chat.id.trim().length > 0 &&
+    !chat.isBlankChat &&
+    !chat.isTemporary &&
+    !chat.decryptionFailed &&
+    !chat.dataCorrupted &&
+    !chat.pendingSave,
+  )
+}
+
+export function isResolvedFavoriteChat(chat: FavoriteChatState): boolean {
+  return Boolean(
+    chat.id.trim().length > 0 &&
+    !chat.isBlankChat &&
+    !chat.isTemporary &&
+    !chat.isLocalOnly &&
+    !chat.decryptionFailed &&
+    !chat.dataCorrupted,
+  )
+}
+
+export function normalizePinnedChatIds(value: unknown): string[] {
+  if (!Array.isArray(value)) return []
+
+  const seen = new Set<string>()
+  const ids: string[] = []
+  for (const valueId of value) {
+    if (
+      typeof valueId !== 'string' ||
+      valueId.trim().length === 0 ||
+      seen.has(valueId)
+    ) {
+      continue
+    }
+    seen.add(valueId)
+    ids.push(valueId)
+    if (ids.length === MAX_PINNED_CHATS) break
+  }
+  return ids
+}
+
+export function loadPinnedChatIds(): string[] | undefined {
+  if (typeof window === 'undefined') return undefined
+  const stored = localStorage.getItem(USER_PREFS_PINNED_CHAT_IDS)
+  if (stored === null) return undefined
+  try {
+    const parsed: unknown = JSON.parse(stored)
+    return Array.isArray(parsed) ? normalizePinnedChatIds(parsed) : undefined
+  } catch {
+    return undefined
+  }
+}
+
+export function savePinnedChatIds(pinnedChatIds: readonly string[]): string[] {
+  const normalized = normalizePinnedChatIds(pinnedChatIds)
+  localStorage.setItem(USER_PREFS_PINNED_CHAT_IDS, JSON.stringify(normalized))
+  window.dispatchEvent(
+    new CustomEvent(PINNED_CHAT_IDS_CHANGED_EVENT, {
+      detail: { pinnedChatIds: normalized },
+    }),
+  )
+  return normalized
+}
+
+export function addPinnedChatId(
+  pinnedChatIds: readonly string[],
+  chatId: string,
+): string[] {
+  return normalizePinnedChatIds([chatId, ...pinnedChatIds])
+}
+
+export function removePinnedChatIds(
+  pinnedChatIds: readonly string[],
+  chatIds: readonly string[],
+): string[] {
+  const removed = new Set(chatIds)
+  return normalizePinnedChatIds(pinnedChatIds.filter((id) => !removed.has(id)))
+}

--- a/src/services/storage/pinned-chats.ts
+++ b/src/services/storage/pinned-chats.ts
@@ -41,15 +41,13 @@ export function normalizePinnedChatIds(value: unknown): string[] {
   const seen = new Set<string>()
   const ids: string[] = []
   for (const valueId of value) {
-    if (
-      typeof valueId !== 'string' ||
-      valueId.trim().length === 0 ||
-      seen.has(valueId)
-    ) {
+    if (typeof valueId !== 'string') {
       continue
     }
-    seen.add(valueId)
-    ids.push(valueId)
+    const id = valueId.trim()
+    if (id.length === 0 || seen.has(id)) continue
+    seen.add(id)
+    ids.push(id)
     if (ids.length === MAX_PINNED_CHATS) break
   }
   return ids

--- a/tests/components/chat/chat-list-item.test.tsx
+++ b/tests/components/chat/chat-list-item.test.tsx
@@ -101,9 +101,30 @@ describe('ChatListItem favorites', () => {
     expect(onTogglePin).toHaveBeenCalledOnce()
   })
 
-  it('does not offer pinning for temporary or pending chats', () => {
+  it('does not offer pinning for temporary chats', () => {
     renderChatListItem({
       chat: { ...savedChat, isTemporary: true },
+      onTogglePin: vi.fn(),
+    })
+    expect(
+      screen.queryByRole('button', { name: 'Pin to Favorites' }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('only offers unpinning while a chat save is pending', () => {
+    renderChatListItem({
+      chat: { ...savedChat, pendingSave: true },
+      isPinned: true,
+      onTogglePin: vi.fn(),
+    })
+    expect(
+      screen.getByRole('button', { name: 'Remove from Favorites' }),
+    ).toBeInTheDocument()
+  })
+
+  it('does not offer pinning while a chat save is pending', () => {
+    renderChatListItem({
+      chat: { ...savedChat, pendingSave: true },
       onTogglePin: vi.fn(),
     })
     expect(

--- a/tests/components/chat/chat-list-item.test.tsx
+++ b/tests/components/chat/chat-list-item.test.tsx
@@ -21,6 +21,7 @@ function renderChatListItem({
   isStreaming = false,
   isPinned = false,
   showPinnedIndicator = true,
+  showDesktopPinAction = true,
   onTogglePin,
 }: {
   href?: string
@@ -32,6 +33,7 @@ function renderChatListItem({
   isStreaming?: boolean
   isPinned?: boolean
   showPinnedIndicator?: boolean
+  showDesktopPinAction?: boolean
   onTogglePin?: () => void
 } = {}) {
   const renderItem = (item: ChatItemData, streaming: boolean) => (
@@ -47,6 +49,7 @@ function renderChatListItem({
       isStreaming={streaming}
       isPinned={isPinned}
       showPinnedIndicator={showPinnedIndicator}
+      showDesktopPinAction={showDesktopPinAction}
       onTogglePin={onTogglePin}
       onSelect={onSelect}
       onStartEdit={vi.fn()}
@@ -104,17 +107,18 @@ describe('ChatListItem favorites', () => {
     expect(onTogglePin).toHaveBeenCalledOnce()
   })
 
-  it('can hide the pinned marker while retaining the unpin action', () => {
+  it('can hide pin controls next to a favorite title', () => {
     renderChatListItem({
       isPinned: true,
       showPinnedIndicator: false,
+      showDesktopPinAction: false,
       onTogglePin: vi.fn(),
     })
 
     expect(screen.queryByLabelText('Pinned to Favorites')).toBeNull()
     expect(
-      screen.getByRole('button', { name: 'Remove from Favorites' }),
-    ).toBeInTheDocument()
+      screen.queryByRole('button', { name: 'Remove from Favorites' }),
+    ).toBeNull()
   })
 
   it('does not offer pinning for temporary chats', () => {

--- a/tests/components/chat/chat-list-item.test.tsx
+++ b/tests/components/chat/chat-list-item.test.tsx
@@ -121,6 +121,19 @@ describe('ChatListItem favorites', () => {
     ).toBeNull()
   })
 
+  it('can hide only the pinned marker', () => {
+    renderChatListItem({
+      isPinned: true,
+      showPinnedIndicator: false,
+      onTogglePin: vi.fn(),
+    })
+
+    expect(screen.queryByLabelText('Pinned to Favorites')).toBeNull()
+    expect(
+      screen.getByRole('button', { name: 'Remove from Favorites' }),
+    ).toBeInTheDocument()
+  })
+
   it('does not offer pinning for temporary chats', () => {
     renderChatListItem({
       chat: { ...savedChat, isTemporary: true },

--- a/tests/components/chat/chat-list-item.test.tsx
+++ b/tests/components/chat/chat-list-item.test.tsx
@@ -20,6 +20,7 @@ function renderChatListItem({
   enableTitleAnimation = false,
   isStreaming = false,
   isPinned = false,
+  showPinnedIndicator = true,
   onTogglePin,
 }: {
   href?: string
@@ -30,6 +31,7 @@ function renderChatListItem({
   enableTitleAnimation?: boolean
   isStreaming?: boolean
   isPinned?: boolean
+  showPinnedIndicator?: boolean
   onTogglePin?: () => void
 } = {}) {
   const renderItem = (item: ChatItemData, streaming: boolean) => (
@@ -44,6 +46,7 @@ function renderChatListItem({
       enableTitleAnimation={enableTitleAnimation}
       isStreaming={streaming}
       isPinned={isPinned}
+      showPinnedIndicator={showPinnedIndicator}
       onTogglePin={onTogglePin}
       onSelect={onSelect}
       onStartEdit={vi.fn()}
@@ -99,6 +102,19 @@ describe('ChatListItem favorites', () => {
       screen.getByRole('button', { name: 'Remove from Favorites' }),
     )
     expect(onTogglePin).toHaveBeenCalledOnce()
+  })
+
+  it('can hide the pinned marker while retaining the unpin action', () => {
+    renderChatListItem({
+      isPinned: true,
+      showPinnedIndicator: false,
+      onTogglePin: vi.fn(),
+    })
+
+    expect(screen.queryByLabelText('Pinned to Favorites')).toBeNull()
+    expect(
+      screen.getByRole('button', { name: 'Remove from Favorites' }),
+    ).toBeInTheDocument()
   })
 
   it('does not offer pinning for temporary chats', () => {

--- a/tests/components/chat/chat-list-item.test.tsx
+++ b/tests/components/chat/chat-list-item.test.tsx
@@ -19,6 +19,8 @@ function renderChatListItem({
   pixelateSidebarChatTitles = true,
   enableTitleAnimation = false,
   isStreaming = false,
+  isPinned = false,
+  onTogglePin,
 }: {
   href?: string
   onSelect?: () => void
@@ -27,6 +29,8 @@ function renderChatListItem({
   pixelateSidebarChatTitles?: boolean
   enableTitleAnimation?: boolean
   isStreaming?: boolean
+  isPinned?: boolean
+  onTogglePin?: () => void
 } = {}) {
   const renderItem = (item: ChatItemData, streaming: boolean) => (
     <ChatListItem
@@ -39,6 +43,8 @@ function renderChatListItem({
       pixelateSidebarChatTitles={pixelateSidebarChatTitles}
       enableTitleAnimation={enableTitleAnimation}
       isStreaming={streaming}
+      isPinned={isPinned}
+      onTogglePin={onTogglePin}
       onSelect={onSelect}
       onStartEdit={vi.fn()}
       onTitleChange={vi.fn()}
@@ -80,6 +86,49 @@ describe('ChatListItem navigation semantics', () => {
     fireEvent.click(screen.getByRole('button', { name: /Trip planning/ }))
     expect(onSelect).toHaveBeenCalledOnce()
     expect(screen.queryByRole('link')).not.toBeInTheDocument()
+  })
+})
+
+describe('ChatListItem favorites', () => {
+  it('shows pinned state and removes a favorite from the desktop action', () => {
+    const onTogglePin = vi.fn()
+    renderChatListItem({ isPinned: true, onTogglePin })
+
+    expect(screen.getByLabelText('Pinned to Favorites')).toBeInTheDocument()
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Remove from Favorites' }),
+    )
+    expect(onTogglePin).toHaveBeenCalledOnce()
+  })
+
+  it('does not offer pinning for temporary or pending chats', () => {
+    renderChatListItem({
+      chat: { ...savedChat, isTemporary: true },
+      onTogglePin: vi.fn(),
+    })
+    expect(
+      screen.queryByRole('button', { name: 'Pin to Favorites' }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('does not offer pinning for corrupted chats', () => {
+    renderChatListItem({
+      chat: { ...savedChat, dataCorrupted: true },
+      onTogglePin: vi.fn(),
+    })
+    expect(
+      screen.queryByRole('button', { name: 'Pin to Favorites' }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('offers the favorite action in the mobile menu', () => {
+    const onTogglePin = vi.fn()
+    renderChatListItem({ onTogglePin })
+
+    fireEvent.click(screen.getByRole('button', { name: 'More chat options' }))
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Pin to Favorites' }))
+
+    expect(onTogglePin).toHaveBeenCalledOnce()
   })
 })
 

--- a/tests/components/chat/favorite-navigation.test.ts
+++ b/tests/components/chat/favorite-navigation.test.ts
@@ -1,0 +1,92 @@
+import { openFavoriteChat } from '@/components/chat/favorite-navigation'
+import { describe, expect, it, vi } from 'vitest'
+
+describe('openFavoriteChat', () => {
+  it('enters project context before opening the chat', async () => {
+    const calls: string[] = []
+
+    const opened = await openFavoriteChat({
+      favorite: { id: 'chat-a', projectId: 'project-a' },
+      isProjectMode: false,
+      enterProjectMode: async () => {
+        calls.push('project')
+        return true
+      },
+      exitProjectMode: vi.fn(),
+      openChat: async () => {
+        calls.push('chat')
+      },
+      isCurrent: () => true,
+    })
+
+    expect(opened).toBe(true)
+    expect(calls).toEqual(['project', 'chat'])
+  })
+
+  it('does not open after project failure or superseded navigation', async () => {
+    const openChat = vi.fn(async () => {})
+    const failed = await openFavoriteChat({
+      favorite: { id: 'chat-a', projectId: 'project-a' },
+      isProjectMode: false,
+      enterProjectMode: async () => false,
+      exitProjectMode: vi.fn(),
+      openChat,
+      isCurrent: () => true,
+    })
+    expect(failed).toBe(false)
+
+    const stale = await openFavoriteChat({
+      favorite: { id: 'chat-b', projectId: 'project-b' },
+      isProjectMode: false,
+      enterProjectMode: async () => true,
+      exitProjectMode: vi.fn(),
+      openChat,
+      isCurrent: () => false,
+    })
+    expect(stale).toBe(false)
+    expect(openChat).not.toHaveBeenCalled()
+  })
+
+  it('reloads context when the project id matches but project mode is inactive', async () => {
+    const enterProjectMode = vi.fn(async () => true)
+
+    await openFavoriteChat({
+      favorite: { id: 'chat-a', projectId: 'project-a' },
+      activeProjectId: 'project-a',
+      isProjectMode: false,
+      enterProjectMode,
+      exitProjectMode: vi.fn(),
+      openChat: vi.fn(async () => {}),
+      isCurrent: () => true,
+    })
+
+    expect(enterProjectMode).toHaveBeenCalledWith(
+      'project-a',
+      expect.any(Function),
+    )
+  })
+
+  it('does not open when normal navigation invalidates a pending favorite', async () => {
+    let resolveProject: ((entered: boolean) => void) | undefined
+    const projectLoad = new Promise<boolean>((resolve) => {
+      resolveProject = resolve
+    })
+    let generation = 0
+    const favoriteGeneration = ++generation
+    const openChat = vi.fn(async () => {})
+    const opening = openFavoriteChat({
+      favorite: { id: 'favorite', projectId: 'project-a' },
+      isProjectMode: false,
+      enterProjectMode: () => projectLoad,
+      exitProjectMode: vi.fn(),
+      openChat,
+      isCurrent: () => generation === favoriteGeneration,
+    })
+
+    generation += 1
+    resolveProject?.(true)
+
+    await expect(opening).resolves.toBe(false)
+    expect(openChat).not.toHaveBeenCalled()
+  })
+})

--- a/tests/components/chat/use-favorite-drop-target.test.tsx
+++ b/tests/components/chat/use-favorite-drop-target.test.tsx
@@ -34,6 +34,7 @@ describe('useFavoriteDropTarget', () => {
     const event = dragEvent('chat-a')
 
     act(() => result.current.favoriteDropTargetProps.onDragOver(event as never))
+    act(() => result.current.favoriteDropTargetProps.onDragOver(event as never))
     expect(event.dataTransfer.dropEffect).toBe('copy')
     expect(result.current.isFavoriteDropTarget).toBe(true)
     expect(onActivate).toHaveBeenCalledOnce()

--- a/tests/components/chat/use-favorite-drop-target.test.tsx
+++ b/tests/components/chat/use-favorite-drop-target.test.tsx
@@ -19,6 +19,7 @@ function dragEvent(chatId: string) {
 describe('useFavoriteDropTarget', () => {
   it('pins a dropped chat and clears drag state', async () => {
     const onToggleFavorite = vi.fn()
+    const onActivate = vi.fn()
     const clearDragState = vi.fn()
     const { result } = renderHook(() =>
       useFavoriteDropTarget({
@@ -26,6 +27,7 @@ describe('useFavoriteDropTarget', () => {
         pinnedChatIds: [],
         draggingChatId: 'chat-a',
         onToggleFavorite,
+        onActivate,
         clearDragState,
       }),
     )
@@ -34,6 +36,7 @@ describe('useFavoriteDropTarget', () => {
     act(() => result.current.favoriteDropTargetProps.onDragOver(event as never))
     expect(event.dataTransfer.dropEffect).toBe('copy')
     expect(result.current.isFavoriteDropTarget).toBe(true)
+    expect(onActivate).toHaveBeenCalledOnce()
 
     await act(async () => {
       result.current.favoriteDropTargetProps.onDrop(event as never)

--- a/tests/components/chat/use-favorite-drop-target.test.tsx
+++ b/tests/components/chat/use-favorite-drop-target.test.tsx
@@ -1,0 +1,95 @@
+import { useFavoriteDropTarget } from '@/components/chat/use-favorite-drop-target'
+import { act, renderHook } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+function dragEvent(chatId: string) {
+  return {
+    preventDefault: vi.fn(),
+    stopPropagation: vi.fn(),
+    relatedTarget: null,
+    currentTarget: document.createElement('div'),
+    dataTransfer: {
+      types: ['application/x-chat-id'],
+      dropEffect: 'move',
+      getData: vi.fn(() => chatId),
+    },
+  }
+}
+
+describe('useFavoriteDropTarget', () => {
+  it('pins a dropped chat and clears drag state', async () => {
+    const onToggleFavorite = vi.fn()
+    const clearDragState = vi.fn()
+    const { result } = renderHook(() =>
+      useFavoriteDropTarget({
+        chats: [{ id: 'chat-a', title: 'Chat A', createdAt: new Date() }],
+        pinnedChatIds: [],
+        draggingChatId: 'chat-a',
+        onToggleFavorite,
+        clearDragState,
+      }),
+    )
+    const event = dragEvent('chat-a')
+
+    act(() => result.current.favoriteDropTargetProps.onDragOver(event as never))
+    expect(event.dataTransfer.dropEffect).toBe('copy')
+    expect(result.current.isFavoriteDropTarget).toBe(true)
+
+    await act(async () => {
+      result.current.favoriteDropTargetProps.onDrop(event as never)
+      await Promise.resolve()
+    })
+
+    expect(onToggleFavorite).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'chat-a' }),
+    )
+    expect(clearDragState).toHaveBeenCalledOnce()
+    expect(result.current.isFavoriteDropTarget).toBe(false)
+  })
+
+  it('does not toggle an already pinned chat', () => {
+    const onToggleFavorite = vi.fn()
+    const clearDragState = vi.fn()
+    const { result } = renderHook(() =>
+      useFavoriteDropTarget({
+        chats: [{ id: 'chat-a', title: 'Chat A', createdAt: new Date() }],
+        pinnedChatIds: ['chat-a'],
+        draggingChatId: 'chat-a',
+        onToggleFavorite,
+        clearDragState,
+      }),
+    )
+
+    act(() =>
+      result.current.favoriteDropTargetProps.onDrop(
+        dragEvent('chat-a') as never,
+      ),
+    )
+
+    expect(onToggleFavorite).not.toHaveBeenCalled()
+    expect(clearDragState).toHaveBeenCalledOnce()
+  })
+
+  it('clears its highlight when dragging ends elsewhere', () => {
+    const { result, rerender } = renderHook(
+      ({ draggingChatId }: { draggingChatId: string | null }) =>
+        useFavoriteDropTarget({
+          chats: [{ id: 'chat-a', title: 'Chat A', createdAt: new Date() }],
+          pinnedChatIds: [],
+          draggingChatId,
+          clearDragState: vi.fn(),
+        }),
+      { initialProps: { draggingChatId: 'chat-a' as string | null } },
+    )
+
+    act(() =>
+      result.current.favoriteDropTargetProps.onDragOver(
+        dragEvent('chat-a') as never,
+      ),
+    )
+    expect(result.current.isFavoriteDropTarget).toBe(true)
+
+    rerender({ draggingChatId: null })
+    expect(result.current.isFavoriteDropTarget).toBe(false)
+  })
+})

--- a/tests/components/chat/use-favorite-drop-target.test.tsx
+++ b/tests/components/chat/use-favorite-drop-target.test.tsx
@@ -34,7 +34,6 @@ describe('useFavoriteDropTarget', () => {
     const event = dragEvent('chat-a')
 
     act(() => result.current.favoriteDropTargetProps.onDragOver(event as never))
-    act(() => result.current.favoriteDropTargetProps.onDragOver(event as never))
     expect(event.dataTransfer.dropEffect).toBe('copy')
     expect(result.current.isFavoriteDropTarget).toBe(true)
     expect(onActivate).toHaveBeenCalledOnce()
@@ -73,6 +72,28 @@ describe('useFavoriteDropTarget', () => {
 
     expect(onToggleFavorite).not.toHaveBeenCalled()
     expect(clearDragState).toHaveBeenCalledOnce()
+  })
+
+  it('activates once while a drag remains over the target', () => {
+    const onActivate = vi.fn()
+    const { result } = renderHook(() =>
+      useFavoriteDropTarget({
+        chats: [{ id: 'chat-a', title: 'Chat A', createdAt: new Date() }],
+        pinnedChatIds: [],
+        draggingChatId: 'chat-a',
+        onToggleFavorite: vi.fn(),
+        onActivate,
+        clearDragState: vi.fn(),
+      }),
+    )
+    const event = dragEvent('chat-a')
+
+    act(() =>
+      result.current.favoriteDropTargetProps.onDragEnter(event as never),
+    )
+    act(() => result.current.favoriteDropTargetProps.onDragOver(event as never))
+
+    expect(onActivate).toHaveBeenCalledOnce()
   })
 
   it('clears its highlight when dragging ends elsewhere', () => {

--- a/tests/components/chat/use-favorite-drop-target.test.tsx
+++ b/tests/components/chat/use-favorite-drop-target.test.tsx
@@ -60,11 +60,12 @@ describe('useFavoriteDropTarget', () => {
       }),
     )
 
-    act(() =>
-      result.current.favoriteDropTargetProps.onDrop(
-        dragEvent('chat-a') as never,
-      ),
-    )
+    const event = dragEvent('chat-a')
+    act(() => result.current.favoriteDropTargetProps.onDragOver(event as never))
+    expect(result.current.isFavoriteDropTarget).toBe(false)
+    expect(event.preventDefault).not.toHaveBeenCalled()
+
+    act(() => result.current.favoriteDropTargetProps.onDrop(event as never))
 
     expect(onToggleFavorite).not.toHaveBeenCalled()
     expect(clearDragState).toHaveBeenCalledOnce()
@@ -77,6 +78,7 @@ describe('useFavoriteDropTarget', () => {
           chats: [{ id: 'chat-a', title: 'Chat A', createdAt: new Date() }],
           pinnedChatIds: [],
           draggingChatId,
+          onToggleFavorite: vi.fn(),
           clearDragState: vi.fn(),
         }),
       { initialProps: { draggingChatId: 'chat-a' as string | null } },
@@ -91,5 +93,36 @@ describe('useFavoriteDropTarget', () => {
 
     rerender({ draggingChatId: null })
     expect(result.current.isFavoriteDropTarget).toBe(false)
+  })
+
+  it('does not highlight for an ineligible chat', () => {
+    const onToggleFavorite = vi.fn()
+    const clearDragState = vi.fn()
+    const { result } = renderHook(() =>
+      useFavoriteDropTarget({
+        chats: [
+          {
+            id: 'chat-a',
+            title: 'Chat A',
+            createdAt: new Date(),
+            isTemporary: true,
+          },
+        ],
+        pinnedChatIds: [],
+        draggingChatId: 'chat-a',
+        onToggleFavorite,
+        clearDragState,
+      }),
+    )
+    const event = dragEvent('chat-a')
+
+    act(() => result.current.favoriteDropTargetProps.onDragOver(event as never))
+
+    expect(result.current.isFavoriteDropTarget).toBe(false)
+    expect(event.preventDefault).not.toHaveBeenCalled()
+
+    act(() => result.current.favoriteDropTargetProps.onDrop(event as never))
+    expect(onToggleFavorite).not.toHaveBeenCalled()
+    expect(clearDragState).toHaveBeenCalledOnce()
   })
 })

--- a/tests/components/project/project-load-validity.test.ts
+++ b/tests/components/project/project-load-validity.test.ts
@@ -1,0 +1,22 @@
+import { canCommitProjectLoad } from '@/components/project/project-load-validity'
+import { describe, expect, it, vi } from 'vitest'
+
+describe('canCommitProjectLoad', () => {
+  it('requires provider and caller generations to remain current', () => {
+    expect(canCommitProjectLoad(2, 2, 'project-a', 'project-a')).toBe(true)
+    expect(canCommitProjectLoad(2, 3, 'project-a', 'project-a')).toBe(false)
+    expect(canCommitProjectLoad(2, 2, 'project-a', 'project-b')).toBe(false)
+    expect(
+      canCommitProjectLoad(2, 2, 'project-a', 'project-a', () => false),
+    ).toBe(false)
+  })
+
+  it('checks caller validity only after provider identity checks pass', () => {
+    const isCurrent = vi.fn(() => true)
+
+    expect(
+      canCommitProjectLoad(1, 2, 'project-a', 'project-a', isCurrent),
+    ).toBe(false)
+    expect(isCurrent).not.toHaveBeenCalled()
+  })
+})

--- a/tests/hooks/use-pinned-chats.test.ts
+++ b/tests/hooks/use-pinned-chats.test.ts
@@ -1,3 +1,4 @@
+import { AUTH_ACTIVE_USER_CHANGED_EVENT } from '@/constants/auth-events'
 import { PINNED_CHAT_IDS_CHANGED_EVENT } from '@/constants/settings-events'
 import {
   AUTH_ACTIVE_USER_ID,
@@ -56,6 +57,21 @@ describe('usePinnedChats', () => {
     act(() => result.current.pinChat('chat-b'))
     expect(localStorage.getItem(AUTH_ACTIVE_USER_ID)).toBe('user-a')
     expect(localStorage.getItem(USER_PREFS_PINNED_CHAT_IDS)).toBe('["chat-a"]')
+  })
+
+  it('exposes pins once the active account is established', () => {
+    savePinnedChatIds(['chat-a'])
+
+    const { result } = renderHook(() => usePinnedChats('user-a'))
+
+    expect(result.current.pinnedChatIds).toEqual([])
+
+    act(() => {
+      localStorage.setItem(AUTH_ACTIVE_USER_ID, 'user-a')
+      window.dispatchEvent(new Event(AUTH_ACTIVE_USER_CHANGED_EVENT))
+    })
+
+    expect(result.current.pinnedChatIds).toEqual(['chat-a'])
   })
 
   it('does not dispatch changes for no-op removals', () => {

--- a/tests/hooks/use-pinned-chats.test.ts
+++ b/tests/hooks/use-pinned-chats.test.ts
@@ -1,0 +1,43 @@
+import { usePinnedChats } from '@/hooks/use-pinned-chats'
+import { chatEvents } from '@/services/storage/chat-events'
+import { savePinnedChatIds } from '@/services/storage/pinned-chats'
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+describe('usePinnedChats', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    chatEvents.clear()
+  })
+
+  it('prunes pins only after a confirmed delete event', () => {
+    savePinnedChatIds(['chat-a', 'chat-b'])
+    const { result } = renderHook(() => usePinnedChats())
+
+    act(() => chatEvents.emit({ reason: 'sync', ids: ['chat-a'] }))
+    expect(result.current.pinnedChatIds).toEqual(['chat-a', 'chat-b'])
+
+    act(() => chatEvents.emit({ reason: 'delete', ids: ['chat-a'] }))
+    expect(result.current.pinnedChatIds).toEqual(['chat-b'])
+  })
+
+  it('removes multiple confirmed ids atomically', () => {
+    savePinnedChatIds(['chat-a', 'chat-b', 'chat-c'])
+    const { result } = renderHook(() => usePinnedChats())
+
+    act(() => result.current.unpinChats(['chat-a', 'chat-c']))
+
+    expect(result.current.pinnedChatIds).toEqual(['chat-b'])
+  })
+
+  it('clears every pin only for an explicit delete-all event', () => {
+    savePinnedChatIds(['chat-a', 'chat-b'])
+    const { result } = renderHook(() => usePinnedChats())
+
+    act(() => chatEvents.emit({ reason: 'delete', ids: [] }))
+    expect(result.current.pinnedChatIds).toEqual(['chat-a', 'chat-b'])
+
+    act(() => chatEvents.emit({ reason: 'delete-all' }))
+    expect(result.current.pinnedChatIds).toEqual([])
+  })
+})

--- a/tests/hooks/use-pinned-chats.test.ts
+++ b/tests/hooks/use-pinned-chats.test.ts
@@ -1,8 +1,13 @@
+import { PINNED_CHAT_IDS_CHANGED_EVENT } from '@/constants/settings-events'
+import {
+  AUTH_ACTIVE_USER_ID,
+  USER_PREFS_PINNED_CHAT_IDS,
+} from '@/constants/storage-keys'
 import { usePinnedChats } from '@/hooks/use-pinned-chats'
 import { chatEvents } from '@/services/storage/chat-events'
 import { savePinnedChatIds } from '@/services/storage/pinned-chats'
 import { act, renderHook } from '@testing-library/react'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 describe('usePinnedChats', () => {
   beforeEach(() => {
@@ -39,5 +44,31 @@ describe('usePinnedChats', () => {
 
     act(() => chatEvents.emit({ reason: 'delete-all' }))
     expect(result.current.pinnedChatIds).toEqual([])
+  })
+
+  it('does not expose or mutate pins from another active account', () => {
+    localStorage.setItem(AUTH_ACTIVE_USER_ID, 'user-a')
+    savePinnedChatIds(['chat-a'])
+
+    const { result } = renderHook(() => usePinnedChats('user-b'))
+    expect(result.current.pinnedChatIds).toEqual([])
+
+    act(() => result.current.pinChat('chat-b'))
+    expect(localStorage.getItem(AUTH_ACTIVE_USER_ID)).toBe('user-a')
+    expect(localStorage.getItem(USER_PREFS_PINNED_CHAT_IDS)).toBe('["chat-a"]')
+  })
+
+  it('does not dispatch changes for no-op removals', () => {
+    savePinnedChatIds([])
+    const listener = vi.fn()
+    window.addEventListener(PINNED_CHAT_IDS_CHANGED_EVENT, listener)
+    const { result } = renderHook(() => usePinnedChats())
+    listener.mockClear()
+
+    act(() => result.current.unpinChat('chat-b'))
+    act(() => chatEvents.emit({ reason: 'delete-all' }))
+
+    expect(listener).not.toHaveBeenCalled()
+    window.removeEventListener(PINNED_CHAT_IDS_CHANGED_EVENT, listener)
   })
 })

--- a/tests/services/cloud/profile-merge.test.ts
+++ b/tests/services/cloud/profile-merge.test.ts
@@ -13,6 +13,7 @@ import {
   isProfilePopulated,
   mergeProfiles,
   mergeProfilesThreeWay,
+  overlayProfileChanges,
 } from '@/services/cloud/profile-merge'
 import type { ProfileData } from '@/services/cloud/profile-sync'
 import { describe, expect, it } from 'vitest'
@@ -213,6 +214,34 @@ describe('changedProfileFields', () => {
   })
 })
 
+describe('overlayProfileChanges', () => {
+  it('overlays only fields changed between local snapshots', () => {
+    const result = overlayProfileChanges(
+      { nickname: 'Remote', profession: 'Researcher', version: 4 },
+      { nickname: 'Before', profession: 'Engineer', version: 1 },
+      { nickname: 'After', profession: 'Engineer', version: 99 },
+    )
+
+    expect(result.profile).toEqual({
+      nickname: 'After',
+      profession: 'Researcher',
+      version: 4,
+    })
+    expect(result.changedFields).toEqual(['nickname'])
+  })
+
+  it('removes a field cleared during the fetch', () => {
+    const result = overlayProfileChanges(
+      { customSystemPrompt: 'Remote prompt', version: 2 },
+      { customSystemPrompt: 'Before prompt' },
+      {},
+    )
+
+    expect(result.profile).toEqual({ version: 2 })
+    expect(result.changedFields).toEqual(['customSystemPrompt'])
+  })
+})
+
 describe('mergeProfilesThreeWay', () => {
   it('preserves local pins when an older remote omits the field', () => {
     const result = mergeProfilesThreeWay({
@@ -222,6 +251,17 @@ describe('mergeProfilesThreeWay', () => {
     })
 
     expect(result.merged.pinnedChatIds).toEqual(['chat-a'])
+  })
+
+  it('preserves locally edited pins when an older remote omits the field', () => {
+    const result = mergeProfilesThreeWay({
+      baseline: { pinnedChatIds: ['chat-a'] },
+      local: { pinnedChatIds: ['chat-b', 'chat-a'] },
+      remote: { nickname: 'Remote' },
+    })
+
+    expect(result.merged.pinnedChatIds).toEqual(['chat-b', 'chat-a'])
+    expect(result.conflicts).not.toContain('pinnedChatIds')
   })
 
   it('adopts an explicit remote clear of pins', () => {

--- a/tests/services/cloud/profile-merge.test.ts
+++ b/tests/services/cloud/profile-merge.test.ts
@@ -165,6 +165,7 @@ describe('isProfilePopulated', () => {
     expect(isProfilePopulated({ nickname: 'x' })).toBe(true)
     expect(isProfilePopulated({ traits: ['a'] })).toBe(true)
     expect(isProfilePopulated({ customSystemPrompt: 'hi' })).toBe(true)
+    expect(isProfilePopulated({ pinnedChatIds: ['chat-a'] })).toBe(true)
   })
 
   it('is false for empty or default-only profiles', () => {
@@ -213,6 +214,26 @@ describe('changedProfileFields', () => {
 })
 
 describe('mergeProfilesThreeWay', () => {
+  it('preserves local pins when an older remote omits the field', () => {
+    const result = mergeProfilesThreeWay({
+      baseline: { pinnedChatIds: ['chat-a'] },
+      local: { pinnedChatIds: ['chat-a'] },
+      remote: { nickname: 'Remote' },
+    })
+
+    expect(result.merged.pinnedChatIds).toEqual(['chat-a'])
+  })
+
+  it('adopts an explicit remote clear of pins', () => {
+    const result = mergeProfilesThreeWay({
+      baseline: { pinnedChatIds: ['chat-a'] },
+      local: { pinnedChatIds: ['chat-a'] },
+      remote: { pinnedChatIds: [] },
+    })
+
+    expect(result.merged.pinnedChatIds).toEqual([])
+  })
+
   it('adopts populated remote fields when local stayed empty', () => {
     const result = mergeProfilesThreeWay({
       baseline: { nickname: '', customSystemPrompt: '' },

--- a/tests/services/cloud/profile-settings-serializer.test.ts
+++ b/tests/services/cloud/profile-settings-serializer.test.ts
@@ -14,6 +14,7 @@ import {
   USER_PREFS_FAVORITE_PROMPT_PRESETS,
   USER_PREFS_NICKNAME,
   USER_PREFS_PERSONALIZATION_ENABLED,
+  USER_PREFS_PINNED_CHAT_IDS,
   USER_PREFS_PROFESSION,
   USER_PREFS_TRAITS,
 } from '@/constants/storage-keys'
@@ -45,6 +46,32 @@ describe('profile-settings-serializer', () => {
       customSystemPrompt: '',
       isUsingPersonalization: false,
     })
+  })
+
+  it('round-trips pins while preserving absent and explicit-clear semantics', () => {
+    expect(loadLocalSettings().pinnedChatIds).toBeUndefined()
+    expect(hasProfileChanged({}, { pinnedChatIds: [] })).toBe(true)
+
+    applySettingsToLocal({ pinnedChatIds: ['chat-b', 'chat-a', 'chat-b'] })
+    expect(loadLocalSettings().pinnedChatIds).toEqual(['chat-b', 'chat-a'])
+
+    applySettingsToLocal({ nickname: 'Alice' })
+    expect(loadLocalSettings().pinnedChatIds).toEqual(['chat-b', 'chat-a'])
+
+    applySettingsToLocal({ pinnedChatIds: 'invalid' } as never)
+    expect(loadLocalSettings().pinnedChatIds).toEqual(['chat-b', 'chat-a'])
+
+    applySettingsToLocal({ pinnedChatIds: [] })
+    expect(localStorage.getItem(USER_PREFS_PINNED_CHAT_IDS)).toBe('[]')
+    expect(loadLocalSettings().pinnedChatIds).toEqual([])
+  })
+
+  it('does not serialize malformed local pin storage as an explicit clear', () => {
+    localStorage.setItem(USER_PREFS_PINNED_CHAT_IDS, '{broken')
+    expect(loadLocalSettings().pinnedChatIds).toBeUndefined()
+
+    localStorage.setItem(USER_PREFS_PINNED_CHAT_IDS, '[]')
+    expect(loadLocalSettings().pinnedChatIds).toEqual([])
   })
 
   it('keeps unspecified personalization fields intact on partial remote updates', () => {

--- a/tests/services/storage/chat-storage-pending-save.test.ts
+++ b/tests/services/storage/chat-storage-pending-save.test.ts
@@ -20,7 +20,10 @@ const {
   resetChatTimestampsSpy,
   updateChatLocalOnlySpy,
   updateChatProjectSpy,
+  deleteChatWithPendingIntentSpy,
+  deleteLocalChatSpy,
   deleteFromCloudSpy,
+  hasPendingUploadSpy,
   isDeletedSpy,
 } = vi.hoisted(() => ({
   saveChatSpy: vi.fn(async (chat: unknown) => ({
@@ -43,7 +46,10 @@ const {
   resetChatTimestampsSpy: vi.fn(async () => {}),
   updateChatLocalOnlySpy: vi.fn(async () => {}),
   updateChatProjectSpy: vi.fn(async () => {}),
+  deleteChatWithPendingIntentSpy: vi.fn(async () => true),
+  deleteLocalChatSpy: vi.fn(async () => {}),
   deleteFromCloudSpy: vi.fn(async () => {}),
+  hasPendingUploadSpy: vi.fn(() => false),
   isDeletedSpy: vi.fn((_id: unknown) => false),
 }))
 
@@ -56,6 +62,8 @@ vi.mock('@/services/storage/indexed-db', () => ({
     resetChatTimestamps: resetChatTimestampsSpy,
     updateChatLocalOnly: updateChatLocalOnlySpy,
     updateChatProject: updateChatProjectSpy,
+    deleteChatWithPendingIntent: deleteChatWithPendingIntentSpy,
+    deleteChat: deleteLocalChatSpy,
     deleteChatsByProject: deleteChatsByProjectSpy,
     acknowledgePendingDeletes: acknowledgePendingDeletesSpy,
   },
@@ -64,6 +72,7 @@ vi.mock('@/services/cloud/cloud-sync', () => ({
   cloudSync: {
     backupChat: backupChatSpy,
     deleteFromCloud: deleteFromCloudSpy,
+    hasPendingUpload: hasPendingUploadSpy,
     createAccountOperationGuard: createAccountOperationGuardSpy,
     withProjectUploadBarrier: withProjectUploadBarrierSpy,
   },
@@ -113,6 +122,8 @@ describe('chatStorage pendingSave is not persisted', () => {
     deleteRemoteProjectChatsSpy.mockResolvedValue({ deleted: 0 })
     acknowledgePendingDeletesSpy.mockResolvedValue(undefined)
     listChatIdsByProjectSpy.mockResolvedValue([])
+    deleteChatWithPendingIntentSpy.mockResolvedValue(true)
+    hasPendingUploadSpy.mockReturnValue(false)
     createAccountOperationGuardSpy.mockImplementation(() => {
       const userId = localStorage.getItem(AUTH_ACTIVE_USER_ID)
       const isCurrent = () =>
@@ -156,6 +167,34 @@ describe('chatStorage pendingSave is not persisted', () => {
 
     expect(saveChatSpy).not.toHaveBeenCalled()
     expect(backupChatSpy).not.toHaveBeenCalled()
+  })
+
+  it('queues and dispatches cloud deletion for a memory-only remote chat', async () => {
+    getChatSpy.mockResolvedValueOnce(null)
+
+    await chatStorage.deleteChat('memory-only-chat')
+
+    expect(deleteChatWithPendingIntentSpy).toHaveBeenCalledWith(
+      'memory-only-chat',
+      'delete-key',
+      'user-1',
+      { forceQueue: true },
+    )
+    expect(deleteFromCloudSpy).toHaveBeenCalledWith(
+      'memory-only-chat',
+      'delete-key',
+    )
+    expect(deleteLocalChatSpy).not.toHaveBeenCalled()
+  })
+
+  it('preserves local-only deletion behavior', async () => {
+    getChatSpy.mockResolvedValueOnce({ isLocalOnly: true } as never)
+
+    await chatStorage.deleteChat('local-chat')
+
+    expect(deleteLocalChatSpy).toHaveBeenCalledWith('local-chat')
+    expect(deleteChatWithPendingIntentSpy).not.toHaveBeenCalled()
+    expect(deleteFromCloudSpy).not.toHaveBeenCalled()
   })
 
   it('does not recreate deleted guest chats in session storage', () => {
@@ -224,7 +263,9 @@ describe('chatStorage pendingSave is not persisted', () => {
     listChatIdsByProjectSpy.mockResolvedValueOnce(['remote-1', 'remote-2'])
     deleteChatsByProjectSpy.mockResolvedValue(['remote-1', 'remote-2'])
 
-    await expect(chatStorage.deleteChatsByProject('project-1')).resolves.toBe(2)
+    await expect(
+      chatStorage.deleteChatsByProjectWithIds('project-1'),
+    ).resolves.toEqual(['remote-1', 'remote-2'])
 
     expect(withProjectUploadBarrierSpy).toHaveBeenCalledWith(
       'project-1',

--- a/tests/services/storage/indexed-db-sync-v2.test.ts
+++ b/tests/services/storage/indexed-db-sync-v2.test.ts
@@ -271,6 +271,27 @@ describe('IndexedDB sync protocol v2 migration', () => {
     await expect(storage.getPendingDeletes('user-1')).resolves.toEqual([])
   })
 
+  it('persists a forced delete intent when the local row is missing', async () => {
+    const storage = new IndexedDBStorage()
+    await storage.initialize()
+
+    const queued = await storage.deleteChatWithPendingIntent(
+      'memory-only-chat',
+      'forced-delete-key',
+      'user-1',
+      { forceQueue: true },
+    )
+
+    expect(queued).toBe(true)
+    await expect(storage.getPendingDeletes('user-1')).resolves.toEqual([
+      expect.objectContaining({
+        id: 'memory-only-chat',
+        userId: 'user-1',
+        idempotencyKey: 'forced-delete-key',
+      }),
+    ])
+  })
+
   it('removes a matching delete intent with a remote deletion', async () => {
     const storage = new IndexedDBStorage()
     await storage.initialize()

--- a/tests/services/storage/pinned-chat-hydration.test.ts
+++ b/tests/services/storage/pinned-chat-hydration.test.ts
@@ -1,0 +1,51 @@
+import type { StoredChat } from '@/services/storage/indexed-db'
+import { hydratePinnedChatById } from '@/services/storage/pinned-chat-hydration'
+import { describe, expect, it } from 'vitest'
+
+function remoteChat(overrides: Partial<StoredChat> = {}): StoredChat {
+  return {
+    id: 'chat-a',
+    title: 'Remote title',
+    messages: [],
+    createdAt: '2026-08-01T00:00:00.000Z',
+    updatedAt: '2026-08-01T00:00:00.000Z',
+    lastAccessedAt: 0,
+    ...overrides,
+  }
+}
+
+describe('hydratePinnedChatById', () => {
+  it('keeps an ambiguous null download unavailable instead of pruning it', async () => {
+    const result = await hydratePinnedChatById('chat-a', {
+      downloadChat: async () => null,
+    })
+
+    expect(result.status).toBe('unavailable')
+  })
+
+  it('returns downloaded chats for memory-only rendering', async () => {
+    const result = await hydratePinnedChatById('chat-a', {
+      downloadChat: async () => remoteChat(),
+    })
+
+    expect(result).toMatchObject({
+      status: 'ready',
+      chat: { id: 'chat-a', title: 'Remote title' },
+    })
+    if (result.status === 'ready') {
+      expect(result.chat.createdAt).toBeInstanceOf(Date)
+    }
+  })
+
+  it('keeps unavailable chats pinned and rejects corrupted chats', async () => {
+    const unavailable = await hydratePinnedChatById('chat-a', {
+      downloadChat: async () => remoteChat({ decryptionFailed: true }),
+    })
+    expect(unavailable.status).toBe('unavailable')
+
+    const corrupted = await hydratePinnedChatById('chat-a', {
+      downloadChat: async () => remoteChat({ dataCorrupted: true }),
+    })
+    expect(corrupted.status).toBe('invalid')
+  })
+})

--- a/tests/services/storage/pinned-chats.test.ts
+++ b/tests/services/storage/pinned-chats.test.ts
@@ -1,0 +1,72 @@
+import { USER_PREFS_PINNED_CHAT_IDS } from '@/constants/storage-keys'
+import {
+  addPinnedChatId,
+  canRequestChatPin,
+  isResolvedFavoriteChat,
+  loadPinnedChatIds,
+  MAX_PINNED_CHATS,
+  normalizePinnedChatIds,
+  removePinnedChatIds,
+  savePinnedChatIds,
+} from '@/services/storage/pinned-chats'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+describe('pinned chats storage', () => {
+  beforeEach(() => localStorage.clear())
+
+  it('preserves absent and explicit-empty states', () => {
+    expect(loadPinnedChatIds()).toBeUndefined()
+
+    savePinnedChatIds([])
+
+    expect(loadPinnedChatIds()).toEqual([])
+    expect(localStorage.getItem(USER_PREFS_PINNED_CHAT_IDS)).toBe('[]')
+  })
+
+  it('puts the newest pin first, deduplicates, and caps new pins', () => {
+    const existing = Array.from(
+      { length: MAX_PINNED_CHATS },
+      (_, index) => `chat-${index}`,
+    )
+
+    expect(addPinnedChatId(existing, 'chat-new')).toEqual([
+      'chat-new',
+      ...existing.slice(0, MAX_PINNED_CHATS - 1),
+    ])
+    expect(addPinnedChatId(existing, 'chat-3')[0]).toBe('chat-3')
+  })
+
+  it('sanitizes malformed ids and removes confirmed deletions', () => {
+    expect(
+      normalizePinnedChatIds(['chat-a', '', '   ', 3, 'chat-a', ' chat-b ']),
+    ).toEqual(['chat-a', ' chat-b '])
+    expect(removePinnedChatIds(['chat-a', 'chat-b'], ['chat-a'])).toEqual([
+      'chat-b',
+    ])
+  })
+
+  it('treats malformed storage as unmanaged without losing explicit clears', () => {
+    localStorage.setItem(USER_PREFS_PINNED_CHAT_IDS, '{broken')
+    expect(loadPinnedChatIds()).toBeUndefined()
+
+    localStorage.setItem(
+      USER_PREFS_PINNED_CHAT_IDS,
+      JSON.stringify({ ids: [] }),
+    )
+    expect(loadPinnedChatIds()).toBeUndefined()
+
+    localStorage.setItem(USER_PREFS_PINNED_CHAT_IDS, '[]')
+    expect(loadPinnedChatIds()).toEqual([])
+  })
+
+  it('allows local conversion actions but never resolves local or corrupted favorites', () => {
+    expect(canRequestChatPin({ id: 'local', isLocalOnly: true })).toBe(true)
+    expect(isResolvedFavoriteChat({ id: 'local', isLocalOnly: true })).toBe(
+      false,
+    )
+    expect(canRequestChatPin({ id: 'lost', dataCorrupted: true })).toBe(false)
+    expect(isResolvedFavoriteChat({ id: 'lost', dataCorrupted: true })).toBe(
+      false,
+    )
+  })
+})

--- a/tests/services/storage/pinned-chats.test.ts
+++ b/tests/services/storage/pinned-chats.test.ts
@@ -38,8 +38,16 @@ describe('pinned chats storage', () => {
 
   it('sanitizes malformed ids and removes confirmed deletions', () => {
     expect(
-      normalizePinnedChatIds(['chat-a', '', '   ', 3, 'chat-a', ' chat-b ']),
-    ).toEqual(['chat-a', ' chat-b '])
+      normalizePinnedChatIds([
+        'chat-a',
+        '',
+        '   ',
+        3,
+        'chat-a',
+        ' chat-b ',
+        'chat-b',
+      ]),
+    ).toEqual(['chat-a', 'chat-b'])
     expect(removePinnedChatIds(['chat-a', 'chat-b'], ['chat-a'])).toEqual([
       'chat-b',
     ])


### PR DESCRIPTION
## Summary
- add a synced Favorites section for standalone and project chats
- convert local chats to cloud storage before pinning and safely hydrate older favorites by ID
- synchronize a lightweight ordered `pinnedChatIds` profile field with deletion and navigation safeguards

## Testing
- `npm run test:unit -- --run` (1,770 tests)
- `npx tsc --noEmit`
- `npm run lint`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds cloud‑synced, collapsible chat favorites in chat and project sidebars. Previously chats could not be pinned; now users can pin/unpin by click or drag‑and‑drop, and pins sync across devices and account switches without changing existing sidebar defaults.

- UI/UX: Favorites render only when signed in with cloud sync enabled. The section is collapsible with state in `UI_SIDEBAR_FAVORITES_EXPANDED`; headers remain visible and usable as drop targets even when empty or collapsed. A collapsed‑sidebar Favorites button activates on drag enter and accepts drops. Favorite rows hide pin icons.
- DnD and rules: Only eligible chats can be pinned. Drops are accepted on the Favorites section and the collapsed Favorites button. Pins are ordered newest‑first, deduped, and capped at 20.
- Navigation and consistency: Opening a favorite auto‑enters or exits project mode and aborts if superseded; normal navigation cancels a pending favorite open. Missing favorites hydrate by ID and retry on sync/pagination/recovery/online/encryption‑key changes. Blank/temporary/local‑only/corrupted chats are unpinned; decryption‑failed favorites remain pinned but hidden. Project bulk deletes unpin removed chats; a `delete-all` chat event clears all pins. Pins update on active‑account change.

**Migration**
- `ChatSidebar` and `ProjectSidebar` accept `pinnedChatIds`, `onToggleFavorite`, `onOpenFavorite`, and `cloudSyncEnabled` and render a collapsible Favorites section and collapsed‑sidebar Favorites button with drag‑and‑drop.
- `ChatList` accepts `pinnedChatIds`, `showPinnedIndicators?`, `showDesktopPinActions?`, and `onTogglePin`. `ChatListItem` accepts `isPinned`, `showPinnedIndicator`, `showDesktopPinAction?`, and `onTogglePin`.
- `ChatItemData` adds `decryptionFailed`, `dataCorrupted`, `isTemporary`, `pendingSave`, and `projectId`. `Chat` adds `dataCorrupted`.
- `enterProjectMode` accepts `{ isCurrent }` via `EnterProjectModeOptions`.

<sup>Written for commit 3c67ff4a62fbd5a386f52d1c069f020fa3275d71. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/505?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

