### PR TITLE
fix: blur content behind the mobile sidebar

### DIFF
--- a/src/components/verification-sidebar.tsx
+++ b/src/components/verification-sidebar.tsx
@@ -242,7 +242,7 @@ export function VerifierSidebar({
 
       {isOpen && (
         <div
-          className="fixed inset-0 z-30 bg-black/50 md:hidden"
+          className="fixed inset-0 z-30 bg-black/50 backdrop-blur-sm md:hidden"
           onClick={() => setIsOpen(false)}
         />
       )}


### PR DESCRIPTION
## Summary
- blur page content behind the verification sidebar on mobile
- retain the existing dimmed backdrop and tap-to-close behavior

## Testing
- `npx eslint src/components/verification-sidebar.tsx`
- `npm run test:unit -- --run tests/components/verification-sidebar.test.tsx`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Blurs page content behind the mobile verification sidebar to improve focus without changing interaction. Previously the mobile overlay only dimmed content; now it dims and lightly blurs while preserving tap-to-close.

- Scope: mobile only (`md:hidden`), within `VerifierSidebar`.
- Change: adds `backdrop-blur-sm` to the overlay; z-index and backdrop color are unchanged.
- Verify: on mobile, content blurs and tap-to-close still works; desktop behavior is unchanged.
- Watch for minor performance impact on low-end devices when the overlay is active.

<sup>Written for commit 7c8230caf1c0577298c23410d15819ec009ede2a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/509?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

