### PR TITLE
Create releases from version tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+name: Create Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check release settings
+        run: node scripts/check-release-settings.mjs "${GITHUB_REF_NAME}"
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          draft: false
+          prerelease: ${{ contains(github.ref_name, '-') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         run: node scripts/check-release-settings.mjs "${GITHUB_REF_NAME}"
 
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65
         with:
           generate_release_notes: true
           draft: false

--- a/scripts/check-release-settings.mjs
+++ b/scripts/check-release-settings.mjs
@@ -1,0 +1,29 @@
+import { readFile } from 'node:fs/promises'
+
+const packageJson = JSON.parse(await readFile('package.json', 'utf8'))
+const packageLock = JSON.parse(await readFile('package-lock.json', 'utf8'))
+const packageVersion = packageJson.version
+const lockVersion = packageLock.packages?.['']?.version
+
+if (
+  !packageVersion ||
+  packageVersion !== packageLock.version ||
+  packageVersion !== lockVersion
+) {
+  throw new Error('Package release versions are missing or inconsistent.')
+}
+
+const releaseRef = process.argv[2] ?? ''
+
+if (releaseRef.startsWith('v')) {
+  const releaseVersion = releaseRef.slice(1)
+  const releaseBaseVersion = releaseVersion.split('-', 1)[0]
+
+  if (releaseBaseVersion !== packageVersion) {
+    throw new Error(
+      `Release tag ${releaseRef} does not match package version ${packageVersion}.`,
+    )
+  }
+}
+
+process.stdout.write(`Release settings are consistent: ${packageVersion}.\n`)

--- a/scripts/check-release-settings.mjs
+++ b/scripts/check-release-settings.mjs
@@ -13,17 +13,19 @@ if (
   throw new Error('Package release versions are missing or inconsistent.')
 }
 
-const releaseRef = process.argv[2] ?? ''
+const releaseRef = process.argv[2]
 
-if (releaseRef.startsWith('v')) {
-  const releaseVersion = releaseRef.slice(1)
-  const releaseBaseVersion = releaseVersion.split('-', 1)[0]
+if (!releaseRef?.startsWith('v')) {
+  throw new Error('A release tag starting with v is required.')
+}
 
-  if (releaseBaseVersion !== packageVersion) {
-    throw new Error(
-      `Release tag ${releaseRef} does not match package version ${packageVersion}.`,
-    )
-  }
+const releaseVersion = releaseRef.slice(1)
+const releaseBaseVersion = releaseVersion.split('-', 1)[0]
+
+if (releaseBaseVersion !== packageVersion) {
+  throw new Error(
+    `Release tag ${releaseRef} does not match package version ${packageVersion}.`,
+  )
 }
 
 process.stdout.write(`Release settings are consistent: ${packageVersion}.\n`)

--- a/scripts/check-release-settings.mjs
+++ b/scripts/check-release-settings.mjs
@@ -22,7 +22,10 @@ if (!releaseRef?.startsWith('v')) {
 const releaseVersion = releaseRef.slice(1)
 const releaseBaseVersion = releaseVersion.split('-', 1)[0]
 
-if (releaseBaseVersion !== packageVersion) {
+if (
+  releaseVersion !== packageVersion &&
+  releaseBaseVersion !== packageVersion
+) {
   throw new Error(
     `Release tag ${releaseRef} does not match package version ${packageVersion}.`,
   )


### PR DESCRIPTION
## Summary
- create GitHub releases with generated notes when `v*` tags are pushed
- mark hyphenated version tags as prereleases
- validate tags against the synchronized package and lockfile version before publishing

## Verification
- `node scripts/check-release-settings.mjs v1.0.0`
- `npx prettier --check .github/workflows/release.yml scripts/check-release-settings.mjs`
- `npm run lint -- --no-warn-ignored scripts/check-release-settings.mjs`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Creates GitHub Releases from v* tags with generated notes using a commit‑pinned `softprops/action-gh-release`; hyphenated tags publish as prereleases. Blocks publishing unless the tag matches versions in `package.json` and the root of `package-lock.json`; stable packages allow hyphenated prerelease tags (v1.2.3-rc.1), while prerelease package versions require an exact tag match.

**Rollout**
- Tag releases as v<version>; use hyphenated tags for prereleases only when the package is stable.
- Ensure `package.json` and `package-lock.json` versions match before tagging, or the job fails.

<sup>Written for commit f59047a5457f501053ba29b5bb4ceb68c79d7356. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/510?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

