### PR TITLE
Send clearer images to models

### DIFF
--- a/src/components/chat/constants.ts
+++ b/src/components/chat/constants.ts
@@ -22,6 +22,7 @@ export const CONSTANTS = {
   // model's context window by token estimate rather than by byte size
   MAX_TEXT_DOCUMENT_SIZE_MB: 50,
   MAX_TEXT_DOCUMENT_SIZE_BYTES: 50 * 1024 * 1024,
+  MAX_IMAGE_DIMENSION_PX: 1536,
   // Voice recording timeout in milliseconds (10 minutes)
   RECORDING_TIMEOUT_MS: 600000,
   // Default audio model for voice transcription

--- a/src/components/chat/document-uploader.tsx
+++ b/src/components/chat/document-uploader.tsx
@@ -206,8 +206,8 @@ export const useDocumentUploader = (isCurrentModelMultimodal?: boolean) => {
       if (isImageFile(file)) {
         try {
           const scaled = await scaleAndEncodeImage(file, {
-            maxWidth: 768,
-            maxHeight: 768,
+            maxWidth: CONSTANTS.MAX_IMAGE_DIMENSION_PX,
+            maxHeight: CONSTANTS.MAX_IMAGE_DIMENSION_PX,
             quality: 0.85,
           })
 


### PR DESCRIPTION
## Summary
- increase the maximum model image dimension from 768px to 1536px
- centralize the shared width and height limit in chat constants
- preserve existing compression quality and thumbnail sizing

## Validation
- pre-commit ESLint and Prettier checks
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sends clearer images to vision models by increasing the maximum scaled dimension from 768px to 1536px. The client still compresses at quality 0.85 and keeps thumbnail sizing unchanged, but uploads may be larger and slightly slower.

- Review: Confirm `document-uploader.tsx` uses `CONSTANTS.MAX_IMAGE_DIMENSION_PX` for both `maxWidth` and `maxHeight`. Verify compression quality remains 0.85 and thumbnail logic is unaffected. Spot-check typical image sizes/latency stay within existing upload limits.

<sup>Written for commit f30f31777d8113c6c04f44b9c7579f1fd45929b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/507?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

