### PR TITLE
feat: show cloud sync status in the sidebar

### DIFF
--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -406,6 +406,7 @@ export function ChatInterface({
   const {
     syncing,
     lastSyncTime,
+    lastSyncFailed,
     syncChats,
     smartSyncChats,
     encryptionKey,
@@ -3510,6 +3511,7 @@ export function ChatInterface({
                 onManualSync={handleManualSync}
                 isSyncing={syncing}
                 lastSyncTime={lastSyncTime}
+                lastSyncFailed={lastSyncFailed}
                 isProjectMode={isProjectMode}
                 activeProjectName={activeProject?.name}
                 onEnterProject={async (projectId, projectName) => {

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -405,6 +405,7 @@ export function ChatInterface({
 
   const {
     syncing,
+    lastSyncTime,
     syncChats,
     smartSyncChats,
     encryptionKey,
@@ -3508,6 +3509,7 @@ export function ChatInterface({
                 }
                 onManualSync={handleManualSync}
                 isSyncing={syncing}
+                lastSyncTime={lastSyncTime}
                 isProjectMode={isProjectMode}
                 activeProjectName={activeProject?.name}
                 onEnterProject={async (projectId, projectName) => {

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -1831,13 +1831,15 @@ export function ChatInterface({
 
   const handleManualSync = useCallback(async () => {
     try {
-      await syncChats()
+      const result = await syncChats()
       await reloadChats()
+      return result !== false && result.errors.length === 0
     } catch (error) {
       logError('Manual chat sync failed', error, {
         component: 'ChatInterface',
         action: 'handleManualSync',
       })
+      return false
     }
   }, [syncChats, reloadChats])
 

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -405,7 +405,6 @@ export function ChatInterface({
 
   const {
     syncing,
-    lastSyncTime,
     lastSyncFailed,
     syncChats,
     smartSyncChats,
@@ -3510,7 +3509,6 @@ export function ChatInterface({
                 }
                 onManualSync={handleManualSync}
                 isSyncing={syncing}
-                lastSyncTime={lastSyncTime}
                 lastSyncFailed={lastSyncFailed}
                 isProjectMode={isProjectMode}
                 activeProjectName={activeProject?.name}

--- a/src/components/chat/chat-sidebar.tsx
+++ b/src/components/chat/chat-sidebar.tsx
@@ -125,8 +125,6 @@ type ChatSidebarProps = {
   onManualSync?: () => Promise<void>
   /** True while a cloud sync is in progress; drives the Sync button spinner. */
   isSyncing?: boolean
-  /** Time the most recent cloud sync attempt completed. */
-  lastSyncTime?: number | null
   /** Whether the most recent cloud sync attempt failed. */
   lastSyncFailed?: boolean
   isProjectMode?: boolean
@@ -199,7 +197,6 @@ export function ChatSidebar({
   isInitialChatPageReady = false,
   onManualSync,
   isSyncing = false,
-  lastSyncTime = null,
   lastSyncFailed = false,
   isProjectMode,
   activeProjectName,
@@ -329,12 +326,10 @@ export function ChatSidebar({
     Object.keys(syncHealth.failedChats).length > 0
   const syncFailed = lastSyncFailed || syncHealthFailed
   const syncStatusLabel = isSyncing
-    ? 'Syncing...'
-    : lastSyncTime
-      ? `${syncFailed ? 'Failed' : 'Synced'} ${formatRelativeTime(new Date(lastSyncTime))}`
-      : syncFailed
-        ? 'Sync failed'
-        : 'Not synced yet'
+    ? 'Syncing'
+    : syncFailed
+      ? 'Sync failed'
+      : 'Sync healthy'
 
   const {
     projects,
@@ -1229,27 +1224,12 @@ export function ChatSidebar({
                 </span>
                 <span
                   className={cn(
-                    'flex items-center gap-1.5 text-xs',
-                    isSyncing
-                      ? 'text-content-muted'
-                      : syncFailed
-                        ? 'text-orange-500'
-                        : lastSyncTime
-                          ? 'text-green-600 dark:text-green-400'
-                          : 'text-content-muted',
+                    'h-2 w-2 rounded-full',
+                    syncFailed ? 'bg-orange-500' : 'bg-green-500',
                   )}
-                >
-                  {!isSyncing && (lastSyncTime || syncFailed) && (
-                    <span
-                      className={cn(
-                        'h-1.5 w-1.5 rounded-full',
-                        syncFailed ? 'bg-orange-500' : 'bg-green-500',
-                      )}
-                      aria-hidden="true"
-                    />
-                  )}
-                  {syncStatusLabel}
-                </span>
+                  title={syncStatusLabel}
+                  aria-hidden="true"
+                />
               </button>
             </div>
           )}

--- a/src/components/chat/chat-sidebar.tsx
+++ b/src/components/chat/chat-sidebar.tsx
@@ -125,6 +125,8 @@ type ChatSidebarProps = {
   onManualSync?: () => Promise<void>
   /** True while a cloud sync is in progress; drives the Sync button spinner. */
   isSyncing?: boolean
+  /** Time of the most recent successful cloud sync. */
+  lastSyncTime?: number | null
   isProjectMode?: boolean
   activeProjectName?: string
   onEnterProject?: (projectId: string, projectName?: string) => Promise<void>
@@ -195,6 +197,7 @@ export function ChatSidebar({
   isInitialChatPageReady = false,
   onManualSync,
   isSyncing = false,
+  lastSyncTime = null,
   isProjectMode,
   activeProjectName,
   onEnterProject,
@@ -317,6 +320,11 @@ export function ChatSidebar({
     currentChat?.isBlankChat &&
     !currentChat.isTemporary &&
     Boolean(currentChat.isLocalOnly) === (activeTab === 'local')
+  const syncStatusLabel = isSyncing
+    ? 'Syncing...'
+    : lastSyncTime
+      ? `Last synced ${formatRelativeTime(new Date(lastSyncTime))}`
+      : 'Not synced yet'
 
   const {
     projects,
@@ -846,6 +854,36 @@ export function ChatSidebar({
 
             {/* Action buttons */}
             <div className="flex flex-col items-center gap-1 px-2">
+              {isSignedIn && cloudSyncEnabled && onManualSync && (
+                <div className="group relative">
+                  <button
+                    type="button"
+                    onClick={() => {
+                      if (isSyncing) return
+                      void onManualSync()
+                    }}
+                    disabled={isSyncing}
+                    className={cn(
+                      'flex h-10 w-10 items-center justify-center rounded-lg transition-colors',
+                      'text-content-secondary hover:bg-surface-chat hover:text-content-primary disabled:cursor-default disabled:opacity-60',
+                    )}
+                    aria-label={`Sync chats. ${syncStatusLabel}`}
+                  >
+                    {isSyncing ? (
+                      <PiSpinner className="h-5 w-5 animate-spin" />
+                    ) : (
+                      <GoSync className="h-5 w-5" />
+                    )}
+                  </button>
+                  <span className="pointer-events-none absolute left-full top-1/2 z-50 ml-2 -translate-y-1/2 whitespace-nowrap rounded border border-border-subtle bg-surface-chat-background px-2 py-1 text-xs text-content-primary opacity-0 shadow-sm transition-opacity group-hover:opacity-100">
+                    Sync chats{' '}
+                    <span className="text-content-muted">
+                      {syncStatusLabel}
+                    </span>
+                  </span>
+                </div>
+              )}
+
               {/* New chat button */}
               <div className="group relative">
                 <Link
@@ -1181,6 +1219,38 @@ export function ChatSidebar({
                   </button>
                 )}
               </div>
+            </div>
+          )}
+
+          {isSignedIn && cloudSyncEnabled && onManualSync && (
+            <div className="relative z-10 flex-none px-2 pt-2">
+              <button
+                type="button"
+                onClick={() => {
+                  if (isSyncing) return
+                  void onManualSync()
+                }}
+                disabled={isSyncing}
+                aria-label={`Sync chats. ${syncStatusLabel}`}
+                className={cn(
+                  'flex w-full items-center justify-between rounded-lg border px-2 py-2 text-sm transition-colors disabled:cursor-default disabled:opacity-60',
+                  isDarkMode
+                    ? 'border-border-strong bg-surface-chat text-content-primary hover:bg-surface-chat/80'
+                    : 'border-border-subtle bg-white text-content-primary hover:bg-gray-50',
+                )}
+              >
+                <span className="flex items-center gap-2">
+                  {isSyncing ? (
+                    <PiSpinner className="h-4 w-4 animate-spin" />
+                  ) : (
+                    <GoSync className="h-4 w-4" />
+                  )}
+                  <span className="font-aeonik font-medium">Sync</span>
+                </span>
+                <span className="text-xs text-content-muted">
+                  {syncStatusLabel}
+                </span>
+              </button>
             </div>
           )}
 
@@ -1721,25 +1791,6 @@ export function ChatSidebar({
                   <ChevronRightIcon className="h-4 w-4" />
                 )}
               </button>
-              {isSignedIn && cloudSyncEnabled && onManualSync && (
-                <button
-                  type="button"
-                  onClick={() => {
-                    if (isSyncing) return
-                    void onManualSync()
-                  }}
-                  disabled={isSyncing}
-                  aria-label="Sync chats"
-                  title="Sync chats"
-                  className="absolute right-9 rounded p-1 text-content-muted transition-colors hover:text-content-secondary disabled:cursor-default disabled:opacity-60"
-                >
-                  {isSyncing ? (
-                    <PiSpinner className="h-4 w-4 animate-spin" />
-                  ) : (
-                    <GoSync className="h-4 w-4" />
-                  )}
-                </button>
-              )}
             </div>
 
             {/* Expanded Chats content */}

--- a/src/components/chat/chat-sidebar.tsx
+++ b/src/components/chat/chat-sidebar.tsx
@@ -854,36 +854,6 @@ export function ChatSidebar({
 
             {/* Action buttons */}
             <div className="flex flex-col items-center gap-1 px-2">
-              {isSignedIn && cloudSyncEnabled && onManualSync && (
-                <div className="group relative">
-                  <button
-                    type="button"
-                    onClick={() => {
-                      if (isSyncing) return
-                      void onManualSync()
-                    }}
-                    disabled={isSyncing}
-                    className={cn(
-                      'flex h-10 w-10 items-center justify-center rounded-lg transition-colors',
-                      'text-content-secondary hover:bg-surface-chat hover:text-content-primary disabled:cursor-default disabled:opacity-60',
-                    )}
-                    aria-label={`Sync chats. ${syncStatusLabel}`}
-                  >
-                    {isSyncing ? (
-                      <PiSpinner className="h-5 w-5 animate-spin" />
-                    ) : (
-                      <GoSync className="h-5 w-5" />
-                    )}
-                  </button>
-                  <span className="pointer-events-none absolute left-full top-1/2 z-50 ml-2 -translate-y-1/2 whitespace-nowrap rounded border border-border-subtle bg-surface-chat-background px-2 py-1 text-xs text-content-primary opacity-0 shadow-sm transition-opacity group-hover:opacity-100">
-                    Sync chats{' '}
-                    <span className="text-content-muted">
-                      {syncStatusLabel}
-                    </span>
-                  </span>
-                </div>
-              )}
-
               {/* New chat button */}
               <div className="group relative">
                 <Link

--- a/src/components/chat/chat-sidebar.tsx
+++ b/src/components/chat/chat-sidebar.tsx
@@ -9,7 +9,7 @@ import {
   USER_PREFS_NATIVE_APP_DISMISSED,
 } from '@/constants/storage-keys'
 import { useProjects } from '@/hooks/use-projects'
-import { useSyncHealthAttention } from '@/hooks/use-sync-health'
+import { useSyncHealth, useSyncHealthAttention } from '@/hooks/use-sync-health'
 import { toast } from '@/hooks/use-toast'
 import { useUpgradeToPro } from '@/hooks/use-upgrade-to-pro'
 import { encryptionService } from '@/services/encryption/encryption-service'
@@ -125,8 +125,10 @@ type ChatSidebarProps = {
   onManualSync?: () => Promise<void>
   /** True while a cloud sync is in progress; drives the Sync button spinner. */
   isSyncing?: boolean
-  /** Time of the most recent successful cloud sync. */
+  /** Time the most recent cloud sync attempt completed. */
   lastSyncTime?: number | null
+  /** Whether the most recent cloud sync attempt failed. */
+  lastSyncFailed?: boolean
   isProjectMode?: boolean
   activeProjectName?: string
   onEnterProject?: (projectId: string, projectName?: string) => Promise<void>
@@ -198,6 +200,7 @@ export function ChatSidebar({
   onManualSync,
   isSyncing = false,
   lastSyncTime = null,
+  lastSyncFailed = false,
   isProjectMode,
   activeProjectName,
   onEnterProject,
@@ -211,6 +214,7 @@ export function ChatSidebar({
   chatDecryptionProgress,
 }: ChatSidebarProps) {
   const syncNeedsAttention = useSyncHealthAttention()
+  const syncHealth = useSyncHealth()
   const [isInitialLoad, setIsInitialLoad] = useState(true)
   const [isProjectsExpanded, setIsProjectsExpanded] = useState(() => {
     if (typeof window !== 'undefined') {
@@ -320,11 +324,17 @@ export function ChatSidebar({
     currentChat?.isBlankChat &&
     !currentChat.isTemporary &&
     Boolean(currentChat.isLocalOnly) === (activeTab === 'local')
+  const syncHealthFailed =
+    syncHealth.gate.kind !== 'ok' ||
+    Object.keys(syncHealth.failedChats).length > 0
+  const syncFailed = lastSyncFailed || syncHealthFailed
   const syncStatusLabel = isSyncing
     ? 'Syncing...'
     : lastSyncTime
-      ? `Last synced ${formatRelativeTime(new Date(lastSyncTime))}`
-      : 'Not synced yet'
+      ? `${syncFailed ? 'Failed' : 'Synced'} ${formatRelativeTime(new Date(lastSyncTime))}`
+      : syncFailed
+        ? 'Sync failed'
+        : 'Not synced yet'
 
   const {
     projects,
@@ -1217,7 +1227,27 @@ export function ChatSidebar({
                   )}
                   <span className="font-aeonik font-medium">Sync</span>
                 </span>
-                <span className="text-xs text-content-muted">
+                <span
+                  className={cn(
+                    'flex items-center gap-1.5 text-xs',
+                    isSyncing
+                      ? 'text-content-muted'
+                      : syncFailed
+                        ? 'text-orange-500'
+                        : lastSyncTime
+                          ? 'text-green-600 dark:text-green-400'
+                          : 'text-content-muted',
+                  )}
+                >
+                  {!isSyncing && (lastSyncTime || syncFailed) && (
+                    <span
+                      className={cn(
+                        'h-1.5 w-1.5 rounded-full',
+                        syncFailed ? 'bg-orange-500' : 'bg-green-500',
+                      )}
+                      aria-hidden="true"
+                    />
+                  )}
                   {syncStatusLabel}
                 </span>
               </button>

--- a/src/components/chat/chat-sidebar.tsx
+++ b/src/components/chat/chat-sidebar.tsx
@@ -39,7 +39,7 @@ import {
 import { AnimatePresence, motion } from 'framer-motion'
 import { CiFloppyDisk } from 'react-icons/ci'
 import { FaLock } from 'react-icons/fa6'
-import { GoSidebarCollapse, GoSidebarExpand, GoSync } from 'react-icons/go'
+import { GoSidebarCollapse, GoSidebarExpand } from 'react-icons/go'
 import { IoChatbubblesOutline } from 'react-icons/io5'
 import {
   PiFolder,
@@ -52,6 +52,7 @@ import { ChatList, type ChatItemData } from './chat-list'
 import { formatRelativeTime } from './chat-list-utils'
 import { CONSTANTS } from './constants'
 import { useDrag } from './drag-context'
+import { SidebarSyncButton } from './sidebar-sync-button'
 
 import { useProject } from '@/components/project/project-context'
 import {
@@ -122,7 +123,7 @@ type ChatSidebarProps = {
   initialChatPageToken?: string
   isInitialChatPageReady?: boolean
   /** Triggers a deep (all-pages) cloud sync from the sidebar "Sync" button. */
-  onManualSync?: () => Promise<void>
+  onManualSync?: () => Promise<boolean>
   /** True while a cloud sync is in progress; drives the Sync button spinner. */
   isSyncing?: boolean
   /** Whether the most recent cloud sync attempt failed. */
@@ -325,11 +326,6 @@ export function ChatSidebar({
     syncHealth.gate.kind !== 'ok' ||
     Object.keys(syncHealth.failedChats).length > 0
   const syncFailed = lastSyncFailed || syncHealthFailed
-  const syncStatusLabel = isSyncing
-    ? 'Syncing'
-    : syncFailed
-      ? 'Sync failed'
-      : 'Sync healthy'
 
   const {
     projects,
@@ -1198,40 +1194,12 @@ export function ChatSidebar({
           )}
 
           {isSignedIn && cloudSyncEnabled && onManualSync && (
-            <div className="relative z-10 flex-none px-2 pt-2">
-              <button
-                type="button"
-                onClick={() => {
-                  if (isSyncing) return
-                  void onManualSync()
-                }}
-                disabled={isSyncing}
-                aria-label={`Sync chats. ${syncStatusLabel}`}
-                className={cn(
-                  'flex w-full items-center justify-between rounded-lg border px-2 py-2 text-sm transition-colors disabled:cursor-default disabled:opacity-60',
-                  isDarkMode
-                    ? 'border-border-strong bg-surface-chat text-content-primary hover:bg-surface-chat/80'
-                    : 'border-border-subtle bg-white text-content-primary hover:bg-gray-50',
-                )}
-              >
-                <span className="flex items-center gap-2">
-                  {isSyncing ? (
-                    <PiSpinner className="h-4 w-4 animate-spin" />
-                  ) : (
-                    <GoSync className="h-4 w-4" />
-                  )}
-                  <span className="font-aeonik font-medium">Sync</span>
-                </span>
-                <span
-                  className={cn(
-                    'h-2 w-2 rounded-full',
-                    syncFailed ? 'bg-orange-500' : 'bg-green-500',
-                  )}
-                  title={syncStatusLabel}
-                  aria-hidden="true"
-                />
-              </button>
-            </div>
+            <SidebarSyncButton
+              isDarkMode={isDarkMode}
+              isSyncing={isSyncing}
+              syncFailed={syncFailed}
+              onSync={onManualSync}
+            />
           )}
 
           {/* New Chat button */}

--- a/src/components/chat/constants.ts
+++ b/src/components/chat/constants.ts
@@ -42,7 +42,9 @@ export const CONSTANTS = {
   CHAT_SIDEBAR_RAIL_FADE_OUT_DURATION_S: 0.1,
   SIDEBAR_SYNC_MIN_SPINNER_MS: 1000,
   SIDEBAR_SYNC_SUCCESS_FEEDBACK_MS: 1500,
-  SIDEBAR_SYNC_FEEDBACK_ANIMATION_S: 0.18,
+  SIDEBAR_SYNC_FEEDBACK_EXIT_S: 0.14,
+  SIDEBAR_SYNC_FEEDBACK_ENTER_S: 0.22,
+  SIDEBAR_SYNC_FEEDBACK_ENTER_DELAY_S: 0.06,
   // Height of a pinned sidebar section header (Projects/Chats). The Chats
   // header offsets by this amount so it stacks below the pinned Projects
   // header while scrolling.

--- a/src/components/chat/constants.ts
+++ b/src/components/chat/constants.ts
@@ -40,6 +40,9 @@ export const CONSTANTS = {
   CHAT_SIDEBAR_RAIL_FADE_IN_DURATION_S: 0.15,
   CHAT_SIDEBAR_RAIL_FADE_IN_DELAY_S: 0.04,
   CHAT_SIDEBAR_RAIL_FADE_OUT_DURATION_S: 0.1,
+  SIDEBAR_SYNC_MIN_SPINNER_MS: 1000,
+  SIDEBAR_SYNC_SUCCESS_FEEDBACK_MS: 1500,
+  SIDEBAR_SYNC_FEEDBACK_ANIMATION_S: 0.18,
   // Height of a pinned sidebar section header (Projects/Chats). The Chats
   // header offsets by this amount so it stacks below the pinned Projects
   // header while scrolling.

--- a/src/components/chat/sidebar-sync-button.tsx
+++ b/src/components/chat/sidebar-sync-button.tsx
@@ -1,0 +1,123 @@
+import { cn } from '@/components/ui/utils'
+import { AnimatePresence, motion } from 'framer-motion'
+import { useState } from 'react'
+import { GoSync } from 'react-icons/go'
+import { PiSpinner } from 'react-icons/pi'
+import { CONSTANTS } from './constants'
+
+type SyncFeedback = 'idle' | 'syncing' | 'success'
+
+interface SidebarSyncButtonProps {
+  isDarkMode: boolean
+  isSyncing: boolean
+  syncFailed: boolean
+  onSync: () => Promise<boolean>
+}
+
+function wait(durationMs: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, durationMs))
+}
+
+export function SidebarSyncButton({
+  isDarkMode,
+  isSyncing,
+  syncFailed,
+  onSync,
+}: SidebarSyncButtonProps) {
+  const [feedback, setFeedback] = useState<SyncFeedback>('idle')
+  const showSpinner = isSyncing || feedback === 'syncing'
+  const isDisabled = isSyncing || feedback !== 'idle'
+  const statusLabel = showSpinner
+    ? 'Syncing'
+    : syncFailed
+      ? 'Sync failed'
+      : 'Sync healthy'
+
+  const handleSync = async () => {
+    const startedAt = Date.now()
+    setFeedback('syncing')
+
+    let succeeded = false
+    try {
+      succeeded = await onSync()
+    } catch {
+      succeeded = false
+    }
+
+    const remainingSpinnerTime = Math.max(
+      0,
+      CONSTANTS.SIDEBAR_SYNC_MIN_SPINNER_MS - (Date.now() - startedAt),
+    )
+    if (remainingSpinnerTime > 0) {
+      await wait(remainingSpinnerTime)
+    }
+
+    if (!succeeded) {
+      setFeedback('idle')
+      return
+    }
+
+    setFeedback('success')
+    await wait(CONSTANTS.SIDEBAR_SYNC_SUCCESS_FEEDBACK_MS)
+    setFeedback('idle')
+  }
+
+  return (
+    <div className="relative z-10 flex-none px-2 pt-2">
+      <button
+        type="button"
+        onClick={() => void handleSync()}
+        disabled={isDisabled}
+        aria-label={`Sync chats. ${feedback === 'success' ? 'Synced' : statusLabel}`}
+        className={cn(
+          'flex w-full items-center justify-between rounded-lg border px-2 py-2 text-sm transition-colors disabled:cursor-default',
+          showSpinner && 'opacity-60',
+          isDarkMode
+            ? 'border-border-strong bg-surface-chat text-content-primary hover:bg-surface-chat/80'
+            : 'border-border-subtle bg-white text-content-primary hover:bg-gray-50',
+        )}
+      >
+        <span className="flex items-center gap-2">
+          {showSpinner ? (
+            <PiSpinner className="h-4 w-4 animate-spin" />
+          ) : (
+            <GoSync className="h-4 w-4" />
+          )}
+          <span className="font-aeonik font-medium">Sync</span>
+        </span>
+        <AnimatePresence initial={false}>
+          {feedback === 'success' ? (
+            <motion.span
+              key="success"
+              initial={{ opacity: 0, y: 3 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -3 }}
+              transition={{
+                duration: CONSTANTS.SIDEBAR_SYNC_FEEDBACK_ANIMATION_S,
+              }}
+              className="text-xs font-medium text-green-600 dark:text-green-400"
+            >
+              Synced!
+            </motion.span>
+          ) : (
+            <motion.span
+              key="status"
+              initial={{ opacity: 0, scale: 0.5 }}
+              animate={{ opacity: 1, scale: 1 }}
+              exit={{ opacity: 0, scale: 0.5 }}
+              transition={{
+                duration: CONSTANTS.SIDEBAR_SYNC_FEEDBACK_ANIMATION_S,
+              }}
+              className={cn(
+                'h-2 w-2 rounded-full',
+                syncFailed ? 'bg-orange-500' : 'bg-green-500',
+              )}
+              title={statusLabel}
+              aria-hidden="true"
+            />
+          )}
+        </AnimatePresence>
+      </button>
+    </div>
+  )
+}

--- a/src/components/chat/sidebar-sync-button.tsx
+++ b/src/components/chat/sidebar-sync-button.tsx
@@ -1,5 +1,5 @@
 import { cn } from '@/components/ui/utils'
-import { AnimatePresence, motion } from 'framer-motion'
+import { motion } from 'framer-motion'
 import { useState } from 'react'
 import { GoSync } from 'react-icons/go'
 import { PiSpinner } from 'react-icons/pi'
@@ -27,6 +27,7 @@ export function SidebarSyncButton({
   const [feedback, setFeedback] = useState<SyncFeedback>('idle')
   const showSpinner = isSyncing || feedback === 'syncing'
   const isDisabled = isSyncing || feedback !== 'idle'
+  const showSuccess = feedback === 'success'
   const statusLabel = showSpinner
     ? 'Syncing'
     : syncFailed
@@ -85,38 +86,75 @@ export function SidebarSyncButton({
           )}
           <span className="font-aeonik font-medium">Sync</span>
         </span>
-        <AnimatePresence initial={false}>
-          {feedback === 'success' ? (
+        <span className="relative h-5 w-16 shrink-0">
+          <motion.span
+            initial={false}
+            animate={{
+              opacity: showSuccess ? 0 : 1,
+              filter: showSuccess ? 'blur(2px)' : 'blur(0px)',
+            }}
+            transition={
+              showSuccess
+                ? {
+                    duration: CONSTANTS.SIDEBAR_SYNC_FEEDBACK_EXIT_S,
+                    ease: 'easeOut',
+                  }
+                : {
+                    duration: CONSTANTS.SIDEBAR_SYNC_FEEDBACK_ENTER_S,
+                    delay: CONSTANTS.SIDEBAR_SYNC_FEEDBACK_ENTER_DELAY_S,
+                    ease: 'easeOut',
+                  }
+            }
+            className="absolute inset-0 flex items-center justify-end"
+            aria-hidden="true"
+          >
             <motion.span
-              key="success"
-              initial={{ opacity: 0, y: 3 }}
-              animate={{ opacity: 1, y: 0 }}
-              exit={{ opacity: 0, y: -3 }}
-              transition={{
-                duration: CONSTANTS.SIDEBAR_SYNC_FEEDBACK_ANIMATION_S,
-              }}
-              className="text-xs font-medium text-green-600 dark:text-green-400"
-            >
-              Synced!
-            </motion.span>
-          ) : (
-            <motion.span
-              key="status"
-              initial={{ opacity: 0, scale: 0.5 }}
-              animate={{ opacity: 1, scale: 1 }}
-              exit={{ opacity: 0, scale: 0.5 }}
-              transition={{
-                duration: CONSTANTS.SIDEBAR_SYNC_FEEDBACK_ANIMATION_S,
-              }}
+              initial={false}
+              animate={{ scale: showSuccess ? 0.7 : 1 }}
+              transition={
+                showSuccess
+                  ? {
+                      duration: CONSTANTS.SIDEBAR_SYNC_FEEDBACK_EXIT_S,
+                      ease: 'easeOut',
+                    }
+                  : {
+                      duration: CONSTANTS.SIDEBAR_SYNC_FEEDBACK_ENTER_S,
+                      delay: CONSTANTS.SIDEBAR_SYNC_FEEDBACK_ENTER_DELAY_S,
+                      ease: 'easeOut',
+                    }
+              }
               className={cn(
                 'h-2 w-2 rounded-full',
                 syncFailed ? 'bg-orange-500' : 'bg-green-500',
               )}
               title={statusLabel}
-              aria-hidden="true"
             />
-          )}
-        </AnimatePresence>
+          </motion.span>
+          <motion.span
+            initial={false}
+            animate={{
+              opacity: showSuccess ? 1 : 0,
+              y: showSuccess ? 0 : 3,
+              filter: showSuccess ? 'blur(0px)' : 'blur(2px)',
+            }}
+            transition={
+              showSuccess
+                ? {
+                    duration: CONSTANTS.SIDEBAR_SYNC_FEEDBACK_ENTER_S,
+                    delay: CONSTANTS.SIDEBAR_SYNC_FEEDBACK_ENTER_DELAY_S,
+                    ease: 'easeOut',
+                  }
+                : {
+                    duration: CONSTANTS.SIDEBAR_SYNC_FEEDBACK_EXIT_S,
+                    ease: 'easeOut',
+                  }
+            }
+            className="pointer-events-none absolute inset-0 flex items-center justify-end whitespace-nowrap text-xs font-medium text-green-600 dark:text-green-400"
+            aria-hidden={!showSuccess}
+          >
+            Synced!
+          </motion.span>
+        </span>
       </button>
     </div>
   )

--- a/src/hooks/use-cloud-sync.ts
+++ b/src/hooks/use-cloud-sync.ts
@@ -14,6 +14,7 @@ import {
   validateCurrentPrimaryKey,
 } from '@/services/cloud/cloud-key-preflight'
 import { cloudSync, type SyncResult } from '@/services/cloud/cloud-sync'
+import { reportSyncSuccess } from '@/services/cloud/sync-health'
 import { encryptionService } from '@/services/encryption/encryption-service'
 import { indexedDBStorage } from '@/services/storage/indexed-db'
 import {
@@ -28,6 +29,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 export interface CloudSyncState {
   syncing: boolean
   lastSyncTime: number | null
+  lastSyncFailed: boolean
   encryptionKey: string | null
   /** True once the init effect has finished (encryption key resolved) */
   initialized: boolean
@@ -50,6 +52,7 @@ export function useCloudSync(options?: UseCloudSyncOptions) {
   const [state, setState] = useState<CloudSyncState>({
     syncing: false,
     lastSyncTime: null,
+    lastSyncFailed: false,
     encryptionKey: null,
     initialized: false,
     decryptionProgress: null,
@@ -188,12 +191,18 @@ export function useCloudSync(options?: UseCloudSyncOptions) {
     const syncPromise = (async () => {
       try {
         const result = await cloudSync.smartSync(projectId)
+        const syncFailed = result.errors.length > 0
+
+        if (!syncFailed) {
+          reportSyncSuccess()
+        }
 
         if (isMountedRef.current) {
           setState((prev) => ({
             ...prev,
             syncing: false,
             lastSyncTime: Date.now(),
+            lastSyncFailed: syncFailed,
           }))
         }
 
@@ -208,7 +217,12 @@ export function useCloudSync(options?: UseCloudSyncOptions) {
         return result
       } catch (error) {
         if (isMountedRef.current) {
-          setState((prev) => ({ ...prev, syncing: false }))
+          setState((prev) => ({
+            ...prev,
+            syncing: false,
+            lastSyncTime: Date.now(),
+            lastSyncFailed: true,
+          }))
         }
         throw error
       } finally {

--- a/src/hooks/use-cloud-sync.ts
+++ b/src/hooks/use-cloud-sync.ts
@@ -220,7 +220,6 @@ export function useCloudSync(options?: UseCloudSyncOptions) {
           setState((prev) => ({
             ...prev,
             syncing: false,
-            lastSyncTime: Date.now(),
             lastSyncFailed: true,
           }))
         }

--- a/tests/components/chat/sidebar-sync-button.test.tsx
+++ b/tests/components/chat/sidebar-sync-button.test.tsx
@@ -40,7 +40,7 @@ describe('SidebarSyncButton', () => {
     expect(screen.getByRole('button')).toHaveAccessibleName(
       'Sync chats. Synced',
     )
-    expect(screen.getByText('Synced!')).toBeInTheDocument()
+    expect(screen.getByText('Synced!')).toHaveAttribute('aria-hidden', 'false')
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(
@@ -81,6 +81,6 @@ describe('SidebarSyncButton', () => {
     expect(screen.getByRole('button')).toHaveAccessibleName(
       'Sync chats. Sync failed',
     )
-    expect(screen.queryByText('Synced!')).not.toBeInTheDocument()
+    expect(screen.getByText('Synced!')).toHaveAttribute('aria-hidden', 'true')
   })
 })

--- a/tests/components/chat/sidebar-sync-button.test.tsx
+++ b/tests/components/chat/sidebar-sync-button.test.tsx
@@ -1,0 +1,86 @@
+import { CONSTANTS } from '@/components/chat/constants'
+import { SidebarSyncButton } from '@/components/chat/sidebar-sync-button'
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+describe('SidebarSyncButton', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('shows the spinner for at least one second before success feedback', async () => {
+    vi.useFakeTimers()
+    const onSync = vi.fn().mockResolvedValue(true)
+    render(
+      <SidebarSyncButton
+        isDarkMode={false}
+        isSyncing={false}
+        syncFailed={false}
+        onSync={onSync}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /sync chats/i }))
+    expect(screen.getByRole('button')).toHaveAccessibleName(
+      'Sync chats. Syncing',
+    )
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(
+        CONSTANTS.SIDEBAR_SYNC_MIN_SPINNER_MS - 1,
+      )
+    })
+    expect(screen.getByRole('button')).toHaveAccessibleName(
+      'Sync chats. Syncing',
+    )
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1)
+    })
+    expect(screen.getByRole('button')).toHaveAccessibleName(
+      'Sync chats. Synced',
+    )
+    expect(screen.getByText('Synced!')).toBeInTheDocument()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(
+        CONSTANTS.SIDEBAR_SYNC_SUCCESS_FEEDBACK_MS,
+      )
+    })
+    expect(screen.getByRole('button')).toHaveAccessibleName(
+      'Sync chats. Sync healthy',
+    )
+  })
+
+  it('returns to the failure dot without showing success feedback', async () => {
+    vi.useFakeTimers()
+    const onSync = vi.fn().mockResolvedValue(false)
+    const { rerender } = render(
+      <SidebarSyncButton
+        isDarkMode={false}
+        isSyncing={false}
+        syncFailed={false}
+        onSync={onSync}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /sync chats/i }))
+    rerender(
+      <SidebarSyncButton
+        isDarkMode={false}
+        isSyncing={false}
+        syncFailed
+        onSync={onSync}
+      />,
+    )
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(CONSTANTS.SIDEBAR_SYNC_MIN_SPINNER_MS)
+    })
+
+    expect(screen.getByRole('button')).toHaveAccessibleName(
+      'Sync chats. Sync failed',
+    )
+    expect(screen.queryByText('Synced!')).not.toBeInTheDocument()
+  })
+})

--- a/tests/hooks/use-cloud-sync.test.tsx
+++ b/tests/hooks/use-cloud-sync.test.tsx
@@ -1,0 +1,95 @@
+import { useCloudSync } from '@/hooks/use-cloud-sync'
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { reportSyncSuccessMock, smartSyncMock } = vi.hoisted(() => ({
+  reportSyncSuccessMock: vi.fn(),
+  smartSyncMock: vi.fn(),
+}))
+
+vi.mock('@clerk/nextjs', () => ({
+  useAuth: () => ({ getToken: vi.fn(), isSignedIn: false }),
+}))
+
+vi.mock('@/services/cloud/cloud-sync', () => ({
+  cloudSync: {
+    retryDecryptionWithNewKey: vi.fn(),
+    smartSync: smartSyncMock,
+  },
+}))
+
+vi.mock('@/services/cloud/sync-health', () => ({
+  reportSyncSuccess: reportSyncSuccessMock,
+}))
+
+vi.mock('@/services/encryption/encryption-service', () => ({
+  encryptionService: {
+    onFallbackKeyAdded: vi.fn(() => vi.fn()),
+  },
+}))
+
+vi.mock('@/utils/cloud-sync-settings', () => ({
+  isCloudSyncEnabled: () => true,
+  setCloudSyncEnabled: vi.fn(),
+}))
+
+describe('useCloudSync status', () => {
+  beforeEach(() => {
+    smartSyncMock.mockReset()
+    reportSyncSuccessMock.mockReset()
+  })
+
+  it('records a successful completed sync', async () => {
+    smartSyncMock.mockResolvedValue({
+      uploaded: 1,
+      downloaded: 0,
+      errors: [],
+    })
+    const { result } = renderHook(() => useCloudSync())
+
+    await act(async () => {
+      await result.current.syncChats()
+    })
+
+    expect(result.current.lastSyncTime).not.toBeNull()
+    expect(result.current.lastSyncFailed).toBe(false)
+    expect(reportSyncSuccessMock).toHaveBeenCalledOnce()
+  })
+
+  it('records returned sync errors as a failed attempt', async () => {
+    smartSyncMock.mockResolvedValue({
+      uploaded: 0,
+      downloaded: 0,
+      errors: ["A chat couldn't be synced"],
+    })
+    const { result } = renderHook(() => useCloudSync())
+
+    await act(async () => {
+      await result.current.syncChats()
+    })
+
+    expect(result.current.lastSyncTime).not.toBeNull()
+    expect(result.current.lastSyncFailed).toBe(true)
+    expect(reportSyncSuccessMock).not.toHaveBeenCalled()
+  })
+
+  it('records a thrown sync error as a failed attempt', async () => {
+    const syncError = new Error('unavailable')
+    smartSyncMock.mockRejectedValue(syncError)
+    const { result } = renderHook(() => useCloudSync())
+    let thrownError: unknown
+
+    await act(async () => {
+      try {
+        await result.current.syncChats()
+      } catch (error) {
+        thrownError = error
+      }
+    })
+
+    expect(thrownError).toBe(syncError)
+    expect(result.current.lastSyncTime).not.toBeNull()
+    expect(result.current.lastSyncFailed).toBe(true)
+    expect(reportSyncSuccessMock).not.toHaveBeenCalled()
+  })
+})

--- a/tests/hooks/use-cloud-sync.test.tsx
+++ b/tests/hooks/use-cloud-sync.test.tsx
@@ -68,7 +68,6 @@ describe('useCloudSync status', () => {
       await result.current.syncChats()
     })
 
-    expect(result.current.lastSyncTime).not.toBeNull()
     expect(result.current.lastSyncFailed).toBe(true)
     expect(reportSyncSuccessMock).not.toHaveBeenCalled()
   })
@@ -88,7 +87,7 @@ describe('useCloudSync status', () => {
     })
 
     expect(thrownError).toBe(syncError)
-    expect(result.current.lastSyncTime).not.toBeNull()
+    expect(result.current.lastSyncTime).toBeNull()
     expect(result.current.lastSyncFailed).toBe(true)
     expect(reportSyncSuccessMock).not.toHaveBeenCalled()
   })


### PR DESCRIPTION
## Summary
- move cloud sync above the new chat action in the expanded sidebar only
- show a green status dot when sync is healthy and an orange dot when it fails
- keep manual sync feedback visible for at least one second, then animate a successful `Synced!` confirmation back to the status dot
- remove the duplicate sync action from the Chats section header
- record successful and failed sync outcomes, with focused hook and UI coverage

## Testing
- `npx vitest run tests/components/chat/sidebar-sync-button.test.tsx tests/hooks/use-cloud-sync.test.tsx tests/services/cloud/sync-health.test.ts`
- `npx eslint src/components/chat/sidebar-sync-button.tsx src/components/chat/chat-sidebar.tsx src/components/chat/chat-interface.tsx src/components/chat/constants.ts tests/components/chat/sidebar-sync-button.test.tsx`
- `npx prettier --check src/components/chat/sidebar-sync-button.tsx src/components/chat/chat-sidebar.tsx src/components/chat/chat-interface.tsx src/components/chat/constants.ts tests/components/chat/sidebar-sync-button.test.tsx`
- `npx tsc --noEmit`
- `git diff --check`