### PR TITLE
feat: delete all projects atomically

### DIFF
--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -1917,10 +1917,11 @@ export function SettingsModal({
     }
 
     setIsDeletingAllProjects(true)
+    const guard = cloudSync.createAccountOperationGuard()
     try {
-      const deleted = await projectStorage.deleteAllProjects()
+      const deleted = await projectStorage.deleteAllProjects(guard)
+      guard.assertCurrent()
       setProjectExportResult(null)
-      invalidateProjects()
       try {
         await projectCache.clear()
       } catch (cacheError) {
@@ -1929,12 +1930,12 @@ export function SettingsModal({
           action: 'handleDeleteAllProjects.clearCache',
         })
       }
+      guard.assertCurrent()
+      invalidateProjects()
       toast({
         title: 'All projects deleted',
         description: `Deleted ${deleted} ${deleted === 1 ? 'project' : 'projects'}.`,
       })
-
-      await refreshProjects()
 
       // Project deletion detaches chats from projects on the server, so the
       // chat list in the sidebar may need to refresh too.

--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -45,7 +45,7 @@ import {
   formatClaudeProjectExportCounts,
   type ClaudeProjectExportCounts,
 } from '@/services/project-export/claude-project-export'
-import { projectEvents } from '@/services/project/project-events'
+import { invalidateProjects } from '@/services/project/project-events'
 import { chatStorage } from '@/services/storage/chat-storage'
 import { projectCache } from '@/services/storage/project-cache'
 import { sessionChatStorage } from '@/services/storage/session-storage'
@@ -1920,7 +1920,7 @@ export function SettingsModal({
     try {
       const deleted = await projectStorage.deleteAllProjects()
       setProjectExportResult(null)
-      projectEvents.emit({ type: 'projects-invalidated' })
+      invalidateProjects()
       try {
         await projectCache.clear()
       } catch (cacheError) {

--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -45,6 +45,7 @@ import {
   formatClaudeProjectExportCounts,
   type ClaudeProjectExportCounts,
 } from '@/services/project-export/claude-project-export'
+import { projectEvents } from '@/services/project/project-events'
 import { chatStorage } from '@/services/storage/chat-storage'
 import { projectCache } from '@/services/storage/project-cache'
 import { sessionChatStorage } from '@/services/storage/session-storage'
@@ -1917,8 +1918,9 @@ export function SettingsModal({
 
     setIsDeletingAllProjects(true)
     try {
-      const result = await projectStorage.deleteAllProjects()
+      const deleted = await projectStorage.deleteAllProjects()
       setProjectExportResult(null)
+      projectEvents.emit({ type: 'projects-invalidated' })
       try {
         await projectCache.clear()
       } catch (cacheError) {
@@ -1929,9 +1931,7 @@ export function SettingsModal({
       }
       toast({
         title: 'All projects deleted',
-        description: result.notificationSent
-          ? 'We will email you a confirmation.'
-          : 'Email confirmation could not be sent.',
+        description: `Deleted ${deleted} ${deleted === 1 ? 'project' : 'projects'}.`,
       })
 
       await refreshProjects()

--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -1920,7 +1920,6 @@ export function SettingsModal({
     const guard = cloudSync.createAccountOperationGuard()
     try {
       const deleted = await projectStorage.deleteAllProjects(guard)
-      guard.assertCurrent()
       setProjectExportResult(null)
       try {
         await projectCache.clear()

--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -45,7 +45,7 @@ import {
   formatClaudeProjectExportCounts,
   type ClaudeProjectExportCounts,
 } from '@/services/project-export/claude-project-export'
-import { invalidateProjects } from '@/services/project/project-events'
+import { clearDeletedProjectsForAccount } from '@/services/project/project-deletion'
 import { chatStorage } from '@/services/storage/chat-storage'
 import { projectCache } from '@/services/storage/project-cache'
 import { sessionChatStorage } from '@/services/storage/session-storage'
@@ -1920,17 +1920,13 @@ export function SettingsModal({
     const guard = cloudSync.createAccountOperationGuard()
     try {
       const deleted = await projectStorage.deleteAllProjects(guard)
-      setProjectExportResult(null)
-      try {
-        await projectCache.clear()
-      } catch (cacheError) {
+      await clearDeletedProjectsForAccount(guard, (cacheError) => {
         logError('Failed to clear cached projects', cacheError, {
           component: 'SettingsModal',
           action: 'handleDeleteAllProjects.clearCache',
         })
-      }
-      guard.assertCurrent()
-      invalidateProjects()
+      })
+      setProjectExportResult(null)
       toast({
         title: 'All projects deleted',
         description: `Deleted ${deleted} ${deleted === 1 ? 'project' : 'projects'}.`,

--- a/src/components/project/project-provider.tsx
+++ b/src/components/project/project-provider.tsx
@@ -72,6 +72,14 @@ export function ProjectProvider({
     setLoadingProject(null)
   }, [])
 
+  useEffect(
+    () =>
+      projectEvents.on('projects-invalidated', () => {
+        resetProjectSessionState()
+      }),
+    [resetProjectSessionState],
+  )
+
   useEffect(() => {
     if (isSignedIn && !initializingRef.current) {
       initializingRef.current = true

--- a/src/components/project/project-provider.tsx
+++ b/src/components/project/project-provider.tsx
@@ -1,6 +1,9 @@
 'use client'
 
-import { UI_EXPAND_PROJECTS_ON_MOUNT } from '@/constants/storage-keys'
+import {
+  SYNC_PROJECTS_INVALIDATED,
+  UI_EXPAND_PROJECTS_ON_MOUNT,
+} from '@/constants/storage-keys'
 import { useMemory } from '@/hooks/use-memory'
 import { projectStorage } from '@/services/cloud/project-storage'
 import { projectEvents } from '@/services/project/project-events'
@@ -72,13 +75,21 @@ export function ProjectProvider({
     setLoadingProject(null)
   }, [])
 
-  useEffect(
-    () =>
-      projectEvents.on('projects-invalidated', () => {
+  useEffect(() => {
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key === SYNC_PROJECTS_INVALIDATED) {
         resetProjectSessionState()
-      }),
-    [resetProjectSessionState],
-  )
+      }
+    }
+    const unsubscribe = projectEvents.on('projects-invalidated', () => {
+      resetProjectSessionState()
+    })
+    window.addEventListener('storage', handleStorage)
+    return () => {
+      unsubscribe()
+      window.removeEventListener('storage', handleStorage)
+    }
+  }, [resetProjectSessionState])
 
   useEffect(() => {
     if (isSignedIn && !initializingRef.current) {

--- a/src/constants/storage-keys.ts
+++ b/src/constants/storage-keys.ts
@@ -134,6 +134,7 @@ export const SYNC_PROFILE_BASELINE = 'tinfoil-sync-profile-baseline'
 export const SYNC_PROFILE_LOCAL_METADATA = 'tinfoil-sync-profile-local-metadata'
 export const SYNC_PROFILE_UNKNOWN_FIELDS = 'tinfoil-sync-profile-unknown-fields'
 export const SYNC_PROFILE_GENERATION = 'tinfoil-sync-profile-generation'
+export const SYNC_PROJECTS_INVALIDATED = 'tinfoil-sync-projects-invalidated'
 // Content modification time of the pending local profile edit, used to
 // arbitrate last-write-wins against a concurrently-updated remote.
 export const SYNC_PROFILE_CHANGED_AT = 'tinfoil-sync-profile-changed-at'

--- a/src/hooks/use-projects.ts
+++ b/src/hooks/use-projects.ts
@@ -282,7 +282,6 @@ export function useProjects(
     if (!isSignedIn || !userId) return
 
     return subscribeToProjectInvalidation(() => {
-      loadGenerationRef.current += 1
       setProjects([])
       setProjectsUserId(userId)
       setError(null)

--- a/src/hooks/use-projects.ts
+++ b/src/hooks/use-projects.ts
@@ -1,5 +1,7 @@
+import { SYNC_PROJECTS_INVALIDATED } from '@/constants/storage-keys'
 import { projectStorage } from '@/services/cloud/project-storage'
 import { ENCRYPTION_KEY_CHANGED_EVENT } from '@/services/encryption/encryption-service'
+import { projectEvents } from '@/services/project/project-events'
 import {
   PROJECT_CACHE_UPDATED_EVENT,
   projectCache,
@@ -34,6 +36,39 @@ const freshProjectsByUser = new Map<
   string,
   { generation: number; refreshedAt: number; projects: Project[] }
 >()
+const projectInvalidationSubscribers = new Set<() => void>()
+let unsubscribeProjectInvalidation: (() => void) | null = null
+
+function invalidateProjectLists(): void {
+  projectCache.invalidate()
+  refreshByUser.clear()
+  freshProjectsByUser.clear()
+  projectInvalidationSubscribers.forEach((subscriber) => subscriber())
+}
+
+function handleProjectInvalidationStorage(event: StorageEvent): void {
+  if (event.key === SYNC_PROJECTS_INVALIDATED) invalidateProjectLists()
+}
+
+function subscribeToProjectInvalidation(subscriber: () => void): () => void {
+  projectInvalidationSubscribers.add(subscriber)
+  if (projectInvalidationSubscribers.size === 1) {
+    unsubscribeProjectInvalidation = projectEvents.on(
+      'projects-invalidated',
+      invalidateProjectLists,
+    )
+    window.addEventListener('storage', handleProjectInvalidationStorage)
+  }
+
+  return () => {
+    projectInvalidationSubscribers.delete(subscriber)
+    if (projectInvalidationSubscribers.size === 0) {
+      unsubscribeProjectInvalidation?.()
+      unsubscribeProjectInvalidation = null
+      window.removeEventListener('storage', handleProjectInvalidationStorage)
+    }
+  }
+}
 
 function projectFromListItem(
   item: ProjectListItem,
@@ -170,7 +205,7 @@ export function useProjects(
   }, [userId])
 
   const loadProjects = useCallback(
-    async (forceRefresh = false) => {
+    async (forceRefresh = false, skipCache = false) => {
       const loadGeneration = loadGenerationRef.current + 1
       loadGenerationRef.current = loadGeneration
       if (!isSignedIn || !userId) {
@@ -180,7 +215,7 @@ export function useProjects(
       }
 
       const requestUserId = userId
-      setLoading(visibleProjects.length === 0)
+      setLoading(skipCache || visibleProjects.length === 0)
       setError(null)
       let remoteApplied = false
       let cacheApplied = false
@@ -188,22 +223,24 @@ export function useProjects(
         currentUserRef.current === requestUserId &&
         loadGenerationRef.current === loadGeneration
 
-      void projectCache
-        .getProjects(requestUserId)
-        .then((cachedProjects) => {
-          if (!isCurrentLoad() || remoteApplied) return
+      if (!skipCache) {
+        void projectCache
+          .getProjects(requestUserId)
+          .then((cachedProjects) => {
+            if (!isCurrentLoad() || remoteApplied) return
 
-          cacheApplied = true
-          setProjectsUserId(requestUserId)
-          setProjects(cachedProjects)
-          if (cachedProjects.length > 0) setLoading(false)
-        })
-        .catch((cacheError) => {
-          logError('Failed to load cached projects', cacheError, {
-            component: 'useProjects',
-            action: 'loadCachedProjects',
+            cacheApplied = true
+            setProjectsUserId(requestUserId)
+            setProjects(cachedProjects)
+            if (cachedProjects.length > 0) setLoading(false)
           })
-        })
+          .catch((cacheError) => {
+            logError('Failed to load cached projects', cacheError, {
+              component: 'useProjects',
+              action: 'loadCachedProjects',
+            })
+          })
+      }
 
       try {
         const remoteProjects = await revalidateProjects(
@@ -240,6 +277,18 @@ export function useProjects(
   )
 
   const refresh = useCallback(() => loadProjects(true), [loadProjects])
+
+  useEffect(() => {
+    if (!isSignedIn || !userId) return
+
+    return subscribeToProjectInvalidation(() => {
+      loadGenerationRef.current += 1
+      setProjects([])
+      setProjectsUserId(userId)
+      setError(null)
+      void loadProjects(true, true)
+    })
+  }, [isSignedIn, userId, loadProjects])
 
   useEffect(() => {
     if (

--- a/src/services/cloud/project-storage.ts
+++ b/src/services/cloud/project-storage.ts
@@ -12,6 +12,7 @@ import type {
 import { logError } from '@/utils/error-handling'
 import { authTokenManager } from '../auth'
 import {
+  deleteAllProjects as enclaveDeleteAllProjects,
   deleteRow as enclaveDeleteRow,
   listStatus as enclaveListStatus,
   pull as enclavePull,
@@ -360,43 +361,18 @@ export class ProjectStorageService {
     })
   }
 
-  async deleteAllProjects(): Promise<{
-    deleted: number
-    notificationSent?: boolean
-  }> {
+  async deleteAllProjects(): Promise<number> {
     if (!(await canWriteToCloud())) {
       throw new Error(
         'Cloud writes are blocked until your encryption key is verified',
       )
     }
 
-    let deleted = 0
-    let cursor: string | undefined
-    do {
-      const status = await enclaveListStatus({
-        scope: PROJECT_SCOPE,
-        cursor,
-        limit: 500,
-      })
-      for (const update of status.updates) {
-        // Bulk delete-all is unconditional: user intent is "drop
-        // everything", and the listed etag can become stale between
-        // the page fetch and the delete (concurrent write from another
-        // device). Passing ifMatch=null avoids spurious STALE_BLOB
-        // failures that would leave the batch partially completed.
-        // Mirrors the single-row deleteProject path.
-        await enclaveDeleteRow({
-          scope: PROJECT_SCOPE,
-          id: update.id,
-          ifMatch: null,
-          idempotencyKey: newIdempotencyKey(),
-          keyB64: requirePrimaryKeyB64(),
-        })
-        deleted++
-      }
-      cursor = status.next_cursor
-    } while (cursor)
-    return { deleted }
+    const response = await enclaveDeleteAllProjects({
+      keyB64: requirePrimaryKeyB64(),
+      idempotencyKey: newIdempotencyKey(),
+    })
+    return response.deleted
   }
 
   async listProjects(options?: {

--- a/src/services/cloud/project-storage.ts
+++ b/src/services/cloud/project-storage.ts
@@ -20,6 +20,7 @@ import {
   newIdempotencyKey,
   pullItemPlaintext,
 } from '../sync-enclave/sync-api'
+import type { AccountOperationGuard } from './account-operation'
 import { pullKey, requirePrimaryKeyB64 } from './cek-encoding'
 import { canWriteToCloud } from './cloud-key-authorization'
 import { ProjectDataSchema, ProjectDocumentPlaintextSchema } from './schemas'
@@ -361,17 +362,20 @@ export class ProjectStorageService {
     })
   }
 
-  async deleteAllProjects(): Promise<number> {
+  async deleteAllProjects(guard: AccountOperationGuard): Promise<number> {
+    guard.assertCurrent()
     if (!(await canWriteToCloud())) {
       throw new Error(
         'Cloud writes are blocked until your encryption key is verified',
       )
     }
 
+    guard.assertCurrent()
     const response = await enclaveDeleteAllProjects({
       keyB64: requirePrimaryKeyB64(),
       idempotencyKey: newIdempotencyKey(),
     })
+    guard.assertCurrent()
     return response.deleted
   }
 

--- a/src/services/project/project-deletion.ts
+++ b/src/services/project/project-deletion.ts
@@ -1,0 +1,17 @@
+import type { AccountOperationGuard } from '@/services/cloud/account-operation'
+import { projectCache } from '@/services/storage/project-cache'
+import { invalidateProjects } from './project-events'
+
+export async function clearDeletedProjectsForAccount(
+  guard: AccountOperationGuard,
+  onCacheError: (error: unknown) => void,
+): Promise<void> {
+  guard.assertCurrent()
+  try {
+    await projectCache.clear()
+  } catch (error) {
+    onCacheError(error)
+  }
+  guard.assertCurrent()
+  invalidateProjects()
+}

--- a/src/services/project/project-events.ts
+++ b/src/services/project/project-events.ts
@@ -1,4 +1,5 @@
 import type { Message } from '@/components/chat/types'
+import { SYNC_PROJECTS_INVALIDATED } from '@/constants/storage-keys'
 import { logError } from '@/utils/error-handling'
 
 type ProjectMemoryUpdateEvent = {
@@ -55,3 +56,13 @@ class ProjectEventsEmitter {
 }
 
 export const projectEvents = new ProjectEventsEmitter()
+
+export function invalidateProjects(): void {
+  projectEvents.emit({ type: 'projects-invalidated' })
+  if (typeof window === 'undefined') return
+  try {
+    localStorage.setItem(SYNC_PROJECTS_INVALIDATED, crypto.randomUUID())
+  } catch {
+    // Cross-tab invalidation is best-effort; the current tab was already reset.
+  }
+}

--- a/src/services/project/project-events.ts
+++ b/src/services/project/project-events.ts
@@ -7,16 +7,20 @@ type ProjectMemoryUpdateEvent = {
   messages: Message[]
 }
 
-type ProjectEvent = ProjectMemoryUpdateEvent
+type ProjectsInvalidatedEvent = {
+  type: 'projects-invalidated'
+}
+
+type ProjectEvent = ProjectMemoryUpdateEvent | ProjectsInvalidatedEvent
 
 type EventHandler<T extends ProjectEvent> = (event: T) => void
 
 class ProjectEventsEmitter {
   private handlers: Map<string, Set<EventHandler<any>>> = new Map()
 
-  on<T extends ProjectEvent>(
-    type: T['type'],
-    handler: EventHandler<T>,
+  on<T extends ProjectEvent['type']>(
+    type: T,
+    handler: EventHandler<Extract<ProjectEvent, { type: T }>>,
   ): () => void {
     if (!this.handlers.has(type)) {
       this.handlers.set(type, new Set())

--- a/src/services/sync-enclave/sync-api.ts
+++ b/src/services/sync-enclave/sync-api.ts
@@ -179,6 +179,17 @@ export interface DeleteRequest {
   keyB64: string
 }
 
+export interface DeleteAllProjectsRequest {
+  /** Base64 CEK; required to derive the op-hash key per spec §7.0. */
+  keyB64: string
+  idempotencyKey: string
+}
+
+export interface DeleteAllProjectsResponse {
+  ok: true
+  deleted: number
+}
+
 export interface OKResponse {
   ok: true
 }
@@ -645,6 +656,21 @@ export async function deleteRow(req: DeleteRequest): Promise<OKResponse> {
       if_match: req.ifMatch,
       idempotency_key: req.idempotencyKey,
       key: req.keyB64,
+    },
+    undefined,
+    { requestScope: 'cloud-sync' },
+  )
+}
+
+export async function deleteAllProjects(
+  req: DeleteAllProjectsRequest,
+): Promise<DeleteAllProjectsResponse> {
+  const client = await getSyncEnclaveClient()
+  return client.post<DeleteAllProjectsResponse>(
+    '/v1/sync/delete-all-projects',
+    {
+      key: req.keyB64,
+      idempotency_key: req.idempotencyKey,
     },
     undefined,
     { requestScope: 'cloud-sync' },

--- a/tests/components/project/project-provider-documents.test.tsx
+++ b/tests/components/project/project-provider-documents.test.tsx
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => ({
   deleteDocument: vi.fn(),
   loadMemory: vi.fn(),
   processMessages: vi.fn(),
+  projectEventHandlers: new Map<string, (event: unknown) => void>(),
 }))
 
 vi.mock('@clerk/nextjs', () => ({
@@ -27,7 +28,12 @@ vi.mock('@/hooks/use-memory', () => ({
 }))
 
 vi.mock('@/services/project/project-events', () => ({
-  projectEvents: { on: vi.fn(() => vi.fn()) },
+  projectEvents: {
+    on: vi.fn((type: string, handler: (event: unknown) => void) => {
+      mocks.projectEventHandlers.set(type, handler)
+      return () => mocks.projectEventHandlers.delete(type)
+    }),
+  },
 }))
 
 vi.mock('@/services/cloud/project-storage', () => ({
@@ -92,6 +98,7 @@ async function renderInProject() {
 describe('ProjectProvider documents', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mocks.projectEventHandlers.clear()
     mocks.getProject.mockResolvedValue(project)
     mocks.listDocuments.mockResolvedValue({ documents: [listedDocument] })
     mocks.getDocuments.mockResolvedValue(
@@ -225,6 +232,38 @@ describe('ProjectProvider documents', () => {
       await refreshPromise
     })
 
+    expect(result.current.projectDocuments).toEqual([])
+  })
+
+  it('invalidates active state and prevents a stale load from restoring it', async () => {
+    const { result } = await renderInProject()
+    let resolvePendingProject!: (project: Project) => void
+    mocks.getProject.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolvePendingProject = resolve
+      }),
+    )
+
+    let pendingLoad!: Promise<boolean>
+    act(() => {
+      pendingLoad = result.current.enterProjectMode('project-2')
+    })
+    await vi.waitFor(() => expect(mocks.getProject).toHaveBeenCalledTimes(2))
+
+    act(() => {
+      mocks.projectEventHandlers.get('projects-invalidated')?.({
+        type: 'projects-invalidated',
+      })
+    })
+    expect(result.current.activeProject).toBeNull()
+    expect(result.current.projectDocuments).toEqual([])
+
+    await act(async () => {
+      resolvePendingProject({ ...project, id: 'project-2' })
+      await pendingLoad
+    })
+
+    expect(result.current.activeProject).toBeNull()
     expect(result.current.projectDocuments).toEqual([])
   })
 

--- a/tests/components/project/project-provider-documents.test.tsx
+++ b/tests/components/project/project-provider-documents.test.tsx
@@ -1,5 +1,6 @@
 import { useProject } from '@/components/project/project-context'
 import { ProjectProvider } from '@/components/project/project-provider'
+import { SYNC_PROJECTS_INVALIDATED } from '@/constants/storage-keys'
 import type { Project, ProjectDocument } from '@/types/project'
 import { act, renderHook } from '@testing-library/react'
 import type { PropsWithChildren } from 'react'
@@ -257,6 +258,39 @@ describe('ProjectProvider documents', () => {
     })
     expect(result.current.activeProject).toBeNull()
     expect(result.current.projectDocuments).toEqual([])
+
+    await act(async () => {
+      resolvePendingProject({ ...project, id: 'project-2' })
+      await pendingLoad
+    })
+
+    expect(result.current.activeProject).toBeNull()
+    expect(result.current.projectDocuments).toEqual([])
+  })
+
+  it('handles cross-tab invalidation without letting a stale load restore state', async () => {
+    const { result } = await renderInProject()
+    let resolvePendingProject!: (project: Project) => void
+    mocks.getProject.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolvePendingProject = resolve
+      }),
+    )
+
+    let pendingLoad!: Promise<boolean>
+    act(() => {
+      pendingLoad = result.current.enterProjectMode('project-2')
+    })
+    await vi.waitFor(() => expect(mocks.getProject).toHaveBeenCalledTimes(2))
+
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent('storage', {
+          key: SYNC_PROJECTS_INVALIDATED,
+          newValue: 'another-tab-signal',
+        }),
+      )
+    })
 
     await act(async () => {
       resolvePendingProject({ ...project, id: 'project-2' })

--- a/tests/hooks/use-projects.test.tsx
+++ b/tests/hooks/use-projects.test.tsx
@@ -1,3 +1,4 @@
+import { SYNC_PROJECTS_INVALIDATED } from '@/constants/storage-keys'
 import { useProjects } from '@/hooks/use-projects'
 import type { Project, ProjectListResponse } from '@/types/project'
 import { act, renderHook, waitFor } from '@testing-library/react'
@@ -9,6 +10,8 @@ const mocks = vi.hoisted(() => ({
   replaceProjects: vi.fn(),
   listProjects: vi.fn(),
   getRemoteProjects: vi.fn(),
+  invalidateCache: vi.fn(),
+  cacheState: { generation: 0, refreshGeneration: 0 },
 }))
 
 vi.mock('@clerk/nextjs', () => ({
@@ -18,9 +21,15 @@ vi.mock('@clerk/nextjs', () => ({
 vi.mock('@/services/storage/project-cache', () => ({
   PROJECT_CACHE_UPDATED_EVENT: 'projectCacheUpdated',
   projectCache: {
-    captureGeneration: () => 0,
-    captureRefreshGeneration: () => 0,
-    isCurrentRefreshGeneration: () => true,
+    captureGeneration: () => mocks.cacheState.generation,
+    captureRefreshGeneration: () => mocks.cacheState.refreshGeneration,
+    isCurrentRefreshGeneration: (generation: number) =>
+      generation === mocks.cacheState.refreshGeneration,
+    invalidate: () => {
+      mocks.cacheState.generation += 1
+      mocks.cacheState.refreshGeneration += 1
+      mocks.invalidateCache()
+    },
     getProjects: mocks.getCachedProjects,
     replaceProjects: mocks.replaceProjects,
   },
@@ -48,6 +57,9 @@ describe('useProjects', () => {
   beforeEach(() => {
     mocks.auth.isSignedIn = true
     mocks.auth.userId = 'cached-project-user'
+    mocks.cacheState.generation = 0
+    mocks.cacheState.refreshGeneration = 0
+    mocks.invalidateCache.mockReset()
     mocks.getCachedProjects.mockReset().mockResolvedValue([cachedProject])
     mocks.replaceProjects.mockReset().mockResolvedValue(undefined)
     mocks.listProjects.mockReset()
@@ -106,6 +118,65 @@ describe('useProjects', () => {
       'cached-project-user',
       [refreshedProject],
       0,
+    )
+  })
+
+  it('clears cross-tab stale state and ignores an invalidated in-flight refresh', async () => {
+    mocks.auth.userId = 'cross-tab-project-user'
+    let resolveStalePage!: (value: ProjectListResponse) => void
+    mocks.listProjects
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveStalePage = resolve
+        }),
+      )
+      .mockResolvedValueOnce({ projects: [], hasMore: false })
+    mocks.getRemoteProjects.mockImplementation(async (ids: string[]) =>
+      ids.includes(cachedProject.id)
+        ? new Map([[cachedProject.id, cachedProject]])
+        : new Map(),
+    )
+
+    const { result } = renderHook(() => useProjects())
+    await waitFor(() =>
+      expect(result.current.projects).toEqual([cachedProject]),
+    )
+
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent('storage', {
+          key: SYNC_PROJECTS_INVALIDATED,
+          newValue: 'another-tab-signal',
+        }),
+      )
+    })
+
+    await waitFor(() => expect(mocks.listProjects).toHaveBeenCalledTimes(2))
+    await waitFor(() => expect(result.current.projects).toEqual([]))
+    expect(mocks.invalidateCache).toHaveBeenCalledOnce()
+
+    await act(async () => {
+      resolveStalePage({
+        projects: [
+          {
+            id: cachedProject.id,
+            key: cachedProject.id,
+            createdAt: cachedProject.createdAt,
+            updatedAt: cachedProject.updatedAt,
+            syncVersion: cachedProject.syncVersion,
+            size: 0,
+          },
+        ],
+        hasMore: false,
+      })
+    })
+
+    await waitFor(() => expect(result.current.projects).toEqual([]))
+    expect(mocks.replaceProjects).toHaveBeenCalledTimes(1)
+    expect(mocks.replaceProjects).toHaveBeenCalledWith(
+      'cross-tab-project-user',
+      [],
+      1,
     )
   })
 

--- a/tests/services/cloud/project-storage.delete-all.test.ts
+++ b/tests/services/cloud/project-storage.delete-all.test.ts
@@ -1,0 +1,65 @@
+import { ProjectStorageService } from '@/services/cloud/project-storage'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  canWriteToCloud: vi.fn(),
+  deleteAllProjects: vi.fn(),
+  newIdempotencyKey: vi.fn(),
+  requirePrimaryKeyB64: vi.fn(),
+}))
+
+vi.mock('@/services/auth', () => ({
+  authTokenManager: {},
+}))
+
+vi.mock('@/services/cloud/cloud-key-authorization', () => ({
+  canWriteToCloud: mocks.canWriteToCloud,
+}))
+
+vi.mock('@/services/cloud/cek-encoding', () => ({
+  pullKey: vi.fn(),
+  requirePrimaryKeyB64: mocks.requirePrimaryKeyB64,
+}))
+
+vi.mock('@/services/sync-enclave/sync-api', () => ({
+  deleteAllProjects: mocks.deleteAllProjects,
+  deleteRow: vi.fn(),
+  listStatus: vi.fn(),
+  pull: vi.fn(),
+  push: vi.fn(),
+  newIdempotencyKey: mocks.newIdempotencyKey,
+  pullItemPlaintext: vi.fn(),
+}))
+
+describe('ProjectStorageService.deleteAllProjects', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.canWriteToCloud.mockResolvedValue(true)
+    mocks.requirePrimaryKeyB64.mockReturnValue('current-cek')
+    mocks.newIdempotencyKey.mockReturnValue('delete-projects-idempotency')
+    mocks.deleteAllProjects.mockResolvedValue({ ok: true, deleted: 4 })
+  })
+
+  it('deletes all projects in one atomic enclave request', async () => {
+    const storage = new ProjectStorageService()
+
+    await expect(storage.deleteAllProjects()).resolves.toBe(4)
+    expect(mocks.deleteAllProjects).toHaveBeenCalledOnce()
+    expect(mocks.deleteAllProjects).toHaveBeenCalledWith({
+      keyB64: 'current-cek',
+      idempotencyKey: 'delete-projects-idempotency',
+    })
+    expect(mocks.requirePrimaryKeyB64).toHaveBeenCalledOnce()
+    expect(mocks.newIdempotencyKey).toHaveBeenCalledOnce()
+  })
+
+  it('does not request deletion when cloud writes are blocked', async () => {
+    mocks.canWriteToCloud.mockResolvedValue(false)
+    const storage = new ProjectStorageService()
+
+    await expect(storage.deleteAllProjects()).rejects.toThrow(
+      'Cloud writes are blocked until your encryption key is verified',
+    )
+    expect(mocks.deleteAllProjects).not.toHaveBeenCalled()
+  })
+})

--- a/tests/services/cloud/project-storage.delete-all.test.ts
+++ b/tests/services/cloud/project-storage.delete-all.test.ts
@@ -1,3 +1,4 @@
+import type { AccountOperationGuard } from '@/services/cloud/account-operation'
 import { ProjectStorageService } from '@/services/cloud/project-storage'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -32,18 +33,25 @@ vi.mock('@/services/sync-enclave/sync-api', () => ({
 }))
 
 describe('ProjectStorageService.deleteAllProjects', () => {
+  let guard: AccountOperationGuard
+
   beforeEach(() => {
     vi.clearAllMocks()
     mocks.canWriteToCloud.mockResolvedValue(true)
     mocks.requirePrimaryKeyB64.mockReturnValue('current-cek')
     mocks.newIdempotencyKey.mockReturnValue('delete-projects-idempotency')
     mocks.deleteAllProjects.mockResolvedValue({ ok: true, deleted: 4 })
+    guard = {
+      userId: 'project-user',
+      assertCurrent: vi.fn(),
+      isCurrent: vi.fn().mockReturnValue(true),
+    }
   })
 
   it('deletes all projects in one atomic enclave request', async () => {
     const storage = new ProjectStorageService()
 
-    await expect(storage.deleteAllProjects()).resolves.toBe(4)
+    await expect(storage.deleteAllProjects(guard)).resolves.toBe(4)
     expect(mocks.deleteAllProjects).toHaveBeenCalledOnce()
     expect(mocks.deleteAllProjects).toHaveBeenCalledWith({
       keyB64: 'current-cek',
@@ -51,15 +59,25 @@ describe('ProjectStorageService.deleteAllProjects', () => {
     })
     expect(mocks.requirePrimaryKeyB64).toHaveBeenCalledOnce()
     expect(mocks.newIdempotencyKey).toHaveBeenCalledOnce()
+    expect(guard.assertCurrent).toHaveBeenCalledTimes(3)
   })
 
   it('does not request deletion when cloud writes are blocked', async () => {
     mocks.canWriteToCloud.mockResolvedValue(false)
     const storage = new ProjectStorageService()
 
-    await expect(storage.deleteAllProjects()).rejects.toThrow(
+    await expect(storage.deleteAllProjects(guard)).rejects.toThrow(
       'Cloud writes are blocked until your encryption key is verified',
     )
     expect(mocks.deleteAllProjects).not.toHaveBeenCalled()
+  })
+
+  it('propagates enclave failures without reporting a deletion', async () => {
+    const failure = new Error('Enclave unavailable')
+    mocks.deleteAllProjects.mockRejectedValue(failure)
+    const storage = new ProjectStorageService()
+
+    await expect(storage.deleteAllProjects(guard)).rejects.toBe(failure)
+    expect(guard.assertCurrent).toHaveBeenCalledTimes(2)
   })
 })

--- a/tests/services/project/project-deletion.test.ts
+++ b/tests/services/project/project-deletion.test.ts
@@ -20,6 +20,30 @@ describe('clearDeletedProjectsForAccount', () => {
     vi.clearAllMocks()
   })
 
+  it('publishes the successful deletion count after clearing the cache', async () => {
+    mocks.clear.mockResolvedValue(undefined)
+    const guard: AccountOperationGuard = {
+      userId: 'project-user',
+      isCurrent: () => true,
+      assertCurrent: vi.fn(),
+    }
+    const onCacheError = vi.fn()
+    const deletedCount = 3
+    const publishUiSuccess = vi.fn((count: number) => count)
+
+    const completion = clearDeletedProjectsForAccount(guard, onCacheError).then(
+      () => publishUiSuccess(deletedCount),
+    )
+
+    await expect(completion).resolves.toBe(deletedCount)
+    expect(guard.isCurrent()).toBe(true)
+    expect(mocks.clear).toHaveBeenCalledOnce()
+    expect(guard.assertCurrent).toHaveBeenCalledTimes(2)
+    expect(mocks.invalidateProjects).toHaveBeenCalledOnce()
+    expect(publishUiSuccess).toHaveBeenCalledExactlyOnceWith(deletedCount)
+    expect(onCacheError).not.toHaveBeenCalled()
+  })
+
   it('does not publish success when the account changes during cache clear', async () => {
     let accountIsCurrent = true
     let finishCacheClear!: () => void

--- a/tests/services/project/project-deletion.test.ts
+++ b/tests/services/project/project-deletion.test.ts
@@ -1,0 +1,59 @@
+import type { AccountOperationGuard } from '@/services/cloud/account-operation'
+import { clearDeletedProjectsForAccount } from '@/services/project/project-deletion'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  clear: vi.fn(),
+  invalidateProjects: vi.fn(),
+}))
+
+vi.mock('@/services/storage/project-cache', () => ({
+  projectCache: { clear: mocks.clear },
+}))
+
+vi.mock('@/services/project/project-events', () => ({
+  invalidateProjects: mocks.invalidateProjects,
+}))
+
+describe('clearDeletedProjectsForAccount', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('does not publish success when the account changes during cache clear', async () => {
+    let accountIsCurrent = true
+    let finishCacheClear!: () => void
+    mocks.clear.mockReturnValue(
+      new Promise<void>((resolve) => {
+        finishCacheClear = resolve
+      }),
+    )
+    const guard: AccountOperationGuard = {
+      userId: 'project-user',
+      isCurrent: () => accountIsCurrent,
+      assertCurrent: vi.fn(() => {
+        if (!accountIsCurrent) {
+          throw new Error('Cloud account changed during synchronization')
+        }
+      }),
+    }
+    const onCacheError = vi.fn()
+    const publishUiSuccess = vi.fn()
+
+    const completion = clearDeletedProjectsForAccount(guard, onCacheError).then(
+      publishUiSuccess,
+    )
+    await vi.waitFor(() => expect(mocks.clear).toHaveBeenCalledOnce())
+
+    accountIsCurrent = false
+    finishCacheClear()
+
+    await expect(completion).rejects.toThrow(
+      'Cloud account changed during synchronization',
+    )
+    expect(guard.assertCurrent).toHaveBeenCalledTimes(2)
+    expect(mocks.invalidateProjects).not.toHaveBeenCalled()
+    expect(publishUiSuccess).not.toHaveBeenCalled()
+    expect(onCacheError).not.toHaveBeenCalled()
+  })
+})

--- a/tests/services/storage/project-events.test.ts
+++ b/tests/services/storage/project-events.test.ts
@@ -1,0 +1,23 @@
+import { SYNC_PROJECTS_INVALIDATED } from '@/constants/storage-keys'
+import {
+  invalidateProjects,
+  projectEvents,
+} from '@/services/project/project-events'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+describe('project invalidation', () => {
+  afterEach(() => {
+    projectEvents.clear()
+    vi.restoreAllMocks()
+  })
+
+  it('notifies the current tab and writes a cross-tab signal', () => {
+    const handler = vi.fn()
+    projectEvents.on('projects-invalidated', handler)
+
+    invalidateProjects()
+
+    expect(handler).toHaveBeenCalledWith({ type: 'projects-invalidated' })
+    expect(localStorage.getItem(SYNC_PROJECTS_INVALIDATED)).toBeTruthy()
+  })
+})

--- a/tests/services/sync-enclave/sync-api.test.ts
+++ b/tests/services/sync-enclave/sync-api.test.ts
@@ -203,6 +203,23 @@ describe('sync-api (enclave JSON-RPC)', () => {
     expect(body.idempotency_key).toBe('del-1')
   })
 
+  it('deleteAllProjects posts the CEK and idempotency key', async () => {
+    const api = await import('@/services/sync-enclave/sync-api')
+    mockFetch.mockResolvedValueOnce(ok({ ok: true, deleted: 3 }))
+
+    const response = await api.deleteAllProjects({
+      keyB64: api.hexToB64('aa'.repeat(32)),
+      idempotencyKey: 'delete-projects-1',
+    })
+
+    expect(response).toEqual({ ok: true, deleted: 3 })
+    expect(lastRequest()[0]).toBe('/v1/sync/delete-all-projects')
+    expect(lastBody()).toEqual({
+      key: api.hexToB64('aa'.repeat(32)),
+      idempotency_key: 'delete-projects-1',
+    })
+  })
+
   it('attachmentPut posts idempotency key', async () => {
     const api = await import('@/services/sync-enclave/sync-api')
     mockFetch.mockResolvedValueOnce(


### PR DESCRIPTION
## Summary
- replace the per-project loop with the deployed atomic enclave endpoint
- invalidate project state and lists across tabs only after success
- keep local state unchanged on failure

## Testing
- 1,824 unit tests
- typecheck and lint

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Delete-all switches from per-project deletes to a single atomic enclave request and only invalidates project state after success. Previously we loop-deleted and refreshed immediately; now we guard by the current account, clear the cache under that guard, signal across tabs, and prevent stale restores.

- Replaces per-item deletes with projectStorage.deleteAllProjects(guard), which posts the CEK and an idempotency key and returns the deleted count.
- Adds clearDeletedProjectsForAccount(guard) to clear the project cache, emit a projects-invalidated event, and write SYNC_PROJECTS_INVALIDATED for cross‑tab signaling.
- useProjects subscribes to the invalidation event and storage signal to wipe state, skip cache on the next load, and ignore invalidated in‑flight loads; ProjectProvider resets the active project and documents on invalidation to block stale restores.
- Settings modal creates an account guard, calls delete‑all, then clearDeletedProjectsForAccount; shows “Deleted N projects.” Removes the email notice and manual refresh.
- Sync client adds deleteAllProjects for /v1/sync/delete-all-projects; ProjectStorageService.deleteAllProjects now requires a guard and returns the deleted count. Tests cover atomic delete‑all, cross‑tab invalidation, and stale‑load blocking.

Rollout
- Ensure /v1/sync/delete-all-projects is deployed; no other migration required.

<sup>Written for commit 244c46bf33c0d34dbd1f90ead4b2cfa184325802. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/519?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

