### PR TITLE
Fix new projects retaining the active chat

### DIFF
--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -155,6 +155,7 @@ import { useSidebarChat } from './hooks/use-sidebar-chat'
 import { MessageQueue } from './message-queue'
 import { getBlankQueueId } from './message-queue-identity'
 import { ModelSelector } from './model-selector'
+import { openProjectChat } from './project-navigation'
 import { QuoteSelectionPopover } from './quote-selection-popover'
 import { initializeRenderers } from './renderers/client'
 import type { ProcessedDocument } from './renderers/types'
@@ -2226,7 +2227,11 @@ export function ChatInterface({
     try {
       const name = `My Project #${projects.length + 1}`
       const project = await createProject({ name, description: '' })
-      await enterProjectMode(project.id)
+      await openProjectChat({
+        projectId: project.id,
+        createNewChat,
+        enterProjectMode,
+      })
     } catch (error) {
       logError('Failed to create project', error, {
         component: 'ChatInterface',
@@ -2240,6 +2245,7 @@ export function ChatInterface({
     }
   }, [
     createProject,
+    createNewChat,
     enterProjectMode,
     invalidateFavoriteNavigation,
     projects.length,
@@ -3869,8 +3875,12 @@ export function ChatInterface({
                 onEnterProject={async (projectId, projectName) => {
                   // Create a new blank chat before entering project mode
                   // This prevents the current chat from being associated with the project
-                  createNewChat(false, true)
-                  await enterProjectMode(projectId, projectName)
+                  await openProjectChat({
+                    projectId,
+                    projectName,
+                    createNewChat,
+                    enterProjectMode,
+                  })
                 }}
                 onCreateProject={handleCreateProject}
                 onMoveChatToProject={handleMoveChatToProject}

--- a/src/components/chat/project-navigation.ts
+++ b/src/components/chat/project-navigation.ts
@@ -1,0 +1,19 @@
+interface OpenProjectChatOptions {
+  projectId: string
+  projectName?: string
+  createNewChat: (isLocalOnly?: boolean, fromUserAction?: boolean) => void
+  enterProjectMode: (
+    projectId: string,
+    projectName?: string,
+  ) => Promise<boolean>
+}
+
+export async function openProjectChat({
+  projectId,
+  projectName,
+  createNewChat,
+  enterProjectMode,
+}: OpenProjectChatOptions): Promise<boolean> {
+  createNewChat(false, true)
+  return enterProjectMode(projectId, projectName)
+}

--- a/tests/components/chat/project-navigation.test.ts
+++ b/tests/components/chat/project-navigation.test.ts
@@ -1,0 +1,28 @@
+import { openProjectChat } from '@/components/chat/project-navigation'
+import { getChatPath, getNewChatPath } from '@/utils/navigation'
+import { describe, expect, it } from 'vitest'
+
+describe('openProjectChat', () => {
+  it('opens a new project without carrying over the active chat', async () => {
+    let activeChatId: string | null = 'existing-chat'
+    let path = getChatPath(activeChatId)
+
+    await openProjectChat({
+      projectId: 'new-project',
+      createNewChat: (isLocalOnly, fromUserAction) => {
+        expect(isLocalOnly).toBe(false)
+        expect(fromUserAction).toBe(true)
+        activeChatId = null
+      },
+      enterProjectMode: async (projectId) => {
+        path = activeChatId
+          ? getChatPath(activeChatId, { projectId })
+          : getNewChatPath({ projectId })
+        return true
+      },
+    })
+
+    expect(activeChatId).toBeNull()
+    expect(path).toBe('/project/new-project')
+  })
+})


### PR DESCRIPTION
## Summary
- open a blank chat before entering a newly created project
- share project-entry navigation so existing and new projects behave consistently
- add regression coverage for preventing an active chat from appearing in the new project

## Testing
- `npx vitest run tests/components/chat/project-navigation.test.ts`
- `npx eslint src/components/chat/chat-interface.tsx src/components/chat/project-navigation.ts tests/components/chat/project-navigation.test.ts`
- `npx prettier --check src/components/chat/chat-interface.tsx src/components/chat/project-navigation.ts tests/components/chat/project-navigation.test.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
New and existing project entries now start with a blank chat to prevent carrying over the active chat into the project. Previously, entering a project could attach the current chat; now we always create a blank chat before switching to project mode.

- Introduces `openProjectChat` in `src/components/chat/project-navigation.ts` to centralize project entry: calls `createNewChat(false, true)` then `enterProjectMode(...)`.
- Replaces inline logic in `ChatInterface` to use `openProjectChat` for both creating a project and entering an existing one.
- Adds `tests/components/chat/project-navigation.test.ts` to prevent regressions and verify navigation opens the project with a blank chat.
- Local checks: `npx vitest run tests/components/chat/project-navigation.test.ts`, `npx eslint src/components/chat/chat-interface.tsx src/components/chat/project-navigation.ts tests/components/chat/project-navigation.test.ts`, `npx prettier --check src/components/chat/chat-interface.tsx src/components/chat/project-navigation.ts tests/components/chat/project-navigation.test.ts`.

<sup>Written for commit 87a691c9af4f48c16c41ba3bd27b1253b4adc736. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/512?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

