### PR TITLE
fix: keep mobile sidebars above the chat input

### DIFF
--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -4189,7 +4189,7 @@ export function ChatInterface({
                 <div
                   ref={inputAreaRef}
                   data-chat-input-area
-                  className="pointer-events-none absolute inset-x-0 bottom-0 isolate z-30 px-4 pb-4"
+                  className="pointer-events-none absolute inset-x-0 bottom-0 isolate z-20 px-4 pb-4"
                   style={{
                     minHeight: '80px',
                     maxHeight: '50dvh',


### PR DESCRIPTION
## Summary
- move the chat input below the mobile sidebar backdrop layer
- ensure the verification blur covers the composer and the rest of the chat
- preserve the sidebar panel above both layers

## Testing
- `npx eslint src/components/chat/chat-interface.tsx`
- `npm run test:unit -- --run tests/components/verification-sidebar.test.tsx`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures mobile sidebars and the verification blur render above the chat input. Previously the input could overlap overlays; now the input area uses z-20 instead of z-30 so overlays consistently cover it.

**Review notes**
- Single change: in `src/components/chat/chat-interface.tsx`, lower `data-chat-input-area` z-index from `z-30` to `z-20`.
- Verify on mobile that the sidebar panel stays above both the blur and the input, and that the verification blur covers the composer.

<sup>Written for commit 04b654bad9c7c3f2c8f1f649bd628b328f51b8a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/511?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

