### PR TITLE
Fix cross-device chat favorite sync

### DIFF
--- a/src/hooks/use-lossless-profile-sync.ts
+++ b/src/hooks/use-lossless-profile-sync.ts
@@ -16,6 +16,7 @@ import {
   isProfilePopulated,
   mergeProfilesThreeWay,
   overlayProfileChanges,
+  reconcileDirtyProfileWithoutBaseline,
 } from '@/services/cloud/profile-merge'
 import {
   applySettingsToLocal,
@@ -201,9 +202,21 @@ export function useProfileSync() {
               clearLocalProfileChanged()
             }
           } else if (wasDirtyBeforeFetch) {
-            throw new Error(
-              'Profile has unsynced changes but no safe merge baseline.',
-            )
+            const reconciled = reconcileDirtyProfileWithoutBaseline({
+              remote: remoteBaseline,
+              localBeforeFetch,
+              localAfterFetch,
+            })
+            if (!reconciled) {
+              throw new Error(
+                'Profile has unsynced changes but no safe merge baseline.',
+              )
+            }
+            saveProfileBaseline(userId, remoteBaseline)
+            baseline = remoteBaseline
+            applyProfile(reconciled)
+            saveLocalProfileMetadata(userId, reconciled)
+            markLocalProfileChanged()
           } else if (changesDuringFetch.length > 0) {
             const overlaid = overlayProfileChanges(
               remoteBaseline,

--- a/src/services/cloud/profile-merge.ts
+++ b/src/services/cloud/profile-merge.ts
@@ -98,12 +98,11 @@ export function reconcileDirtyProfileWithoutBaseline(args: {
   localAfterFetch: ProfileData
 }): ProfileData | null {
   const { remote, localBeforeFetch, localAfterFetch } = args
-  const localHasPinnedChats = Object.prototype.hasOwnProperty.call(
-    localBeforeFetch,
-    'pinnedChatIds',
+  const localHasMigrationSafeField = [...PRESERVE_LOCAL_WHEN_REMOTE_OMITS].some(
+    (field) => Object.prototype.hasOwnProperty.call(localBeforeFetch, field),
   )
 
-  if (!localHasPinnedChats) return null
+  if (!localHasMigrationSafeField) return null
 
   const profile = { ...remote }
   for (const field of PROFILE_MERGE_FIELDS) {

--- a/src/services/cloud/profile-merge.ts
+++ b/src/services/cloud/profile-merge.ts
@@ -122,13 +122,13 @@ export function reconcileDirtyProfileWithoutBaseline(args: {
       return null
     }
     if (!remoteHasField) {
-      if (field !== 'pinnedChatIds') return null
-      profile.pinnedChatIds = localBeforeFetch.pinnedChatIds
+      if (!PRESERVE_LOCAL_WHEN_REMOTE_OMITS.has(field)) return null
+      ;(profile as Record<string, unknown>)[field] = localValue
     }
   }
 
-  // Only the migration-safe favorites field may be missing remotely. Any
-  // other difference remains blocked until a baseline exists.
+  // Only migration-safe fields may be missing remotely. Any other
+  // difference remains blocked until a baseline exists.
   return overlayProfileChanges(profile, localBeforeFetch, localAfterFetch)
     .profile
 }

--- a/src/services/cloud/profile-merge.ts
+++ b/src/services/cloud/profile-merge.ts
@@ -92,6 +92,47 @@ export function overlayProfileChanges(
   return { profile, changedFields }
 }
 
+export function reconcileDirtyProfileWithoutBaseline(args: {
+  remote: ProfileData
+  localBeforeFetch: ProfileData
+  localAfterFetch: ProfileData
+}): ProfileData | null {
+  const { remote, localBeforeFetch, localAfterFetch } = args
+  const localHasPinnedChats = Object.prototype.hasOwnProperty.call(
+    localBeforeFetch,
+    'pinnedChatIds',
+  )
+
+  if (!localHasPinnedChats) return null
+
+  const profile = { ...remote }
+  for (const field of PROFILE_MERGE_FIELDS) {
+    const localHasField = Object.prototype.hasOwnProperty.call(
+      localBeforeFetch,
+      field,
+    )
+    if (!localHasField) continue
+
+    const remoteHasField = Object.prototype.hasOwnProperty.call(remote, field)
+    const localValue = (localBeforeFetch as Record<string, unknown>)[field]
+    if (
+      remoteHasField &&
+      !valuesEqual(localValue, (remote as Record<string, unknown>)[field])
+    ) {
+      return null
+    }
+    if (!remoteHasField) {
+      if (field !== 'pinnedChatIds') return null
+      profile.pinnedChatIds = localBeforeFetch.pinnedChatIds
+    }
+  }
+
+  // Only the migration-safe favorites field may be missing remotely. Any
+  // other difference remains blocked until a baseline exists.
+  return overlayProfileChanges(profile, localBeforeFetch, localAfterFetch)
+    .profile
+}
+
 function nonEmptyString(value: unknown): boolean {
   return typeof value === 'string' && value.trim().length > 0
 }

--- a/tests/hooks/use-lossless-profile-sync.test.ts
+++ b/tests/hooks/use-lossless-profile-sync.test.ts
@@ -1,0 +1,101 @@
+import {
+  SYNC_PROFILE_DIRTY,
+  USER_PREFS_PINNED_CHAT_IDS,
+} from '@/constants/storage-keys'
+import { useProfileSync } from '@/hooks/use-lossless-profile-sync'
+import type { ProfileData } from '@/services/cloud/profile-sync'
+import { renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  localProfile: {} as ProfileData,
+  fetchProfile: vi.fn(),
+  saveProfile: vi.fn(),
+}))
+
+vi.mock('@clerk/nextjs', () => ({
+  useAuth: () => ({ isSignedIn: true, userId: 'user-1' }),
+}))
+
+vi.mock('@/services/cloud/cloud-key-authorization', () => ({
+  getCurrentCloudKeyAuthorizationMode: vi.fn().mockResolvedValue('automatic'),
+}))
+
+vi.mock('@/services/cloud/profile-sync', () => ({
+  profileSync: {
+    fetchProfile: (...args: unknown[]) => mocks.fetchProfile(...args),
+    getSyncStatus: vi.fn().mockResolvedValue(null),
+    hasFailedRemoteDecryption: vi.fn(() => false),
+    saveProfile: (...args: unknown[]) => mocks.saveProfile(...args),
+  },
+}))
+
+vi.mock('@/services/cloud/profile-sync-coordinator', () => ({
+  invalidateProfileSyncGeneration: vi.fn(),
+  runSerializedProfileSync: async (
+    _userId: string,
+    sync: (isCurrent: () => boolean) => Promise<void>,
+  ) => sync(() => true),
+}))
+
+vi.mock(
+  '@/services/cloud/profile-settings-serializer',
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import('@/services/cloud/profile-settings-serializer')
+      >()
+    return {
+      ...actual,
+      applySettingsToLocal: (profile: ProfileData) => {
+        mocks.localProfile = { ...profile }
+      },
+      loadLocalSettings: () => ({ ...mocks.localProfile }),
+    }
+  },
+)
+
+vi.mock('@/utils/cloud-sync-settings', () => ({
+  CLOUD_SYNC_SETTING_CHANGED_EVENT: 'cloudSyncSettingChanged',
+  isCloudSyncEnabled: vi.fn(() => true),
+}))
+
+vi.mock('@/utils/error-handling', () => ({
+  logError: vi.fn(),
+  logInfo: vi.fn(),
+}))
+
+describe('useProfileSync', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.clearAllMocks()
+    mocks.localProfile = {
+      nickname: 'Remote',
+      pinnedChatIds: ['chat-a'],
+    }
+    localStorage.setItem(USER_PREFS_PINNED_CHAT_IDS, '["chat-a"]')
+    localStorage.setItem(SYNC_PROFILE_DIRTY, 'true')
+    mocks.fetchProfile.mockResolvedValue({
+      nickname: 'Remote',
+      version: 4,
+    })
+    mocks.saveProfile.mockResolvedValue({ success: true, version: 5 })
+  })
+
+  it('uploads local favorites after establishing a missing baseline', async () => {
+    const { unmount } = renderHook(() => useProfileSync())
+
+    await waitFor(() => expect(mocks.saveProfile).toHaveBeenCalledTimes(1))
+
+    expect(mocks.saveProfile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        nickname: 'Remote',
+        pinnedChatIds: ['chat-a'],
+        version: 4,
+      }),
+      expect.objectContaining({ nickname: 'Remote', version: 4 }),
+    )
+    expect(localStorage.getItem(SYNC_PROFILE_DIRTY)).toBeNull()
+    unmount()
+  })
+})

--- a/tests/services/cloud/profile-merge.test.ts
+++ b/tests/services/cloud/profile-merge.test.ts
@@ -256,12 +256,14 @@ describe('reconcileDirtyProfileWithoutBaseline', () => {
         nickname: 'Remote',
         themeMode: 'light',
         profession: 'Researcher',
+        pixelateSidebarChatTitlesEnabled: false,
         pinnedChatIds: ['chat-a'],
       },
       localAfterFetch: {
         nickname: 'Remote',
         themeMode: 'light',
         profession: 'Researcher',
+        pixelateSidebarChatTitlesEnabled: false,
         pinnedChatIds: ['chat-a'],
       },
     })
@@ -270,6 +272,7 @@ describe('reconcileDirtyProfileWithoutBaseline', () => {
       nickname: 'Remote',
       themeMode: 'light',
       profession: 'Researcher',
+      pixelateSidebarChatTitlesEnabled: false,
       pinnedChatIds: ['chat-a'],
       version: 4,
     })

--- a/tests/services/cloud/profile-merge.test.ts
+++ b/tests/services/cloud/profile-merge.test.ts
@@ -14,6 +14,7 @@ import {
   mergeProfiles,
   mergeProfilesThreeWay,
   overlayProfileChanges,
+  reconcileDirtyProfileWithoutBaseline,
 } from '@/services/cloud/profile-merge'
 import type { ProfileData } from '@/services/cloud/profile-sync'
 import { describe, expect, it } from 'vitest'
@@ -239,6 +240,132 @@ describe('overlayProfileChanges', () => {
 
     expect(result.profile).toEqual({ version: 2 })
     expect(result.changedFields).toEqual(['customSystemPrompt'])
+  })
+})
+
+describe('reconcileDirtyProfileWithoutBaseline', () => {
+  it('preserves local pins without replacing remote settings', () => {
+    const profile = reconcileDirtyProfileWithoutBaseline({
+      remote: {
+        nickname: 'Remote',
+        themeMode: 'light',
+        profession: 'Researcher',
+        version: 4,
+      },
+      localBeforeFetch: {
+        nickname: 'Remote',
+        themeMode: 'light',
+        profession: 'Researcher',
+        pinnedChatIds: ['chat-a'],
+      },
+      localAfterFetch: {
+        nickname: 'Remote',
+        themeMode: 'light',
+        profession: 'Researcher',
+        pinnedChatIds: ['chat-a'],
+      },
+    })
+
+    expect(profile).toEqual({
+      nickname: 'Remote',
+      themeMode: 'light',
+      profession: 'Researcher',
+      pinnedChatIds: ['chat-a'],
+      version: 4,
+    })
+  })
+
+  it('preserves an explicit local clear when the remote omits pins', () => {
+    const profile = reconcileDirtyProfileWithoutBaseline({
+      remote: { nickname: 'Remote', version: 4 },
+      localBeforeFetch: { pinnedChatIds: [] },
+      localAfterFetch: { pinnedChatIds: [] },
+    })
+
+    expect(profile?.pinnedChatIds).toEqual([])
+  })
+
+  it('overlays settings changed while the remote profile was loading', () => {
+    const profile = reconcileDirtyProfileWithoutBaseline({
+      remote: { nickname: 'Remote', profession: 'Researcher', version: 4 },
+      localBeforeFetch: {
+        nickname: 'Remote',
+        profession: 'Researcher',
+        pinnedChatIds: ['chat-a'],
+      },
+      localAfterFetch: {
+        nickname: 'Changed during fetch',
+        profession: 'Researcher',
+        pinnedChatIds: ['chat-a'],
+      },
+    })
+
+    expect(profile).toMatchObject({
+      nickname: 'Changed during fetch',
+      profession: 'Researcher',
+      pinnedChatIds: ['chat-a'],
+    })
+  })
+
+  it('accepts matching remote pins', () => {
+    const profile = reconcileDirtyProfileWithoutBaseline({
+      remote: { nickname: 'Remote', pinnedChatIds: ['chat-a'] },
+      localBeforeFetch: {
+        nickname: 'Remote',
+        pinnedChatIds: ['chat-a'],
+      },
+      localAfterFetch: {
+        nickname: 'Remote',
+        pinnedChatIds: ['chat-a'],
+      },
+    })
+
+    expect(profile?.pinnedChatIds).toEqual(['chat-a'])
+  })
+
+  it('rejects reconciliation without pins or with overlapping changes', () => {
+    expect(
+      reconcileDirtyProfileWithoutBaseline({
+        remote: { nickname: 'Remote' },
+        localBeforeFetch: { nickname: 'Local' },
+        localAfterFetch: { nickname: 'Local' },
+      }),
+    ).toBeNull()
+    expect(
+      reconcileDirtyProfileWithoutBaseline({
+        remote: { nickname: 'Remote' },
+        localBeforeFetch: {
+          nickname: 'Remote',
+          profession: 'Researcher',
+          pinnedChatIds: ['chat-a'],
+        },
+        localAfterFetch: {
+          nickname: 'Remote',
+          profession: 'Researcher',
+          pinnedChatIds: ['chat-a'],
+        },
+      }),
+    ).toBeNull()
+    expect(
+      reconcileDirtyProfileWithoutBaseline({
+        remote: { nickname: 'Remote' },
+        localBeforeFetch: {
+          nickname: 'Local',
+          pinnedChatIds: ['chat-a'],
+        },
+        localAfterFetch: {
+          nickname: 'Local',
+          pinnedChatIds: ['chat-a'],
+        },
+      }),
+    ).toBeNull()
+    expect(
+      reconcileDirtyProfileWithoutBaseline({
+        remote: { pinnedChatIds: ['remote-chat'] },
+        localBeforeFetch: { pinnedChatIds: ['local-chat'] },
+        localAfterFetch: { pinnedChatIds: ['local-chat'] },
+      }),
+    ).toBeNull()
   })
 })
 

--- a/tests/services/cloud/profile-merge.test.ts
+++ b/tests/services/cloud/profile-merge.test.ts
@@ -288,6 +288,22 @@ describe('reconcileDirtyProfileWithoutBaseline', () => {
     expect(profile?.pinnedChatIds).toEqual([])
   })
 
+  it('recovers another migration-safe field without local pins', () => {
+    const profile = reconcileDirtyProfileWithoutBaseline({
+      remote: { nickname: 'Remote', version: 4 },
+      localBeforeFetch: {
+        nickname: 'Remote',
+        pixelateSidebarChatTitlesEnabled: false,
+      },
+      localAfterFetch: {
+        nickname: 'Remote',
+        pixelateSidebarChatTitlesEnabled: false,
+      },
+    })
+
+    expect(profile?.pixelateSidebarChatTitlesEnabled).toBe(false)
+  })
+
   it('overlays settings changed while the remote profile was loading', () => {
     const profile = reconcileDirtyProfileWithoutBaseline({
       remote: { nickname: 'Remote', profession: 'Researcher', version: 4 },


### PR DESCRIPTION
## Summary
- recover favorite changes that were blocked before the first profile baseline
- preserve remote profile settings and reject ambiguous bootstrap merges
- add hook and merge regression coverage for cross-browser synchronization

## Testing
- `npm run test:unit -- --run` (1797 passed)
- `npx eslint src/services/cloud/profile-merge.ts src/hooks/use-lossless-profile-sync.ts tests/services/cloud/profile-merge.test.ts tests/hooks/use-lossless-profile-sync.test.ts`
- `npm run build` *(blocked by the existing missing `out/_next/static/media/local-tinfoil-import-parser` generated module)*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores cross‑device sync for chat favorites and other migration‑safe profile settings when no remote baseline exists. Previously, a dirty local profile without a baseline aborted sync; now we reconcile compatible fields against the remote, preserve remote settings, overlay changes made during fetch, and still abort on conflicts.

- Adds reconciliation to accept local `pinnedChatIds` and other migration‑safe fields when the remote matches or omits them; any conflicting field rejects reconciliation.
- Updates the sync hook to apply the reconciled profile, set the remote as the baseline, persist locally, and perform a single upload.
- Adds focused tests for reconciliation and the hook, including changes made during fetch and recovery of all compatible settings.

**Rollout**
- No migration required; previously blocked favorites and compatible settings sync on next profile load.
- Monitor “Profile has unsynced changes but no safe merge baseline” to detect remaining ambiguous cases.

<sup>Written for commit 843edab1819932286bf04d1c2187f9c9a8d97302. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/513?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

