### PR TITLE
fix: clarify Claude project exports

### DIFF
--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -1918,6 +1918,7 @@ export function SettingsModal({
     setIsDeletingAllProjects(true)
     try {
       const result = await projectStorage.deleteAllProjects()
+      setProjectExportResult(null)
       try {
         await projectCache.clear()
       } catch (cacheError) {

--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -1954,7 +1954,6 @@ export function SettingsModal({
       setIsDeletingAllProjects(false)
       setShowDeleteAllProjectsConfirm(false)
       setDeleteAllProjectsConfirmText('')
-      setProjectExportResult(null)
     }
   }
 
@@ -2043,6 +2042,7 @@ export function SettingsModal({
       setDeleteAllChatsConfirmText('')
       setShowDeleteAllProjectsConfirm(false)
       setDeleteAllProjectsConfirmText('')
+      setProjectExportResult(null)
     }
   }, [isOpen])
 

--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -1954,6 +1954,7 @@ export function SettingsModal({
       setIsDeletingAllProjects(false)
       setShowDeleteAllProjectsConfirm(false)
       setDeleteAllProjectsConfirmText('')
+      setProjectExportResult(null)
     }
   }
 

--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -42,6 +42,7 @@ import {
 import {
   buildClaudeProjectExport,
   ClaudeProjectExportSizeError,
+  formatClaudeProjectExportCounts,
   type ClaudeProjectExportCounts,
 } from '@/services/project-export/claude-project-export'
 import { chatStorage } from '@/services/storage/chat-storage'
@@ -4350,15 +4351,9 @@ ${encryptionKey.replace('key_', '')}
                           >
                             {projectExportResult.counts && (
                               <div>
-                                Exported{' '}
-                                {projectExportResult.counts.exportedProjects}{' '}
-                                projects and{' '}
-                                {projectExportResult.counts.exportedDocuments}{' '}
-                                documents. Skipped{' '}
-                                {projectExportResult.counts.skippedProjects}{' '}
-                                projects and{' '}
-                                {projectExportResult.counts.skippedDocuments}{' '}
-                                documents.
+                                {formatClaudeProjectExportCounts(
+                                  projectExportResult.counts,
+                                )}
                               </div>
                             )}
                             {projectExportResult.error && (

--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -39,6 +39,11 @@ import {
   PrfNotSupportedError,
   type PasskeyCredentialEntry,
 } from '@/services/passkey'
+import {
+  buildClaudeProjectExport,
+  ClaudeProjectExportSizeError,
+  type ClaudeProjectExportCounts,
+} from '@/services/project-export/claude-project-export'
 import { chatStorage } from '@/services/storage/chat-storage'
 import { projectCache } from '@/services/storage/project-cache'
 import { sessionChatStorage } from '@/services/storage/session-storage'
@@ -379,14 +384,7 @@ export function SettingsModal({
   const { user } = useUser()
   const { toast } = useToast()
 
-  // Projects for export functionality
-  const {
-    projects,
-    loading: projectsLoading,
-    refresh: refreshProjects,
-  } = useProjects({
-    autoLoad: isSignedIn && isPremium,
-  })
+  const { refresh: refreshProjects } = useProjects({ autoLoad: false })
   // Encryption key management state
   const [isCopied, setIsCopied] = useState(false)
   const [isQRCodeExpanded, setIsQRCodeExpanded] = useState(false)
@@ -533,6 +531,11 @@ export function SettingsModal({
   const [exportType, setExportType] = useState<'chats' | 'projects' | null>(
     null,
   )
+  const [projectExportResult, setProjectExportResult] = useState<{
+    counts?: ClaudeProjectExportCounts
+    warnings: string[]
+    error?: string
+  } | null>(null)
 
   // Danger zone state
   const [showDeleteAllChatsConfirm, setShowDeleteAllChatsConfirm] =
@@ -1953,91 +1956,31 @@ export function SettingsModal({
     }
   }
 
-  // Export projects as projects.json
-  const downloadProjects = async (
-    projectsToExport: Array<{
-      id: string
-      name: string
-      description: string
-      systemInstructions: string
-      memory: Array<{ fact: string }>
-      createdAt: string
-      updatedAt: string
-    }>,
-  ) => {
-    if (projectsToExport.length === 0) {
-      toast({
-        title: 'No projects to export',
-        description: 'You have no projects to export yet.',
-        variant: 'destructive',
-      })
-      return
-    }
-
+  const downloadProjectsForClaude = async () => {
     setIsExporting(true)
     setExportType('projects')
+    setProjectExportResult(null)
 
     try {
-      // Fetch documents for each project and convert to Claude-compatible format
-      const projectsWithDocs = await Promise.all(
-        projectsToExport.map(async (project) => {
-          const docs: Array<{
-            uuid: string
-            filename: string
-            content: string
-            created_at: string
-          }> = []
+      const result = await buildClaudeProjectExport(projectStorage)
+      setProjectExportResult({
+        counts: result.counts,
+        warnings: result.warnings,
+      })
 
-          // Try to fetch documents for this project
-          try {
-            const docsResponse = await projectStorage.listDocuments(
-              project.id,
-              {
-                includeContent: true,
-              },
-            )
+      if (result.counts.exportedProjects === 0) {
+        toast({
+          title: 'No projects exported',
+          description:
+            result.counts.skippedProjects > 0
+              ? 'The available projects could not be read.'
+              : 'You have no projects to export yet.',
+          variant: 'destructive',
+        })
+        return
+      }
 
-            if (docsResponse.documents && docsResponse.documents.length > 0) {
-              await Promise.all(
-                docsResponse.documents.map(async (doc) => {
-                  try {
-                    const fullDoc = await projectStorage.getDocument(
-                      project.id,
-                      doc.id,
-                    )
-                    if (fullDoc && fullDoc.content) {
-                      docs.push({
-                        uuid: doc.id,
-                        filename: fullDoc.filename,
-                        content: fullDoc.content,
-                        created_at: new Date().toISOString(),
-                      })
-                    }
-                  } catch {
-                    // Skip documents that fail to fetch
-                  }
-                }),
-              )
-            }
-          } catch {
-            // Skip documents if we can't fetch them
-          }
-
-          return {
-            uuid: project.id,
-            name: project.name,
-            description: project.description || undefined,
-            prompt_template: project.systemInstructions || undefined,
-            created_at: new Date(project.createdAt).toISOString(),
-            updated_at: new Date(project.updatedAt).toISOString(),
-            docs: docs.length > 0 ? docs : undefined,
-          }
-        }),
-      )
-
-      // Create and download JSON file
-      const jsonContent = JSON.stringify(projectsWithDocs, null, 2)
-      const blob = new Blob([jsonContent], { type: 'application/json' })
+      const blob = new Blob([result.json], { type: 'application/json' })
       const url = window.URL.createObjectURL(blob)
       const a = document.createElement('a')
       a.href = url
@@ -2049,16 +1992,21 @@ export function SettingsModal({
 
       toast({
         title: 'Export complete',
-        description: `Exported ${projectsToExport.length} project${projectsToExport.length !== 1 ? 's' : ''} successfully.`,
+        description: `Exported ${result.counts.exportedProjects} project${result.counts.exportedProjects !== 1 ? 's' : ''} for Claude.`,
       })
     } catch (error) {
       logError('Failed to create projects export', error, {
         component: 'SettingsModal',
-        action: 'downloadProjects',
+        action: 'downloadProjectsForClaude',
       })
+      const message =
+        error instanceof ClaudeProjectExportSizeError
+          ? error.message
+          : 'The Claude-compatible project export could not be created.'
+      setProjectExportResult({ warnings: [], error: message })
       toast({
         title: 'Export failed',
-        description: 'Failed to download projects. Please try again.',
+        description: message,
         variant: 'destructive',
       })
     } finally {
@@ -4358,7 +4306,7 @@ ${encryptionKey.replace('key_', '')}
                   {isPremium && (
                     <div className="space-y-3">
                       <h3 className="font-aeonik text-sm font-medium text-content-secondary">
-                        Export Projects
+                        Export Projects for Claude
                       </h3>
                       <div
                         className={cn(
@@ -4367,21 +4315,18 @@ ${encryptionKey.replace('key_', '')}
                         )}
                       >
                         <div className="font-aeonik-fono text-xs text-content-muted">
-                          Download all your projects including their settings,
-                          system instructions, memory, and documents.
+                          Creates a lossy, Claude-compatible projects.json with
+                          project names, descriptions, instructions, and
+                          extracted document text and metadata. Memory, colors,
+                          chats, images, and original document bytes are not
+                          included.
                         </div>
                         <button
-                          onClick={() => downloadProjects(projects)}
-                          disabled={
-                            isExporting ||
-                            projects.length === 0 ||
-                            projectsLoading
-                          }
+                          onClick={downloadProjectsForClaude}
+                          disabled={isExporting}
                           className={cn(
                             'flex w-full items-center justify-center gap-2 rounded-lg border border-border-subtle px-4 py-2.5 text-sm font-medium transition-colors',
-                            isExporting ||
-                              projects.length === 0 ||
-                              projectsLoading
+                            isExporting
                               ? 'cursor-not-allowed opacity-50'
                               : 'hover:bg-surface-chat',
                             isDarkMode
@@ -4391,17 +4336,39 @@ ${encryptionKey.replace('key_', '')}
                         >
                           {isExporting && exportType === 'projects' ? (
                             <ArrowPathIcon className="h-4 w-4 animate-spin" />
-                          ) : projectsLoading ? (
-                            <ArrowPathIcon className="h-4 w-4 animate-spin" />
                           ) : (
                             <AiOutlineExport className="h-4 w-4" />
                           )}
                           {isExporting && exportType === 'projects'
                             ? 'Exporting...'
-                            : projectsLoading
-                              ? 'Loading projects...'
-                              : 'Export Projects'}
+                            : 'Export Projects for Claude'}
                         </button>
+                        {projectExportResult && (
+                          <div
+                            className="space-y-1 font-aeonik-fono text-xs text-content-muted"
+                            role="status"
+                          >
+                            {projectExportResult.counts && (
+                              <div>
+                                Exported{' '}
+                                {projectExportResult.counts.exportedProjects}{' '}
+                                projects and{' '}
+                                {projectExportResult.counts.exportedDocuments}{' '}
+                                documents. Skipped{' '}
+                                {projectExportResult.counts.skippedProjects}{' '}
+                                projects and{' '}
+                                {projectExportResult.counts.skippedDocuments}{' '}
+                                documents.
+                              </div>
+                            )}
+                            {projectExportResult.error && (
+                              <div>{projectExportResult.error}</div>
+                            )}
+                            {projectExportResult.warnings.map((warning) => (
+                              <div key={warning}>{warning}</div>
+                            ))}
+                          </div>
+                        )}
                       </div>
                     </div>
                   )}

--- a/src/services/project-export/claude-project-export.ts
+++ b/src/services/project-export/claude-project-export.ts
@@ -22,7 +22,6 @@ export interface ClaudeProjectExportCounts {
 
 export interface ClaudeProjectExportResult {
   json: string
-  encodedBytes: number
   counts: ClaudeProjectExportCounts
   warnings: string[]
 }
@@ -299,8 +298,7 @@ export async function buildClaudeProjectExport(
     serializedProjects.length === 0
       ? '[]'
       : `[\n${serializedProjects.join(',\n')}\n]`
-  const encodedBytes = sizeGuard.encodedLength(json)
-  sizeGuard.assertFinal(encodedBytes)
+  sizeGuard.assertFinal(sizeGuard.encodedLength(json))
 
-  return { json, encodedBytes, counts, warnings }
+  return { json, counts, warnings }
 }

--- a/src/services/project-export/claude-project-export.ts
+++ b/src/services/project-export/claude-project-export.ts
@@ -81,7 +81,11 @@ async function listAllProjects(
     continuationToken = page.nextContinuationToken
   } while (continuationToken)
 
-  return [...projectsById.values()]
+  return [...projectsById.values()].sort((a, b) => {
+    if (a.updatedAt !== b.updatedAt) return a.updatedAt < b.updatedAt ? 1 : -1
+    if (a.syncVersion !== b.syncVersion) return b.syncVersion - a.syncVersion
+    return a.id < b.id ? -1 : a.id > b.id ? 1 : 0
+  })
 }
 
 class ExportSizeGuard {
@@ -89,34 +93,59 @@ class ExportSizeGuard {
   private completedProjectBytes = 0
   private completedProjects = 0
   private pendingProjectBytes = 0
+  private pendingDocuments = 0
 
   constructor(private readonly maxEncodedBytes: number) {}
 
   beginProject(project: ClaudeProject): void {
-    this.pendingProjectBytes = this.encodedLength(JSON.stringify(project))
+    this.pendingProjectBytes = this.encodedLength(this.indent(project, 2))
+    this.pendingDocuments = 0
     this.assertWithinBound(this.pendingProjectBytes)
   }
 
   addDocument(document: NonNullable<ClaudeProject['docs']>[number]): void {
-    this.pendingProjectBytes += this.encodedLength(JSON.stringify(document))
+    const documentBytes = this.encodedLength(this.indent(document, 6))
+    if (this.pendingDocuments === 0) {
+      const projectClosingBytes = this.encodedLength('\n  }')
+      this.pendingProjectBytes +=
+        this.encodedLength(',\n    "docs": [\n') +
+        documentBytes +
+        this.encodedLength('\n    ]\n  }') -
+        projectClosingBytes
+    } else {
+      this.pendingProjectBytes += this.encodedLength(',\n') + documentBytes
+    }
+    this.pendingDocuments++
     this.assertWithinBound(this.pendingProjectBytes)
   }
 
   finishProject(project: ClaudeProject): string {
-    const serialized = JSON.stringify(project, null, 2)
-      .split('\n')
-      .map((line) => `  ${line}`)
-      .join('\n')
+    const serialized = this.indent(project, 2)
     const serializedBytes = this.encodedLength(serialized)
     this.assertWithinBound(serializedBytes)
     this.completedProjectBytes += serializedBytes
     this.completedProjects++
     this.pendingProjectBytes = 0
+    this.pendingDocuments = 0
     return serialized
   }
 
   encodedLength(value: string): number {
     return this.encoder.encode(value).length
+  }
+
+  assertFinal(encodedBytes: number): void {
+    if (encodedBytes > this.maxEncodedBytes) {
+      throw new ClaudeProjectExportSizeError()
+    }
+  }
+
+  private indent(value: unknown, spaces: number): string {
+    const indentation = ' '.repeat(spaces)
+    return JSON.stringify(value, null, 2)
+      .split('\n')
+      .map((line) => `${indentation}${line}`)
+      .join('\n')
   }
 
   private assertWithinBound(pendingProjectBytes: number): void {
@@ -271,6 +300,7 @@ export async function buildClaudeProjectExport(
       ? '[]'
       : `[\n${serializedProjects.join(',\n')}\n]`
   const encodedBytes = sizeGuard.encodedLength(json)
+  sizeGuard.assertFinal(encodedBytes)
 
   return { json, encodedBytes, counts, warnings }
 }

--- a/src/services/project-export/claude-project-export.ts
+++ b/src/services/project-export/claude-project-export.ts
@@ -59,7 +59,7 @@ interface ExportOptions {
 async function listAllProjects(
   storage: Pick<ProjectStorageService, 'listProjects'>,
 ): Promise<ProjectListItem[]> {
-  const projects: ProjectListItem[] = []
+  const projectsById = new Map<string, ProjectListItem>()
   let continuationToken: string | undefined
 
   do {
@@ -67,11 +67,73 @@ async function listAllProjects(
       limit: PROJECT_PAGE_LIMIT,
       continuationToken,
     })
-    projects.push(...page.projects)
+    for (const project of page.projects) {
+      const existing = projectsById.get(project.id)
+      if (
+        !existing ||
+        project.updatedAt > existing.updatedAt ||
+        (project.updatedAt === existing.updatedAt &&
+          project.syncVersion > existing.syncVersion)
+      ) {
+        projectsById.set(project.id, project)
+      }
+    }
     continuationToken = page.nextContinuationToken
   } while (continuationToken)
 
-  return projects
+  return [...projectsById.values()]
+}
+
+class ExportSizeGuard {
+  private readonly encoder = new TextEncoder()
+  private completedProjectBytes = 0
+  private completedProjects = 0
+  private pendingProjectBytes = 0
+
+  constructor(private readonly maxEncodedBytes: number) {}
+
+  beginProject(project: ClaudeProject): void {
+    this.pendingProjectBytes = this.encodedLength(JSON.stringify(project))
+    this.assertWithinBound(this.pendingProjectBytes)
+  }
+
+  addDocument(document: NonNullable<ClaudeProject['docs']>[number]): void {
+    this.pendingProjectBytes += this.encodedLength(JSON.stringify(document))
+    this.assertWithinBound(this.pendingProjectBytes)
+  }
+
+  finishProject(project: ClaudeProject): string {
+    const serialized = JSON.stringify(project, null, 2)
+      .split('\n')
+      .map((line) => `  ${line}`)
+      .join('\n')
+    const serializedBytes = this.encodedLength(serialized)
+    this.assertWithinBound(serializedBytes)
+    this.completedProjectBytes += serializedBytes
+    this.completedProjects++
+    this.pendingProjectBytes = 0
+    return serialized
+  }
+
+  encodedLength(value: string): number {
+    return this.encoder.encode(value).length
+  }
+
+  private assertWithinBound(pendingProjectBytes: number): void {
+    const framingBytes = 4
+    const separatorBytes = this.completedProjects > 0 ? 2 : 0
+    const completedSeparatorBytes = Math.max(0, this.completedProjects - 1) * 2
+    if (
+      framingBytes +
+        this.completedProjectBytes +
+        completedSeparatorBytes +
+        separatorBytes +
+        pendingProjectBytes >
+      this.maxEncodedBytes
+    ) {
+      throw new ClaudeProjectExportSizeError()
+    }
+  }
 }
 
 async function readDocuments(
@@ -80,6 +142,7 @@ async function readDocuments(
   documents: ProjectDocumentListItem[],
   counts: ClaudeProjectExportCounts,
   warnings: string[],
+  sizeGuard: ExportSizeGuard,
 ): Promise<NonNullable<ClaudeProject['docs']>> {
   const exported: Array<NonNullable<ClaudeProject['docs']>[number] | null> =
     new Array(documents.length).fill(null)
@@ -102,14 +165,17 @@ async function readDocuments(
           )
           continue
         }
-        exported[index] = {
+        const exportedDocument = {
           uuid: listedDocument.id,
           filename: document.filename,
           content: document.content,
           created_at: listedDocument.createdAt,
         }
+        sizeGuard.addDocument(exportedDocument)
+        exported[index] = exportedDocument
         counts.exportedDocuments++
-      } catch {
+      } catch (error) {
+        if (error instanceof ClaudeProjectExportSizeError) throw error
         counts.skippedDocuments++
         warnings.push(
           `Skipped document ${listedDocument.id} in project ${projectId}.`,
@@ -139,7 +205,10 @@ export async function buildClaudeProjectExport(
   // Finish the authoritative project listing before reading any content. A
   // listing failure must abort rather than produce an incomplete project set.
   const listedProjects = await listAllProjects(storage)
-  const projects: ClaudeProject[] = []
+  const serializedProjects: string[] = []
+  const sizeGuard = new ExportSizeGuard(
+    options.maxEncodedBytes ?? CLAUDE_PROJECT_EXPORT_MAX_BYTES,
+  )
   const counts: ClaudeProjectExportCounts = {
     exportedProjects: 0,
     skippedProjects: 0,
@@ -162,6 +231,18 @@ export async function buildClaudeProjectExport(
       continue
     }
 
+    const exportedProject: ClaudeProject = {
+      uuid: project.id,
+      name: project.name,
+      ...(project.description ? { description: project.description } : {}),
+      ...(project.systemInstructions
+        ? { prompt_template: project.systemInstructions }
+        : {}),
+      created_at: listedProject.createdAt,
+      updated_at: listedProject.updatedAt,
+    }
+    sizeGuard.beginProject(exportedProject)
+
     let listedDocuments: ProjectDocumentListItem[] = []
     try {
       listedDocuments = (await storage.listDocuments(project.id)).documents
@@ -177,29 +258,19 @@ export async function buildClaudeProjectExport(
       listedDocuments,
       counts,
       warnings,
+      sizeGuard,
     )
 
-    projects.push({
-      uuid: project.id,
-      name: project.name,
-      ...(project.description ? { description: project.description } : {}),
-      ...(project.systemInstructions
-        ? { prompt_template: project.systemInstructions }
-        : {}),
-      created_at: listedProject.createdAt,
-      updated_at: listedProject.updatedAt,
-      ...(docs.length > 0 ? { docs } : {}),
-    })
+    if (docs.length > 0) exportedProject.docs = docs
+    serializedProjects.push(sizeGuard.finishProject(exportedProject))
     counts.exportedProjects++
   }
 
-  const json = JSON.stringify(projects, null, 2)
-  const encodedBytes = new TextEncoder().encode(json).length
-  if (
-    encodedBytes > (options.maxEncodedBytes ?? CLAUDE_PROJECT_EXPORT_MAX_BYTES)
-  ) {
-    throw new ClaudeProjectExportSizeError()
-  }
+  const json =
+    serializedProjects.length === 0
+      ? '[]'
+      : `[\n${serializedProjects.join(',\n')}\n]`
+  const encodedBytes = sizeGuard.encodedLength(json)
 
   return { json, encodedBytes, counts, warnings }
 }

--- a/src/services/project-export/claude-project-export.ts
+++ b/src/services/project-export/claude-project-export.ts
@@ -1,0 +1,184 @@
+import type { ProjectStorageService } from '@/services/cloud/project-storage'
+import type {
+  ProjectDocumentListItem,
+  ProjectListResponse,
+} from '@/types/project'
+import type { ClaudeProject } from '@/utils/chat-import-parsers'
+
+export const CLAUDE_PROJECT_EXPORT_MAX_BYTES = 64 * 1024 * 1024
+
+const PROJECT_PAGE_LIMIT = 100
+const DOCUMENT_READ_CONCURRENCY = 4
+
+type ProjectListItem = ProjectListResponse['projects'][number]
+
+export interface ClaudeProjectExportCounts {
+  exportedProjects: number
+  skippedProjects: number
+  exportedDocuments: number
+  skippedDocuments: number
+}
+
+export interface ClaudeProjectExportResult {
+  json: string
+  encodedBytes: number
+  counts: ClaudeProjectExportCounts
+  warnings: string[]
+}
+
+export class ClaudeProjectExportSizeError extends Error {
+  constructor() {
+    super('The Claude-compatible project export exceeds the 64 MiB limit.')
+    this.name = 'ClaudeProjectExportSizeError'
+  }
+}
+
+interface ExportOptions {
+  maxEncodedBytes?: number
+}
+
+async function listAllProjects(
+  storage: Pick<ProjectStorageService, 'listProjects'>,
+): Promise<ProjectListItem[]> {
+  const projects: ProjectListItem[] = []
+  let continuationToken: string | undefined
+
+  do {
+    const page = await storage.listProjects({
+      limit: PROJECT_PAGE_LIMIT,
+      continuationToken,
+    })
+    projects.push(...page.projects)
+    continuationToken = page.nextContinuationToken
+  } while (continuationToken)
+
+  return projects
+}
+
+async function readDocuments(
+  storage: Pick<ProjectStorageService, 'getDocument'>,
+  projectId: string,
+  documents: ProjectDocumentListItem[],
+  counts: ClaudeProjectExportCounts,
+  warnings: string[],
+): Promise<NonNullable<ClaudeProject['docs']>> {
+  const exported: Array<NonNullable<ClaudeProject['docs']>[number] | null> =
+    new Array(documents.length).fill(null)
+  let nextIndex = 0
+
+  const worker = async () => {
+    while (nextIndex < documents.length) {
+      const index = nextIndex++
+      const listedDocument = documents[index]
+      try {
+        const document = await storage.getDocument(projectId, listedDocument.id)
+        if (
+          !document ||
+          document.decryptionFailed ||
+          document.content == null
+        ) {
+          counts.skippedDocuments++
+          warnings.push(
+            `Skipped document ${listedDocument.id} in project ${projectId}.`,
+          )
+          continue
+        }
+        exported[index] = {
+          uuid: listedDocument.id,
+          filename: document.filename,
+          content: document.content,
+          created_at: listedDocument.createdAt,
+        }
+        counts.exportedDocuments++
+      } catch {
+        counts.skippedDocuments++
+        warnings.push(
+          `Skipped document ${listedDocument.id} in project ${projectId}.`,
+        )
+      }
+    }
+  }
+
+  await Promise.all(
+    Array.from(
+      { length: Math.min(DOCUMENT_READ_CONCURRENCY, documents.length) },
+      worker,
+    ),
+  )
+  return exported.filter(
+    (document): document is NonNullable<typeof document> => document !== null,
+  )
+}
+
+export async function buildClaudeProjectExport(
+  storage: Pick<
+    ProjectStorageService,
+    'listProjects' | 'getProject' | 'listDocuments' | 'getDocument'
+  >,
+  options: ExportOptions = {},
+): Promise<ClaudeProjectExportResult> {
+  // Finish the authoritative project listing before reading any content. A
+  // listing failure must abort rather than produce an incomplete project set.
+  const listedProjects = await listAllProjects(storage)
+  const projects: ClaudeProject[] = []
+  const counts: ClaudeProjectExportCounts = {
+    exportedProjects: 0,
+    skippedProjects: 0,
+    exportedDocuments: 0,
+    skippedDocuments: 0,
+  }
+  const warnings: string[] = []
+
+  for (const listedProject of listedProjects) {
+    let project
+    try {
+      project = await storage.getProject(listedProject.id)
+    } catch {
+      project = null
+    }
+    if (!project || project.decryptionFailed) {
+      counts.skippedProjects++
+      warnings.push(`Skipped project ${listedProject.id}.`)
+      continue
+    }
+
+    let listedDocuments: ProjectDocumentListItem[] = []
+    try {
+      listedDocuments = (await storage.listDocuments(project.id)).documents
+    } catch {
+      warnings.push(
+        `Documents for project ${project.id} could not be listed, so their skipped count is unknown.`,
+      )
+    }
+    const docs = await readDocuments(
+      storage,
+      project.id,
+      listedDocuments,
+      counts,
+      warnings,
+    )
+
+    projects.push({
+      uuid: project.id,
+      name: project.name,
+      ...(project.description ? { description: project.description } : {}),
+      ...(project.systemInstructions
+        ? { prompt_template: project.systemInstructions }
+        : {}),
+      created_at: listedProject.createdAt,
+      updated_at: listedProject.updatedAt,
+      ...(docs.length > 0 ? { docs } : {}),
+    })
+    counts.exportedProjects++
+  }
+
+  const json = JSON.stringify(projects, null, 2)
+  const encodedBytes = new TextEncoder().encode(json).length
+  if (
+    encodedBytes > (options.maxEncodedBytes ?? CLAUDE_PROJECT_EXPORT_MAX_BYTES)
+  ) {
+    throw new ClaudeProjectExportSizeError()
+  }
+
+  return { json, encodedBytes, counts, warnings }
+}

--- a/src/services/project-export/claude-project-export.ts
+++ b/src/services/project-export/claude-project-export.ts
@@ -17,6 +17,7 @@ export interface ClaudeProjectExportCounts {
   skippedProjects: number
   exportedDocuments: number
   skippedDocuments: number
+  failedDocumentListings: number
 }
 
 export interface ClaudeProjectExportResult {
@@ -31,6 +32,24 @@ export class ClaudeProjectExportSizeError extends Error {
     super('The Claude-compatible project export exceeds the 64 MiB limit.')
     this.name = 'ClaudeProjectExportSizeError'
   }
+}
+
+export function formatClaudeProjectExportCounts(
+  counts: ClaudeProjectExportCounts,
+): string {
+  const count = (value: number, noun: string) =>
+    `${value} ${noun}${value === 1 ? '' : 's'}`
+  const exported = `Exported ${count(counts.exportedProjects, 'project')} and ${count(counts.exportedDocuments, 'document')}.`
+  if (counts.failedDocumentListings === 0) {
+    return `${exported} Skipped ${count(counts.skippedProjects, 'project')} and ${count(counts.skippedDocuments, 'document')}.`
+  }
+
+  const failedListings = count(counts.failedDocumentListings, 'project')
+  const knownSkippedDocuments =
+    counts.skippedDocuments > 0
+      ? ` Of the documents that were listed, ${count(counts.skippedDocuments, 'document')} ${counts.skippedDocuments === 1 ? 'was' : 'were'} skipped.`
+      : ''
+  return `${exported} Skipped ${count(counts.skippedProjects, 'project')}. The skipped document total is unknown because document listing failed for ${failedListings}.${knownSkippedDocuments}`
 }
 
 interface ExportOptions {
@@ -126,6 +145,7 @@ export async function buildClaudeProjectExport(
     skippedProjects: 0,
     exportedDocuments: 0,
     skippedDocuments: 0,
+    failedDocumentListings: 0,
   }
   const warnings: string[] = []
 
@@ -146,6 +166,7 @@ export async function buildClaudeProjectExport(
     try {
       listedDocuments = (await storage.listDocuments(project.id)).documents
     } catch {
+      counts.failedDocumentListings++
       warnings.push(
         `Documents for project ${project.id} could not be listed, so their skipped count is unknown.`,
       )

--- a/tests/fixtures/claude-projects.json
+++ b/tests/fixtures/claude-projects.json
@@ -1,0 +1,18 @@
+[
+  {
+    "uuid": "project-1",
+    "name": "Research",
+    "description": "Source notes",
+    "prompt_template": "Answer from the provided material.",
+    "created_at": "2026-01-02T03:04:05.000Z",
+    "updated_at": "2026-02-03T04:05:06.000Z",
+    "docs": [
+      {
+        "uuid": "document-1",
+        "filename": "notes.txt",
+        "content": "Extracted text only",
+        "created_at": "2026-01-03T03:04:05.000Z"
+      }
+    ]
+  }
+]

--- a/tests/services/project-export/claude-project-export.test.ts
+++ b/tests/services/project-export/claude-project-export.test.ts
@@ -185,6 +185,33 @@ describe('buildClaudeProjectExport', () => {
     expect(testStorage.getProject).toHaveBeenCalledOnce()
   })
 
+  it('sorts deduplicated projects by freshness with a stable ID tie-break', async () => {
+    const older = { ...listItem('older'), updatedAt: createdAt }
+    const first = { ...listItem('first'), syncVersion: 2 }
+    const second = { ...listItem('second'), syncVersion: 2 }
+    const moved = { ...listItem('moved'), updatedAt: createdAt }
+    const refreshedMoved = { ...moved, updatedAt, syncVersion: 3 }
+    const testStorage = storage({
+      listProjects: vi
+        .fn()
+        .mockResolvedValueOnce({
+          projects: [moved, second, older],
+          hasMore: true,
+          nextContinuationToken: 'next',
+        })
+        .mockResolvedValueOnce({
+          projects: [first, refreshedMoved],
+          hasMore: false,
+        }),
+    })
+
+    const result = await buildClaudeProjectExport(testStorage)
+
+    expect(
+      JSON.parse(result.json).map((item: { uuid: string }) => item.uuid),
+    ).toEqual(['moved', 'first', 'second', 'older'])
+  })
+
   it('returns counts and warnings for project and document failures', async () => {
     const testStorage = storage({
       listProjects: vi.fn().mockResolvedValue({
@@ -290,6 +317,59 @@ describe('buildClaudeProjectExport', () => {
   it('rejects encoded JSON over the configured bound', async () => {
     await expect(
       buildClaudeProjectExport(storage(), { maxEncodedBytes: 10 }),
+    ).rejects.toBeInstanceOf(ClaudeProjectExportSizeError)
+  })
+
+  it('applies the encoded bound exactly to pretty-printed output', async () => {
+    const testStorage = storage({
+      listDocuments: vi.fn().mockResolvedValue({
+        documents: [
+          {
+            ...listItem('document-1'),
+            projectId: 'project-1',
+            sizeBytes: 4,
+          },
+        ],
+      }),
+      getDocument: vi.fn().mockResolvedValue({
+        id: 'document-1',
+        projectId: 'project-1',
+        filename: 'notes.txt',
+        contentType: 'text/plain',
+        sizeBytes: 4,
+        syncVersion: 1,
+        createdAt,
+        updatedAt,
+        content: 'text',
+      }),
+    })
+    const result = await buildClaudeProjectExport(testStorage)
+
+    await expect(
+      buildClaudeProjectExport(testStorage, {
+        maxEncodedBytes: result.encodedBytes,
+      }),
+    ).resolves.toEqual(result)
+    await expect(
+      buildClaudeProjectExport(testStorage, {
+        maxEncodedBytes: result.encodedBytes - 1,
+      }),
+    ).rejects.toBeInstanceOf(ClaudeProjectExportSizeError)
+  })
+
+  it('applies the encoded bound to an empty export', async () => {
+    const emptyStorage = storage({
+      listProjects: vi.fn().mockResolvedValue({
+        projects: [],
+        hasMore: false,
+      }),
+    })
+
+    await expect(
+      buildClaudeProjectExport(emptyStorage, { maxEncodedBytes: 2 }),
+    ).resolves.toMatchObject({ json: '[]', encodedBytes: 2 })
+    await expect(
+      buildClaudeProjectExport(emptyStorage, { maxEncodedBytes: 1 }),
     ).rejects.toBeInstanceOf(ClaudeProjectExportSizeError)
   })
 

--- a/tests/services/project-export/claude-project-export.test.ts
+++ b/tests/services/project-export/claude-project-export.test.ts
@@ -344,15 +344,16 @@ describe('buildClaudeProjectExport', () => {
       }),
     })
     const result = await buildClaudeProjectExport(testStorage)
+    const encodedBytes = new TextEncoder().encode(result.json).length
 
     await expect(
       buildClaudeProjectExport(testStorage, {
-        maxEncodedBytes: result.encodedBytes,
+        maxEncodedBytes: encodedBytes,
       }),
     ).resolves.toEqual(result)
     await expect(
       buildClaudeProjectExport(testStorage, {
-        maxEncodedBytes: result.encodedBytes - 1,
+        maxEncodedBytes: encodedBytes - 1,
       }),
     ).rejects.toBeInstanceOf(ClaudeProjectExportSizeError)
   })
@@ -367,7 +368,7 @@ describe('buildClaudeProjectExport', () => {
 
     await expect(
       buildClaudeProjectExport(emptyStorage, { maxEncodedBytes: 2 }),
-    ).resolves.toMatchObject({ json: '[]', encodedBytes: 2 })
+    ).resolves.toMatchObject({ json: '[]' })
     await expect(
       buildClaudeProjectExport(emptyStorage, { maxEncodedBytes: 1 }),
     ).rejects.toBeInstanceOf(ClaudeProjectExportSizeError)

--- a/tests/services/project-export/claude-project-export.test.ts
+++ b/tests/services/project-export/claude-project-export.test.ts
@@ -163,6 +163,28 @@ describe('buildClaudeProjectExport', () => {
     expect(getProject).not.toHaveBeenCalled()
   })
 
+  it('keeps the freshest project when pagination returns a duplicate', async () => {
+    const stale = { ...listItem('project-1'), updatedAt: createdAt }
+    const fresh = { ...listItem('project-1'), syncVersion: 2 }
+    const testStorage = storage({
+      listProjects: vi
+        .fn()
+        .mockResolvedValueOnce({
+          projects: [fresh],
+          hasMore: true,
+          nextContinuationToken: 'next',
+        })
+        .mockResolvedValueOnce({ projects: [stale], hasMore: false }),
+    })
+
+    const result = await buildClaudeProjectExport(testStorage)
+
+    expect(JSON.parse(result.json)).toEqual([
+      expect.objectContaining({ updated_at: updatedAt }),
+    ])
+    expect(testStorage.getProject).toHaveBeenCalledOnce()
+  })
+
   it('returns counts and warnings for project and document failures', async () => {
     const testStorage = storage({
       listProjects: vi.fn().mockResolvedValue({
@@ -269,5 +291,35 @@ describe('buildClaudeProjectExport', () => {
     await expect(
       buildClaudeProjectExport(storage(), { maxEncodedBytes: 10 }),
     ).rejects.toBeInstanceOf(ClaudeProjectExportSizeError)
+  })
+
+  it('stops reading documents when their content exceeds the bound', async () => {
+    const documents = Array.from({ length: 8 }, (_, index) => ({
+      ...listItem(`document-${index}`),
+      projectId: 'project-1',
+      sizeBytes: 100,
+    }))
+    const getDocument = vi.fn().mockImplementation(async (_projectId, id) => ({
+      id,
+      projectId: 'project-1',
+      filename: `${id}.txt`,
+      contentType: 'text/plain',
+      sizeBytes: 100,
+      syncVersion: 1,
+      createdAt,
+      updatedAt,
+      content: 'x'.repeat(100),
+    }))
+
+    await expect(
+      buildClaudeProjectExport(
+        storage({
+          listDocuments: vi.fn().mockResolvedValue({ documents }),
+          getDocument,
+        }),
+        { maxEncodedBytes: 300 },
+      ),
+    ).rejects.toBeInstanceOf(ClaudeProjectExportSizeError)
+    expect(getDocument.mock.calls.length).toBeLessThan(documents.length)
   })
 })

--- a/tests/services/project-export/claude-project-export.test.ts
+++ b/tests/services/project-export/claude-project-export.test.ts
@@ -1,0 +1,256 @@
+import {
+  buildClaudeProjectExport,
+  ClaudeProjectExportSizeError,
+} from '@/services/project-export/claude-project-export'
+import type {
+  Project,
+  ProjectDocument,
+  ProjectListResponse,
+} from '@/types/project'
+import claudeProjectsFixture from '../../fixtures/claude-projects.json'
+
+type ExportStorage = Parameters<typeof buildClaudeProjectExport>[0]
+
+const createdAt = '2026-01-02T03:04:05.000Z'
+const updatedAt = '2026-02-03T04:05:06.000Z'
+
+function listItem(id: string): ProjectListResponse['projects'][number] {
+  return {
+    id,
+    key: id,
+    createdAt,
+    updatedAt,
+    syncVersion: 1,
+    size: 0,
+  }
+}
+
+function project(id: string): Project {
+  return {
+    id,
+    name: id === 'project-1' ? 'Research' : id,
+    description: id === 'project-1' ? 'Source notes' : '',
+    systemInstructions:
+      id === 'project-1' ? 'Answer from the provided material.' : '',
+    memory: [
+      {
+        id: 'fact-1',
+        fact: 'unsupported',
+        date: createdAt,
+        category: 'test',
+        confidence: 1,
+      },
+    ],
+    color: '#ffffff',
+    createdAt: 'ignored',
+    updatedAt: 'ignored',
+    syncVersion: 1,
+  }
+}
+
+function storage(overrides: Partial<ExportStorage> = {}): ExportStorage {
+  return {
+    listProjects: vi.fn().mockResolvedValue({
+      projects: [listItem('project-1')],
+      hasMore: false,
+    }),
+    getProject: vi.fn().mockImplementation(async (id: string) => project(id)),
+    listDocuments: vi.fn().mockResolvedValue({ documents: [] }),
+    getDocument: vi.fn(),
+    ...overrides,
+  } as ExportStorage
+}
+
+describe('buildClaudeProjectExport', () => {
+  it('paginates a fresh project listing before reading projects', async () => {
+    const calls: string[] = []
+    const testStorage = storage({
+      listProjects: vi
+        .fn()
+        .mockImplementationOnce(async () => {
+          calls.push('list-1')
+          return {
+            projects: [listItem('project-1')],
+            hasMore: true,
+            nextContinuationToken: 'next',
+          }
+        })
+        .mockImplementationOnce(async () => {
+          calls.push('list-2')
+          return {
+            projects: [listItem('project-2')],
+            hasMore: false,
+          }
+        }),
+      getProject: vi.fn().mockImplementation(async (id: string) => {
+        calls.push(`get-${id}`)
+        return project(id)
+      }),
+    })
+
+    const result = await buildClaudeProjectExport(testStorage)
+
+    expect(JSON.parse(result.json)).toHaveLength(2)
+    expect(calls).toEqual([
+      'list-1',
+      'list-2',
+      'get-project-1',
+      'get-project-2',
+    ])
+  })
+
+  it('matches the Claude projects fixture without unsupported fields', async () => {
+    const testStorage = storage({
+      listDocuments: vi.fn().mockResolvedValue({
+        documents: [
+          {
+            id: 'document-1',
+            projectId: 'project-1',
+            sizeBytes: 123,
+            syncVersion: 1,
+            createdAt: '2026-01-03T03:04:05.000Z',
+            updatedAt,
+          },
+        ],
+      }),
+      getDocument: vi.fn().mockResolvedValue({
+        id: 'document-1',
+        projectId: 'project-1',
+        filename: 'notes.txt',
+        contentType: 'text/plain',
+        sizeBytes: 123,
+        syncVersion: 1,
+        createdAt,
+        updatedAt,
+        content: 'Extracted text only',
+      } satisfies ProjectDocument),
+    })
+
+    const result = await buildClaudeProjectExport(testStorage)
+
+    expect(JSON.parse(result.json)).toEqual(claudeProjectsFixture)
+    expect(result.counts).toEqual({
+      exportedProjects: 1,
+      skippedProjects: 0,
+      exportedDocuments: 1,
+      skippedDocuments: 0,
+    })
+    expect(result.json).not.toContain('memory')
+    expect(result.json).not.toContain('color')
+    expect(result.json).not.toContain('contentType')
+    expect(result.json).not.toContain('sizeBytes')
+  })
+
+  it('aborts when any project-list page fails', async () => {
+    const getProject = vi.fn()
+    const testStorage = storage({
+      listProjects: vi
+        .fn()
+        .mockResolvedValueOnce({
+          projects: [listItem('project-1')],
+          hasMore: true,
+          nextContinuationToken: 'next',
+        })
+        .mockRejectedValueOnce(new Error('unavailable')),
+      getProject,
+    })
+
+    await expect(buildClaudeProjectExport(testStorage)).rejects.toThrow(
+      'unavailable',
+    )
+    expect(getProject).not.toHaveBeenCalled()
+  })
+
+  it('returns counts and warnings for project and document failures', async () => {
+    const testStorage = storage({
+      listProjects: vi.fn().mockResolvedValue({
+        projects: [
+          listItem('missing'),
+          listItem('docs-unavailable'),
+          listItem('partial'),
+        ],
+        hasMore: false,
+      }),
+      getProject: vi
+        .fn()
+        .mockImplementation(async (id: string) =>
+          id === 'missing' ? null : project(id),
+        ),
+      listDocuments: vi.fn().mockImplementation(async (id: string) => {
+        if (id === 'docs-unavailable') throw new Error('unavailable')
+        return {
+          documents: ['good', 'bad'].map((documentId) => ({
+            ...listItem(documentId),
+            projectId: id,
+            sizeBytes: 1,
+          })),
+        }
+      }),
+      getDocument: vi.fn().mockImplementation(async (_projectId, id) => {
+        if (id === 'bad') throw new Error('unavailable')
+        return {
+          id,
+          projectId: 'partial',
+          filename: 'good.txt',
+          contentType: 'text/plain',
+          sizeBytes: 1,
+          syncVersion: 1,
+          createdAt,
+          updatedAt,
+          content: 'text',
+        }
+      }),
+    })
+
+    const result = await buildClaudeProjectExport(testStorage)
+
+    expect(result.counts).toEqual({
+      exportedProjects: 2,
+      skippedProjects: 1,
+      exportedDocuments: 1,
+      skippedDocuments: 1,
+    })
+    expect(result.warnings).toHaveLength(3)
+    expect(JSON.parse(result.json)).toHaveLength(2)
+  })
+
+  it('never reads more than four documents concurrently', async () => {
+    let active = 0
+    let maximumActive = 0
+    const documents = Array.from({ length: 10 }, (_, index) => ({
+      ...listItem(`document-${index}`),
+      projectId: 'project-1',
+      sizeBytes: 1,
+    }))
+    const testStorage = storage({
+      listDocuments: vi.fn().mockResolvedValue({ documents }),
+      getDocument: vi.fn().mockImplementation(async (_projectId, id) => {
+        active++
+        maximumActive = Math.max(maximumActive, active)
+        await new Promise<void>((resolve) => queueMicrotask(resolve))
+        active--
+        return {
+          id,
+          projectId: 'project-1',
+          filename: `${id}.txt`,
+          contentType: 'text/plain',
+          sizeBytes: 1,
+          syncVersion: 1,
+          createdAt,
+          updatedAt,
+          content: 'text',
+        }
+      }),
+    })
+
+    await buildClaudeProjectExport(testStorage)
+
+    expect(maximumActive).toBe(4)
+  })
+
+  it('rejects encoded JSON over the configured bound', async () => {
+    await expect(
+      buildClaudeProjectExport(storage(), { maxEncodedBytes: 10 }),
+    ).rejects.toBeInstanceOf(ClaudeProjectExportSizeError)
+  })
+})

--- a/tests/services/project-export/claude-project-export.test.ts
+++ b/tests/services/project-export/claude-project-export.test.ts
@@ -1,6 +1,7 @@
 import {
   buildClaudeProjectExport,
   ClaudeProjectExportSizeError,
+  formatClaudeProjectExportCounts,
 } from '@/services/project-export/claude-project-export'
 import type {
   Project,
@@ -134,6 +135,7 @@ describe('buildClaudeProjectExport', () => {
       skippedProjects: 0,
       exportedDocuments: 1,
       skippedDocuments: 0,
+      failedDocumentListings: 0,
     })
     expect(result.json).not.toContain('memory')
     expect(result.json).not.toContain('color')
@@ -209,9 +211,24 @@ describe('buildClaudeProjectExport', () => {
       skippedProjects: 1,
       exportedDocuments: 1,
       skippedDocuments: 1,
+      failedDocumentListings: 1,
     })
     expect(result.warnings).toHaveLength(3)
     expect(JSON.parse(result.json)).toHaveLength(2)
+  })
+
+  it('reports unknown skipped documents when a document listing fails', () => {
+    const summary = formatClaudeProjectExportCounts({
+      exportedProjects: 2,
+      skippedProjects: 0,
+      exportedDocuments: 3,
+      skippedDocuments: 0,
+      failedDocumentListings: 1,
+    })
+
+    expect(summary).toContain('The skipped document total is unknown')
+    expect(summary).toContain('document listing failed for 1 project')
+    expect(summary).not.toContain('Skipped 0 projects and 0 documents')
   })
 
   it('never reads more than four documents concurrently', async () => {


### PR DESCRIPTION
## Summary
- label the existing project export as Claude-compatible and lossy
- enumerate authoritative projects and documents with bounded concurrency
- report partial failures accurately and enforce a 64 MiB output bound

## Testing
- 1,824 unit tests
- typecheck and lint

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies and hardens Claude project exports. The old flow preloaded projects, skipped failures silently, and could leave stale status; the new flow lists projects authoritatively, enforces a 64 MiB UTF‑8 JSON cap, reports partial failures, and clears stale export state after deletion.

- build: `buildClaudeProjectExport` creates `projects.json`; finishes project pagination before reads; keeps the freshest duplicate by `updatedAt`/`syncVersion` with an ID tie‑break; aborts on a failed list page; reads documents with concurrency 4; skips unreadable content; returns `{ json, counts, warnings }`; adds `ClaudeProjectExportSizeError` and `formatClaudeProjectExportCounts`.
- boundaries: Applies a deterministic bound to pretty‑printed UTF‑8 bytes (including array framing/separators). Stops early if adding a document would exceed the limit, throws over 64 MiB, and validates the final size.
- UI: In `SettingsModal`, renamed to “Export Projects for Claude”. One click triggers export and download, shows summaries via `formatClaudeProjectExportCounts`, size‑limit errors, and per‑item warnings. Disables only while exporting, does not preload projects, and clears any prior export result after deleting all projects and when the modal closes.
- data: Projects include `uuid`, `name`, optional `description`/`prompt_template`, `created_at`, `updated_at`; documents include `uuid`, `filename`, `content`, `created_at`. Excludes memory, colors, chats, images, and original document bytes.
- tests: Cover pagination and stable dedupe, abort on listing failure, 4‑doc concurrency cap, partial‑failure counts with unknown skipped‑doc totals when listings fail, exact encoded bound on empty and non‑empty outputs, and early stop when content would exceed the bound.

<sup>Written for commit 4cff99aa3590568ec604946277d1f10200d109d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/518?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

