### PR TITLE
fix: restore passkey recovery after auth hydration

### DIFF
--- a/src/components/auth-cleanup-handler.tsx
+++ b/src/components/auth-cleanup-handler.tsx
@@ -233,10 +233,7 @@ export function AuthCleanupHandler() {
       return
     }
 
-    const storedUserId = localStorage.getItem(AUTH_ACTIVE_USER_ID)
-    const shouldCleanup =
-      isSignedIn === false &&
-      (storedUserId !== null || hadSignedInSessionRef.current)
+    const shouldCleanup = isSignedIn === false && hadSignedInSessionRef.current
 
     if (shouldCleanup && !hasCheckedRef.current) {
       if (pendingSignoutCleanupRef.current === null) {

--- a/src/components/auth-cleanup-handler.tsx
+++ b/src/components/auth-cleanup-handler.tsx
@@ -6,6 +6,7 @@ import {
   AUTH_ACCOUNT_RESET_FAILED,
   AUTH_ACTIVE_USER_ID,
   AUTH_ANONYMOUS_RESTORE_PENDING_CLEANUP,
+  AUTH_SIGNOUT_PENDING_CLEANUP,
 } from '@/constants/storage-keys'
 import { logError, logInfo } from '@/utils/error-handling'
 import {
@@ -32,6 +33,7 @@ export function AuthCleanupHandler() {
   const [cleanupError, setCleanupError] = useState<{
     message: string
     retryStorage: boolean
+    retrySignout: boolean
   } | null>(null)
   const [cleanupRetrying, setCleanupRetrying] = useState(false)
   const hasCheckedRef = useRef(false)
@@ -89,6 +91,7 @@ export function AuthCleanupHandler() {
         message:
           'Local data could not be cleared after another tab changed accounts.',
         retryStorage: true,
+        retrySignout: false,
       })
     }
     if (sessionStorage.getItem(AUTH_ACCOUNT_RESET_FAILED) === 'true') {
@@ -104,6 +107,20 @@ export function AuthCleanupHandler() {
         handleCrossTabResetFailure,
       )
   }, [])
+
+  useEffect(() => {
+    if (
+      isLoaded &&
+      isSignedIn === false &&
+      localStorage.getItem(AUTH_SIGNOUT_PENDING_CLEANUP) === 'true'
+    ) {
+      setCleanupError({
+        message: 'Local data could not be cleared after signing out.',
+        retryStorage: false,
+        retrySignout: true,
+      })
+    }
+  }, [isLoaded, isSignedIn])
 
   const clearPendingSignoutCleanup = useCallback(() => {
     if (pendingSignoutCleanupRef.current !== null) {
@@ -146,6 +163,7 @@ export function AuthCleanupHandler() {
               message:
                 'Local data from the previous account could not be cleared.',
               retryStorage: false,
+              retrySignout: false,
             })
             return
           }
@@ -202,9 +220,11 @@ export function AuthCleanupHandler() {
           action: 'signout',
         })
         hideSignoutProgress()
+        setCleanupRetrying(false)
         setCleanupError({
           message: 'Local data could not be cleared after signing out.',
           retryStorage: false,
+          retrySignout: true,
         })
       })
   }, [])
@@ -295,6 +315,11 @@ export function AuthCleanupHandler() {
         <button
           type="button"
           onClick={() => {
+            if (cleanupError.retrySignout) {
+              setCleanupRetrying(true)
+              runSignoutCleanup()
+              return
+            }
             if (!cleanupError.retryStorage) {
               window.location.reload()
               return
@@ -309,6 +334,7 @@ export function AuthCleanupHandler() {
                   message:
                     'Local data still could not be cleared after another tab changed accounts.',
                   retryStorage: true,
+                  retrySignout: false,
                 })
               })
           }}

--- a/src/components/auth-cleanup-handler.tsx
+++ b/src/components/auth-cleanup-handler.tsx
@@ -114,11 +114,15 @@ export function AuthCleanupHandler() {
       isSignedIn === false &&
       localStorage.getItem(AUTH_SIGNOUT_PENDING_CLEANUP) === 'true'
     ) {
-      setCleanupError({
-        message: 'Local data could not be cleared after signing out.',
-        retryStorage: false,
-        retrySignout: true,
-      })
+      setCleanupError((currentError) =>
+        currentError?.retryStorage
+          ? currentError
+          : {
+              message: 'Local data could not be cleared after signing out.',
+              retryStorage: false,
+              retrySignout: true,
+            },
+      )
     }
   }, [isLoaded, isSignedIn])
 
@@ -203,6 +207,11 @@ export function AuthCleanupHandler() {
   )
 
   const runSignoutCleanup = useCallback(() => {
+    const latestAuthState = latestAuthStateRef.current
+    if (!latestAuthState.isLoaded || latestAuthState.isSignedIn !== false) {
+      window.location.reload()
+      return
+    }
     completeSignoutStep(SIGNOUT_STEPS.SIGN_OUT)
     logInfo('Clearing all data after signout', {
       component: 'AuthCleanupHandler',

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -56,7 +56,10 @@ import {
   shouldShowRateLimitBanner,
 } from '@/components/chat/rate-limit-banner'
 import { StreamErrorBanner } from '@/components/chat/stream-error-banner'
-import { classifyCloudKeySetupError } from '@/components/modals/cloud-sync-setup-mode'
+import {
+  classifyCloudKeySetupError,
+  waitForCloudSyncRouting,
+} from '@/components/modals/cloud-sync-setup-mode'
 import {
   ProjectModeIndicator,
   ProjectSidebar,
@@ -2163,10 +2166,42 @@ export function ChatInterface({
       }
       return
     }
-    retryPasskeyInitialization()
-    setShowCloudSyncSetupModal(true)
+    const generation = ++cloudSyncRouteGenerationRef.current
+    setIsCloudSyncRoutePending(true)
+    try {
+      const routingState = await waitForCloudSyncRouting(
+        retryPasskeyInitialization(),
+      )
+      if (generation !== cloudSyncRouteGenerationRef.current) return
+
+      if (
+        routingState?.passkeyRecoveryNeeded ||
+        routingState?.manualRecoveryNeeded
+      ) {
+        setShowCloudSyncSetupModal(true)
+        return
+      }
+      if (routingState?.passkeyAddDeviceAvailable) {
+        await addPasskeyToThisDevice()
+        return
+      }
+      if (routingState?.passkeyActive) {
+        setCloudSyncEnabled(true)
+        return
+      }
+
+      // A timeout is intentionally conservative: try to wrap the existing
+      // key rather than exposing replacement-key setup before routing settles.
+      await setupPasskey()
+    } finally {
+      if (generation === cloudSyncRouteGenerationRef.current) {
+        setIsCloudSyncRoutePending(false)
+      }
+    }
   }, [
+    addPasskeyToThisDevice,
     retryPasskeyInitialization,
+    setupPasskey,
     showPasskeyRecoveryPrompt,
     showFirstTimePasskeyPrompt,
   ])

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -468,6 +468,7 @@ export function ChatInterface({
     setupFirstTimePasskey,
     showFirstTimePasskeyPrompt,
     showPasskeyRecoveryPrompt,
+    cancelPasskeyRoutingProbe,
     dismissFirstTimePasskeyPrompt,
     recoverWithPasskey,
     setupNewKeySplit,
@@ -537,6 +538,7 @@ export function ChatInterface({
   // State for cloud sync setup modal
   const [showCloudSyncSetupModal, setShowCloudSyncSetupModal] = useState(false)
   const [isCloudSyncRoutePending, setIsCloudSyncRoutePending] = useState(false)
+  const cloudSyncRouteGenerationRef = useRef(0)
   // Tracks the in-flight first-time passkey setup call so the modal can
   // disable its buttons while the native dialog is showing.
   const [isFirstTimePasskeySetupBusy, setIsFirstTimePasskeySetupBusy] =
@@ -2139,6 +2141,7 @@ export function ChatInterface({
   // the intro and routes directly to recovery.
   const handleOpenCloudSyncSetup = useCallback(async () => {
     if (!encryptionService.getKey()) {
+      const generation = ++cloudSyncRouteGenerationRef.current
       // Open the modal immediately for instant feedback. It renders
       // its recovery / manual UI from the live hook state, so we don't
       // block the popup on the slow enclave key-state probe. The
@@ -2149,10 +2152,13 @@ export function ChatInterface({
       setIsCloudSyncRoutePending(true)
       try {
         const recovered = await showPasskeyRecoveryPrompt()
+        if (generation !== cloudSyncRouteGenerationRef.current) return
         if (recovered) return
         await showFirstTimePasskeyPrompt()
       } finally {
-        setIsCloudSyncRoutePending(false)
+        if (generation === cloudSyncRouteGenerationRef.current) {
+          setIsCloudSyncRoutePending(false)
+        }
       }
       return
     }
@@ -4408,6 +4414,9 @@ export function ChatInterface({
         <CloudSyncSetupModal
           isOpen={showCloudSyncSetupModal}
           onClose={() => {
+            cloudSyncRouteGenerationRef.current += 1
+            cancelPasskeyRoutingProbe()
+            setIsCloudSyncRoutePending(false)
             setShowCloudSyncSetupModal(false)
             if (passkeyFirstTimePromptAvailable) {
               dismissFirstTimePasskeyPrompt()
@@ -4454,7 +4463,9 @@ export function ChatInterface({
           }
           isPasskeySetupBusy={isFirstTimePasskeySetupBusy}
           onSkipRecovery={() => {
+            cloudSyncRouteGenerationRef.current += 1
             skipPasskeyRecovery()
+            setIsCloudSyncRoutePending(false)
             setShowCloudSyncSetupModal(false)
           }}
           onRecoverWithPasskey={async () => {

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -58,6 +58,7 @@ import {
 import { StreamErrorBanner } from '@/components/chat/stream-error-banner'
 import {
   classifyCloudKeySetupError,
+  enableCloudSyncAfterPasskey,
   waitForCloudSyncRouting,
 } from '@/components/modals/cloud-sync-setup-mode'
 import {
@@ -71,7 +72,10 @@ import { LogoLoading } from '@/components/ui/logo-loading'
 import { cn } from '@/components/ui/utils'
 import { CLOUD_SYNC } from '@/config'
 import { useCloudSync } from '@/hooks/use-cloud-sync'
-import { usePasskeyBackup } from '@/hooks/use-passkey-backup'
+import {
+  PasskeyInitializationCanceledError,
+  usePasskeyBackup,
+} from '@/hooks/use-passkey-backup'
 import { usePinnedChats } from '@/hooks/use-pinned-chats'
 import { useProfileSync } from '@/hooks/use-profile-sync'
 import { runManualCloudSync } from '@/services/cloud/manual-cloud-sync'
@@ -85,7 +89,11 @@ import {
 import { cloudSync, SyncInProgressError } from '@/services/cloud/cloud-sync'
 import { encryptionService } from '@/services/encryption/encryption-service'
 import { generateCodeExecutionAccessToken } from '@/services/exec-snapshot/access-token'
-import { isPrfSupported, PrfNotSupportedError } from '@/services/passkey'
+import {
+  isPrfSupported,
+  PasskeyTimeoutError,
+  PrfNotSupportedError,
+} from '@/services/passkey'
 import { chatEvents } from '@/services/storage/chat-events'
 import { chatStorage } from '@/services/storage/chat-storage'
 import {
@@ -2182,7 +2190,7 @@ export function ChatInterface({
         return
       }
       if (routingState?.passkeyAddDeviceAvailable) {
-        await addPasskeyToThisDevice()
+        await enableCloudSyncAfterPasskey(addPasskeyToThisDevice)
         return
       }
       if (routingState?.passkeyActive) {
@@ -2192,7 +2200,20 @@ export function ChatInterface({
 
       // A timeout is intentionally conservative: try to wrap the existing
       // key rather than exposing replacement-key setup before routing settles.
-      await setupPasskey()
+      await enableCloudSyncAfterPasskey(setupPasskey)
+    } catch (error) {
+      if (error instanceof PasskeyInitializationCanceledError) return
+      if (
+        error instanceof PrfNotSupportedError ||
+        error instanceof PasskeyTimeoutError
+      ) {
+        logError('Passkey setup from Cloud Sync routing failed', error, {
+          component: 'ChatInterface',
+          action: 'handleOpenCloudSyncSetup',
+        })
+        return
+      }
+      throw error
     } finally {
       if (generation === cloudSyncRouteGenerationRef.current) {
         setIsCloudSyncRoutePending(false)

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -477,6 +477,7 @@ export function ChatInterface({
     skipPasskeyRecovery,
     addPasskeyToThisDevice,
     refreshBundleState,
+    retryPasskeyInitialization,
   } = usePasskeyBackup({
     encryptionKey,
     initialized: cloudSyncInitialized && !showOnboarding,
@@ -2162,8 +2163,13 @@ export function ChatInterface({
       }
       return
     }
+    retryPasskeyInitialization()
     setShowCloudSyncSetupModal(true)
-  }, [showPasskeyRecoveryPrompt, showFirstTimePasskeyPrompt])
+  }, [
+    retryPasskeyInitialization,
+    showPasskeyRecoveryPrompt,
+    showFirstTimePasskeyPrompt,
+  ])
 
   // Pre-warm the cloud-sync modal chunks as soon as a cloud-sync entry
   // point is reachable, so clicking the sidebar prompt opens the popup

--- a/src/components/modals/cloud-sync-setup-modal.tsx
+++ b/src/components/modals/cloud-sync-setup-modal.tsx
@@ -188,9 +188,7 @@ export function CloudSyncSetupModal({
       return
     }
     setCurrentStep(
-      passkeyRecoveryNeeded || isContinuePending
-        ? 'passkey-recovery'
-        : 'generate-or-restore',
+      passkeyRecoveryNeeded ? 'passkey-recovery' : 'generate-or-restore',
     )
   }
 
@@ -515,7 +513,7 @@ ${generatedKey.replace('key_', '')}
           size="landing"
           chevron
           onClick={handleContinue}
-          disabled={isPasskeySetupBusy}
+          disabled={isPasskeySetupBusy || isContinuePending}
           className="w-full min-w-[7rem]"
         >
           {isPasskeySetupBusy ? 'Setting up...' : 'Continue'}

--- a/src/components/modals/cloud-sync-setup-modal.tsx
+++ b/src/components/modals/cloud-sync-setup-modal.tsx
@@ -53,7 +53,8 @@ interface CloudSyncSetupModalBaseProps {
   isDarkMode: boolean
   prfSupported?: boolean
   manualRecoveryNeeded?: boolean
-  passkeyRecoveryFailure?: 'auth_failed' | 'stale_backup' | null
+  passkeyRecoveryFailure?:
+    'auth_failed' | 'inventory_timeout' | 'stale_backup' | null
   /**
    * Called when the user clicks "Skip for Now" on the passkey-recovery step.
    * Lets the caller persist a "don't auto-reopen" flag. When omitted, the
@@ -922,7 +923,9 @@ ${generatedKey.replace('key_', '')}
             <p className="text-balance text-center text-xs text-amber-700 dark:text-amber-400">
               {passkeyRecoveryFailure === 'stale_backup'
                 ? "This passkey is valid, but its backup key doesn't match your existing cloud data. Enter your backup key manually, or start fresh if you no longer need the old data."
-                : 'Passkey authentication failed. You can try again or enter your encryption key manually.'}
+                : passkeyRecoveryFailure === 'inventory_timeout'
+                  ? 'Passkey recovery took too long. Please try again or enter your encryption key manually.'
+                  : 'Passkey authentication failed. You can try again or enter your encryption key manually.'}
             </p>
           </div>
         )}

--- a/src/components/modals/cloud-sync-setup-modal.tsx
+++ b/src/components/modals/cloud-sync-setup-modal.tsx
@@ -187,7 +187,9 @@ export function CloudSyncSetupModal({
       return
     }
     setCurrentStep(
-      passkeyRecoveryNeeded ? 'passkey-recovery' : 'generate-or-restore',
+      passkeyRecoveryNeeded || isContinuePending
+        ? 'passkey-recovery'
+        : 'generate-or-restore',
     )
   }
 
@@ -503,7 +505,6 @@ ${generatedKey.replace('key_', '')}
           size="landing"
           chevron
           onClick={handleMaybeLater}
-          disabled={isContinuePending || isPasskeySetupBusy}
           className="w-full min-w-[7rem]"
         >
           Maybe later
@@ -513,7 +514,7 @@ ${generatedKey.replace('key_', '')}
           size="landing"
           chevron
           onClick={handleContinue}
-          disabled={isContinuePending || isPasskeySetupBusy}
+          disabled={isPasskeySetupBusy}
           className="w-full min-w-[7rem]"
         >
           {isPasskeySetupBusy ? 'Setting up...' : 'Continue'}

--- a/src/components/modals/cloud-sync-setup-modal.tsx
+++ b/src/components/modals/cloud-sync-setup-modal.tsx
@@ -54,7 +54,11 @@ interface CloudSyncSetupModalBaseProps {
   prfSupported?: boolean
   manualRecoveryNeeded?: boolean
   passkeyRecoveryFailure?:
-    'auth_failed' | 'inventory_timeout' | 'stale_backup' | null
+    | 'auth_failed'
+    | 'inventory_timeout'
+    | 'inventory_unavailable'
+    | 'stale_backup'
+    | null
   /**
    * Called when the user clicks "Skip for Now" on the passkey-recovery step.
    * Lets the caller persist a "don't auto-reopen" flag. When omitted, the
@@ -923,7 +927,9 @@ ${generatedKey.replace('key_', '')}
                 ? "This passkey is valid, but its backup key doesn't match your existing cloud data. Enter your backup key manually, or start fresh if you no longer need the old data."
                 : passkeyRecoveryFailure === 'inventory_timeout'
                   ? 'Passkey recovery took too long. Please try again or enter your encryption key manually.'
-                  : 'Passkey authentication failed. You can try again or enter your encryption key manually.'}
+                  : passkeyRecoveryFailure === 'inventory_unavailable'
+                    ? 'Passkey recovery inventory is unavailable. Please try again or enter your encryption key manually.'
+                    : 'Passkey authentication failed. You can try again or enter your encryption key manually.'}
             </p>
           </div>
         )}

--- a/src/components/modals/cloud-sync-setup-mode.ts
+++ b/src/components/modals/cloud-sync-setup-mode.ts
@@ -83,8 +83,8 @@ export async function determineGeneratedKeySetupMode({
 
   try {
     const remoteState = await inspectRemoteStateWithTimeout()
-    return remoteState === 'empty' ? 'recoverExisting' : 'explicitStartFresh'
+    return remoteState === 'exists' ? 'explicitStartFresh' : 'recoverExisting'
   } catch {
-    return 'explicitStartFresh'
+    return 'recoverExisting'
   }
 }

--- a/src/components/modals/cloud-sync-setup-mode.ts
+++ b/src/components/modals/cloud-sync-setup-mode.ts
@@ -5,6 +5,24 @@ import {
 
 export type CloudKeySetupMode = 'recoverExisting' | 'explicitStartFresh'
 
+const REMOTE_STATE_ROUTING_TIMEOUT_MS = 3_000
+
+async function inspectRemoteStateWithTimeout() {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined
+  const timeout = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(
+      () => reject(new Error('Remote state routing probe timed out')),
+      REMOTE_STATE_ROUTING_TIMEOUT_MS,
+    )
+  })
+
+  try {
+    return await Promise.race([inspectRemoteEncryptedState(), timeout])
+  } finally {
+    if (timeoutId !== undefined) clearTimeout(timeoutId)
+  }
+}
+
 /**
  * Why a key activation failed. `key_mismatch` means the enclave
  * confirmed different cloud data exists under another key;
@@ -13,13 +31,10 @@ export type CloudKeySetupMode = 'recoverExisting' | 'explicitStartFresh'
  * correct; `invalid_key` covers malformed input or unexpected errors.
  */
 export type CloudKeySetupFailureReason =
-  | 'key_mismatch'
-  | 'verification_unavailable'
-  | 'invalid_key'
+  'key_mismatch' | 'verification_unavailable' | 'invalid_key'
 
 export type CloudKeySetupResult =
-  | { ok: true }
-  | { ok: false; reason: CloudKeySetupFailureReason }
+  { ok: true } | { ok: false; reason: CloudKeySetupFailureReason }
 
 export function classifyCloudKeySetupError(
   error: unknown,
@@ -67,9 +82,9 @@ export async function determineGeneratedKeySetupMode({
   }
 
   try {
-    const remoteState = await inspectRemoteEncryptedState()
-    return remoteState === 'exists' ? 'explicitStartFresh' : 'recoverExisting'
+    const remoteState = await inspectRemoteStateWithTimeout()
+    return remoteState === 'empty' ? 'recoverExisting' : 'explicitStartFresh'
   } catch {
-    return 'recoverExisting'
+    return 'explicitStartFresh'
   }
 }

--- a/src/components/modals/cloud-sync-setup-mode.ts
+++ b/src/components/modals/cloud-sync-setup-mode.ts
@@ -23,6 +23,23 @@ async function inspectRemoteStateWithTimeout() {
   }
 }
 
+export async function waitForCloudSyncRouting<T>(
+  routing: Promise<T>,
+): Promise<T | null> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined
+  const timeout = new Promise<null>((resolve) => {
+    timeoutId = setTimeout(() => resolve(null), REMOTE_STATE_ROUTING_TIMEOUT_MS)
+  })
+
+  try {
+    return await Promise.race([routing, timeout])
+  } catch {
+    return null
+  } finally {
+    if (timeoutId !== undefined) clearTimeout(timeoutId)
+  }
+}
+
 /**
  * Why a key activation failed. `key_mismatch` means the enclave
  * confirmed different cloud data exists under another key;

--- a/src/components/modals/cloud-sync-setup-mode.ts
+++ b/src/components/modals/cloud-sync-setup-mode.ts
@@ -2,6 +2,7 @@ import {
   CloudKeySetupError,
   inspectRemoteEncryptedState,
 } from '@/services/cloud/cloud-key-preflight'
+import { setCloudSyncEnabled } from '@/utils/cloud-sync-settings'
 
 export type CloudKeySetupMode = 'recoverExisting' | 'explicitStartFresh'
 
@@ -33,11 +34,17 @@ export async function waitForCloudSyncRouting<T>(
 
   try {
     return await Promise.race([routing, timeout])
-  } catch {
-    return null
   } finally {
     if (timeoutId !== undefined) clearTimeout(timeoutId)
   }
+}
+
+export async function enableCloudSyncAfterPasskey(
+  setupPasskey: () => Promise<boolean>,
+): Promise<boolean> {
+  const succeeded = await setupPasskey()
+  if (succeeded) setCloudSyncEnabled(true)
+  return succeeded
 }
 
 /**

--- a/src/constants/storage-keys.ts
+++ b/src/constants/storage-keys.ts
@@ -27,6 +27,8 @@ export const AUTH_ACTIVE_USER_ID = 'tinfoil-auth-active-user-id'
 export const AUTH_ACCOUNT_RESET_SIGNAL = 'tinfoil-auth-account-reset-signal'
 export const AUTH_ANONYMOUS_RESTORE_PENDING_CLEANUP =
   'tinfoil-auth-anonymous-restore-pending-cleanup'
+export const AUTH_SIGNOUT_PENDING_CLEANUP =
+  'tinfoil-auth-signout-pending-cleanup'
 
 // --- localStorage: App settings --------------------------------------------
 export const SETTINGS_CLOUD_SYNC_ENABLED = 'tinfoil-settings-cloud-sync-enabled'

--- a/src/hooks/use-passkey-backup.ts
+++ b/src/hooks/use-passkey-backup.ts
@@ -96,7 +96,7 @@ export interface PasskeyBackupState {
 }
 
 export type PasskeyRecoveryFailure =
-  'auth_failed' | 'inventory_timeout' | 'stale_backup'
+  'auth_failed' | 'inventory_timeout' | 'inventory_unavailable' | 'stale_backup'
 
 type StoredPasskeyBackup = {
   credentialId: string
@@ -140,7 +140,7 @@ class PasskeyRoutingProbeTimeoutError extends Error {
 }
 
 class PasskeyRecoveryInventoryError extends Error {
-  constructor() {
+  constructor(readonly reason: 'timeout' | 'unavailable') {
     super('Passkey recovery candidate inventory could not be loaded')
     this.name = 'PasskeyRecoveryInventoryError'
   }
@@ -298,6 +298,8 @@ export function usePasskeyBackup({
     passkeyFirstTimePromptAvailable: false,
     passkeyRecoveryFailure: null,
   })
+  const [passkeyInitializationAttempt, setPasskeyInitializationAttempt] =
+    useState(0)
 
   const isMountedRef = useRef(true)
   const passkeyFlowInProgressRef = useRef(false)
@@ -491,8 +493,12 @@ export function usePasskeyBackup({
         (signal) => loadRecoveryCandidates({ signal }),
         PASSKEY_RECOVERY_INVENTORY_TIMEOUT_MS,
       )
-    } catch {
-      throw new PasskeyRecoveryInventoryError()
+    } catch (error) {
+      throw new PasskeyRecoveryInventoryError(
+        error instanceof PasskeyRoutingProbeTimeoutError
+          ? 'timeout'
+          : 'unavailable',
+      )
     }
     if (entries.length === 0) return null
 
@@ -973,7 +979,10 @@ export function usePasskeyBackup({
         if (isMountedRef.current) {
           setState((prev) => ({
             ...prev,
-            passkeyRecoveryFailure: 'inventory_timeout',
+            passkeyRecoveryFailure:
+              error.reason === 'timeout'
+                ? 'inventory_timeout'
+                : 'inventory_unavailable',
           }))
         }
         return null
@@ -1005,6 +1014,11 @@ export function usePasskeyBackup({
       return null
     }
   }, [applyRecoveredKeyBundle])
+
+  const retryPasskeyInitialization = useCallback(() => {
+    hasInitializedPasskeyRef.current = false
+    setPasskeyInitializationAttempt((attempt) => attempt + 1)
+  }, [])
 
   // --- Passkey initialization (runs once after cloud sync init completes) ---
   useEffect(() => {
@@ -1265,7 +1279,7 @@ export function usePasskeyBackup({
     }
 
     initializePasskey()
-  }, [initialized, isSignedIn, encryptionKey])
+  }, [initialized, isSignedIn, encryptionKey, passkeyInitializationAttempt])
 
   // Clear the persistent "recovery dismissed" flag and the session
   // first-time-prompt flag once the user has a key again (via passkey
@@ -1967,5 +1981,6 @@ export function usePasskeyBackup({
     skipPasskeyRecovery,
     addPasskeyToThisDevice,
     refreshBundleState,
+    retryPasskeyInitialization,
   }
 }

--- a/src/hooks/use-passkey-backup.ts
+++ b/src/hooks/use-passkey-backup.ts
@@ -302,6 +302,8 @@ export function usePasskeyBackup({
     useState(0)
 
   const isMountedRef = useRef(true)
+  const latestStateRef = useRef(state)
+  latestStateRef.current = state
   const passkeyFlowInProgressRef = useRef(false)
   const userRef = useRef(user)
   userRef.current = user
@@ -310,6 +312,10 @@ export function usePasskeyBackup({
   const hasInitializedPasskeyRef = useRef(false)
   const previousUserIdRef = useRef<string | null | undefined>(undefined)
   const routingProbeGenerationRef = useRef(0)
+  const passkeyInitializationGenerationRef = useRef(0)
+  const passkeyInitializationWaitersRef = useRef<
+    Array<(state: PasskeyBackupState) => void>
+  >([])
 
   // Cleanup on unmount
   useEffect(() => {
@@ -337,6 +343,7 @@ export function usePasskeyBackup({
       return
     }
     if (currentUserId !== null && currentUserId !== previousUserIdRef.current) {
+      passkeyInitializationGenerationRef.current += 1
       hasInitializedPasskeyRef.current = false
       passkeyRecoveryDismissedFlag.clear()
       firstTimePromptDismissedFlag.clear()
@@ -1016,14 +1023,33 @@ export function usePasskeyBackup({
   }, [applyRecoveredKeyBundle])
 
   const retryPasskeyInitialization = useCallback(() => {
+    passkeyInitializationGenerationRef.current += 1
     hasInitializedPasskeyRef.current = false
     setPasskeyInitializationAttempt((attempt) => attempt + 1)
+    return new Promise<PasskeyBackupState>((resolve) => {
+      passkeyInitializationWaitersRef.current.push(resolve)
+    })
   }, [])
 
   // --- Passkey initialization (runs once after cloud sync init completes) ---
   useEffect(() => {
     if (!initialized || !isSignedIn || hasInitializedPasskeyRef.current) return
     hasInitializedPasskeyRef.current = true
+    const generation = ++passkeyInitializationGenerationRef.current
+    let resultState = latestStateRef.current
+    const isCurrentInitialization = () =>
+      isMountedRef.current &&
+      generation === passkeyInitializationGenerationRef.current
+    const applyInitializationState = (
+      update: (state: PasskeyBackupState) => PasskeyBackupState,
+    ) => {
+      if (!isCurrentInitialization()) return
+      resultState = update(resultState)
+      latestStateRef.current = resultState
+      setState((previousState) =>
+        isCurrentInitialization() ? update(previousState) : previousState,
+      )
+    }
 
     const initializePasskey = async () => {
       let prfSupported: boolean
@@ -1031,14 +1057,16 @@ export function usePasskeyBackup({
         prfSupported = await withPasskeyRoutingProbeTimeout(() =>
           isPrfSupported(),
         )
+        if (!isCurrentInitialization()) return
       } catch (error) {
+        if (!isCurrentInitialization()) return
         hasInitializedPasskeyRef.current = false
         logError('Could not determine passkey PRF support', error, {
           component: 'usePasskeyBackup',
           action: 'initializePasskey',
         })
-        if (isMountedRef.current) {
-          setState((prev) => ({
+        if (isCurrentInitialization()) {
+          applyInitializationState((prev) => ({
             ...prev,
             manualRecoveryNeeded:
               !encryptionKey && !manualRecoveryDismissedFlag.isSet(),
@@ -1059,25 +1087,27 @@ export function usePasskeyBackup({
         // key entry when it was adopted bundleless (e.g. by the
         // migration path on another device).
         const validation = await validateCurrentPrimaryKey()
+        if (!isCurrentInitialization()) return
         if (!validation.canWrite && validation.remoteState === 'exists') {
           let hasRemoteBundles = false
           try {
             const current = await enclaveKeyCurrent()
+            if (!isCurrentInitialization()) return
             hasRemoteBundles = Object.keys(current.bundles).length > 0
           } catch {
             // Transient enclave failure: fall through to the manual
             // prompt, which is dismissible and retried next visit.
           }
-          if (!isMountedRef.current) return
+          if (!isCurrentInitialization()) return
           if (hasRemoteBundles && prfSupported) {
             if (!passkeyRecoveryDismissedFlag.isSet()) {
-              setState((prev) => ({
+              applyInitializationState((prev) => ({
                 ...prev,
                 passkeyRecoveryNeeded: true,
               }))
             }
           } else if (!manualRecoveryDismissedFlag.isSet()) {
-            setState((prev) => ({
+            applyInitializationState((prev) => ({
               ...prev,
               manualRecoveryNeeded: true,
               passkeySetupFailed: setupWarningDismissedFlag.isSet()
@@ -1088,7 +1118,7 @@ export function usePasskeyBackup({
           }
           return
         }
-        if (!isMountedRef.current) return
+        if (!isCurrentInitialization()) return
       }
 
       if (!prfSupported) {
@@ -1100,10 +1130,10 @@ export function usePasskeyBackup({
         // local key stay silent — local storage works fine even without PRF.
         if (!encryptionKey) {
           const remoteState = await inspectRemoteEncryptedState()
-          if (!isMountedRef.current) return
+          if (!isCurrentInitialization()) return
           if (remoteState === 'empty') {
             if (!backupWarningDismissedFlag.isSet()) {
-              setState((prev) => ({
+              applyInitializationState((prev) => ({
                 ...prev,
                 passkeySetupFailed: true,
                 passkeyRetryAvailable: false,
@@ -1120,7 +1150,7 @@ export function usePasskeyBackup({
             // the retry button since there's nothing to retry with.
             // Skip entirely if the user previously opted out of the manual
             // recovery prompt — they can re-trigger it from Settings.
-            setState((prev) => ({
+            applyInitializationState((prev) => ({
               ...prev,
               manualRecoveryNeeded: true,
               passkeySetupFailed: setupWarningDismissedFlag.isSet()
@@ -1132,7 +1162,7 @@ export function usePasskeyBackup({
             remoteState === 'unknown' &&
             !backupWarningDismissedFlag.isSet()
           ) {
-            setState((prev) => ({
+            applyInitializationState((prev) => ({
               ...prev,
               passkeySetupFailed: true,
               passkeyRetryAvailable: false,
@@ -1146,13 +1176,14 @@ export function usePasskeyBackup({
         // User has local keys — check for existing backup
         const localCredentialId = getLocalPasskeyCredentialId()
         const deviceState = await getPasskeyDeviceState(localCredentialId)
+        if (!isCurrentInitialization()) return
 
         if (deviceState === 'this-device') {
           // This device already has its own bundle — show green badge,
           // hide every flavour of setup button.
           localStorage.setItem(SECRET_PASSKEY_BACKED_UP, 'true')
-          if (isMountedRef.current) {
-            setState((prev) => ({
+          if (isCurrentInitialization()) {
+            applyInitializationState((prev) => ({
               ...prev,
               passkeyActive: true,
               passkeySetupAvailable: false,
@@ -1169,8 +1200,8 @@ export function usePasskeyBackup({
           // passkey on this device too — the enclave / CP already
           // support many bundles per key.
           localStorage.setItem(SECRET_PASSKEY_BACKED_UP, 'true')
-          if (isMountedRef.current) {
-            setState((prev) => ({
+          if (isCurrentInitialization()) {
+            applyInitializationState((prev) => ({
               ...prev,
               passkeyActive: true,
               passkeyAddDeviceAvailable: true,
@@ -1182,8 +1213,8 @@ export function usePasskeyBackup({
           !passkeyFlowInProgressRef.current
         ) {
           localStorage.removeItem(SECRET_PASSKEY_BACKED_UP)
-          if (isMountedRef.current) {
-            setState((prev) => ({
+          if (isCurrentInitialization()) {
+            applyInitializationState((prev) => ({
               ...prev,
               passkeyActive: false,
               passkeySetupAvailable: true,
@@ -1197,11 +1228,15 @@ export function usePasskeyBackup({
         // UI state flag instead and let the user trigger the WebAuthn call
         // explicitly from a confirmation or recovery modal.
         const credentialState = await getPasskeyCredentialState()
+        if (!isCurrentInitialization()) return
 
         if (credentialState === 'exists') {
           localStorage.setItem(SECRET_PASSKEY_BACKED_UP, 'true')
-          if (isMountedRef.current) {
-            setState((prev) => ({ ...prev, passkeyActive: true }))
+          if (isCurrentInitialization()) {
+            applyInitializationState((prev) => ({
+              ...prev,
+              passkeyActive: true,
+            }))
           }
           // If the user explicitly dismissed the recovery prompt on a
           // previous visit, stay silent on reload — they can re-trigger
@@ -1209,29 +1244,36 @@ export function usePasskeyBackup({
           if (passkeyRecoveryDismissedFlag.isSet()) {
             return
           }
-          if (isMountedRef.current) {
-            setState((prev) => ({
+          if (isCurrentInitialization()) {
+            applyInitializationState((prev) => ({
               ...prev,
               passkeyRecoveryNeeded: true,
             }))
           }
         } else if (credentialState === 'empty') {
           localStorage.removeItem(SECRET_PASSKEY_BACKED_UP)
-          if (isMountedRef.current) {
-            setState((prev) => ({ ...prev, passkeyActive: false }))
+          if (isCurrentInitialization()) {
+            applyInitializationState((prev) => ({
+              ...prev,
+              passkeyActive: false,
+            }))
           }
           const remoteState = await inspectRemoteEncryptedState()
+          if (!isCurrentInitialization()) return
 
           if (remoteState === 'empty') {
-            if (isMountedRef.current && !firstTimePromptDismissedFlag.isSet()) {
-              setState((prev) => ({
+            if (
+              isCurrentInitialization() &&
+              !firstTimePromptDismissedFlag.isSet()
+            ) {
+              applyInitializationState((prev) => ({
                 ...prev,
                 passkeyFirstTimePromptAvailable: true,
               }))
             }
           } else if (
             remoteState === 'exists' &&
-            isMountedRef.current &&
+            isCurrentInitialization() &&
             !manualRecoveryDismissedFlag.isSet()
           ) {
             // Remote encrypted data exists but the server has no passkey
@@ -1245,7 +1287,7 @@ export function usePasskeyBackup({
             //    there's no passkey to retry against.
             // Respect the session warning-dismiss flag and the persistent
             // manual-recovery dismiss flag.
-            setState((prev) => ({
+            applyInitializationState((prev) => ({
               ...prev,
               manualRecoveryNeeded: true,
               passkeySetupFailed: setupWarningDismissedFlag.isSet()
@@ -1255,10 +1297,10 @@ export function usePasskeyBackup({
             }))
           } else if (
             remoteState === 'unknown' &&
-            isMountedRef.current &&
+            isCurrentInitialization() &&
             !setupWarningDismissedFlag.isSet()
           ) {
-            setState((prev) => ({
+            applyInitializationState((prev) => ({
               ...prev,
               manualRecoveryNeeded: false,
               passkeyFirstTimePromptAvailable: false,
@@ -1267,10 +1309,10 @@ export function usePasskeyBackup({
             }))
           }
         } else if (
-          isMountedRef.current &&
+          isCurrentInitialization() &&
           !manualRecoveryDismissedFlag.isSet()
         ) {
-          setState((prev) => ({
+          applyInitializationState((prev) => ({
             ...prev,
             manualRecoveryNeeded: true,
           }))
@@ -1278,7 +1320,27 @@ export function usePasskeyBackup({
       }
     }
 
-    initializePasskey()
+    void initializePasskey()
+      .catch((error) => {
+        if (!isCurrentInitialization()) return
+        hasInitializedPasskeyRef.current = false
+        logError('Passkey initialization failed', error, {
+          component: 'usePasskeyBackup',
+          action: 'initializePasskey',
+        })
+      })
+      .finally(() => {
+        if (!isCurrentInitialization()) return
+        const waiters = passkeyInitializationWaitersRef.current.splice(0)
+        waiters.forEach((resolve) => resolve(resultState))
+      })
+
+    return () => {
+      if (generation === passkeyInitializationGenerationRef.current) {
+        passkeyInitializationGenerationRef.current += 1
+        hasInitializedPasskeyRef.current = false
+      }
+    }
   }, [initialized, isSignedIn, encryptionKey, passkeyInitializationAttempt])
 
   // Clear the persistent "recovery dismissed" flag and the session

--- a/src/hooks/use-passkey-backup.ts
+++ b/src/hooks/use-passkey-backup.ts
@@ -94,7 +94,8 @@ export interface PasskeyBackupState {
   passkeyRecoveryFailure: PasskeyRecoveryFailure | null
 }
 
-export type PasskeyRecoveryFailure = 'auth_failed' | 'stale_backup'
+export type PasskeyRecoveryFailure =
+  'auth_failed' | 'inventory_timeout' | 'stale_backup'
 
 type StoredPasskeyBackup = {
   credentialId: string
@@ -128,20 +129,31 @@ export interface UsePasskeyBackupOptions {
 
 const SYNC_CHECK_INTERVAL_MS = 30_000
 const PASSKEY_ROUTING_PROBE_TIMEOUT_MS = 3_000
+const PASSKEY_RECOVERY_INVENTORY_TIMEOUT_MS = 5_000
+
+class PasskeyRoutingProbeTimeoutError extends Error {
+  constructor() {
+    super('Passkey routing probe timed out')
+    this.name = 'PasskeyRoutingProbeTimeoutError'
+  }
+}
 
 async function withPasskeyRoutingProbeTimeout<T>(
-  probe: Promise<T>,
+  probe: (signal: AbortSignal) => Promise<T>,
+  timeoutMs = PASSKEY_ROUTING_PROBE_TIMEOUT_MS,
 ): Promise<T> {
+  const controller = new AbortController()
   let timeoutId: ReturnType<typeof setTimeout> | undefined
   const timeout = new Promise<never>((_, reject) => {
-    timeoutId = setTimeout(
-      () => reject(new Error('Passkey routing probe timed out')),
-      PASSKEY_ROUTING_PROBE_TIMEOUT_MS,
-    )
+    timeoutId = setTimeout(() => {
+      const error = new PasskeyRoutingProbeTimeoutError()
+      controller.abort(error)
+      reject(error)
+    }, timeoutMs)
   })
 
   try {
-    return await Promise.race([probe, timeout])
+    return await Promise.race([probe(controller.signal), timeout])
   } finally {
     if (timeoutId !== undefined) clearTimeout(timeoutId)
   }
@@ -465,7 +477,10 @@ export function usePasskeyBackup({
     bundleVersion: number
     legacyKek?: CryptoKey
   } | null> => {
-    const entries = await loadRecoveryCandidates()
+    const entries = await withPasskeyRoutingProbeTimeout(
+      (signal) => loadRecoveryCandidates({ signal }),
+      PASSKEY_RECOVERY_INVENTORY_TIMEOUT_MS,
+    )
     if (entries.length === 0) return null
 
     const credentialIds = entries.map((e) => e.id)
@@ -937,6 +952,19 @@ export function usePasskeyBackup({
       })
       return recovery.keyBundle.primary
     } catch (error) {
+      if (error instanceof PasskeyRoutingProbeTimeoutError) {
+        logInfo('Passkey recovery candidate inventory timed out', {
+          component: 'usePasskeyBackup',
+          action: 'recoverWithPasskey',
+        })
+        if (isMountedRef.current) {
+          setState((prev) => ({
+            ...prev,
+            passkeyRecoveryFailure: 'inventory_timeout',
+          }))
+        }
+        return null
+      }
       if (
         error instanceof PrfNotSupportedError ||
         error instanceof PasskeyTimeoutError
@@ -1533,13 +1561,17 @@ export function usePasskeyBackup({
   const showPasskeyRecoveryPrompt = useCallback(async (): Promise<boolean> => {
     const generation = ++routingProbeGenerationRef.current
     if (encryptionService.getKey()) return false
-    const prfSupported = await isPrfSupported()
-    if (!prfSupported) return false
     try {
-      const candidates = await withPasskeyRoutingProbeTimeout(
-        loadRecoveryCandidates(),
+      const { prfSupported, candidates } = await withPasskeyRoutingProbeTimeout(
+        async (signal) => {
+          const prfSupported = await isPrfSupported()
+          if (!prfSupported) return { prfSupported, candidates: [] }
+          const candidates = await loadRecoveryCandidates({ signal })
+          return { prfSupported, candidates }
+        },
       )
       if (generation !== routingProbeGenerationRef.current) return false
+      if (!prfSupported) return false
       if (candidates.length === 0) return false
     } catch {
       if (generation !== routingProbeGenerationRef.current) return false
@@ -1569,26 +1601,37 @@ export function usePasskeyBackup({
   const showFirstTimePasskeyPrompt = useCallback(async (): Promise<boolean> => {
     const generation = ++routingProbeGenerationRef.current
     manualRecoveryDismissedFlag.clear()
-    const prfSupported = await isPrfSupported()
-    if (generation !== routingProbeGenerationRef.current) return false
-    if (!prfSupported) {
-      if (isMountedRef.current) {
-        setState((prev) => ({
-          ...prev,
-          manualRecoveryNeeded: true,
-          passkeyRecoveryNeeded: false,
-          passkeyFirstTimePromptAvailable: false,
-          passkeySetupFailed: true,
-          passkeyRetryAvailable: false,
-        }))
-      }
-      return false
-    }
     try {
-      const [candidates, remoteState] = await withPasskeyRoutingProbeTimeout(
-        Promise.all([loadRecoveryCandidates(), inspectRemoteEncryptedState()]),
-      )
+      const { prfSupported, candidates, remoteState } =
+        await withPasskeyRoutingProbeTimeout(async (signal) => {
+          const prfSupported = await isPrfSupported()
+          if (!prfSupported) {
+            return {
+              prfSupported,
+              candidates: [],
+              remoteState: 'empty' as const,
+            }
+          }
+          const [candidates, remoteState] = await Promise.all([
+            loadRecoveryCandidates({ signal }),
+            inspectRemoteEncryptedState(),
+          ])
+          return { prfSupported, candidates, remoteState }
+        })
       if (generation !== routingProbeGenerationRef.current) return false
+      if (!prfSupported) {
+        if (isMountedRef.current) {
+          setState((prev) => ({
+            ...prev,
+            manualRecoveryNeeded: true,
+            passkeyRecoveryNeeded: false,
+            passkeyFirstTimePromptAvailable: false,
+            passkeySetupFailed: true,
+            passkeyRetryAvailable: false,
+          }))
+        }
+        return false
+      }
       if (candidates.length > 0 || remoteState === 'unknown') {
         passkeyRecoveryDismissedFlag.clear()
         setupWarningDismissedFlag.clear()

--- a/src/hooks/use-passkey-backup.ts
+++ b/src/hooks/use-passkey-backup.ts
@@ -139,6 +139,13 @@ class PasskeyRoutingProbeTimeoutError extends Error {
   }
 }
 
+export class PasskeyInitializationCanceledError extends Error {
+  constructor() {
+    super('Passkey initialization was canceled')
+    this.name = 'PasskeyInitializationCanceledError'
+  }
+}
+
 class PasskeyRecoveryInventoryError extends Error {
   constructor(readonly reason: 'timeout' | 'unavailable') {
     super('Passkey recovery candidate inventory could not be loaded')
@@ -314,15 +321,29 @@ export function usePasskeyBackup({
   const routingProbeGenerationRef = useRef(0)
   const passkeyInitializationGenerationRef = useRef(0)
   const passkeyInitializationWaitersRef = useRef<
-    Array<(state: PasskeyBackupState) => void>
+    Array<{
+      generation: number
+      ownerId: string | null
+      resolve: (state: PasskeyBackupState) => void
+      reject: (error: PasskeyInitializationCanceledError) => void
+    }>
   >([])
+
+  const cancelPasskeyInitializationWaiters = useCallback(() => {
+    const waiters = passkeyInitializationWaitersRef.current.splice(0)
+    waiters.forEach(({ reject }) =>
+      reject(new PasskeyInitializationCanceledError()),
+    )
+  }, [])
 
   // Cleanup on unmount
   useEffect(() => {
     return () => {
       isMountedRef.current = false
+      passkeyInitializationGenerationRef.current += 1
+      cancelPasskeyInitializationWaiters()
     }
-  }, [])
+  }, [cancelPasskeyInitializationWaiters])
 
   // When the signed-in user changes *after* the initial sign-in hydration
   // (sign-out-then-sign-in on the same tab, or a user switch), reset the
@@ -342,8 +363,9 @@ export function usePasskeyBackup({
       }
       return
     }
-    if (currentUserId !== null && currentUserId !== previousUserIdRef.current) {
+    if (currentUserId !== previousUserIdRef.current) {
       passkeyInitializationGenerationRef.current += 1
+      cancelPasskeyInitializationWaiters()
       hasInitializedPasskeyRef.current = false
       passkeyRecoveryDismissedFlag.clear()
       firstTimePromptDismissedFlag.clear()
@@ -365,7 +387,7 @@ export function usePasskeyBackup({
       }
       previousUserIdRef.current = currentUserId
     }
-  }, [isSignedIn, user?.id])
+  }, [cancelPasskeyInitializationWaiters, isSignedIn, user?.id])
 
   /**
    * Build the (userId, userName, displayName) tuple for createPrfPasskey
@@ -1024,22 +1046,32 @@ export function usePasskeyBackup({
 
   const retryPasskeyInitialization = useCallback(() => {
     passkeyInitializationGenerationRef.current += 1
+    cancelPasskeyInitializationWaiters()
     hasInitializedPasskeyRef.current = false
     setPasskeyInitializationAttempt((attempt) => attempt + 1)
-    return new Promise<PasskeyBackupState>((resolve) => {
-      passkeyInitializationWaitersRef.current.push(resolve)
+    const generation = passkeyInitializationGenerationRef.current + 1
+    const ownerId = userRef.current?.id ?? null
+    return new Promise<PasskeyBackupState>((resolve, reject) => {
+      passkeyInitializationWaitersRef.current.push({
+        generation,
+        ownerId,
+        resolve,
+        reject,
+      })
     })
-  }, [])
+  }, [cancelPasskeyInitializationWaiters])
 
   // --- Passkey initialization (runs once after cloud sync init completes) ---
   useEffect(() => {
     if (!initialized || !isSignedIn || hasInitializedPasskeyRef.current) return
     hasInitializedPasskeyRef.current = true
     const generation = ++passkeyInitializationGenerationRef.current
+    const ownerId = user?.id ?? null
     let resultState = latestStateRef.current
     const isCurrentInitialization = () =>
       isMountedRef.current &&
-      generation === passkeyInitializationGenerationRef.current
+      generation === passkeyInitializationGenerationRef.current &&
+      (userRef.current?.id ?? null) === ownerId
     const applyInitializationState = (
       update: (state: PasskeyBackupState) => PasskeyBackupState,
     ) => {
@@ -1331,8 +1363,19 @@ export function usePasskeyBackup({
       })
       .finally(() => {
         if (!isCurrentInitialization()) return
-        const waiters = passkeyInitializationWaitersRef.current.splice(0)
-        waiters.forEach((resolve) => resolve(resultState))
+        const pendingWaiters = passkeyInitializationWaitersRef.current
+        passkeyInitializationWaitersRef.current = pendingWaiters.filter(
+          (waiter) => {
+            if (
+              waiter.generation === generation &&
+              waiter.ownerId === ownerId
+            ) {
+              waiter.resolve(resultState)
+              return false
+            }
+            return true
+          },
+        )
       })
 
     return () => {
@@ -1341,7 +1384,13 @@ export function usePasskeyBackup({
         hasInitializedPasskeyRef.current = false
       }
     }
-  }, [initialized, isSignedIn, encryptionKey, passkeyInitializationAttempt])
+  }, [
+    initialized,
+    isSignedIn,
+    user?.id,
+    encryptionKey,
+    passkeyInitializationAttempt,
+  ])
 
   // Clear the persistent "recovery dismissed" flag and the session
   // first-time-prompt flag once the user has a key again (via passkey
@@ -1390,6 +1439,15 @@ export function usePasskeyBackup({
 
     return () => clearInterval(interval)
   }, [state.passkeyActive, isSignedIn, refreshKeyFromPasskeyBackup])
+
+  const surfacePasskeySetupFailure = useCallback(() => {
+    if (!isMountedRef.current) return
+    setState((prev) => ({
+      ...prev,
+      passkeySetupFailed: true,
+      passkeyRetryAvailable: true,
+    }))
+  }, [])
 
   /**
    * Create a passkey and encrypt existing localStorage keys to the backend.
@@ -1444,15 +1502,20 @@ export function usePasskeyBackup({
       })
       return true
     } catch (error) {
-      if (error instanceof PrfNotSupportedError) throw error
-      if (error instanceof PasskeyTimeoutError) throw error
+      if (
+        error instanceof PrfNotSupportedError ||
+        error instanceof PasskeyTimeoutError
+      ) {
+        surfacePasskeySetupFailure()
+        throw error
+      }
       logError('Passkey setup failed', error, {
         component: 'usePasskeyBackup',
         action: 'setupPasskey',
       })
       return false
     }
-  }, [])
+  }, [surfacePasskeySetupFailure])
 
   /**
    * Generate a new key + create a new passkey (explicit split).
@@ -2016,8 +2079,13 @@ export function usePasskeyBackup({
       passkeyEvents.emit({ type: 'bundle-state-maybe-changed' })
       return true
     } catch (error) {
-      if (error instanceof PrfNotSupportedError) throw error
-      if (error instanceof PasskeyTimeoutError) throw error
+      if (
+        error instanceof PrfNotSupportedError ||
+        error instanceof PasskeyTimeoutError
+      ) {
+        surfacePasskeySetupFailure()
+        throw error
+      }
       logError('Failed to add passkey for this device', error, {
         component: 'usePasskeyBackup',
         action: 'addPasskeyToThisDevice',
@@ -2026,7 +2094,7 @@ export function usePasskeyBackup({
     } finally {
       passkeyFlowInProgressRef.current = false
     }
-  }, [promoteLegacyPasskeyForCurrentDevice])
+  }, [promoteLegacyPasskeyForCurrentDevice, surfacePasskeySetupFailure])
 
   return {
     ...state,

--- a/src/hooks/use-passkey-backup.ts
+++ b/src/hooks/use-passkey-backup.ts
@@ -31,6 +31,7 @@ import {
   loadPasskeyCredentials,
   loadRecoveryCandidates,
   PasskeyCredentialConflictError,
+  type PasskeyCredentialEntry,
   PasskeyTimeoutError,
   PrfNotSupportedError,
   retrieveEncryptedKeys,
@@ -135,6 +136,13 @@ class PasskeyRoutingProbeTimeoutError extends Error {
   constructor() {
     super('Passkey routing probe timed out')
     this.name = 'PasskeyRoutingProbeTimeoutError'
+  }
+}
+
+class PasskeyRecoveryInventoryError extends Error {
+  constructor() {
+    super('Passkey recovery candidate inventory could not be loaded')
+    this.name = 'PasskeyRecoveryInventoryError'
   }
 }
 
@@ -477,10 +485,15 @@ export function usePasskeyBackup({
     bundleVersion: number
     legacyKek?: CryptoKey
   } | null> => {
-    const entries = await withPasskeyRoutingProbeTimeout(
-      (signal) => loadRecoveryCandidates({ signal }),
-      PASSKEY_RECOVERY_INVENTORY_TIMEOUT_MS,
-    )
+    let entries: PasskeyCredentialEntry[]
+    try {
+      entries = await withPasskeyRoutingProbeTimeout(
+        (signal) => loadRecoveryCandidates({ signal }),
+        PASSKEY_RECOVERY_INVENTORY_TIMEOUT_MS,
+      )
+    } catch {
+      throw new PasskeyRecoveryInventoryError()
+    }
     if (entries.length === 0) return null
 
     const credentialIds = entries.map((e) => e.id)
@@ -952,8 +965,8 @@ export function usePasskeyBackup({
       })
       return recovery.keyBundle.primary
     } catch (error) {
-      if (error instanceof PasskeyRoutingProbeTimeoutError) {
-        logInfo('Passkey recovery candidate inventory timed out', {
+      if (error instanceof PasskeyRecoveryInventoryError) {
+        logInfo('Passkey recovery candidate inventory is unavailable', {
           component: 'usePasskeyBackup',
           action: 'recoverWithPasskey',
         })
@@ -999,7 +1012,29 @@ export function usePasskeyBackup({
     hasInitializedPasskeyRef.current = true
 
     const initializePasskey = async () => {
-      const prfSupported = await isPrfSupported()
+      let prfSupported: boolean
+      try {
+        prfSupported = await withPasskeyRoutingProbeTimeout(() =>
+          isPrfSupported(),
+        )
+      } catch (error) {
+        hasInitializedPasskeyRef.current = false
+        logError('Could not determine passkey PRF support', error, {
+          component: 'usePasskeyBackup',
+          action: 'initializePasskey',
+        })
+        if (isMountedRef.current) {
+          setState((prev) => ({
+            ...prev,
+            manualRecoveryNeeded:
+              !encryptionKey && !manualRecoveryDismissedFlag.isSet(),
+            passkeyFirstTimePromptAvailable: false,
+            passkeySetupFailed: true,
+            passkeyRetryAvailable: true,
+          }))
+        }
+        return
+      }
 
       if (encryptionKey) {
         // A local key that derives a different key id than the

--- a/src/hooks/use-passkey-backup.ts
+++ b/src/hooks/use-passkey-backup.ts
@@ -127,6 +127,25 @@ export interface UsePasskeyBackupOptions {
 }
 
 const SYNC_CHECK_INTERVAL_MS = 30_000
+const PASSKEY_ROUTING_PROBE_TIMEOUT_MS = 3_000
+
+async function withPasskeyRoutingProbeTimeout<T>(
+  probe: Promise<T>,
+): Promise<T> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined
+  const timeout = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(
+      () => reject(new Error('Passkey routing probe timed out')),
+      PASSKEY_ROUTING_PROBE_TIMEOUT_MS,
+    )
+  })
+
+  try {
+    return await Promise.race([probe, timeout])
+  } finally {
+    if (timeoutId !== undefined) clearTimeout(timeoutId)
+  }
+}
 
 /**
  * Read the locally remembered sync_version for a credential ID.
@@ -268,6 +287,7 @@ export function usePasskeyBackup({
   onEncryptionKeyRecoveredRef.current = onEncryptionKeyRecovered
   const hasInitializedPasskeyRef = useRef(false)
   const previousUserIdRef = useRef<string | null | undefined>(undefined)
+  const routingProbeGenerationRef = useRef(0)
 
   // Cleanup on unmount
   useEffect(() => {
@@ -1511,14 +1531,18 @@ export function usePasskeyBackup({
   // prompt was made available; false if the caller should fall through to
   // another flow (first-time setup or manual key).
   const showPasskeyRecoveryPrompt = useCallback(async (): Promise<boolean> => {
+    const generation = ++routingProbeGenerationRef.current
     if (encryptionService.getKey()) return false
     const prfSupported = await isPrfSupported()
     if (!prfSupported) return false
     try {
-      const credentialState = await getPasskeyCredentialState()
-      if (credentialState !== 'exists') return false
+      const candidates = await withPasskeyRoutingProbeTimeout(
+        loadRecoveryCandidates(),
+      )
+      if (generation !== routingProbeGenerationRef.current) return false
+      if (candidates.length === 0) return false
     } catch {
-      return false
+      if (generation !== routingProbeGenerationRef.current) return false
     }
     passkeyRecoveryDismissedFlag.clear()
     setupWarningDismissedFlag.clear()
@@ -1526,6 +1550,7 @@ export function usePasskeyBackup({
       setState((prev) => ({
         ...prev,
         passkeyRecoveryNeeded: true,
+        manualRecoveryNeeded: false,
         passkeySetupFailed: false,
         passkeyRetryAvailable: true,
       }))
@@ -1542,16 +1567,42 @@ export function usePasskeyBackup({
   // was made available; false if the caller should route through the
   // manual-key flow instead.
   const showFirstTimePasskeyPrompt = useCallback(async (): Promise<boolean> => {
+    const generation = ++routingProbeGenerationRef.current
     manualRecoveryDismissedFlag.clear()
     const prfSupported = await isPrfSupported()
-    if (!prfSupported) return false
+    if (generation !== routingProbeGenerationRef.current) return false
+    if (!prfSupported) {
+      if (isMountedRef.current) {
+        setState((prev) => ({
+          ...prev,
+          manualRecoveryNeeded: true,
+          passkeyRecoveryNeeded: false,
+          passkeyFirstTimePromptAvailable: false,
+          passkeySetupFailed: true,
+          passkeyRetryAvailable: false,
+        }))
+      }
+      return false
+    }
     try {
-      const [credentialState, remoteState] = await Promise.all([
-        getPasskeyCredentialState(),
-        inspectRemoteEncryptedState(),
-      ])
-      if (credentialState !== 'empty') {
-        return false
+      const [candidates, remoteState] = await withPasskeyRoutingProbeTimeout(
+        Promise.all([loadRecoveryCandidates(), inspectRemoteEncryptedState()]),
+      )
+      if (generation !== routingProbeGenerationRef.current) return false
+      if (candidates.length > 0 || remoteState === 'unknown') {
+        passkeyRecoveryDismissedFlag.clear()
+        setupWarningDismissedFlag.clear()
+        if (isMountedRef.current) {
+          setState((prev) => ({
+            ...prev,
+            passkeyRecoveryNeeded: true,
+            manualRecoveryNeeded: false,
+            passkeyFirstTimePromptAvailable: false,
+            passkeySetupFailed: false,
+            passkeyRetryAvailable: true,
+          }))
+        }
+        return true
       }
       if (remoteState === 'exists') {
         if (isMountedRef.current) {
@@ -1565,27 +1616,29 @@ export function usePasskeyBackup({
         }
         return false
       }
-      if (remoteState === 'unknown') {
-        setupWarningDismissedFlag.clear()
-        if (isMountedRef.current) {
-          setState((prev) => ({
-            ...prev,
-            manualRecoveryNeeded: false,
-            passkeyFirstTimePromptAvailable: false,
-            passkeySetupFailed: true,
-            passkeyRetryAvailable: true,
-          }))
-        }
-        return false
-      }
     } catch {
-      return false
+      if (generation !== routingProbeGenerationRef.current) return false
+      passkeyRecoveryDismissedFlag.clear()
+      setupWarningDismissedFlag.clear()
+      if (isMountedRef.current) {
+        setState((prev) => ({
+          ...prev,
+          passkeyRecoveryNeeded: true,
+          manualRecoveryNeeded: false,
+          passkeyFirstTimePromptAvailable: false,
+          passkeySetupFailed: false,
+          passkeyRetryAvailable: true,
+        }))
+      }
+      return true
     }
     firstTimePromptDismissedFlag.clear()
     if (isMountedRef.current) {
       setState((prev) => ({
         ...prev,
         passkeyFirstTimePromptAvailable: true,
+        passkeyRecoveryNeeded: false,
+        manualRecoveryNeeded: false,
       }))
     }
     return true
@@ -1597,6 +1650,7 @@ export function usePasskeyBackup({
   // chat-interface closes the currently open modal. Cleared automatically
   // once the user regains an encryption key via any path.
   const skipPasskeyRecovery = useCallback((): void => {
+    routingProbeGenerationRef.current += 1
     passkeyRecoveryDismissedFlag.set()
     if (!isMountedRef.current) return
     setState((prev) => {
@@ -1621,6 +1675,10 @@ export function usePasskeyBackup({
         passkeyRetryAvailable: true,
       }
     })
+  }, [])
+
+  const cancelPasskeyRoutingProbe = useCallback((): void => {
+    routingProbeGenerationRef.current += 1
   }, [])
 
   /**
@@ -1822,6 +1880,7 @@ export function usePasskeyBackup({
     setupFirstTimePasskey,
     showFirstTimePasskeyPrompt,
     showPasskeyRecoveryPrompt,
+    cancelPasskeyRoutingProbe,
     dismissFirstTimePasskeyPrompt,
     recoverWithPasskey,
     setupNewKeySplit,

--- a/src/hooks/use-passkey-backup.ts
+++ b/src/hooks/use-passkey-backup.ts
@@ -336,14 +336,19 @@ export function usePasskeyBackup({
     )
   }, [])
 
+  const invalidatePasskeyInitialization = useCallback(() => {
+    passkeyInitializationGenerationRef.current += 1
+    hasInitializedPasskeyRef.current = false
+    cancelPasskeyInitializationWaiters()
+  }, [cancelPasskeyInitializationWaiters])
+
   // Cleanup on unmount
   useEffect(() => {
     return () => {
       isMountedRef.current = false
-      passkeyInitializationGenerationRef.current += 1
-      cancelPasskeyInitializationWaiters()
+      invalidatePasskeyInitialization()
     }
-  }, [cancelPasskeyInitializationWaiters])
+  }, [invalidatePasskeyInitialization])
 
   // When the signed-in user changes *after* the initial sign-in hydration
   // (sign-out-then-sign-in on the same tab, or a user switch), reset the
@@ -364,9 +369,7 @@ export function usePasskeyBackup({
       return
     }
     if (currentUserId !== previousUserIdRef.current) {
-      passkeyInitializationGenerationRef.current += 1
-      cancelPasskeyInitializationWaiters()
-      hasInitializedPasskeyRef.current = false
+      invalidatePasskeyInitialization()
       passkeyRecoveryDismissedFlag.clear()
       firstTimePromptDismissedFlag.clear()
       setupWarningDismissedFlag.clear()
@@ -387,7 +390,7 @@ export function usePasskeyBackup({
       }
       previousUserIdRef.current = currentUserId
     }
-  }, [cancelPasskeyInitializationWaiters, isSignedIn, user?.id])
+  }, [invalidatePasskeyInitialization, isSignedIn, user?.id])
 
   /**
    * Build the (userId, userName, displayName) tuple for createPrfPasskey
@@ -1045,9 +1048,7 @@ export function usePasskeyBackup({
   }, [applyRecoveredKeyBundle])
 
   const retryPasskeyInitialization = useCallback(() => {
-    passkeyInitializationGenerationRef.current += 1
-    cancelPasskeyInitializationWaiters()
-    hasInitializedPasskeyRef.current = false
+    invalidatePasskeyInitialization()
     setPasskeyInitializationAttempt((attempt) => attempt + 1)
     const generation = passkeyInitializationGenerationRef.current + 1
     const ownerId = userRef.current?.id ?? null
@@ -1059,7 +1060,7 @@ export function usePasskeyBackup({
         reject,
       })
     })
-  }, [cancelPasskeyInitializationWaiters])
+  }, [invalidatePasskeyInitialization])
 
   // --- Passkey initialization (runs once after cloud sync init completes) ---
   useEffect(() => {
@@ -1380,8 +1381,7 @@ export function usePasskeyBackup({
 
     return () => {
       if (generation === passkeyInitializationGenerationRef.current) {
-        passkeyInitializationGenerationRef.current += 1
-        hasInitializedPasskeyRef.current = false
+        invalidatePasskeyInitialization()
       }
     }
   }, [
@@ -1390,6 +1390,7 @@ export function usePasskeyBackup({
     user?.id,
     encryptionKey,
     passkeyInitializationAttempt,
+    invalidatePasskeyInitialization,
   ])
 
   // Clear the persistent "recovery dismissed" flag and the session
@@ -1493,6 +1494,7 @@ export function usePasskeyBackup({
           ...prev,
           passkeyActive: true,
           passkeySetupAvailable: false,
+          passkeySetupFailed: false,
         }))
       }
 

--- a/src/services/passkey/index.ts
+++ b/src/services/passkey/index.ts
@@ -18,6 +18,7 @@ export {
 } from './passkey-key-storage'
 export type {
   KeyBundle,
+  LoadPasskeyCredentialsOptions,
   PasskeyCredentialEntry,
   PasskeyCredentialState,
   PasskeyDeviceState,

--- a/src/services/passkey/legacy-passkey-credentials.ts
+++ b/src/services/passkey/legacy-passkey-credentials.ts
@@ -34,9 +34,6 @@ export class LegacyPasskeyCredentialsTimeoutError extends Error {
 export async function fetchLegacyPasskeyCredentials(
   options: FetchLegacyPasskeyCredentialsOptions = {},
 ): Promise<PasskeyCredentialEntry[]> {
-  if (!(await authTokenManager.isAuthenticated())) {
-    return []
-  }
   const controller = new AbortController()
   const timeoutId = setTimeout(
     () => controller.abort(new LegacyPasskeyCredentialsTimeoutError()),
@@ -47,8 +44,17 @@ export async function fetchLegacyPasskeyCredentials(
   else
     options.signal?.addEventListener('abort', abortFromCaller, { once: true })
   try {
+    const isAuthenticated = await settleWithSignal(
+      authTokenManager.isAuthenticated(),
+      controller.signal,
+    )
+    if (!isAuthenticated) return []
+    const headers = await settleWithSignal(
+      authTokenManager.getAuthHeaders(),
+      controller.signal,
+    )
     const resp = await fetch(`${API_BASE_URL}/api/passkey-credentials/`, {
-      headers: await authTokenManager.getAuthHeaders(),
+      headers,
       signal: controller.signal,
     })
     if (resp.status === 404 || resp.status === 401) return []
@@ -76,6 +82,27 @@ export async function fetchLegacyPasskeyCredentials(
     clearTimeout(timeoutId)
     options.signal?.removeEventListener('abort', abortFromCaller)
   }
+}
+
+function settleWithSignal<T>(
+  promise: Promise<T>,
+  signal: AbortSignal,
+): Promise<T> {
+  if (signal.aborted) return Promise.reject(signal.reason)
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(signal.reason)
+    signal.addEventListener('abort', onAbort, { once: true })
+    promise.then(
+      (value) => {
+        signal.removeEventListener('abort', onAbort)
+        resolve(value)
+      },
+      (error) => {
+        signal.removeEventListener('abort', onAbort)
+        reject(error)
+      },
+    )
+  })
 }
 
 function isPasskeyCredentialEntry(

--- a/src/services/passkey/legacy-passkey-credentials.ts
+++ b/src/services/passkey/legacy-passkey-credentials.ts
@@ -44,11 +44,13 @@ export async function fetchLegacyPasskeyCredentials(
   else
     options.signal?.addEventListener('abort', abortFromCaller, { once: true })
   try {
+    if (controller.signal.aborted) throw controller.signal.reason
     const isAuthenticated = await settleWithSignal(
       authTokenManager.isAuthenticated(),
       controller.signal,
     )
     if (!isAuthenticated) return []
+    if (controller.signal.aborted) throw controller.signal.reason
     const headers = await settleWithSignal(
       authTokenManager.getAuthHeaders(),
       controller.signal,

--- a/src/services/passkey/legacy-passkey-credentials.ts
+++ b/src/services/passkey/legacy-passkey-credentials.ts
@@ -4,6 +4,19 @@ import type { PasskeyCredentialEntry } from './passkey-key-storage'
 
 const API_BASE_URL =
   process.env.NEXT_PUBLIC_API_BASE_URL || 'https://api.tinfoil.sh'
+export const LEGACY_PASSKEY_CREDENTIALS_TIMEOUT_MS = 3_000
+
+export interface FetchLegacyPasskeyCredentialsOptions {
+  signal?: AbortSignal
+  timeoutMs?: number
+}
+
+export class LegacyPasskeyCredentialsTimeoutError extends Error {
+  constructor() {
+    super('Legacy passkey credentials fetch timed out')
+    this.name = 'LegacyPasskeyCredentialsTimeoutError'
+  }
+}
 
 /**
  * One-way recovery fetch for users who registered a passkey on the
@@ -18,15 +31,25 @@ const API_BASE_URL =
  * Writes to /api/passkey-credentials/ are intentionally NOT exposed
  * here — the legacy table is read-only for the new client.
  */
-export async function fetchLegacyPasskeyCredentials(): Promise<
-  PasskeyCredentialEntry[]
-> {
+export async function fetchLegacyPasskeyCredentials(
+  options: FetchLegacyPasskeyCredentialsOptions = {},
+): Promise<PasskeyCredentialEntry[]> {
   if (!(await authTokenManager.isAuthenticated())) {
     return []
   }
+  const controller = new AbortController()
+  const timeoutId = setTimeout(
+    () => controller.abort(new LegacyPasskeyCredentialsTimeoutError()),
+    options.timeoutMs ?? LEGACY_PASSKEY_CREDENTIALS_TIMEOUT_MS,
+  )
+  const abortFromCaller = () => controller.abort(options.signal?.reason)
+  if (options.signal?.aborted) abortFromCaller()
+  else
+    options.signal?.addEventListener('abort', abortFromCaller, { once: true })
   try {
     const resp = await fetch(`${API_BASE_URL}/api/passkey-credentials/`, {
       headers: await authTokenManager.getAuthHeaders(),
+      signal: controller.signal,
     })
     if (resp.status === 404 || resp.status === 401) return []
     if (!resp.ok) {
@@ -36,6 +59,10 @@ export async function fetchLegacyPasskeyCredentials(): Promise<
     if (!Array.isArray(body)) return []
     return body.filter(isPasskeyCredentialEntry)
   } catch (err) {
+    const error =
+      controller.signal.reason instanceof LegacyPasskeyCredentialsTimeoutError
+        ? controller.signal.reason
+        : err
     logError('failed to load legacy passkey credentials', err, {
       component: 'LegacyPasskeyCredentials',
       action: 'fetchLegacyPasskeyCredentials',
@@ -44,7 +71,10 @@ export async function fetchLegacyPasskeyCredentials(): Promise<
     // an empty array) apart from "could not find out"; swallowing the
     // failure as [] would misroute recovery into first-time setup and
     // let deletePasskeyCredential report a false success.
-    throw err
+    throw error
+  } finally {
+    clearTimeout(timeoutId)
+    options.signal?.removeEventListener('abort', abortFromCaller)
   }
 }
 

--- a/src/services/passkey/passkey-key-storage.ts
+++ b/src/services/passkey/passkey-key-storage.ts
@@ -48,7 +48,11 @@ import {
 } from '../sync-enclave/sync-api'
 import { SyncEnclaveError } from '../sync-enclave/sync-enclave-client'
 import { IF_MATCH_SENTINELS, WIRE_CODES } from '../sync-enclave/wire-contract'
-import { fetchLegacyPasskeyCredentials } from './legacy-passkey-credentials'
+import {
+  fetchLegacyPasskeyCredentials,
+  LEGACY_PASSKEY_CREDENTIALS_TIMEOUT_MS,
+  LegacyPasskeyCredentialsTimeoutError,
+} from './legacy-passkey-credentials'
 
 const AES_GCM_IV_BYTES = 12
 
@@ -264,23 +268,57 @@ async function loadLegacyFallback(
 export async function loadRecoveryCandidates(
   options: LoadPasskeyCredentialsOptions = {},
 ): Promise<PasskeyCredentialEntry[]> {
-  let enclaveEntries: PasskeyCredentialEntry[] = []
-  try {
-    const resp = await enclaveKeyCurrent()
-    if (resp.key_id) {
-      enclaveEntries = Object.values(resp.bundles).map((bundle) => ({
+  const enclavePromise = (async () => {
+    try {
+      const resp = await enclaveKeyCurrent()
+      if (!resp.key_id) return []
+      return Object.values(resp.bundles).map((bundle) => ({
         ...reshapeBundleToEntry(bundle),
         source: 'enclave' as const,
       }))
+    } catch (err) {
+      if (err instanceof SyncEnclaveError && err.status === 404) return []
+      throw err
     }
-  } catch (err) {
-    if (!(err instanceof SyncEnclaveError) || err.status !== 404) throw err
+  })()
+  const legacyPromise = withLegacyRecoveryTimeout(options)
+  const [enclaveResult, legacyResult] = await Promise.allSettled([
+    enclavePromise,
+    legacyPromise,
+  ])
+  const enclaveEntries =
+    enclaveResult.status === 'fulfilled' ? enclaveResult.value : []
+  const legacyEntries =
+    legacyResult.status === 'fulfilled' ? legacyResult.value : []
+
+  if (enclaveEntries.length === 0 && legacyEntries.length === 0) {
+    if (legacyResult.status === 'rejected') throw legacyResult.reason
+    if (enclaveResult.status === 'rejected') throw enclaveResult.reason
   }
-  const legacyEntries = await loadLegacyFallback(options)
+
   const byId = new Map<string, PasskeyCredentialEntry>()
   for (const entry of legacyEntries) byId.set(entry.id, entry)
   for (const entry of enclaveEntries) byId.set(entry.id, entry)
   return [...byId.values()]
+}
+
+async function withLegacyRecoveryTimeout(
+  options: LoadPasskeyCredentialsOptions,
+): Promise<PasskeyCredentialEntry[]> {
+  const timeoutMs =
+    options.legacyTimeoutMs ?? LEGACY_PASSKEY_CREDENTIALS_TIMEOUT_MS
+  let timeoutId: ReturnType<typeof setTimeout> | undefined
+  const timeout = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(
+      () => reject(new LegacyPasskeyCredentialsTimeoutError()),
+      timeoutMs,
+    )
+  })
+  try {
+    return await Promise.race([loadLegacyFallback(options), timeout])
+  } finally {
+    if (timeoutId !== undefined) clearTimeout(timeoutId)
+  }
 }
 
 /**

--- a/src/services/passkey/passkey-key-storage.ts
+++ b/src/services/passkey/passkey-key-storage.ts
@@ -100,10 +100,7 @@ export type PasskeyCredentialState = 'exists' | 'empty' | 'unknown'
  *  - `unknown`: enclave was unreachable; caller should leave state alone.
  */
 export type PasskeyDeviceState =
-  | 'this-device'
-  | 'other-device-only'
-  | 'empty'
-  | 'unknown'
+  'this-device' | 'other-device-only' | 'empty' | 'unknown'
 
 export interface StoreEncryptedKeysOptions {
   expectedSyncVersion?: number | null
@@ -207,9 +204,14 @@ function reshapeBundleToEntry(bundle: {
 
 // --- Public API ------------------------------------------------------------
 
-export async function loadPasskeyCredentials(): Promise<
-  PasskeyCredentialEntry[]
-> {
+export interface LoadPasskeyCredentialsOptions {
+  signal?: AbortSignal
+  legacyTimeoutMs?: number
+}
+
+export async function loadPasskeyCredentials(
+  options: LoadPasskeyCredentialsOptions = {},
+): Promise<PasskeyCredentialEntry[]> {
   try {
     const resp = await enclaveKeyCurrent()
     if (resp.key_id) {
@@ -223,19 +225,24 @@ export async function loadPasskeyCredentials(): Promise<
       // bundle is written, so a key_id can exist with no way to unlock
       // it. Fall back to the legacy passkey so the user can still
       // recover instead of being forced into manual key entry.
-      return await loadLegacyFallback()
+      return await loadLegacyFallback(options)
     }
-    return await loadLegacyFallback()
+    return await loadLegacyFallback(options)
   } catch (err) {
     if (err instanceof SyncEnclaveError && err.status === 404) {
-      return loadLegacyFallback()
+      return loadLegacyFallback(options)
     }
     throw err
   }
 }
 
-async function loadLegacyFallback(): Promise<PasskeyCredentialEntry[]> {
-  const legacy = await fetchLegacyPasskeyCredentials()
+async function loadLegacyFallback(
+  options: LoadPasskeyCredentialsOptions = {},
+): Promise<PasskeyCredentialEntry[]> {
+  const legacy = await fetchLegacyPasskeyCredentials({
+    signal: options.signal,
+    timeoutMs: options.legacyTimeoutMs,
+  })
   if (legacy.length === 0) return []
   logInfo('falling back to legacy passkey credentials for recovery', {
     component: 'PasskeyKeyStorage',
@@ -254,9 +261,9 @@ async function loadLegacyFallback(): Promise<PasskeyCredentialEntry[]> {
  * registry still be offered for recovery after another platform has
  * registered the key, so it can unlock the shared CEK and enroll itself.
  */
-export async function loadRecoveryCandidates(): Promise<
-  PasskeyCredentialEntry[]
-> {
+export async function loadRecoveryCandidates(
+  options: LoadPasskeyCredentialsOptions = {},
+): Promise<PasskeyCredentialEntry[]> {
   let enclaveEntries: PasskeyCredentialEntry[] = []
   try {
     const resp = await enclaveKeyCurrent()
@@ -269,7 +276,7 @@ export async function loadRecoveryCandidates(): Promise<
   } catch (err) {
     if (!(err instanceof SyncEnclaveError) || err.status !== 404) throw err
   }
-  const legacyEntries = await loadLegacyFallback()
+  const legacyEntries = await loadLegacyFallback(options)
   const byId = new Map<string, PasskeyCredentialEntry>()
   for (const entry of legacyEntries) byId.set(entry.id, entry)
   for (const entry of enclaveEntries) byId.set(entry.id, entry)

--- a/src/services/passkey/passkey-key-storage.ts
+++ b/src/services/passkey/passkey-key-storage.ts
@@ -217,7 +217,7 @@ export async function loadPasskeyCredentials(
   options: LoadPasskeyCredentialsOptions = {},
 ): Promise<PasskeyCredentialEntry[]> {
   try {
-    const resp = await enclaveKeyCurrent()
+    const resp = await enclaveKeyCurrent({ signal: options.signal })
     if (resp.key_id) {
       const entries = Object.values(resp.bundles).map((bundle) => ({
         ...reshapeBundleToEntry(bundle),
@@ -270,7 +270,7 @@ export async function loadRecoveryCandidates(
 ): Promise<PasskeyCredentialEntry[]> {
   const enclavePromise = (async () => {
     try {
-      const resp = await enclaveKeyCurrent()
+      const resp = await enclaveKeyCurrent({ signal: options.signal })
       if (!resp.key_id) return []
       return Object.values(resp.bundles).map((bundle) => ({
         ...reshapeBundleToEntry(bundle),

--- a/src/services/sync-enclave/sync-api.ts
+++ b/src/services/sync-enclave/sync-api.ts
@@ -739,10 +739,17 @@ export async function removeBundle(
  * enclave is mapped to this empty shape so callers can treat it as a
  * normal "first-time user" state without special-casing exceptions).
  */
-export async function keyCurrent(): Promise<KeyCurrentResponse> {
+export async function keyCurrent(
+  options: { signal?: AbortSignal } = {},
+): Promise<KeyCurrentResponse> {
   const client = await getSyncEnclaveClient()
   try {
-    const resp = await client.post<KeyCurrentResponse>('/v1/key/current', {})
+    const resp = await client.post<KeyCurrentResponse>(
+      '/v1/key/current',
+      {},
+      undefined,
+      options,
+    )
     // The server is a Go service; a nil bundle map marshals to JSON
     // null. Normalize so callers can Object.values/index the map
     // without crashing on edge shapes (e.g. a key registered via

--- a/src/utils/signout-cleanup.ts
+++ b/src/utils/signout-cleanup.ts
@@ -5,6 +5,7 @@ import {
   AUTH_ACCOUNT_RESET_SIGNAL,
   AUTH_ACTIVE_USER_ID,
   AUTH_ANONYMOUS_RESTORE_PENDING_CLEANUP,
+  AUTH_SIGNOUT_PENDING_CLEANUP,
   SECRET_PASSKEY_BACKED_UP,
   SETTINGS_HAS_SEEN_ONBOARDING,
   USER_ENCRYPTION_KEY,
@@ -191,12 +192,18 @@ export async function performSignoutCleanup(): Promise<void> {
     await performAccountCleanup({
       context: 'signoutCleanup',
     })
+    localStorage.removeItem(AUTH_SIGNOUT_PENDING_CLEANUP)
 
     logInfo('Signout cleanup completed', {
       component: 'signoutCleanup',
       action: 'performSignoutCleanup',
     })
   } catch (error) {
+    try {
+      localStorage.setItem(AUTH_SIGNOUT_PENDING_CLEANUP, 'true')
+    } catch {
+      // The current page still blocks on the cleanup error below.
+    }
     logError('Error during signout cleanup', error, {
       component: 'signoutCleanup',
       action: 'performSignoutCleanup',

--- a/src/utils/signout-cleanup.ts
+++ b/src/utils/signout-cleanup.ts
@@ -192,7 +192,11 @@ export async function performSignoutCleanup(): Promise<void> {
     await performAccountCleanup({
       context: 'signoutCleanup',
     })
-    localStorage.removeItem(AUTH_SIGNOUT_PENDING_CLEANUP)
+    try {
+      localStorage.removeItem(AUTH_SIGNOUT_PENDING_CLEANUP)
+    } catch {
+      // Cleanup has already succeeded, so marker removal is best-effort.
+    }
 
     logInfo('Signout cleanup completed', {
       component: 'signoutCleanup',

--- a/tests/components/auth-cleanup-handler.test.tsx
+++ b/tests/components/auth-cleanup-handler.test.tsx
@@ -4,6 +4,7 @@ import {
   AUTH_ACCOUNT_RESET_FAILED,
   AUTH_ACTIVE_USER_ID,
   AUTH_ANONYMOUS_RESTORE_PENDING_CLEANUP,
+  AUTH_SIGNOUT_PENDING_CLEANUP,
   SETTINGS_CLOUD_SYNC_ENABLED,
   USER_ENCRYPTION_KEY,
 } from '@/constants/storage-keys'
@@ -230,5 +231,24 @@ describe('AuthCleanupHandler', () => {
     expect(
       screen.getByRole('alertdialog', { name: 'Unable to clear local data' }),
     ).toBeTruthy()
+  })
+
+  it('blocks a signed-out remount until pending cleanup is retried', async () => {
+    localStorage.setItem(AUTH_SIGNOUT_PENDING_CLEANUP, 'true')
+    render(createElement(AuthCleanupHandler))
+    await act(async () => {})
+
+    expect(
+      screen.getByRole('alertdialog', {
+        name: 'Unable to clear local data',
+      }),
+    ).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry cleanup' }))
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(mockPerformSignoutCleanup).toHaveBeenCalledTimes(1)
   })
 })

--- a/tests/components/auth-cleanup-handler.test.tsx
+++ b/tests/components/auth-cleanup-handler.test.tsx
@@ -4,6 +4,8 @@ import {
   AUTH_ACCOUNT_RESET_FAILED,
   AUTH_ACTIVE_USER_ID,
   AUTH_ANONYMOUS_RESTORE_PENDING_CLEANUP,
+  SETTINGS_CLOUD_SYNC_ENABLED,
+  USER_ENCRYPTION_KEY,
 } from '@/constants/storage-keys'
 import { act, fireEvent, render, screen } from '@testing-library/react'
 import { createElement } from 'react'
@@ -84,10 +86,33 @@ describe('AuthCleanupHandler', () => {
     expect(mockPerformSignoutCleanup).not.toHaveBeenCalled()
   })
 
-  it('clears data after confirmed session expiry', async () => {
+  it('preserves local account data during slow auth hydration', async () => {
     localStorage.setItem(AUTH_ACTIVE_USER_ID, 'user_123')
-    render(createElement(AuthCleanupHandler))
+    localStorage.setItem(USER_ENCRYPTION_KEY, 'key_cek')
+    localStorage.setItem(SETTINGS_CLOUD_SYNC_ENABLED, 'true')
+    const { rerender } = render(createElement(AuthCleanupHandler))
 
+    await act(async () => {
+      vi.advanceTimersByTime(2000)
+    })
+
+    authState = { isSignedIn: true, isLoaded: true }
+    userState = { user: { id: 'user_123' } }
+    rerender(createElement(AuthCleanupHandler))
+
+    expect(mockPerformSignoutCleanup).not.toHaveBeenCalled()
+    expect(localStorage.getItem(USER_ENCRYPTION_KEY)).toBe('key_cek')
+    expect(localStorage.getItem(SETTINGS_CLOUD_SYNC_ENABLED)).toBe('true')
+  })
+
+  it('clears everything after an observed session signs out', async () => {
+    authState = { isSignedIn: true, isLoaded: true }
+    userState = { user: { id: 'user_123' } }
+    const { rerender } = render(createElement(AuthCleanupHandler))
+
+    authState = { isSignedIn: false, isLoaded: true }
+    userState = { user: null }
+    rerender(createElement(AuthCleanupHandler))
     await act(async () => {
       vi.advanceTimersByTime(2000)
       await Promise.resolve()

--- a/tests/components/auth-cleanup-handler.test.tsx
+++ b/tests/components/auth-cleanup-handler.test.tsx
@@ -251,4 +251,33 @@ describe('AuthCleanupHandler', () => {
 
     expect(mockPerformSignoutCleanup).toHaveBeenCalledTimes(1)
   })
+
+  it('does not retry signout cleanup after a session signs in', async () => {
+    localStorage.setItem(AUTH_SIGNOUT_PENDING_CLEANUP, 'true')
+    const { rerender } = render(createElement(AuthCleanupHandler))
+    await act(async () => {})
+
+    authState = { isSignedIn: true, isLoaded: true }
+    userState = { user: { id: 'user_123' } }
+    rerender(createElement(AuthCleanupHandler))
+    fireEvent.click(screen.getByRole('button', { name: 'Retry cleanup' }))
+
+    expect(mockPerformSignoutCleanup).not.toHaveBeenCalled()
+    expect(window.location.reload).toHaveBeenCalledTimes(1)
+  })
+
+  it('prioritizes a cross-tab reset when both cleanup markers exist', async () => {
+    sessionStorage.setItem(AUTH_ACCOUNT_RESET_FAILED, 'true')
+    localStorage.setItem(AUTH_SIGNOUT_PENDING_CLEANUP, 'true')
+    render(createElement(AuthCleanupHandler))
+    await act(async () => {})
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry cleanup' }))
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(mockRetryFailedStorageCleanup).toHaveBeenCalledTimes(1)
+    expect(mockPerformSignoutCleanup).not.toHaveBeenCalled()
+  })
 })

--- a/tests/components/cloud-sync-setup-modal.test.tsx
+++ b/tests/components/cloud-sync-setup-modal.test.tsx
@@ -208,7 +208,7 @@ describe('CloudSyncSetupModal onboarding', () => {
     expect(onClose).toHaveBeenCalledTimes(1)
   })
 
-  it('keeps intro actions enabled while the routing probe hangs', async () => {
+  it('keeps dismissal available while routing disables Continue', () => {
     const onClose = vi.fn()
     render(
       <CloudSyncSetupModal
@@ -221,13 +221,11 @@ describe('CloudSyncSetupModal onboarding', () => {
 
     const continueButton = screen.getByRole('button', { name: 'Continue' })
     const maybeLaterButton = screen.getByRole('button', { name: 'Maybe later' })
-    expect(continueButton).toBeEnabled()
+    expect(continueButton).toBeDisabled()
     expect(maybeLaterButton).toBeEnabled()
 
-    fireEvent.click(continueButton)
-    expect(
-      await screen.findByRole('button', { name: 'Unlock with Passkey' }),
-    ).toBeEnabled()
+    fireEvent.click(maybeLaterButton)
+    expect(onClose).toHaveBeenCalledTimes(1)
   })
 
   it('bypasses the intro for passkey recovery', () => {

--- a/tests/components/cloud-sync-setup-modal.test.tsx
+++ b/tests/components/cloud-sync-setup-modal.test.tsx
@@ -192,17 +192,42 @@ describe('CloudSyncSetupModal onboarding', () => {
     )
   })
 
-  it('disables intro actions while passkey setup is in progress', () => {
+  it('keeps Maybe later available while passkey setup is in progress', () => {
+    const onClose = vi.fn()
     render(
       <CloudSyncSetupModal
         {...baseProps}
+        onClose={onClose}
         onSetupWithPasskey={vi.fn(async () => {})}
         isPasskeySetupBusy
       />,
     )
 
     expect(screen.getByRole('button', { name: 'Setting up...' })).toBeDisabled()
-    expect(screen.getByRole('button', { name: 'Maybe later' })).toBeDisabled()
+    fireEvent.click(screen.getByRole('button', { name: 'Maybe later' }))
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps intro actions enabled while the routing probe hangs', async () => {
+    const onClose = vi.fn()
+    render(
+      <CloudSyncSetupModal
+        {...baseProps}
+        onClose={onClose}
+        isContinuePending
+        onRecoverWithPasskey={vi.fn()}
+      />,
+    )
+
+    const continueButton = screen.getByRole('button', { name: 'Continue' })
+    const maybeLaterButton = screen.getByRole('button', { name: 'Maybe later' })
+    expect(continueButton).toBeEnabled()
+    expect(maybeLaterButton).toBeEnabled()
+
+    fireEvent.click(continueButton)
+    expect(
+      await screen.findByRole('button', { name: 'Unlock with Passkey' }),
+    ).toBeEnabled()
   })
 
   it('bypasses the intro for passkey recovery', () => {

--- a/tests/components/cloud-sync-setup-mode.test.ts
+++ b/tests/components/cloud-sync-setup-mode.test.ts
@@ -1,5 +1,5 @@
 import { determineGeneratedKeySetupMode } from '@/components/modals/cloud-sync-setup-mode'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mockInspectRemoteEncryptedState = vi.fn()
 
@@ -11,6 +11,10 @@ vi.mock('@/services/cloud/cloud-key-preflight', () => ({
 describe('determineGeneratedKeySetupMode', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
   it('uses explicitStartFresh when manual recovery is required', async () => {
@@ -42,17 +46,17 @@ describe('determineGeneratedKeySetupMode', () => {
     expect(mode).toBe('explicitStartFresh')
   })
 
-  it('uses explicitStartFresh when the remote cloud state is unknown', async () => {
+  it('keeps recoverExisting when the remote cloud state is unknown', async () => {
     mockInspectRemoteEncryptedState.mockResolvedValue('unknown')
 
     const mode = await determineGeneratedKeySetupMode({
       manualRecoveryNeeded: false,
     })
 
-    expect(mode).toBe('explicitStartFresh')
+    expect(mode).toBe('recoverExisting')
   })
 
-  it('requires explicit start fresh when remote inspection fails', async () => {
+  it('keeps recoverExisting when remote inspection fails', async () => {
     mockInspectRemoteEncryptedState.mockRejectedValue(
       new Error('Network error'),
     )
@@ -61,6 +65,18 @@ describe('determineGeneratedKeySetupMode', () => {
       manualRecoveryNeeded: false,
     })
 
-    expect(mode).toBe('explicitStartFresh')
+    expect(mode).toBe('recoverExisting')
+  })
+
+  it('keeps recoverExisting when remote inspection times out', async () => {
+    vi.useFakeTimers()
+    mockInspectRemoteEncryptedState.mockReturnValue(new Promise(() => {}))
+
+    const modePromise = determineGeneratedKeySetupMode({
+      manualRecoveryNeeded: false,
+    })
+    await vi.advanceTimersByTimeAsync(3_000)
+
+    await expect(modePromise).resolves.toBe('recoverExisting')
   })
 })

--- a/tests/components/cloud-sync-setup-mode.test.ts
+++ b/tests/components/cloud-sync-setup-mode.test.ts
@@ -49,10 +49,10 @@ describe('determineGeneratedKeySetupMode', () => {
       manualRecoveryNeeded: false,
     })
 
-    expect(mode).toBe('recoverExisting')
+    expect(mode).toBe('explicitStartFresh')
   })
 
-  it('falls back to recoverExisting when remote inspection fails', async () => {
+  it('requires explicit start fresh when remote inspection fails', async () => {
     mockInspectRemoteEncryptedState.mockRejectedValue(
       new Error('Network error'),
     )
@@ -61,6 +61,6 @@ describe('determineGeneratedKeySetupMode', () => {
       manualRecoveryNeeded: false,
     })
 
-    expect(mode).toBe('recoverExisting')
+    expect(mode).toBe('explicitStartFresh')
   })
 })

--- a/tests/components/cloud-sync-setup-mode.test.ts
+++ b/tests/components/cloud-sync-setup-mode.test.ts
@@ -1,4 +1,7 @@
-import { determineGeneratedKeySetupMode } from '@/components/modals/cloud-sync-setup-mode'
+import {
+  determineGeneratedKeySetupMode,
+  waitForCloudSyncRouting,
+} from '@/components/modals/cloud-sync-setup-mode'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mockInspectRemoteEncryptedState = vi.fn()
@@ -75,8 +78,19 @@ describe('determineGeneratedKeySetupMode', () => {
     const modePromise = determineGeneratedKeySetupMode({
       manualRecoveryNeeded: false,
     })
-    await vi.advanceTimersByTimeAsync(3_000)
+    await vi.runAllTimersAsync()
 
     await expect(modePromise).resolves.toBe('recoverExisting')
+  })
+
+  it('bounds cloud sync routing without exposing its timeout', async () => {
+    vi.useFakeTimers()
+
+    const routingPromise = waitForCloudSyncRouting(
+      new Promise<'ready'>(() => {}),
+    )
+    await vi.runAllTimersAsync()
+
+    await expect(routingPromise).resolves.toBeNull()
   })
 })

--- a/tests/components/cloud-sync-setup-mode.test.ts
+++ b/tests/components/cloud-sync-setup-mode.test.ts
@@ -1,14 +1,24 @@
 import {
   determineGeneratedKeySetupMode,
+  enableCloudSyncAfterPasskey,
   waitForCloudSyncRouting,
 } from '@/components/modals/cloud-sync-setup-mode'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const mockInspectRemoteEncryptedState = vi.fn()
+const { mockInspectRemoteEncryptedState, mockSetCloudSyncEnabled } = vi.hoisted(
+  () => ({
+    mockInspectRemoteEncryptedState: vi.fn(),
+    mockSetCloudSyncEnabled: vi.fn(),
+  }),
+)
 
 vi.mock('@/services/cloud/cloud-key-preflight', () => ({
   inspectRemoteEncryptedState: (...args: unknown[]) =>
     mockInspectRemoteEncryptedState(...args),
+}))
+
+vi.mock('@/utils/cloud-sync-settings', () => ({
+  setCloudSyncEnabled: mockSetCloudSyncEnabled,
 }))
 
 describe('determineGeneratedKeySetupMode', () => {
@@ -92,5 +102,26 @@ describe('determineGeneratedKeySetupMode', () => {
     await vi.runAllTimersAsync()
 
     await expect(routingPromise).resolves.toBeNull()
+  })
+
+  it('propagates canceled cloud sync routing', async () => {
+    const error = new Error('canceled')
+
+    await expect(waitForCloudSyncRouting(Promise.reject(error))).rejects.toBe(
+      error,
+    )
+  })
+
+  it('enables cloud sync only after passkey setup succeeds', async () => {
+    await expect(enableCloudSyncAfterPasskey(async () => true)).resolves.toBe(
+      true,
+    )
+    expect(mockSetCloudSyncEnabled).toHaveBeenCalledWith(true)
+
+    mockSetCloudSyncEnabled.mockClear()
+    await expect(enableCloudSyncAfterPasskey(async () => false)).resolves.toBe(
+      false,
+    )
+    expect(mockSetCloudSyncEnabled).not.toHaveBeenCalled()
   })
 })

--- a/tests/hooks/use-passkey-backup.test.tsx
+++ b/tests/hooks/use-passkey-backup.test.tsx
@@ -182,6 +182,34 @@ describe('usePasskeyBackup', () => {
     expect(result.current.passkeyRetryAvailable).toBe(true)
   })
 
+  it('bounds the cold-load PRF probe and leaves initialization retryable', async () => {
+    vi.useFakeTimers()
+    mocks.isPrfSupported.mockReturnValue(new Promise(() => {}))
+    const { result, rerender } = renderHook(
+      (options) => usePasskeyBackup(options),
+      { initialProps: baseOptions },
+    )
+
+    await act(async () => {
+      await Promise.resolve()
+      vi.advanceTimersByTime(3_000)
+    })
+
+    expect(result.current.passkeySetupFailed).toBe(true)
+    expect(result.current.passkeyRetryAvailable).toBe(true)
+    expect(result.current.manualRecoveryNeeded).toBe(true)
+    expect(result.current.passkeyFirstTimePromptAvailable).toBe(false)
+
+    mocks.isPrfSupported.mockResolvedValue(true)
+    rerender({ ...baseOptions, initialized: false })
+    rerender(baseOptions)
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(mocks.getPasskeyCredentialState).toHaveBeenCalled()
+  })
+
   it('routes unknown remote state to passkey recovery', async () => {
     mocks.inspectRemoteEncryptedState.mockResolvedValue('unknown')
     const { result } = renderHook(() =>
@@ -277,6 +305,24 @@ describe('usePasskeyBackup', () => {
     })
 
     await expect(recoveryPromise).resolves.toBeNull()
+    expect(result.current.passkeyRecoveryFailure).toBe('inventory_timeout')
+    expect(mocks.authenticatePrfPasskey).not.toHaveBeenCalled()
+  })
+
+  it('makes failed legacy-only recovery inventory retryable', async () => {
+    mocks.loadRecoveryCandidates.mockRejectedValue(
+      new Error('legacy inventory unavailable'),
+    )
+    const { result } = renderHook(() =>
+      usePasskeyBackup({ ...baseOptions, initialized: false }),
+    )
+
+    let recovered: string | null = 'pending'
+    await act(async () => {
+      recovered = await result.current.recoverWithPasskey()
+    })
+
+    expect(recovered).toBeNull()
     expect(result.current.passkeyRecoveryFailure).toBe('inventory_timeout')
     expect(mocks.authenticatePrfPasskey).not.toHaveBeenCalled()
   })

--- a/tests/hooks/use-passkey-backup.test.tsx
+++ b/tests/hooks/use-passkey-backup.test.tsx
@@ -4,7 +4,7 @@ import {
 } from '@/constants/storage-keys'
 import { usePasskeyBackup } from '@/hooks/use-passkey-backup'
 import { act, renderHook, waitFor } from '@testing-library/react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
   inspectRemoteEncryptedState: vi.fn(),
@@ -155,11 +155,16 @@ describe('usePasskeyBackup', () => {
     mocks.getPasskeyCredentialState.mockResolvedValue('empty')
     mocks.getPasskeyDeviceState.mockResolvedValue('empty')
     mocks.loadPasskeyCredentials.mockResolvedValue([])
+    mocks.loadRecoveryCandidates.mockResolvedValue([])
     mocks.getCachedPrfResult.mockReturnValue(null)
     mocks.getLocalPasskeyCredentialId.mockReturnValue(null)
     mocks.getKey.mockReturnValue(null)
     mocks.getAllKeys.mockReturnValue({ primary: null, alternatives: [] })
     mocks.passkeyEventsOn.mockReturnValue(() => {})
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
   it('keeps transient remote-state failures retriable during initialization', async () => {
@@ -177,7 +182,7 @@ describe('usePasskeyBackup', () => {
     expect(result.current.passkeyRetryAvailable).toBe(true)
   })
 
-  it('keeps manual first-time prompt retries available on unknown remote state', async () => {
+  it('routes unknown remote state to passkey recovery', async () => {
     mocks.inspectRemoteEncryptedState.mockResolvedValue('unknown')
     const { result } = renderHook(() =>
       usePasskeyBackup({ ...baseOptions, initialized: false }),
@@ -188,10 +193,75 @@ describe('usePasskeyBackup', () => {
       prompted = await result.current.showFirstTimePasskeyPrompt()
     })
 
-    expect(prompted).toBe(false)
+    expect(prompted).toBe(true)
     expect(result.current.manualRecoveryNeeded).toBe(false)
-    expect(result.current.passkeySetupFailed).toBe(true)
+    expect(result.current.passkeyRecoveryNeeded).toBe(true)
+    expect(result.current.passkeySetupFailed).toBe(false)
     expect(result.current.passkeyRetryAvailable).toBe(true)
+  })
+
+  it('uses v2 bundle inventory for recovery without a local key marker', async () => {
+    mocks.loadRecoveryCandidates.mockResolvedValue([
+      { id: 'v2-credential', source: 'enclave' },
+    ])
+    expect(localStorage.getItem(SECRET_PASSKEY_BACKED_UP)).toBeNull()
+    const { result } = renderHook(() =>
+      usePasskeyBackup({ ...baseOptions, initialized: false }),
+    )
+
+    let prompted = false
+    await act(async () => {
+      prompted = await result.current.showPasskeyRecoveryPrompt()
+    })
+
+    expect(prompted).toBe(true)
+    expect(result.current.passkeyRecoveryNeeded).toBe(true)
+    expect(mocks.loadRecoveryCandidates).toHaveBeenCalledTimes(1)
+  })
+
+  it('times out a hanging routing probe toward passkey recovery', async () => {
+    vi.useFakeTimers()
+    mocks.loadRecoveryCandidates.mockReturnValue(new Promise(() => {}))
+    const { result } = renderHook(() =>
+      usePasskeyBackup({ ...baseOptions, initialized: false }),
+    )
+
+    let promptPromise!: Promise<boolean>
+    act(() => {
+      promptPromise = result.current.showPasskeyRecoveryPrompt()
+    })
+    await act(async () => {
+      await Promise.resolve()
+      vi.advanceTimersByTime(3_000)
+    })
+
+    await expect(promptPromise).resolves.toBe(true)
+    expect(result.current.passkeyRecoveryNeeded).toBe(true)
+  })
+
+  it('ignores a routing probe after dismissal', async () => {
+    let resolveCandidates!: (value: unknown[]) => void
+    mocks.loadRecoveryCandidates.mockReturnValue(
+      new Promise((resolve) => {
+        resolveCandidates = resolve
+      }),
+    )
+    const { result } = renderHook(() =>
+      usePasskeyBackup({ ...baseOptions, initialized: false }),
+    )
+
+    let promptPromise!: Promise<boolean>
+    act(() => {
+      promptPromise = result.current.showPasskeyRecoveryPrompt()
+    })
+    await act(async () => {
+      await Promise.resolve()
+      result.current.cancelPasskeyRoutingProbe()
+      resolveCandidates([{ id: 'late-v2-bundle', source: 'enclave' }])
+    })
+
+    await expect(promptPromise).resolves.toBe(false)
+    expect(result.current.passkeyRecoveryNeeded).toBe(false)
   })
 
   it('keeps explicit manual recovery available after a reload', async () => {

--- a/tests/hooks/use-passkey-backup.test.tsx
+++ b/tests/hooks/use-passkey-backup.test.tsx
@@ -198,12 +198,47 @@ describe('usePasskeyBackup', () => {
     expect(result.current.passkeyFirstTimePromptAvailable).toBe(false)
 
     mocks.isPrfSupported.mockResolvedValue(true)
-    act(() => result.current.retryPasskeyInitialization())
+    act(() => {
+      void result.current.retryPasskeyInitialization()
+    })
 
     await act(async () => {
       await Promise.resolve()
     })
     expect(mocks.getPasskeyCredentialState).toHaveBeenCalled()
+  })
+
+  it('ignores stale initialization completions after a retry', async () => {
+    let resolveInitialProbe!: (supported: boolean) => void
+    mocks.isPrfSupported
+      .mockReturnValueOnce(
+        new Promise<boolean>((resolve) => {
+          resolveInitialProbe = resolve
+        }),
+      )
+      .mockResolvedValue(true)
+    const { result } = renderHook(() => usePasskeyBackup(baseOptions))
+
+    let retryPromise!: ReturnType<
+      typeof result.current.retryPasskeyInitialization
+    >
+    act(() => {
+      retryPromise = result.current.retryPasskeyInitialization()
+    })
+    await act(async () => {
+      await retryPromise
+    })
+
+    expect(result.current.passkeyFirstTimePromptAvailable).toBe(true)
+    expect(result.current.passkeySetupFailed).toBe(false)
+
+    await act(async () => {
+      resolveInitialProbe(false)
+      await Promise.resolve()
+    })
+
+    expect(result.current.passkeyFirstTimePromptAvailable).toBe(true)
+    expect(result.current.passkeySetupFailed).toBe(false)
   })
 
   it('routes unknown remote state to passkey recovery', async () => {

--- a/tests/hooks/use-passkey-backup.test.tsx
+++ b/tests/hooks/use-passkey-backup.test.tsx
@@ -283,6 +283,62 @@ describe('usePasskeyBackup', () => {
     await rejection
   })
 
+  it('rejects initialization waiters when an effect dependency changes', async () => {
+    mocks.isPrfSupported.mockReturnValue(new Promise(() => {}))
+    const { result, rerender } = renderHook(
+      ({ encryptionKey }) =>
+        usePasskeyBackup({
+          ...baseOptions,
+          encryptionKey,
+        }),
+      { initialProps: { encryptionKey: null as string | null } },
+    )
+
+    let retryPromise!: Promise<unknown>
+    act(() => {
+      retryPromise = result.current.retryPasskeyInitialization()
+    })
+    const rejection = expect(retryPromise).rejects.toMatchObject({
+      name: 'PasskeyInitializationCanceledError',
+    })
+
+    rerender({ encryptionKey: 'key_local' })
+
+    await rejection
+  })
+
+  it('clears the retry warning after existing-key setup succeeds', async () => {
+    const timeout = new PasskeyTimeoutError('Passkey timed out')
+    mocks.getCurrentCloudKeyAuthorizationMode.mockResolvedValue('validated')
+    mocks.getAllKeys.mockReturnValue({ primary: 'key_local', alternatives: [] })
+    mocks.createPrfPasskey
+      .mockRejectedValueOnce(timeout)
+      .mockResolvedValueOnce({
+        prfOutput: new Uint8Array(32),
+        credentialId: 'credential-id',
+      })
+    mocks.deriveKeyEncryptionKey.mockResolvedValue({} as CryptoKey)
+    mocks.storeEncryptedKeys.mockResolvedValue({
+      syncVersion: 1,
+      bundleVersion: 1,
+    })
+    const { result } = renderHook(() =>
+      usePasskeyBackup({ ...baseOptions, initialized: false }),
+    )
+
+    await act(async () => {
+      await expect(result.current.setupPasskey()).rejects.toBe(timeout)
+    })
+    expect(result.current.passkeySetupFailed).toBe(true)
+
+    await act(async () => {
+      await expect(result.current.setupPasskey()).resolves.toBe(true)
+    })
+
+    expect(result.current.passkeySetupFailed).toBe(false)
+    expect(result.current.passkeyActive).toBe(true)
+  })
+
   it('routes unknown remote state to passkey recovery', async () => {
     mocks.inspectRemoteEncryptedState.mockResolvedValue('unknown')
     const { result } = renderHook(() =>

--- a/tests/hooks/use-passkey-backup.test.tsx
+++ b/tests/hooks/use-passkey-backup.test.tsx
@@ -185,10 +185,7 @@ describe('usePasskeyBackup', () => {
   it('bounds the cold-load PRF probe and leaves initialization retryable', async () => {
     vi.useFakeTimers()
     mocks.isPrfSupported.mockReturnValue(new Promise(() => {}))
-    const { result, rerender } = renderHook(
-      (options) => usePasskeyBackup(options),
-      { initialProps: baseOptions },
-    )
+    const { result } = renderHook(() => usePasskeyBackup(baseOptions))
 
     await act(async () => {
       await Promise.resolve()
@@ -201,8 +198,7 @@ describe('usePasskeyBackup', () => {
     expect(result.current.passkeyFirstTimePromptAvailable).toBe(false)
 
     mocks.isPrfSupported.mockResolvedValue(true)
-    rerender({ ...baseOptions, initialized: false })
-    rerender(baseOptions)
+    act(() => result.current.retryPasskeyInitialization())
 
     await act(async () => {
       await Promise.resolve()
@@ -323,7 +319,7 @@ describe('usePasskeyBackup', () => {
     })
 
     expect(recovered).toBeNull()
-    expect(result.current.passkeyRecoveryFailure).toBe('inventory_timeout')
+    expect(result.current.passkeyRecoveryFailure).toBe('inventory_unavailable')
     expect(mocks.authenticatePrfPasskey).not.toHaveBeenCalled()
   })
 

--- a/tests/hooks/use-passkey-backup.test.tsx
+++ b/tests/hooks/use-passkey-backup.test.tsx
@@ -239,6 +239,48 @@ describe('usePasskeyBackup', () => {
     expect(result.current.passkeyRecoveryNeeded).toBe(true)
   })
 
+  it('bounds PRF support detection as part of the routing decision', async () => {
+    vi.useFakeTimers()
+    mocks.isPrfSupported.mockReturnValue(new Promise(() => {}))
+    const { result } = renderHook(() =>
+      usePasskeyBackup({ ...baseOptions, initialized: false }),
+    )
+
+    let promptPromise!: Promise<boolean>
+    act(() => {
+      promptPromise = result.current.showFirstTimePasskeyPrompt()
+    })
+    await act(async () => {
+      await Promise.resolve()
+      vi.advanceTimersByTime(3_000)
+    })
+
+    await expect(promptPromise).resolves.toBe(true)
+    expect(result.current.passkeyRecoveryNeeded).toBe(true)
+    expect(mocks.loadRecoveryCandidates).not.toHaveBeenCalled()
+  })
+
+  it('makes a hanging recovery inventory retryable after timeout', async () => {
+    vi.useFakeTimers()
+    mocks.loadRecoveryCandidates.mockReturnValue(new Promise(() => {}))
+    const { result } = renderHook(() =>
+      usePasskeyBackup({ ...baseOptions, initialized: false }),
+    )
+
+    let recoveryPromise!: Promise<string | null>
+    act(() => {
+      recoveryPromise = result.current.recoverWithPasskey()
+    })
+    await act(async () => {
+      await Promise.resolve()
+      vi.advanceTimersByTime(5_000)
+    })
+
+    await expect(recoveryPromise).resolves.toBeNull()
+    expect(result.current.passkeyRecoveryFailure).toBe('inventory_timeout')
+    expect(mocks.authenticatePrfPasskey).not.toHaveBeenCalled()
+  })
+
   it('ignores a routing probe after dismissal', async () => {
     let resolveCandidates!: (value: unknown[]) => void
     mocks.loadRecoveryCandidates.mockReturnValue(

--- a/tests/hooks/use-passkey-backup.test.tsx
+++ b/tests/hooks/use-passkey-backup.test.tsx
@@ -3,6 +3,7 @@ import {
   SETTINGS_MANUAL_RECOVERY_DISMISSED,
 } from '@/constants/storage-keys'
 import { usePasskeyBackup } from '@/hooks/use-passkey-backup'
+import { PasskeyTimeoutError, PrfNotSupportedError } from '@/services/passkey'
 import { act, renderHook, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -239,6 +240,47 @@ describe('usePasskeyBackup', () => {
 
     expect(result.current.passkeyFirstTimePromptAvailable).toBe(true)
     expect(result.current.passkeySetupFailed).toBe(false)
+  })
+
+  it('rejects initialization waiters when the signed-in user changes', async () => {
+    mocks.isPrfSupported.mockReturnValue(new Promise(() => {}))
+    const { result, rerender } = renderHook(
+      ({ userId }) =>
+        usePasskeyBackup({
+          ...baseOptions,
+          user: { id: userId } as any,
+        }),
+      { initialProps: { userId: 'user_1' } },
+    )
+
+    let retryPromise!: Promise<unknown>
+    act(() => {
+      retryPromise = result.current.retryPasskeyInitialization()
+    })
+    const rejection = expect(retryPromise).rejects.toMatchObject({
+      name: 'PasskeyInitializationCanceledError',
+    })
+
+    rerender({ userId: 'user_2' })
+
+    await rejection
+  })
+
+  it('rejects initialization waiters when the hook unmounts', async () => {
+    mocks.isPrfSupported.mockReturnValue(new Promise(() => {}))
+    const { result, unmount } = renderHook(() => usePasskeyBackup(baseOptions))
+
+    let retryPromise!: Promise<unknown>
+    act(() => {
+      retryPromise = result.current.retryPasskeyInitialization()
+    })
+    const rejection = expect(retryPromise).rejects.toMatchObject({
+      name: 'PasskeyInitializationCanceledError',
+    })
+
+    unmount()
+
+    await rejection
   })
 
   it('routes unknown remote state to passkey recovery', async () => {
@@ -595,6 +637,24 @@ describe('usePasskeyBackup', () => {
 
       expect(success).toBe(true)
       expect(mocks.promoteRecoveredCekToEnclave).toHaveBeenCalledOnce()
+    })
+
+    it.each([
+      new PrfNotSupportedError('PRF unavailable'),
+      new PasskeyTimeoutError('Passkey timed out'),
+    ])('surfaces retry UI for expected setup errors', async (error) => {
+      mocks.keyCurrent.mockResolvedValue({ key_id: 'key-id', has_data: true })
+      mocks.addBundleForCurrentKey.mockRejectedValue(error)
+      const { result } = renderHook(() => usePasskeyBackup(baseOptions))
+
+      await act(async () => {
+        await expect(result.current.addPasskeyToThisDevice()).rejects.toBe(
+          error,
+        )
+      })
+
+      expect(result.current.passkeySetupFailed).toBe(true)
+      expect(result.current.passkeyRetryAvailable).toBe(true)
     })
   })
 })

--- a/tests/services/passkey/legacy-passkey-credentials.test.ts
+++ b/tests/services/passkey/legacy-passkey-credentials.test.ts
@@ -48,14 +48,12 @@ describe('fetchLegacyPasskeyCredentials', () => {
   it('aborts a hanging request after the named timeout', async () => {
     vi.useFakeTimers()
     const credentialsPromise = fetchLegacyPasskeyCredentials({ timeoutMs: 50 })
-    await Promise.resolve()
-    await Promise.resolve()
-
-    vi.advanceTimersByTime(50)
-
-    await expect(credentialsPromise).rejects.toBeInstanceOf(
+    const rejection = expect(credentialsPromise).rejects.toBeInstanceOf(
       LegacyPasskeyCredentialsTimeoutError,
     )
+    await vi.advanceTimersByTimeAsync(50)
+
+    await rejection
   })
 
   it('propagates caller cancellation to the request', async () => {
@@ -64,13 +62,29 @@ describe('fetchLegacyPasskeyCredentials', () => {
       signal: controller.signal,
       timeoutMs: 5_000,
     })
-    await Promise.resolve()
-    await Promise.resolve()
-
-    controller.abort()
-
-    await expect(credentialsPromise).rejects.toMatchObject({
+    const rejection = expect(credentialsPromise).rejects.toMatchObject({
       name: 'AbortError',
     })
+    controller.abort()
+
+    await rejection
   })
+
+  it.each(['isAuthenticated', 'getAuthHeaders'] as const)(
+    'bounds hanging %s acquisition with the same timeout',
+    async (method) => {
+      vi.useFakeTimers()
+      mocks[method].mockReturnValue(new Promise(() => {}))
+
+      const credentialsPromise = fetchLegacyPasskeyCredentials({
+        timeoutMs: 50,
+      })
+      const rejection = expect(credentialsPromise).rejects.toBeInstanceOf(
+        LegacyPasskeyCredentialsTimeoutError,
+      )
+      await vi.advanceTimersByTimeAsync(50)
+
+      await rejection
+    },
+  )
 })

--- a/tests/services/passkey/legacy-passkey-credentials.test.ts
+++ b/tests/services/passkey/legacy-passkey-credentials.test.ts
@@ -1,0 +1,76 @@
+import {
+  LegacyPasskeyCredentialsTimeoutError,
+  fetchLegacyPasskeyCredentials,
+} from '@/services/passkey/legacy-passkey-credentials'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  isAuthenticated: vi.fn(),
+  getAuthHeaders: vi.fn(),
+  logError: vi.fn(),
+}))
+
+vi.mock('@/services/auth', () => ({
+  authTokenManager: {
+    isAuthenticated: mocks.isAuthenticated,
+    getAuthHeaders: mocks.getAuthHeaders,
+  },
+}))
+
+vi.mock('@/utils/error-handling', () => ({
+  logError: mocks.logError,
+}))
+
+describe('fetchLegacyPasskeyCredentials', () => {
+  beforeEach(() => {
+    mocks.isAuthenticated.mockResolvedValue(true)
+    mocks.getAuthHeaders.mockResolvedValue({ Authorization: 'Bearer token' })
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        (_url: string, init?: RequestInit) =>
+          new Promise((_resolve, reject) => {
+            init?.signal?.addEventListener(
+              'abort',
+              () => reject(init.signal?.reason),
+              { once: true },
+            )
+          }),
+      ),
+    )
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  it('aborts a hanging request after the named timeout', async () => {
+    vi.useFakeTimers()
+    const credentialsPromise = fetchLegacyPasskeyCredentials({ timeoutMs: 50 })
+    await Promise.resolve()
+    await Promise.resolve()
+
+    vi.advanceTimersByTime(50)
+
+    await expect(credentialsPromise).rejects.toBeInstanceOf(
+      LegacyPasskeyCredentialsTimeoutError,
+    )
+  })
+
+  it('propagates caller cancellation to the request', async () => {
+    const controller = new AbortController()
+    const credentialsPromise = fetchLegacyPasskeyCredentials({
+      signal: controller.signal,
+      timeoutMs: 5_000,
+    })
+    await Promise.resolve()
+    await Promise.resolve()
+
+    controller.abort()
+
+    await expect(credentialsPromise).rejects.toMatchObject({
+      name: 'AbortError',
+    })
+  })
+})

--- a/tests/services/passkey/legacy-passkey-credentials.test.ts
+++ b/tests/services/passkey/legacy-passkey-credentials.test.ts
@@ -23,6 +23,7 @@ vi.mock('@/utils/error-handling', () => ({
 
 describe('fetchLegacyPasskeyCredentials', () => {
   beforeEach(() => {
+    vi.clearAllMocks()
     mocks.isAuthenticated.mockResolvedValue(true)
     mocks.getAuthHeaders.mockResolvedValue({ Authorization: 'Bearer token' })
     vi.stubGlobal(
@@ -68,6 +69,19 @@ describe('fetchLegacyPasskeyCredentials', () => {
     controller.abort()
 
     await rejection
+  })
+
+  it('does not start auth work for a pre-aborted request', async () => {
+    const controller = new AbortController()
+    controller.abort()
+
+    await expect(
+      fetchLegacyPasskeyCredentials({ signal: controller.signal }),
+    ).rejects.toMatchObject({ name: 'AbortError' })
+
+    expect(mocks.isAuthenticated).not.toHaveBeenCalled()
+    expect(mocks.getAuthHeaders).not.toHaveBeenCalled()
+    expect(fetch).not.toHaveBeenCalled()
   })
 
   it.each(['isAuthenticated', 'getAuthHeaders'] as const)(

--- a/tests/services/passkey/passkey-key-storage-load.test.ts
+++ b/tests/services/passkey/passkey-key-storage-load.test.ts
@@ -268,6 +268,21 @@ describe('passkey-key-storage load + delete (enclave wire)', () => {
       expect(entries).toHaveLength(1)
       expect(entries[0].source).toBe('legacy')
     })
+
+    it('propagates cancellation and timeout options to legacy loading', async () => {
+      const controller = new AbortController()
+      mockKeyCurrent.mockResolvedValue({ key_id: null, bundles: {} })
+
+      await loadRecoveryCandidates({
+        signal: controller.signal,
+        legacyTimeoutMs: 123,
+      })
+
+      expect(mockFetchLegacy).toHaveBeenCalledWith({
+        signal: controller.signal,
+        timeoutMs: 123,
+      })
+    })
   })
 
   describe('deletePasskeyCredential', () => {

--- a/tests/services/passkey/passkey-key-storage-load.test.ts
+++ b/tests/services/passkey/passkey-key-storage-load.test.ts
@@ -338,6 +338,7 @@ describe('passkey-key-storage load + delete (enclave wire)', () => {
         legacyTimeoutMs: 123,
       })
 
+      expect(mockKeyCurrent).toHaveBeenCalledWith({ signal: controller.signal })
       expect(mockFetchLegacy).toHaveBeenCalledWith({
         signal: controller.signal,
         timeoutMs: 123,

--- a/tests/services/passkey/passkey-key-storage-load.test.ts
+++ b/tests/services/passkey/passkey-key-storage-load.test.ts
@@ -48,10 +48,20 @@ vi.mock('@/services/sync-enclave/sync-api', async () => {
   }
 })
 
-vi.mock('@/services/passkey/legacy-passkey-credentials', () => ({
-  fetchLegacyPasskeyCredentials: (...args: unknown[]) =>
-    mockFetchLegacy(...args),
-}))
+vi.mock(
+  '@/services/passkey/legacy-passkey-credentials',
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import('@/services/passkey/legacy-passkey-credentials')
+      >()
+    return {
+      ...actual,
+      fetchLegacyPasskeyCredentials: (...args: unknown[]) =>
+        mockFetchLegacy(...args),
+    }
+  },
+)
 
 describe('passkey-key-storage load + delete (enclave wire)', () => {
   beforeEach(() => {
@@ -62,6 +72,7 @@ describe('passkey-key-storage load + delete (enclave wire)', () => {
   })
 
   afterEach(() => {
+    vi.useRealTimers()
     vi.clearAllMocks()
   })
 
@@ -267,6 +278,55 @@ describe('passkey-key-storage load + delete (enclave wire)', () => {
       const entries = await loadRecoveryCandidates()
       expect(entries).toHaveLength(1)
       expect(entries[0].source).toBe('legacy')
+    })
+
+    it('returns enclave entries when legacy inventory fails', async () => {
+      mockKeyCurrent.mockResolvedValue({
+        key_id: 'abc',
+        bundles: {
+          'cred-a': {
+            credential_id: 'cred-a',
+            kek_iv: '000102030405060708090a0b',
+            encrypted_keys: '0a'.repeat(16),
+          },
+        },
+      })
+      mockFetchLegacy.mockRejectedValue(new Error('legacy unavailable'))
+
+      const entries = await loadRecoveryCandidates()
+
+      expect(entries.map((entry) => entry.id)).toEqual(['cred-a'])
+      expect(entries[0].source).toBe('enclave')
+    })
+
+    it('returns enclave entries when legacy inventory hangs past its timeout', async () => {
+      vi.useFakeTimers()
+      mockKeyCurrent.mockResolvedValue({
+        key_id: 'abc',
+        bundles: {
+          'cred-a': {
+            credential_id: 'cred-a',
+            kek_iv: '000102030405060708090a0b',
+            encrypted_keys: '0a'.repeat(16),
+          },
+        },
+      })
+      mockFetchLegacy.mockReturnValue(new Promise(() => {}))
+
+      const candidatesPromise = loadRecoveryCandidates({ legacyTimeoutMs: 50 })
+      await vi.advanceTimersByTimeAsync(50)
+
+      await expect(candidatesPromise).resolves.toMatchObject([
+        { id: 'cred-a', source: 'enclave' },
+      ])
+    })
+
+    it('rejects for retry when only legacy inventory could recover', async () => {
+      mockKeyCurrent.mockResolvedValue({ key_id: null, bundles: {} })
+      const legacyError = new Error('legacy unavailable')
+      mockFetchLegacy.mockRejectedValue(legacyError)
+
+      await expect(loadRecoveryCandidates()).rejects.toBe(legacyError)
     })
 
     it('propagates cancellation and timeout options to legacy loading', async () => {

--- a/tests/services/sync-enclave/sync-api.test.ts
+++ b/tests/services/sync-enclave/sync-api.test.ts
@@ -336,6 +336,17 @@ describe('sync-api (enclave JSON-RPC)', () => {
     })
   })
 
+  it('propagates caller cancellation through keyCurrent', async () => {
+    const api = await import('@/services/sync-enclave/sync-api')
+    const controller = new AbortController()
+    controller.abort()
+
+    await expect(
+      api.keyCurrent({ signal: controller.signal }),
+    ).rejects.toMatchObject({ name: 'AbortError' })
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
   it('migrate posts /v1/blobs/migrate with target key', async () => {
     const api = await import('@/services/sync-enclave/sync-api')
     mockFetch.mockResolvedValueOnce(

--- a/tests/utils/signout-cleanup.test.ts
+++ b/tests/utils/signout-cleanup.test.ts
@@ -258,6 +258,17 @@ describe('performSignoutCleanup', () => {
     expect(localStorage.getItem(AUTH_SIGNOUT_PENDING_CLEANUP)).toBeNull()
   })
 
+  it('does not fail successful cleanup when marker removal is unavailable', async () => {
+    const removeItem = vi.spyOn(Storage.prototype, 'removeItem')
+    removeItem.mockImplementation(function (key) {
+      if (key === AUTH_SIGNOUT_PENDING_CLEANUP) {
+        throw new Error('storage unavailable')
+      }
+    })
+
+    await expect(performSignoutCleanup()).resolves.toBeUndefined()
+  })
+
   it('surfaces user-switch cleanup failures without replacing the marker', async () => {
     vi.mocked(indexedDBStorage.resetForAccountChange).mockRejectedValueOnce(
       new Error('reset failed'),

--- a/tests/utils/signout-cleanup.test.ts
+++ b/tests/utils/signout-cleanup.test.ts
@@ -5,6 +5,7 @@ import {
   AUTH_ACCOUNT_RESET_SIGNAL,
   AUTH_ACTIVE_USER_ID,
   AUTH_ANONYMOUS_RESTORE_PENDING_CLEANUP,
+  AUTH_SIGNOUT_PENDING_CLEANUP,
   SECRET_PASSKEY_BACKED_UP,
   SETTINGS_HAS_SEEN_ONBOARDING,
   USER_ENCRYPTION_KEY,
@@ -246,6 +247,15 @@ describe('performSignoutCleanup', () => {
     await expect(performSignoutCleanup()).rejects.toThrow('reset failed')
 
     expect(localStorage.getItem(AUTH_ACTIVE_USER_ID)).toBe('user_123')
+    expect(localStorage.getItem(AUTH_SIGNOUT_PENDING_CLEANUP)).toBe('true')
+  })
+
+  it('clears a pending signout marker after cleanup succeeds', async () => {
+    localStorage.setItem(AUTH_SIGNOUT_PENDING_CLEANUP, 'true')
+
+    await performSignoutCleanup()
+
+    expect(localStorage.getItem(AUTH_SIGNOUT_PENDING_CLEANUP)).toBeNull()
   })
 
   it('surfaces user-switch cleanup failures without replacing the marker', async () => {


### PR DESCRIPTION
## Summary
- prevent cold Clerk hydration from clearing an existing local key and cloud-sync state
- bound passkey capability and bundle inventory probes so setup never hangs indefinitely
- keep the cloud-sync escape action available and route unknown state toward recovery instead of key replacement
- recover from current enclave bundles even when legacy credential inventory is unavailable

## Production impact
The deployed web release can clear local sync state during auth hydration, then leave both Cloud Sync intro actions disabled while recovery probes hang. This restores access to the existing passkey recovery flow.

## Testing
- 1,868 unit tests
- `npx tsc --noEmit`
- `npm run lint`
- `npm run build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores reliable passkey-based Cloud Sync recovery after cold auth hydration and keeps setup strictly scoped to the active account. Previously, hydration could clear the local key and hang routing; late or cross-account probes could flip state after dismissal; and recovery inventory issues could block retries.

- Gate cleanup to real sign‑outs: add `AUTH_SIGNOUT_PENDING_CLEANUP`, show a blocking “Retry cleanup” that re-runs sign‑out cleanup only when signed out (reload otherwise), and prefer cross‑tab storage cleanup when both markers exist.
- Bound and cancel routing/initialization: 3s timeouts for PRF checks and routing; 5s for recovery inventory; cancel in‑flight probes on modal close/skip; guard late results with generation counters; add `waitForCloudSyncRouting`, `cancelPasskeyRoutingProbe`, and `retryPasskeyInitialization`; reject waiters on unmount or user change.
- Recovery‑first routing and enablement: route unknown/indeterminate state or detected candidates to passkey recovery; fall back to manual key when PRF is unsupported; treat timeouts as “recover existing”; enable Cloud Sync only after passkey succeeds via `enableCloudSyncAfterPasskey`.
- Resilient inventory: merge enclave bundles with legacy credentials; add AbortSignal and timeouts; return enclave entries when legacy inventory fails or times out; surface `inventory_timeout` and `inventory_unavailable` to keep retries safe.
- Cloud Sync UI: keep “Maybe later” enabled while routing or native dialogs are busy; cancel pending probes on close/skip; show specific messages for new recovery failures.

<sup>Written for commit 69c4e87f89265a1397485325203542fdbaf9b7bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/516?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

