### PR TITLE
Sync profiles and improve favorite removal

### DIFF
--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -71,6 +71,7 @@ import { useCloudSync } from '@/hooks/use-cloud-sync'
 import { usePasskeyBackup } from '@/hooks/use-passkey-backup'
 import { usePinnedChats } from '@/hooks/use-pinned-chats'
 import { useProfileSync } from '@/hooks/use-profile-sync'
+import { runManualCloudSync } from '@/services/cloud/manual-cloud-sync'
 import { ENCRYPTION_KEY_CHANGED_EVENT } from '@/services/encryption/encryption-service'
 import { hydratePinnedChatById } from '@/services/storage/pinned-chat-hydration'
 import {
@@ -2055,17 +2056,19 @@ export function ChatInterface({
 
   const handleManualSync = useCallback(async () => {
     try {
-      const result = await syncChats()
-      await reloadChats()
-      return result !== false && result.errors.length === 0
+      return await runManualCloudSync({
+        syncChats,
+        syncProfile: syncProfileFromCloud,
+        reloadChats,
+      })
     } catch (error) {
-      logError('Manual chat sync failed', error, {
+      logError('Manual cloud sync failed', error, {
         component: 'ChatInterface',
         action: 'handleManualSync',
       })
       return false
     }
-  }, [syncChats, reloadChats])
+  }, [syncChats, syncProfileFromCloud, reloadChats])
 
   // Handler for opening verifier sidebar
   const handleOpenVerifierSidebar = () => {
@@ -3769,6 +3772,7 @@ export function ChatInterface({
                   favoriteChats={favoriteChats}
                   pinnedChatIds={pinnedChatIds}
                   onToggleFavorite={handleToggleFavorite}
+                  onRemoveFavorite={unpinChat}
                   onOpenFavorite={handleOpenFavorite}
                   cloudSyncEnabled={cloudSyncSettingEnabled}
                   windowWidth={windowWidth}
@@ -3812,6 +3816,7 @@ export function ChatInterface({
                   favoriteChats={favoriteChats}
                   pinnedChatIds={pinnedChatIds}
                   onToggleFavorite={handleToggleFavorite}
+                  onRemoveFavorite={unpinChat}
                   onOpenFavorite={handleOpenFavorite}
                   cloudSyncEnabled={cloudSyncSettingEnabled}
                   windowWidth={windowWidth}
@@ -3890,6 +3895,7 @@ export function ChatInterface({
                 onSettingsClick={handleOpenSettingsModal}
                 pinnedChatIds={pinnedChatIds}
                 onToggleFavorite={handleToggleFavorite}
+                onRemoveFavorite={unpinChat}
                 onOpenFavorite={handleOpenFavorite}
                 windowWidth={windowWidth}
                 chatDecryptionProgress={decryptionProgress}

--- a/src/components/chat/chat-sidebar.tsx
+++ b/src/components/chat/chat-sidebar.tsx
@@ -1455,24 +1455,26 @@ export function ChatSidebar({
                 onDragOver={(e) => {
                   if (
                     e.dataTransfer.types.includes('application/x-chat-id') &&
-                    cloudSyncEnabled &&
-                    draggingChatSource !== 'favorites'
+                    cloudSyncEnabled
                   ) {
                     e.preventDefault()
-                    e.dataTransfer.dropEffect = 'move'
-                    setIsDropTargetProjectsHeader(true)
+                    if (draggingChatSource !== 'favorites') {
+                      e.dataTransfer.dropEffect = 'move'
+                      setIsDropTargetProjectsHeader(true)
+                    }
                   }
                 }}
                 onDragEnter={(e) => {
                   if (
                     e.dataTransfer.types.includes('application/x-chat-id') &&
-                    cloudSyncEnabled &&
-                    draggingChatSource !== 'favorites'
+                    cloudSyncEnabled
                   ) {
                     e.preventDefault()
-                    setIsDropTargetProjectsHeader(true)
-                    if (!isProjectsExpanded) {
-                      expandProjectsSection()
+                    if (draggingChatSource !== 'favorites') {
+                      setIsDropTargetProjectsHeader(true)
+                      if (!isProjectsExpanded) {
+                        expandProjectsSection()
+                      }
                     }
                   }
                 }}
@@ -1733,12 +1735,13 @@ export function ChatSidebar({
                                       e.dataTransfer.types.includes(
                                         'application/x-chat-id',
                                       ) &&
-                                      !project.decryptionFailed &&
-                                      draggingChatSource !== 'favorites'
+                                      !project.decryptionFailed
                                     ) {
                                       e.preventDefault()
-                                      e.dataTransfer.dropEffect = 'move'
-                                      setDropTargetProject(project.id)
+                                      if (draggingChatSource !== 'favorites') {
+                                        e.dataTransfer.dropEffect = 'move'
+                                        setDropTargetProject(project.id)
+                                      }
                                     }
                                   },
                                   onDragEnter: (
@@ -1748,25 +1751,24 @@ export function ChatSidebar({
                                       e.dataTransfer.types.includes(
                                         'application/x-chat-id',
                                       ) &&
-                                      !project.decryptionFailed &&
-                                      draggingChatSource !== 'favorites'
+                                      !project.decryptionFailed
                                     ) {
                                       e.preventDefault()
-                                      setDropTargetProject(project.id)
-                                      if (projectHoverTimerRef.current) {
-                                        clearTimeout(
-                                          projectHoverTimerRef.current,
-                                        )
-                                      }
-                                      projectHoverTimerRef.current = setTimeout(
-                                        () => {
-                                          onEnterProject?.(
-                                            project.id,
-                                            project.name,
+                                      if (draggingChatSource !== 'favorites') {
+                                        setDropTargetProject(project.id)
+                                        if (projectHoverTimerRef.current) {
+                                          clearTimeout(
+                                            projectHoverTimerRef.current,
                                           )
-                                        },
-                                        400,
-                                      )
+                                        }
+                                        projectHoverTimerRef.current =
+                                          setTimeout(() => {
+                                            onEnterProject?.(
+                                              project.id,
+                                              project.name,
+                                            )
+                                          }, 400)
+                                      }
                                     }
                                   },
                                   onDragLeave: (
@@ -2024,12 +2026,13 @@ export function ChatSidebar({
                             e.dataTransfer.types.includes(
                               'application/x-chat-id',
                             ) &&
-                            onConvertChatToCloud &&
-                            draggingChatSource !== 'favorites'
+                            onConvertChatToCloud
                           ) {
                             e.preventDefault()
-                            e.dataTransfer.dropEffect = 'move'
-                            setDropTargetTab('cloud')
+                            if (draggingChatSource !== 'favorites') {
+                              e.dataTransfer.dropEffect = 'move'
+                              setDropTargetTab('cloud')
+                            }
                           }
                         }}
                         onDragEnter={(e) => {
@@ -2037,12 +2040,13 @@ export function ChatSidebar({
                             e.dataTransfer.types.includes(
                               'application/x-chat-id',
                             ) &&
-                            onConvertChatToCloud &&
-                            draggingChatSource !== 'favorites'
+                            onConvertChatToCloud
                           ) {
                             e.preventDefault()
-                            setDropTargetTab('cloud')
-                            setActiveTab('cloud')
+                            if (draggingChatSource !== 'favorites') {
+                              setDropTargetTab('cloud')
+                              setActiveTab('cloud')
+                            }
                           }
                         }}
                         onDragLeave={() => {
@@ -2106,12 +2110,13 @@ export function ChatSidebar({
                             e.dataTransfer.types.includes(
                               'application/x-chat-id',
                             ) &&
-                            onConvertChatToLocal &&
-                            draggingChatSource !== 'favorites'
+                            onConvertChatToLocal
                           ) {
                             e.preventDefault()
-                            e.dataTransfer.dropEffect = 'move'
-                            setDropTargetTab('local')
+                            if (draggingChatSource !== 'favorites') {
+                              e.dataTransfer.dropEffect = 'move'
+                              setDropTargetTab('local')
+                            }
                           }
                         }}
                         onDragEnter={(e) => {
@@ -2119,12 +2124,13 @@ export function ChatSidebar({
                             e.dataTransfer.types.includes(
                               'application/x-chat-id',
                             ) &&
-                            onConvertChatToLocal &&
-                            draggingChatSource !== 'favorites'
+                            onConvertChatToLocal
                           ) {
                             e.preventDefault()
-                            setActiveTab('local')
-                            setDropTargetTab('local')
+                            if (draggingChatSource !== 'favorites') {
+                              setActiveTab('local')
+                              setDropTargetTab('local')
+                            }
                           }
                         }}
                         onDragLeave={() => {

--- a/src/components/chat/chat-sidebar.tsx
+++ b/src/components/chat/chat-sidebar.tsx
@@ -55,6 +55,7 @@ import { ChatList, type ChatItemData } from './chat-list'
 import { formatRelativeTime } from './chat-list-utils'
 import { CONSTANTS } from './constants'
 import { useDrag } from './drag-context'
+import { consumeFavoriteDrop } from './favorite-drag'
 import { SidebarSyncButton } from './sidebar-sync-button'
 import { useFavoriteDropTarget } from './use-favorite-drop-target'
 
@@ -145,6 +146,7 @@ type ChatSidebarProps = {
   onSettingsClick?: () => void
   pinnedChatIds?: readonly string[]
   onToggleFavorite?: (chat: ChatItemData) => void | Promise<void>
+  onRemoveFavorite?: (chatId: string) => void
   onOpenFavorite?: (chat: ChatItemData) => void | Promise<void>
   windowWidth: number
   /**
@@ -219,6 +221,7 @@ export function ChatSidebar({
   onSettingsClick,
   pinnedChatIds = [],
   onToggleFavorite,
+  onRemoveFavorite,
   onOpenFavorite,
   windowWidth,
   chatDecryptionProgress,
@@ -311,6 +314,7 @@ export function ChatSidebar({
   const {
     draggingChatId,
     draggingChatFromProjectId,
+    draggingChatSource,
     dropTargetProjectId,
     dropTargetTab,
     isDropTargetChatHistory,
@@ -1411,9 +1415,13 @@ export function ChatSidebar({
                         }}
                         onUpdateTitle={updateChatTitle}
                         onDeleteChat={deleteChat}
+                        isDraggable={Boolean(onRemoveFavorite)}
+                        onDragStart={(chatId) =>
+                          setDraggingChat(chatId, null, 'favorites')
+                        }
+                        onDragEnd={clearDragState}
                         pinnedChatIds={pinnedChatIds}
                         showPinnedIndicators={false}
-                        showDesktopPinActions={false}
                         onTogglePin={onToggleFavorite}
                       />
                     ) : (
@@ -1461,7 +1469,10 @@ export function ChatSidebar({
                   ) {
                     e.preventDefault()
                     setIsDropTargetProjectsHeader(true)
-                    if (!isProjectsExpanded) {
+                    if (
+                      !isProjectsExpanded &&
+                      draggingChatSource !== 'favorites'
+                    ) {
                       expandProjectsSection()
                     }
                   }
@@ -1469,8 +1480,19 @@ export function ChatSidebar({
                 onDragLeave={() => {
                   setIsDropTargetProjectsHeader(false)
                 }}
-                onDrop={() => {
+                onDrop={(e) => {
+                  e.preventDefault()
+                  const chatId = e.dataTransfer.getData('application/x-chat-id')
+                  if (chatId) {
+                    consumeFavoriteDrop({
+                      source: draggingChatSource,
+                      chatId,
+                      pinnedChatIds,
+                      onRemoveFavorite,
+                    })
+                  }
                   setIsDropTargetProjectsHeader(false)
+                  clearDragState()
                 }}
                 style={{
                   // Explicit height shared with the Chats header's stacking
@@ -1735,15 +1757,15 @@ export function ChatSidebar({
                                           projectHoverTimerRef.current,
                                         )
                                       }
-                                      projectHoverTimerRef.current = setTimeout(
-                                        () => {
-                                          onEnterProject?.(
-                                            project.id,
-                                            project.name,
-                                          )
-                                        },
-                                        400,
-                                      )
+                                      if (draggingChatSource !== 'favorites') {
+                                        projectHoverTimerRef.current =
+                                          setTimeout(() => {
+                                            onEnterProject?.(
+                                              project.id,
+                                              project.name,
+                                            )
+                                          }, 400)
+                                      }
                                     }
                                   },
                                   onDragLeave: (
@@ -1777,7 +1799,16 @@ export function ChatSidebar({
                                     const chatId = e.dataTransfer.getData(
                                       'application/x-chat-id',
                                     )
+                                    const favoriteDropConsumed = chatId
+                                      ? consumeFavoriteDrop({
+                                          source: draggingChatSource,
+                                          chatId,
+                                          pinnedChatIds,
+                                          onRemoveFavorite,
+                                        })
+                                      : false
                                     if (
+                                      !favoriteDropConsumed &&
                                       chatId &&
                                       onMoveChatToProject &&
                                       !project.decryptionFailed
@@ -1877,7 +1908,10 @@ export function ChatSidebar({
                 if (chatId) {
                   e.preventDefault()
                   setDropTargetChatHistory(true)
-                  if (!isChatHistoryExpanded) {
+                  if (
+                    !isChatHistoryExpanded &&
+                    draggingChatSource !== 'favorites'
+                  ) {
                     expandChatsSection()
                   }
                 }
@@ -1888,7 +1922,17 @@ export function ChatSidebar({
               onDrop={async (e) => {
                 e.preventDefault()
                 const chatId = e.dataTransfer.getData('application/x-chat-id')
-                if (chatId && onRemoveChatFromProject) {
+                const favoriteDropConsumed = chatId
+                  ? consumeFavoriteDrop({
+                      source: draggingChatSource,
+                      chatId,
+                      pinnedChatIds,
+                      onRemoveFavorite,
+                    })
+                  : false
+                if (favoriteDropConsumed) {
+                  expandChatsSection()
+                } else if (chatId && onRemoveChatFromProject) {
                   await onRemoveChatFromProject(chatId)
                 }
                 clearDragState()
@@ -2009,13 +2053,23 @@ export function ChatSidebar({
                             'application/x-chat-id',
                           )
                           if (chatId) {
+                            const favoriteDropConsumed = consumeFavoriteDrop({
+                              source: draggingChatSource,
+                              chatId,
+                              pinnedChatIds,
+                              onRemoveFavorite,
+                            })
                             if (
+                              !favoriteDropConsumed &&
                               draggingChatFromProjectId &&
                               onRemoveChatFromProject
                             ) {
                               // Chat from project is already cloud, just remove from project
                               await onRemoveChatFromProject(chatId)
-                            } else if (onConvertChatToCloud) {
+                            } else if (
+                              !favoriteDropConsumed &&
+                              onConvertChatToCloud
+                            ) {
                               // Only convert if dragging from local (not from project)
                               await onConvertChatToCloud(chatId)
                             }
@@ -2078,7 +2132,19 @@ export function ChatSidebar({
                           const chatId = e.dataTransfer.getData(
                             'application/x-chat-id',
                           )
-                          if (chatId && onConvertChatToLocal) {
+                          const favoriteDropConsumed = chatId
+                            ? consumeFavoriteDrop({
+                                source: draggingChatSource,
+                                chatId,
+                                pinnedChatIds,
+                                onRemoveFavorite,
+                              })
+                            : false
+                          if (
+                            !favoriteDropConsumed &&
+                            chatId &&
+                            onConvertChatToLocal
+                          ) {
                             // convertChatToLocal also clears projectId
                             await onConvertChatToLocal(chatId)
                           }
@@ -2223,7 +2289,16 @@ export function ChatSidebar({
                       )
                       if (chatId) {
                         const chat = chats.find((c) => c.id === chatId)
-                        if (draggingChatFromProjectId) {
+                        const favoriteDropConsumed = consumeFavoriteDrop({
+                          source: draggingChatSource,
+                          chatId,
+                          pinnedChatIds,
+                          onRemoveFavorite,
+                        })
+                        if (
+                          !favoriteDropConsumed &&
+                          draggingChatFromProjectId
+                        ) {
                           // Dragging from project - remove from project
                           if (activeTab === 'local' && onConvertChatToLocal) {
                             await onConvertChatToLocal(chatId)

--- a/src/components/chat/chat-sidebar.tsx
+++ b/src/components/chat/chat-sidebar.tsx
@@ -1455,7 +1455,8 @@ export function ChatSidebar({
                 onDragOver={(e) => {
                   if (
                     e.dataTransfer.types.includes('application/x-chat-id') &&
-                    cloudSyncEnabled
+                    cloudSyncEnabled &&
+                    draggingChatSource !== 'favorites'
                   ) {
                     e.preventDefault()
                     e.dataTransfer.dropEffect = 'move'
@@ -1465,14 +1466,12 @@ export function ChatSidebar({
                 onDragEnter={(e) => {
                   if (
                     e.dataTransfer.types.includes('application/x-chat-id') &&
-                    cloudSyncEnabled
+                    cloudSyncEnabled &&
+                    draggingChatSource !== 'favorites'
                   ) {
                     e.preventDefault()
                     setIsDropTargetProjectsHeader(true)
-                    if (
-                      !isProjectsExpanded &&
-                      draggingChatSource !== 'favorites'
-                    ) {
+                    if (!isProjectsExpanded) {
                       expandProjectsSection()
                     }
                   }
@@ -1734,7 +1733,8 @@ export function ChatSidebar({
                                       e.dataTransfer.types.includes(
                                         'application/x-chat-id',
                                       ) &&
-                                      !project.decryptionFailed
+                                      !project.decryptionFailed &&
+                                      draggingChatSource !== 'favorites'
                                     ) {
                                       e.preventDefault()
                                       e.dataTransfer.dropEffect = 'move'
@@ -1748,7 +1748,8 @@ export function ChatSidebar({
                                       e.dataTransfer.types.includes(
                                         'application/x-chat-id',
                                       ) &&
-                                      !project.decryptionFailed
+                                      !project.decryptionFailed &&
+                                      draggingChatSource !== 'favorites'
                                     ) {
                                       e.preventDefault()
                                       setDropTargetProject(project.id)
@@ -1757,15 +1758,15 @@ export function ChatSidebar({
                                           projectHoverTimerRef.current,
                                         )
                                       }
-                                      if (draggingChatSource !== 'favorites') {
-                                        projectHoverTimerRef.current =
-                                          setTimeout(() => {
-                                            onEnterProject?.(
-                                              project.id,
-                                              project.name,
-                                            )
-                                          }, 400)
-                                      }
+                                      projectHoverTimerRef.current = setTimeout(
+                                        () => {
+                                          onEnterProject?.(
+                                            project.id,
+                                            project.name,
+                                          )
+                                        },
+                                        400,
+                                      )
                                     }
                                   },
                                   onDragLeave: (
@@ -2023,7 +2024,8 @@ export function ChatSidebar({
                             e.dataTransfer.types.includes(
                               'application/x-chat-id',
                             ) &&
-                            onConvertChatToCloud
+                            onConvertChatToCloud &&
+                            draggingChatSource !== 'favorites'
                           ) {
                             e.preventDefault()
                             e.dataTransfer.dropEffect = 'move'
@@ -2035,7 +2037,8 @@ export function ChatSidebar({
                             e.dataTransfer.types.includes(
                               'application/x-chat-id',
                             ) &&
-                            onConvertChatToCloud
+                            onConvertChatToCloud &&
+                            draggingChatSource !== 'favorites'
                           ) {
                             e.preventDefault()
                             setDropTargetTab('cloud')
@@ -2103,7 +2106,8 @@ export function ChatSidebar({
                             e.dataTransfer.types.includes(
                               'application/x-chat-id',
                             ) &&
-                            onConvertChatToLocal
+                            onConvertChatToLocal &&
+                            draggingChatSource !== 'favorites'
                           ) {
                             e.preventDefault()
                             e.dataTransfer.dropEffect = 'move'
@@ -2115,7 +2119,8 @@ export function ChatSidebar({
                             e.dataTransfer.types.includes(
                               'application/x-chat-id',
                             ) &&
-                            onConvertChatToLocal
+                            onConvertChatToLocal &&
+                            draggingChatSource !== 'favorites'
                           ) {
                             e.preventDefault()
                             setActiveTab('local')

--- a/src/components/chat/drag-context.tsx
+++ b/src/components/chat/drag-context.tsx
@@ -8,9 +8,12 @@ import {
   type ReactNode,
 } from 'react'
 
+export type ChatDragSource = 'chat-history' | 'project' | 'favorites'
+
 interface DragContextValue {
   draggingChatId: string | null
   draggingChatFromProjectId: string | null
+  draggingChatSource: ChatDragSource | null
   dropTargetProjectId: string | null
   dropTargetTab: 'cloud' | 'local' | null
   isDropTargetChatHistory: boolean
@@ -18,6 +21,7 @@ interface DragContextValue {
   setDraggingChat: (
     chatId: string | null,
     fromProjectId?: string | null,
+    source?: ChatDragSource,
   ) => void
   setDropTargetProject: (projectId: string | null) => void
   setDropTargetTab: (tab: 'cloud' | 'local' | null) => void
@@ -32,6 +36,8 @@ export function DragProvider({ children }: { children: ReactNode }) {
   const [draggingChatFromProjectId, setDraggingChatFromProjectId] = useState<
     string | null
   >(null)
+  const [draggingChatSource, setDraggingChatSource] =
+    useState<ChatDragSource | null>(null)
   const [dropTargetProjectId, setDropTargetProjectId] = useState<string | null>(
     null,
   )
@@ -41,9 +47,18 @@ export function DragProvider({ children }: { children: ReactNode }) {
   const [isDropTargetChatHistory, setIsDropTargetChatHistory] = useState(false)
 
   const setDraggingChat = useCallback(
-    (chatId: string | null, fromProjectId?: string | null) => {
+    (
+      chatId: string | null,
+      fromProjectId?: string | null,
+      source?: ChatDragSource,
+    ) => {
       setDraggingChatId(chatId)
       setDraggingChatFromProjectId(fromProjectId ?? null)
+      setDraggingChatSource(
+        chatId === null
+          ? null
+          : (source ?? (fromProjectId ? 'project' : 'chat-history')),
+      )
     },
     [],
   )
@@ -51,6 +66,7 @@ export function DragProvider({ children }: { children: ReactNode }) {
   const clearDragState = useCallback(() => {
     setDraggingChatId(null)
     setDraggingChatFromProjectId(null)
+    setDraggingChatSource(null)
     setDropTargetProjectId(null)
     setDropTargetTab(null)
     setIsDropTargetChatHistory(false)
@@ -61,6 +77,7 @@ export function DragProvider({ children }: { children: ReactNode }) {
       value={{
         draggingChatId,
         draggingChatFromProjectId,
+        draggingChatSource,
         dropTargetProjectId,
         dropTargetTab,
         isDropTargetChatHistory,

--- a/src/components/chat/favorite-drag.ts
+++ b/src/components/chat/favorite-drag.ts
@@ -13,7 +13,13 @@ export function consumeFavoriteDrop({
   pinnedChatIds,
   onRemoveFavorite,
 }: ConsumeFavoriteDropOptions): boolean {
-  if (source !== 'favorites') return false
-  if (pinnedChatIds.includes(chatId)) onRemoveFavorite?.(chatId)
+  if (
+    source !== 'favorites' ||
+    !pinnedChatIds.includes(chatId) ||
+    !onRemoveFavorite
+  ) {
+    return false
+  }
+  onRemoveFavorite(chatId)
   return true
 }

--- a/src/components/chat/favorite-drag.ts
+++ b/src/components/chat/favorite-drag.ts
@@ -1,0 +1,19 @@
+import type { ChatDragSource } from './drag-context'
+
+interface ConsumeFavoriteDropOptions {
+  source: ChatDragSource | null
+  chatId: string
+  pinnedChatIds: readonly string[]
+  onRemoveFavorite?: (chatId: string) => void
+}
+
+export function consumeFavoriteDrop({
+  source,
+  chatId,
+  pinnedChatIds,
+  onRemoveFavorite,
+}: ConsumeFavoriteDropOptions): boolean {
+  if (source !== 'favorites') return false
+  if (pinnedChatIds.includes(chatId)) onRemoveFavorite?.(chatId)
+  return true
+}

--- a/src/components/chat/sidebar-sync-button.tsx
+++ b/src/components/chat/sidebar-sync-button.tsx
@@ -25,18 +25,21 @@ export function SidebarSyncButton({
   onSync,
 }: SidebarSyncButtonProps) {
   const [feedback, setFeedback] = useState<SyncFeedback>('idle')
+  const [manualSyncFailed, setManualSyncFailed] = useState(false)
   const showSpinner = isSyncing || feedback === 'syncing'
   const isDisabled = isSyncing || feedback !== 'idle'
   const showSuccess = feedback === 'success'
+  const hasSyncFailure = syncFailed || manualSyncFailed
   const statusLabel = showSpinner
     ? 'Syncing'
-    : syncFailed
+    : hasSyncFailure
       ? 'Sync failed'
       : 'Sync healthy'
 
   const handleSync = async () => {
     const startedAt = Date.now()
     setFeedback('syncing')
+    setManualSyncFailed(false)
 
     let succeeded = false
     try {
@@ -54,6 +57,7 @@ export function SidebarSyncButton({
     }
 
     if (!succeeded) {
+      setManualSyncFailed(true)
       setFeedback('idle')
       return
     }
@@ -125,7 +129,7 @@ export function SidebarSyncButton({
               }
               className={cn(
                 'h-2 w-2 rounded-full',
-                syncFailed ? 'bg-orange-500' : 'bg-green-500',
+                hasSyncFailure ? 'bg-orange-500' : 'bg-green-500',
               )}
               title={statusLabel}
             />

--- a/src/components/chat/sidebar-sync-button.tsx
+++ b/src/components/chat/sidebar-sync-button.tsx
@@ -69,7 +69,7 @@ export function SidebarSyncButton({
         type="button"
         onClick={() => void handleSync()}
         disabled={isDisabled}
-        aria-label={`Sync chats. ${feedback === 'success' ? 'Synced' : statusLabel}`}
+        aria-label={`Sync cloud data. ${feedback === 'success' ? 'Synced' : statusLabel}`}
         className={cn(
           'flex w-full items-center justify-between rounded-lg border px-2 py-2 text-sm transition-colors disabled:cursor-default',
           showSpinner && 'opacity-60',

--- a/src/components/project/project-sidebar.tsx
+++ b/src/components/project/project-sidebar.tsx
@@ -5,6 +5,7 @@ import { formatRelativeTime } from '@/components/chat/chat-list-utils'
 import { getDocumentTextContent } from '@/components/chat/document-content'
 import { useDocumentUploader } from '@/components/chat/document-uploader'
 import { useDrag } from '@/components/chat/drag-context'
+import { consumeFavoriteDrop } from '@/components/chat/favorite-drag'
 import { TypingAnimation } from '@/components/chat/typing-animation'
 import { useFavoriteDropTarget } from '@/components/chat/use-favorite-drop-target'
 import { PiSpinnerThin } from '@/components/icons/lazy-icons'
@@ -132,6 +133,7 @@ interface ProjectSidebarProps {
   favoriteChats?: ChatItemData[]
   pinnedChatIds?: readonly string[]
   onToggleFavorite?: (chat: ChatItemData) => void | Promise<void>
+  onRemoveFavorite?: (chatId: string) => void
   onOpenFavorite?: (chat: ChatItemData) => void | Promise<void>
   cloudSyncEnabled: boolean
   windowWidth: number
@@ -307,12 +309,18 @@ export function ProjectSidebar({
   favoriteChats = [],
   pinnedChatIds = [],
   onToggleFavorite,
+  onRemoveFavorite,
   onOpenFavorite,
   cloudSyncEnabled,
   windowWidth,
 }: ProjectSidebarProps) {
   const { isSignedIn } = useAuth()
-  const { draggingChatId, setDraggingChat, clearDragState } = useDrag()
+  const {
+    draggingChatId,
+    draggingChatSource,
+    setDraggingChat,
+    clearDragState,
+  } = useDrag()
   const {
     projectDocuments,
     uploadDocument,
@@ -942,9 +950,11 @@ export function ProjectSidebar({
                   if (exitHoverTimerRef.current) {
                     clearTimeout(exitHoverTimerRef.current)
                   }
-                  exitHoverTimerRef.current = setTimeout(() => {
-                    onExitProjectWhileDragging?.()
-                  }, 400)
+                  if (draggingChatSource !== 'favorites') {
+                    exitHoverTimerRef.current = setTimeout(() => {
+                      onExitProjectWhileDragging?.()
+                    }, 400)
+                  }
                 }
               }}
               onDragOver={(e) => {
@@ -967,6 +977,16 @@ export function ProjectSidebar({
                   clearTimeout(exitHoverTimerRef.current)
                   exitHoverTimerRef.current = null
                 }
+                const chatId = e.dataTransfer.getData('application/x-chat-id')
+                if (chatId) {
+                  consumeFavoriteDrop({
+                    source: draggingChatSource,
+                    chatId,
+                    pinnedChatIds,
+                    onRemoveFavorite,
+                  })
+                }
+                clearDragState()
               }}
               className={cn(
                 'flex w-full items-center gap-2 rounded-lg p-2 text-sm transition-colors',
@@ -1143,9 +1163,13 @@ export function ProjectSidebar({
                         }}
                         onUpdateTitle={updateChatTitle}
                         onDeleteChat={handleDeleteChat}
+                        isDraggable={Boolean(onRemoveFavorite)}
+                        onDragStart={(chatId) =>
+                          setDraggingChat(chatId, null, 'favorites')
+                        }
+                        onDragEnd={clearDragState}
                         pinnedChatIds={pinnedChatIds}
                         showPinnedIndicators={false}
-                        showDesktopPinActions={false}
                         onTogglePin={onToggleFavorite}
                       />
                     ) : (
@@ -1580,7 +1604,15 @@ export function ProjectSidebar({
               e.preventDefault()
               setIsDropTargetChatList(false)
               const chatId = e.dataTransfer.getData('application/x-chat-id')
-              if (chatId && onAddChatToProject) {
+              const favoriteDropConsumed = chatId
+                ? consumeFavoriteDrop({
+                    source: draggingChatSource,
+                    chatId,
+                    pinnedChatIds,
+                    onRemoveFavorite,
+                  })
+                : false
+              if (!favoriteDropConsumed && chatId && onAddChatToProject) {
                 await onAddChatToProject(chatId)
               }
               clearDragState()

--- a/src/hooks/use-lossless-profile-sync.ts
+++ b/src/hooks/use-lossless-profile-sync.ts
@@ -225,10 +225,10 @@ export function useProfileSync() {
               localAfterFetch,
             ).profile
             saveProfileBaseline(userId, remoteBaseline)
+            baseline = remoteBaseline
             applyProfile(overlaid)
             saveLocalProfileMetadata(userId, overlaid)
             markLocalProfileChanged()
-            return
           } else {
             applyProfile(remoteBaseline)
             saveLocalProfileMetadata(userId, remoteBaseline)

--- a/src/hooks/use-lossless-profile-sync.ts
+++ b/src/hooks/use-lossless-profile-sync.ts
@@ -141,10 +141,11 @@ export function useProfileSync() {
   )
 
   const runFullSync = useCallback(async () => {
-    if (!isSignedIn || !userId || !isCloudSyncEnabled()) return
+    if (!isSignedIn || !userId || !isCloudSyncEnabled()) return false
     const activeUserId = localStorage.getItem(AUTH_ACTIVE_USER_ID)
-    if (activeUserId !== null && activeUserId !== userId) return
+    if (activeUserId !== null && activeUserId !== userId) return false
 
+    let syncSucceeded = false
     await runSerializedProfileSync(userId, async (isCurrent) => {
       if (!isCurrent() || !isCloudSyncEnabled()) return
 
@@ -258,6 +259,7 @@ export function useProfileSync() {
             component: 'ProfileSync',
             action: 'runFullSync',
           })
+          syncSucceeded = true
           return
         }
 
@@ -271,6 +273,7 @@ export function useProfileSync() {
         const profileToPush = prepareLocalProfile(userId, baseline)
         if (baseline && !hasProfileChanged(profileToPush, baseline)) {
           clearLocalProfileChanged()
+          syncSucceeded = true
           return
         }
 
@@ -322,6 +325,7 @@ export function useProfileSync() {
             adoptedRemote: !!result.remoteProfile,
           },
         })
+        syncSucceeded = true
       } catch (error) {
         if (isCurrent()) {
           logError('Failed to synchronize profile', error, {
@@ -331,6 +335,7 @@ export function useProfileSync() {
         }
       }
     })
+    return syncSucceeded
   }, [
     applyProfile,
     clearLocalProfileChanged,

--- a/src/hooks/use-lossless-profile-sync.ts
+++ b/src/hooks/use-lossless-profile-sync.ts
@@ -247,7 +247,7 @@ export function useProfileSync() {
           const remoteStatus = await profileSync.getSyncStatus()
           if (!isCurrent()) return
           if (!remoteStatus || remoteStatus.exists) return
-          if (!remoteStatus.exists && isProfilePopulated(loadLocalSettings())) {
+          if (isProfilePopulated(loadLocalSettings())) {
             markLocalProfileChanged()
           }
         }

--- a/src/hooks/use-lossless-profile-sync.ts
+++ b/src/hooks/use-lossless-profile-sync.ts
@@ -9,7 +9,10 @@ import {
   SYNC_PROFILE_CHANGED_AT,
   SYNC_PROFILE_DIRTY,
 } from '@/constants/storage-keys'
-import { getCurrentCloudKeyAuthorizationMode } from '@/services/cloud/cloud-key-authorization'
+import {
+  canWriteToCloud,
+  getCurrentCloudKeyAuthorizationMode,
+} from '@/services/cloud/cloud-key-authorization'
 import { nextClock, type EditClock } from '@/services/cloud/edit-clock'
 import {
   changedProfileFields,
@@ -150,9 +153,6 @@ export function useProfileSync() {
       if (!isCurrent() || !isCloudSyncEnabled()) return
 
       try {
-        const authorizationMode = await getCurrentCloudKeyAuthorizationMode()
-        if (!isCurrent() || !authorizationMode) return
-
         let baseline = loadProfileBaseline(userId)
         const wasDirtyBeforeFetch = hasLocalProfileChanges()
         const localBeforeFetch = loadLocalSettings()
@@ -246,10 +246,8 @@ export function useProfileSync() {
         } else {
           const remoteStatus = await profileSync.getSyncStatus()
           if (!isCurrent()) return
-          if (
-            remoteStatus?.deleted &&
-            isProfilePopulated(loadLocalSettings())
-          ) {
+          if (!remoteStatus || remoteStatus.exists) return
+          if (!remoteStatus.exists && isProfilePopulated(loadLocalSettings())) {
             markLocalProfileChanged()
           }
         }
@@ -260,6 +258,19 @@ export function useProfileSync() {
             action: 'runFullSync',
           })
           syncSucceeded = true
+          return
+        }
+
+        const authorizationMode = await getCurrentCloudKeyAuthorizationMode()
+        if (!isCurrent() || !authorizationMode || !(await canWriteToCloud())) {
+          return
+        }
+        const activeUserBeforePush = localStorage.getItem(AUTH_ACTIVE_USER_ID)
+        if (
+          !isCurrent() ||
+          !isCloudSyncEnabled() ||
+          (activeUserBeforePush !== null && activeUserBeforePush !== userId)
+        ) {
           return
         }
 

--- a/src/services/cloud/manual-cloud-sync.ts
+++ b/src/services/cloud/manual-cloud-sync.ts
@@ -15,12 +15,14 @@ export async function runManualCloudSync({
     syncChats(),
     syncProfile(),
   ])
-  await reloadChats()
+  const [reloadOutcome] = await Promise.allSettled([reloadChats()])
   if (chatOutcome.status === 'rejected') throw chatOutcome.reason
   if (profileOutcome.status === 'rejected') throw profileOutcome.reason
-  return (
+  const syncSucceeded =
     chatOutcome.value !== false &&
     chatOutcome.value.errors.length === 0 &&
     profileOutcome.value
-  )
+  if (!syncSucceeded) return false
+  if (reloadOutcome.status === 'rejected') throw reloadOutcome.reason
+  return true
 }

--- a/src/services/cloud/manual-cloud-sync.ts
+++ b/src/services/cloud/manual-cloud-sync.ts
@@ -1,0 +1,26 @@
+import type { SyncResult } from '@/services/cloud/cloud-sync'
+
+interface ManualCloudSyncOptions {
+  syncChats: () => Promise<SyncResult | false>
+  syncProfile: () => Promise<boolean>
+  reloadChats: () => Promise<void>
+}
+
+export async function runManualCloudSync({
+  syncChats,
+  syncProfile,
+  reloadChats,
+}: ManualCloudSyncOptions): Promise<boolean> {
+  const [chatOutcome, profileOutcome] = await Promise.allSettled([
+    syncChats(),
+    syncProfile(),
+  ])
+  await reloadChats()
+  if (chatOutcome.status === 'rejected') throw chatOutcome.reason
+  if (profileOutcome.status === 'rejected') throw profileOutcome.reason
+  return (
+    chatOutcome.value !== false &&
+    chatOutcome.value.errors.length === 0 &&
+    profileOutcome.value
+  )
+}

--- a/src/services/cloud/profile-merge.ts
+++ b/src/services/cloud/profile-merge.ts
@@ -146,7 +146,7 @@ export function reconcileDirtyProfileWithoutBaseline(args: {
   ) {
     const localBeforePins = localBeforeFetch.pinnedChatIds ?? []
     const localAfterPins = localAfterFetch.pinnedChatIds ?? localBeforePins
-    if (localAfterPins.length === 0) {
+    if (localBeforePins.length === 0 && localAfterPins.length === 0) {
       reconciled.pinnedChatIds = []
       return reconciled
     }

--- a/src/services/cloud/profile-merge.ts
+++ b/src/services/cloud/profile-merge.ts
@@ -1,3 +1,7 @@
+import {
+  MAX_PINNED_CHATS,
+  normalizePinnedChatIds,
+} from '../storage/pinned-chats'
 import type { EditClock } from './edit-clock'
 import type { ProfileData } from './profile-sync'
 import { remoteWins } from './sync-predicates'
@@ -114,6 +118,9 @@ export function reconcileDirtyProfileWithoutBaseline(args: {
 
     const remoteHasField = Object.prototype.hasOwnProperty.call(remote, field)
     const localValue = (localBeforeFetch as Record<string, unknown>)[field]
+    if (field === 'pinnedChatIds' && remoteHasField) {
+      continue
+    }
     if (
       remoteHasField &&
       !valuesEqual(localValue, (remote as Record<string, unknown>)[field])
@@ -128,8 +135,33 @@ export function reconcileDirtyProfileWithoutBaseline(args: {
 
   // Only migration-safe fields may be missing remotely. Any other
   // difference remains blocked until a baseline exists.
-  return overlayProfileChanges(profile, localBeforeFetch, localAfterFetch)
-    .profile
+  const reconciled = overlayProfileChanges(
+    profile,
+    localBeforeFetch,
+    localAfterFetch,
+  ).profile
+  if (
+    localBeforeFetch.pinnedChatIds !== undefined ||
+    localAfterFetch.pinnedChatIds !== undefined
+  ) {
+    const localBeforePins = localBeforeFetch.pinnedChatIds ?? []
+    const localAfterPins = localAfterFetch.pinnedChatIds ?? localBeforePins
+    const removedDuringFetch = new Set(
+      localBeforePins.filter((chatId) => !localAfterPins.includes(chatId)),
+    )
+    const candidates = [
+      ...localAfterPins,
+      ...(remote.pinnedChatIds ?? []).filter(
+        (chatId) => !removedDuringFetch.has(chatId),
+      ),
+    ]
+    const uniqueCandidateCount = new Set(
+      candidates.map((chatId) => chatId.trim()).filter(Boolean),
+    ).size
+    if (uniqueCandidateCount > MAX_PINNED_CHATS) return null
+    reconciled.pinnedChatIds = normalizePinnedChatIds(candidates)
+  }
+  return reconciled
 }
 
 function nonEmptyString(value: unknown): boolean {

--- a/src/services/cloud/profile-merge.ts
+++ b/src/services/cloud/profile-merge.ts
@@ -146,7 +146,12 @@ export function reconcileDirtyProfileWithoutBaseline(args: {
   ) {
     const localBeforePins = localBeforeFetch.pinnedChatIds ?? []
     const localAfterPins = localAfterFetch.pinnedChatIds ?? localBeforePins
-    if (localBeforePins.length === 0 && localAfterPins.length === 0) {
+    if (
+      localBeforeFetch.pinnedChatIds !== undefined &&
+      localAfterFetch.pinnedChatIds !== undefined &&
+      localBeforePins.length === 0 &&
+      localAfterPins.length === 0
+    ) {
       reconciled.pinnedChatIds = []
       return reconciled
     }

--- a/src/services/cloud/profile-merge.ts
+++ b/src/services/cloud/profile-merge.ts
@@ -146,6 +146,10 @@ export function reconcileDirtyProfileWithoutBaseline(args: {
   ) {
     const localBeforePins = localBeforeFetch.pinnedChatIds ?? []
     const localAfterPins = localAfterFetch.pinnedChatIds ?? localBeforePins
+    if (localAfterPins.length === 0) {
+      reconciled.pinnedChatIds = []
+      return reconciled
+    }
     const removedDuringFetch = new Set(
       localBeforePins.filter((chatId) => !localAfterPins.includes(chatId)),
     )

--- a/tests/components/chat/drag-context.test.tsx
+++ b/tests/components/chat/drag-context.test.tsx
@@ -1,0 +1,37 @@
+import { DragProvider, useDrag } from '@/components/chat/drag-context'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+function DragHarness() {
+  const { draggingChatSource, setDraggingChat, clearDragState } = useDrag()
+  return (
+    <>
+      <output aria-label="drag source">{draggingChatSource ?? 'none'}</output>
+      <button
+        type="button"
+        onClick={() => setDraggingChat('chat-a', null, 'favorites')}
+      >
+        Start favorite drag
+      </button>
+      <button type="button" onClick={clearDragState}>
+        Clear drag
+      </button>
+    </>
+  )
+}
+
+describe('DragProvider', () => {
+  it('tracks and clears favorite drag sources', () => {
+    render(
+      <DragProvider>
+        <DragHarness />
+      </DragProvider>,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Start favorite drag' }))
+    expect(screen.getByLabelText('drag source')).toHaveTextContent('favorites')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Clear drag' }))
+    expect(screen.getByLabelText('drag source')).toHaveTextContent('none')
+  })
+})

--- a/tests/components/chat/favorite-drag.test.ts
+++ b/tests/components/chat/favorite-drag.test.ts
@@ -1,0 +1,32 @@
+import { consumeFavoriteDrop } from '@/components/chat/favorite-drag'
+import { describe, expect, it, vi } from 'vitest'
+
+describe('consumeFavoriteDrop', () => {
+  it('removes a dragged favorite without moving the chat', () => {
+    const onRemoveFavorite = vi.fn()
+
+    expect(
+      consumeFavoriteDrop({
+        source: 'favorites',
+        chatId: 'chat-a',
+        pinnedChatIds: ['chat-a'],
+        onRemoveFavorite,
+      }),
+    ).toBe(true)
+    expect(onRemoveFavorite).toHaveBeenCalledWith('chat-a')
+  })
+
+  it('leaves non-favorite drag sources for other drop handlers', () => {
+    const onRemoveFavorite = vi.fn()
+
+    expect(
+      consumeFavoriteDrop({
+        source: 'chat-history',
+        chatId: 'chat-a',
+        pinnedChatIds: ['chat-a'],
+        onRemoveFavorite,
+      }),
+    ).toBe(false)
+    expect(onRemoveFavorite).not.toHaveBeenCalled()
+  })
+})

--- a/tests/components/chat/favorite-drag.test.ts
+++ b/tests/components/chat/favorite-drag.test.ts
@@ -29,4 +29,18 @@ describe('consumeFavoriteDrop', () => {
     ).toBe(false)
     expect(onRemoveFavorite).not.toHaveBeenCalled()
   })
+
+  it('leaves stale favorite sources for other drop handlers', () => {
+    const onRemoveFavorite = vi.fn()
+
+    expect(
+      consumeFavoriteDrop({
+        source: 'favorites',
+        chatId: 'chat-a',
+        pinnedChatIds: [],
+        onRemoveFavorite,
+      }),
+    ).toBe(false)
+    expect(onRemoveFavorite).not.toHaveBeenCalled()
+  })
 })

--- a/tests/components/chat/sidebar-sync-button.test.tsx
+++ b/tests/components/chat/sidebar-sync-button.test.tsx
@@ -20,9 +20,9 @@ describe('SidebarSyncButton', () => {
       />,
     )
 
-    fireEvent.click(screen.getByRole('button', { name: /sync chats/i }))
+    fireEvent.click(screen.getByRole('button', { name: /sync cloud data/i }))
     expect(screen.getByRole('button')).toHaveAccessibleName(
-      'Sync chats. Syncing',
+      'Sync cloud data. Syncing',
     )
 
     await act(async () => {
@@ -31,14 +31,14 @@ describe('SidebarSyncButton', () => {
       )
     })
     expect(screen.getByRole('button')).toHaveAccessibleName(
-      'Sync chats. Syncing',
+      'Sync cloud data. Syncing',
     )
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(1)
     })
     expect(screen.getByRole('button')).toHaveAccessibleName(
-      'Sync chats. Synced',
+      'Sync cloud data. Synced',
     )
     expect(screen.getByText('Synced!')).toHaveAttribute('aria-hidden', 'false')
 
@@ -48,7 +48,7 @@ describe('SidebarSyncButton', () => {
       )
     })
     expect(screen.getByRole('button')).toHaveAccessibleName(
-      'Sync chats. Sync healthy',
+      'Sync cloud data. Sync healthy',
     )
   })
 
@@ -64,7 +64,7 @@ describe('SidebarSyncButton', () => {
       />,
     )
 
-    fireEvent.click(screen.getByRole('button', { name: /sync chats/i }))
+    fireEvent.click(screen.getByRole('button', { name: /sync cloud data/i }))
     rerender(
       <SidebarSyncButton
         isDarkMode={false}
@@ -79,7 +79,7 @@ describe('SidebarSyncButton', () => {
     })
 
     expect(screen.getByRole('button')).toHaveAccessibleName(
-      'Sync chats. Sync failed',
+      'Sync cloud data. Sync failed',
     )
     expect(screen.getByText('Synced!')).toHaveAttribute('aria-hidden', 'true')
   })

--- a/tests/components/chat/sidebar-sync-button.test.tsx
+++ b/tests/components/chat/sidebar-sync-button.test.tsx
@@ -55,7 +55,7 @@ describe('SidebarSyncButton', () => {
   it('returns to the failure dot without showing success feedback', async () => {
     vi.useFakeTimers()
     const onSync = vi.fn().mockResolvedValue(false)
-    const { rerender } = render(
+    render(
       <SidebarSyncButton
         isDarkMode={false}
         isSyncing={false}
@@ -65,14 +65,6 @@ describe('SidebarSyncButton', () => {
     )
 
     fireEvent.click(screen.getByRole('button', { name: /sync cloud data/i }))
-    rerender(
-      <SidebarSyncButton
-        isDarkMode={false}
-        isSyncing={false}
-        syncFailed
-        onSync={onSync}
-      />,
-    )
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(CONSTANTS.SIDEBAR_SYNC_MIN_SPINNER_MS)

--- a/tests/hooks/use-lossless-profile-sync.test.ts
+++ b/tests/hooks/use-lossless-profile-sync.test.ts
@@ -10,7 +10,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const mocks = vi.hoisted(() => ({
   localProfile: {} as ProfileData,
   fetchProfile: vi.fn(),
+  getSyncStatus: vi.fn(),
   saveProfile: vi.fn(),
+  getAuthorizationMode: vi.fn(),
+  canWriteToCloud: vi.fn(),
 }))
 
 vi.mock('@clerk/nextjs', () => ({
@@ -18,13 +21,14 @@ vi.mock('@clerk/nextjs', () => ({
 }))
 
 vi.mock('@/services/cloud/cloud-key-authorization', () => ({
-  getCurrentCloudKeyAuthorizationMode: vi.fn().mockResolvedValue('automatic'),
+  getCurrentCloudKeyAuthorizationMode: () => mocks.getAuthorizationMode(),
+  canWriteToCloud: () => mocks.canWriteToCloud(),
 }))
 
 vi.mock('@/services/cloud/profile-sync', () => ({
   profileSync: {
     fetchProfile: (...args: unknown[]) => mocks.fetchProfile(...args),
-    getSyncStatus: vi.fn().mockResolvedValue(null),
+    getSyncStatus: (...args: unknown[]) => mocks.getSyncStatus(...args),
     hasFailedRemoteDecryption: vi.fn(() => false),
     saveProfile: (...args: unknown[]) => mocks.saveProfile(...args),
   },
@@ -80,6 +84,9 @@ describe('useProfileSync', () => {
       version: 4,
     })
     mocks.saveProfile.mockResolvedValue({ success: true, version: 5 })
+    mocks.getSyncStatus.mockResolvedValue(null)
+    mocks.getAuthorizationMode.mockResolvedValue('validated')
+    mocks.canWriteToCloud.mockResolvedValue(true)
   })
 
   it('uploads local favorites after establishing a missing baseline', async () => {
@@ -96,6 +103,54 @@ describe('useProfileSync', () => {
       expect.objectContaining({ nickname: 'Remote', version: 4 }),
     )
     expect(localStorage.getItem(SYNC_PROFILE_DIRTY)).toBeNull()
+    unmount()
+  })
+
+  it('uploads populated local settings when the remote profile is absent', async () => {
+    localStorage.removeItem(SYNC_PROFILE_DIRTY)
+    mocks.fetchProfile.mockResolvedValue(null)
+    mocks.getSyncStatus.mockResolvedValue({ exists: false, deleted: false })
+
+    const { unmount } = renderHook(() => useProfileSync())
+
+    await waitFor(() => expect(mocks.saveProfile).toHaveBeenCalledTimes(1))
+    expect(mocks.saveProfile).toHaveBeenCalledWith(
+      expect.objectContaining({ pinnedChatIds: ['chat-a'] }),
+      null,
+    )
+    unmount()
+  })
+
+  it('pulls remote favorites before write authorization is available', async () => {
+    localStorage.removeItem(SYNC_PROFILE_DIRTY)
+    mocks.localProfile = {}
+    mocks.getAuthorizationMode.mockResolvedValue(null)
+    mocks.fetchProfile.mockResolvedValue({
+      pinnedChatIds: ['remote-chat'],
+      version: 4,
+    })
+
+    const { unmount } = renderHook(() => useProfileSync())
+
+    await waitFor(() =>
+      expect(mocks.localProfile.pinnedChatIds).toEqual(['remote-chat']),
+    )
+    expect(mocks.getAuthorizationMode).not.toHaveBeenCalled()
+    expect(mocks.saveProfile).not.toHaveBeenCalled()
+    unmount()
+  })
+
+  it('reports an indeterminate missing profile as an unsuccessful sync', async () => {
+    localStorage.removeItem(SYNC_PROFILE_DIRTY)
+    mocks.localProfile = {}
+    mocks.fetchProfile.mockResolvedValue(null)
+    mocks.getSyncStatus.mockResolvedValue(null)
+
+    const { result, unmount } = renderHook(() => useProfileSync())
+
+    await waitFor(() => expect(mocks.fetchProfile).toHaveBeenCalled())
+    await expect(result.current.syncFromCloud()).resolves.toBe(false)
+    expect(mocks.saveProfile).not.toHaveBeenCalled()
     unmount()
   })
 })

--- a/tests/services/cloud/manual-cloud-sync.test.ts
+++ b/tests/services/cloud/manual-cloud-sync.test.ts
@@ -1,0 +1,80 @@
+import { runManualCloudSync } from '@/services/cloud/manual-cloud-sync'
+import { describe, expect, it, vi } from 'vitest'
+
+const successfulChatSync = { uploaded: 1, downloaded: 1, errors: [] }
+
+describe('runManualCloudSync', () => {
+  it('awaits chat and profile sync before reloading chats', async () => {
+    const order: string[] = []
+    const syncChats = vi.fn(async () => {
+      order.push('chats')
+      return successfulChatSync
+    })
+    const syncProfile = vi.fn(async () => {
+      order.push('profile')
+      return true
+    })
+    const reloadChats = vi.fn(async () => {
+      order.push('reload')
+    })
+
+    await expect(
+      runManualCloudSync({ syncChats, syncProfile, reloadChats }),
+    ).resolves.toBe(true)
+    expect(syncChats).toHaveBeenCalledOnce()
+    expect(syncProfile).toHaveBeenCalledOnce()
+    expect(reloadChats).toHaveBeenCalledOnce()
+    expect(order.at(-1)).toBe('reload')
+  })
+
+  it('reports chat sync failures after syncing the profile', async () => {
+    const syncProfile = vi.fn().mockResolvedValue(true)
+
+    await expect(
+      runManualCloudSync({
+        syncChats: vi.fn().mockResolvedValue(false),
+        syncProfile,
+        reloadChats: vi.fn().mockResolvedValue(undefined),
+      }),
+    ).resolves.toBe(false)
+    expect(syncProfile).toHaveBeenCalledOnce()
+  })
+
+  it('waits for profile sync when chat sync rejects', async () => {
+    let finishProfile: ((value: boolean) => void) | undefined
+    const syncPromise = runManualCloudSync({
+      syncChats: vi.fn().mockRejectedValue(new Error('chat sync failed')),
+      syncProfile: vi.fn(
+        () =>
+          new Promise<boolean>((resolve) => {
+            finishProfile = resolve
+          }),
+      ),
+      reloadChats: vi.fn().mockResolvedValue(undefined),
+    })
+    let settled = false
+    void syncPromise.then(
+      () => {
+        settled = true
+      },
+      () => {
+        settled = true
+      },
+    )
+
+    await Promise.resolve()
+    expect(settled).toBe(false)
+    finishProfile?.(true)
+    await expect(syncPromise).rejects.toThrow('chat sync failed')
+  })
+
+  it('reports profile sync failures', async () => {
+    await expect(
+      runManualCloudSync({
+        syncChats: vi.fn().mockResolvedValue(successfulChatSync),
+        syncProfile: vi.fn().mockResolvedValue(false),
+        reloadChats: vi.fn().mockResolvedValue(undefined),
+      }),
+    ).resolves.toBe(false)
+  })
+})

--- a/tests/services/cloud/manual-cloud-sync.test.ts
+++ b/tests/services/cloud/manual-cloud-sync.test.ts
@@ -77,4 +77,24 @@ describe('runManualCloudSync', () => {
       }),
     ).resolves.toBe(false)
   })
+
+  it('prioritizes sync failures over reload failures', async () => {
+    await expect(
+      runManualCloudSync({
+        syncChats: vi.fn().mockRejectedValue(new Error('chat sync failed')),
+        syncProfile: vi.fn().mockResolvedValue(true),
+        reloadChats: vi.fn().mockRejectedValue(new Error('reload failed')),
+      }),
+    ).rejects.toThrow('chat sync failed')
+  })
+
+  it('reports a resolved sync failure before a reload rejection', async () => {
+    await expect(
+      runManualCloudSync({
+        syncChats: vi.fn().mockResolvedValue(false),
+        syncProfile: vi.fn().mockResolvedValue(true),
+        reloadChats: vi.fn().mockRejectedValue(new Error('reload failed')),
+      }),
+    ).resolves.toBe(false)
+  })
 })

--- a/tests/services/cloud/profile-merge.test.ts
+++ b/tests/services/cloud/profile-merge.test.ts
@@ -414,6 +414,16 @@ describe('reconcileDirtyProfileWithoutBaseline', () => {
     expect(profile?.pinnedChatIds).toEqual(['local-chat', 'remote-chat'])
   })
 
+  it('preserves remote-only pins when the last local pin is removed', () => {
+    const profile = reconcileDirtyProfileWithoutBaseline({
+      remote: { pinnedChatIds: ['local-chat', 'remote-chat'] },
+      localBeforeFetch: { pinnedChatIds: ['local-chat'] },
+      localAfterFetch: { pinnedChatIds: [] },
+    })
+
+    expect(profile?.pinnedChatIds).toEqual(['remote-chat'])
+  })
+
   it('combines a first pin added while the remote profile was loading', () => {
     const profile = reconcileDirtyProfileWithoutBaseline({
       remote: {

--- a/tests/services/cloud/profile-merge.test.ts
+++ b/tests/services/cloud/profile-merge.test.ts
@@ -424,6 +424,22 @@ describe('reconcileDirtyProfileWithoutBaseline', () => {
     expect(profile?.pinnedChatIds).toEqual(['remote-chat'])
   })
 
+  it('does not treat a missing local snapshot as an explicit clear', () => {
+    const profile = reconcileDirtyProfileWithoutBaseline({
+      remote: {
+        pixelateSidebarChatTitlesEnabled: true,
+        pinnedChatIds: ['remote-chat'],
+      },
+      localBeforeFetch: { pixelateSidebarChatTitlesEnabled: true },
+      localAfterFetch: {
+        pixelateSidebarChatTitlesEnabled: true,
+        pinnedChatIds: [],
+      },
+    })
+
+    expect(profile?.pinnedChatIds).toEqual(['remote-chat'])
+  })
+
   it('combines a first pin added while the remote profile was loading', () => {
     const profile = reconcileDirtyProfileWithoutBaseline({
       remote: {

--- a/tests/services/cloud/profile-merge.test.ts
+++ b/tests/services/cloud/profile-merge.test.ts
@@ -306,7 +306,12 @@ describe('reconcileDirtyProfileWithoutBaseline', () => {
 
   it('overlays settings changed while the remote profile was loading', () => {
     const profile = reconcileDirtyProfileWithoutBaseline({
-      remote: { nickname: 'Remote', profession: 'Researcher', version: 4 },
+      remote: {
+        nickname: 'Remote',
+        profession: 'Researcher',
+        pinnedChatIds: ['remote-chat'],
+        version: 4,
+      },
       localBeforeFetch: {
         nickname: 'Remote',
         profession: 'Researcher',
@@ -315,14 +320,14 @@ describe('reconcileDirtyProfileWithoutBaseline', () => {
       localAfterFetch: {
         nickname: 'Changed during fetch',
         profession: 'Researcher',
-        pinnedChatIds: ['chat-a'],
+        pinnedChatIds: ['chat-b', 'chat-a'],
       },
     })
 
     expect(profile).toMatchObject({
       nickname: 'Changed during fetch',
       profession: 'Researcher',
-      pinnedChatIds: ['chat-a'],
+      pinnedChatIds: ['chat-b', 'chat-a', 'remote-chat'],
     })
   })
 
@@ -378,13 +383,57 @@ describe('reconcileDirtyProfileWithoutBaseline', () => {
         },
       }),
     ).toBeNull()
-    expect(
-      reconcileDirtyProfileWithoutBaseline({
-        remote: { pinnedChatIds: ['remote-chat'] },
-        localBeforeFetch: { pinnedChatIds: ['local-chat'] },
-        localAfterFetch: { pinnedChatIds: ['local-chat'] },
-      }),
-    ).toBeNull()
+  })
+
+  it('combines divergent pins when no baseline exists', () => {
+    const profile = reconcileDirtyProfileWithoutBaseline({
+      remote: { pinnedChatIds: ['remote-chat', 'shared-chat'] },
+      localBeforeFetch: { pinnedChatIds: ['local-chat', 'shared-chat'] },
+      localAfterFetch: { pinnedChatIds: ['local-chat', 'shared-chat'] },
+    })
+
+    expect(profile?.pinnedChatIds).toEqual([
+      'local-chat',
+      'shared-chat',
+      'remote-chat',
+    ])
+  })
+
+  it('preserves pins removed while the remote profile was loading', () => {
+    const profile = reconcileDirtyProfileWithoutBaseline({
+      remote: { pinnedChatIds: ['removed-chat', 'remote-chat'] },
+      localBeforeFetch: { pinnedChatIds: ['removed-chat', 'local-chat'] },
+      localAfterFetch: { pinnedChatIds: ['local-chat'] },
+    })
+
+    expect(profile?.pinnedChatIds).toEqual(['local-chat', 'remote-chat'])
+  })
+
+  it('combines a first pin added while the remote profile was loading', () => {
+    const profile = reconcileDirtyProfileWithoutBaseline({
+      remote: {
+        pixelateSidebarChatTitlesEnabled: true,
+        pinnedChatIds: ['remote-chat'],
+      },
+      localBeforeFetch: { pixelateSidebarChatTitlesEnabled: true },
+      localAfterFetch: {
+        pixelateSidebarChatTitlesEnabled: true,
+        pinnedChatIds: ['local-chat'],
+      },
+    })
+
+    expect(profile?.pinnedChatIds).toEqual(['local-chat', 'remote-chat'])
+  })
+
+  it('rejects a baseline-free pin merge that exceeds the limit', () => {
+    const localPins = Array.from({ length: 20 }, (_, index) => `local-${index}`)
+    const profile = reconcileDirtyProfileWithoutBaseline({
+      remote: { pinnedChatIds: ['remote-chat'] },
+      localBeforeFetch: { pinnedChatIds: localPins },
+      localAfterFetch: { pinnedChatIds: localPins },
+    })
+
+    expect(profile).toBeNull()
   })
 })
 

--- a/tests/services/cloud/profile-merge.test.ts
+++ b/tests/services/cloud/profile-merge.test.ts
@@ -17,6 +17,7 @@ import {
   reconcileDirtyProfileWithoutBaseline,
 } from '@/services/cloud/profile-merge'
 import type { ProfileData } from '@/services/cloud/profile-sync'
+import { MAX_PINNED_CHATS } from '@/services/storage/pinned-chats'
 import { describe, expect, it } from 'vitest'
 
 // A trusted blob has clockVersion === version, so its field clocks are
@@ -278,9 +279,13 @@ describe('reconcileDirtyProfileWithoutBaseline', () => {
     })
   })
 
-  it('preserves an explicit local clear when the remote omits pins', () => {
+  it('preserves an explicit local clear when the remote has pins', () => {
     const profile = reconcileDirtyProfileWithoutBaseline({
-      remote: { nickname: 'Remote', version: 4 },
+      remote: {
+        nickname: 'Remote',
+        pinnedChatIds: ['remote-chat'],
+        version: 4,
+      },
       localBeforeFetch: { pinnedChatIds: [] },
       localAfterFetch: { pinnedChatIds: [] },
     })
@@ -426,7 +431,10 @@ describe('reconcileDirtyProfileWithoutBaseline', () => {
   })
 
   it('rejects a baseline-free pin merge that exceeds the limit', () => {
-    const localPins = Array.from({ length: 20 }, (_, index) => `local-${index}`)
+    const localPins = Array.from(
+      { length: MAX_PINNED_CHATS },
+      (_, index) => `local-${index}`,
+    )
     const profile = reconcileDirtyProfileWithoutBaseline({
       remote: { pinnedChatIds: ['remote-chat'] },
       localBeforeFetch: { pinnedChatIds: localPins },


### PR DESCRIPTION
## Summary
- make the sidebar Sync action await both chat and profile synchronization
- restore the desktop Remove from Favorites action on favorite rows
- let favorite rows be dragged onto sidebar destinations to unfavorite without moving the chat

## Testing
- `npm run test:unit -- --run` (1803 passed)
- targeted sync, drag, favorite, and profile tests (34 passed)
- ESLint passed for all modified files
- `npm run build` *(blocked by the existing missing `out/_next/static/media/local-tinfoil-import-parser` generated module)*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs chats and the profile together from the sidebar Sync button and makes favorite removal via drag safe. Previously, the Sync button only synced chats and dragging a favorite could move/convert a chat; now it syncs chats + profile and dragging a favorite onto any sidebar destination unpins it instead of moving, preventing unintended moves and preserving remote favorites when a local favorite is removed.

- Sidebar Sync: uses `runManualCloudSync` to await chat and profile sync in parallel, then reload chats; the profile sync returns a boolean. The button’s aria-label is “Sync cloud data…”, and its status dot reflects the last manual attempt as well as background failures.
- Favorite removal via drag: favorite rows are draggable when `onRemoveFavorite` is provided; the drag context tracks a `favorites` source, and drop targets use `consumeFavoriteDrop` to unpin and suppress moves/conversions, auto-expansion, tab switching, and hover timers; drag state is cleared afterward.
- Profile sync resilience: pulls remote settings before write authorization is available; only pushes when `canWriteToCloud()` allows writes; reports an indeterminate “missing remote profile” as an unsuccessful sync. Baseline-free merging ignores remote `pinnedChatIds` during conflict detection and then safely combines local and remote pins—preserves removals during fetch, preserves remote-only pins when local pins are cleared, does not treat a missing local snapshot as an explicit clear—enforces `MAX_PINNED_CHATS` via `normalizePinnedChatIds`, and returns `null` if over the limit.
- No migration required. `onRemoveFavorite` is optional on `ChatSidebar`/`ProjectSidebar` (passed from `ChatInterface` as `unpinChat`). Update any tests that assert the old “Sync chats” label.

<sup>Written for commit db8faaff8a65394ae62cd6e9f6face087aaf2e68. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/514?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

