### PR TITLE
Fix mobile response action layouts

### DIFF
--- a/src/components/chat/genui/GenUIToolCallRenderer.tsx
+++ b/src/components/chat/genui/GenUIToolCallRenderer.tsx
@@ -390,20 +390,20 @@ function ParseFailureCard({
           : `The response didn't match the ${toolName} widget's expected shape.`
 
   return (
-    <div className="my-4 flex items-center justify-between gap-3 rounded-lg border border-border-subtle bg-surface-card px-4 py-3 text-sm">
-      <div className="flex flex-col">
+    <div className="my-4 flex flex-col items-stretch gap-3 rounded-lg border border-border-subtle bg-surface-card px-4 py-3 text-sm md:flex-row md:items-center md:justify-between">
+      <div className="flex min-w-0 flex-col">
         <span className="font-medium text-content-primary">
           Couldn&apos;t display {prettyWidgetName(toolName)}
         </span>
         <span className="text-xs text-content-muted">{description}</span>
       </div>
-      <div className="flex flex-shrink-0 items-center gap-2">
+      <div className="flex w-full flex-shrink-0 flex-col items-stretch gap-2 md:w-auto md:flex-row md:items-center">
         {onRetryToolCall && (
           <button
             type="button"
             onClick={() => void handleRetryToolCall()}
             disabled={isRetrying}
-            className="inline-flex flex-shrink-0 items-center gap-1.5 rounded-md border border-border-subtle bg-surface-chat-background px-3 py-1.5 text-sm font-medium text-content-primary transition-colors hover:bg-surface-card disabled:cursor-default disabled:opacity-60"
+            className="inline-flex w-full flex-shrink-0 items-center justify-center gap-1.5 rounded-md border border-brand-accent-dark bg-brand-accent-dark px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-brand-accent-dark/90 disabled:cursor-default disabled:opacity-60 md:w-auto"
           >
             <RefreshCw
               className={`h-3.5 w-3.5 ${isRetrying ? 'animate-spin' : ''}`}
@@ -416,7 +416,7 @@ function ParseFailureCard({
             type="button"
             onClick={onRetry}
             disabled={isRetrying}
-            className="inline-flex flex-shrink-0 items-center rounded-md border border-border-subtle bg-surface-chat-background px-3 py-1.5 text-sm font-medium text-content-primary transition-colors hover:bg-surface-card disabled:cursor-default disabled:opacity-60"
+            className="inline-flex w-full flex-shrink-0 items-center justify-center rounded-md border border-border-subtle bg-surface-chat-background px-3 py-1.5 text-sm font-medium text-content-primary transition-colors hover:bg-surface-card disabled:cursor-default disabled:opacity-60 md:w-auto"
           >
             Regenerate response
           </button>

--- a/src/components/chat/renderers/default/DefaultMessageRenderer.tsx
+++ b/src/components/chat/renderers/default/DefaultMessageRenderer.tsx
@@ -712,7 +712,8 @@ const DefaultMessageComponent = ({
 
       {/* Actions for assistant messages - hidden while streaming the last response */}
       {showAssistantFooter && (
-        <div className="mt-4 flex w-full items-center justify-between gap-3 px-4">
+        <div className="mt-4 flex w-full flex-col items-start gap-2 px-4 md:flex-row-reverse md:items-center md:justify-between md:gap-3">
+          <MessageMetadata modelDisplayName={modelDisplayName} />
           <div
             className={`flex items-center gap-1 transition-opacity duration-500 ease-in-out ${
               showActions ? 'opacity-100' : 'pointer-events-none opacity-0'
@@ -750,7 +751,6 @@ const DefaultMessageComponent = ({
               </>
             )}
           </div>
-          <MessageMetadata modelDisplayName={modelDisplayName} />
         </div>
       )}
     </div>

--- a/tests/components/chat/default-message-renderer.test.tsx
+++ b/tests/components/chat/default-message-renderer.test.tsx
@@ -51,6 +51,9 @@ describe('DefaultMessageRenderer metadata', () => {
     expect(screen.queryByText('Current Model')).not.toBeInTheDocument()
     expect(
       screen.getByText('Retired Model').parentElement?.parentElement,
+    ).toHaveClass('flex-col', 'md:flex-row-reverse')
+    expect(
+      screen.getByText('Retired Model').parentElement?.parentElement,
     ).toContainElement(screen.getByRole('button', { name: 'Copy message' }))
   })
 

--- a/tests/components/chat/genui/tool-call-renderer.test.tsx
+++ b/tests/components/chat/genui/tool-call-renderer.test.tsx
@@ -302,6 +302,17 @@ describe('GenUIToolCallRenderer', () => {
     )
 
     const retryButton = screen.getByRole('button', { name: 'Retry widget' })
+    expect(retryButton).toHaveClass(
+      'w-full',
+      'bg-brand-accent-dark',
+      'text-white',
+      'md:w-auto',
+    )
+    expect(retryButton.parentElement).toHaveClass('flex-col', 'md:flex-row')
+    expect(retryButton.parentElement?.parentElement).toHaveClass(
+      'flex-col',
+      'md:flex-row',
+    )
     expect(
       screen.getByRole('button', { name: 'Regenerate response' }),
     ).toBeInTheDocument()


### PR DESCRIPTION
## Summary
- move model and encryption metadata above source controls on mobile
- stack widget recovery actions below failure content on mobile while preserving desktop layout
- use the existing green brand treatment for the primary widget retry action

## Tests
- `npm run test:unit -- --run` (1742 passed)
- `npm run lint`
- `npx tsc --noEmit`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes mobile layouts for assistant response actions and widget recovery actions to improve readability and tap targets. Previously, metadata and controls shared a single row and the retry button used a neutral style; now metadata appears above controls on mobile, actions stack vertically with a full‑width primary retry button using the brand treatment, and desktop layout remains unchanged.

- Assistant message footer: metadata renders before actions; mobile uses a column layout, desktop uses row‑reverse to preserve prior visual order.
- Widget parse failure card: actions stack below the failure content on mobile; “Retry widget” is full‑width and branded (`bg-brand-accent-dark`, white text); desktop keeps the horizontal layout.
- Tests updated to assert the new responsive classes; no API changes or migrations required.

<sup>Written for commit 03cec0d3a02ecef65e853f1cb4b42236a7f5fabe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/506?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

