### PR TITLE
feat: add guarded native backup exports

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,4 @@ NEXT_PUBLIC_API_BASE_URL=https://api.tinfoil.sh
 NEXT_PUBLIC_DEV=false
 # Only necessary if local dev mode is on.
 NEXT_PUBLIC_DEV_API_KEY=your-tinfoil-api-key-here
+NEXT_PUBLIC_NATIVE_BACKUP_EXPORT_ENABLED=false

--- a/src/components/chat/native-backup-export.tsx
+++ b/src/components/chat/native-backup-export.tsx
@@ -1,0 +1,102 @@
+import {
+  nativeBackupExportError,
+  runNativeBackupExport,
+  type NativeBackupExportProgress,
+} from '@/services/native-backup/export'
+import { ArrowDownTrayIcon } from '@heroicons/react/24/outline'
+import { useEffect, useRef, useState } from 'react'
+import { ConfirmDialog } from './components/confirm-dialog'
+
+const progressLabel: Record<NativeBackupExportProgress, string> = {
+  collecting: 'Collecting cloud data...',
+  formatting: 'Formatting backup...',
+  writing: 'Saving archive...',
+}
+
+export function NativeBackupExport({
+  available,
+  runExport = runNativeBackupExport,
+}: {
+  available: boolean
+  runExport?: typeof runNativeBackupExport
+}) {
+  const [showWarning, setShowWarning] = useState(false)
+  const [progress, setProgress] = useState<NativeBackupExportProgress | null>(
+    null,
+  )
+  const [message, setMessage] = useState<string | null>(null)
+  const [failed, setFailed] = useState(false)
+  const controller = useRef<AbortController | null>(null)
+
+  useEffect(() => () => controller.current?.abort(), [])
+
+  const createBackup = async () => {
+    setShowWarning(false)
+    setMessage(null)
+    setFailed(false)
+    const current = new AbortController()
+    controller.current = current
+    try {
+      await runExport(current.signal, setProgress)
+      setMessage('Backup saved successfully.')
+    } catch (error) {
+      setFailed(true)
+      setMessage(nativeBackupExportError(error))
+    } finally {
+      if (controller.current === current) controller.current = null
+      setProgress(null)
+    }
+  }
+
+  if (!available) return null
+
+  return (
+    <div>
+      <div className="rounded-lg border border-border-subtle bg-surface-sidebar p-4">
+        <p className="font-aeonik-fono text-xs text-content-muted">
+          Export your cloud and local data as a portable ZIP archive.
+        </p>
+        <button
+          type="button"
+          onClick={() => setShowWarning(true)}
+          disabled={progress !== null}
+          className="mt-3 flex w-full items-center justify-center gap-2 rounded-lg border border-border-subtle px-4 py-2.5 text-sm font-medium transition-colors hover:bg-surface-chat disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          <ArrowDownTrayIcon className="h-4 w-4" />
+          Create Tinfoil Backup
+        </button>
+        {progress && (
+          <div
+            className="mt-3 flex items-center justify-between gap-3 text-xs text-content-muted"
+            role="status"
+          >
+            <span>{progressLabel[progress]}</span>
+            <button
+              type="button"
+              onClick={() => controller.current?.abort()}
+              className="font-medium text-content-primary hover:underline"
+            >
+              Cancel
+            </button>
+          </div>
+        )}
+        {message && (
+          <p
+            role="status"
+            className={`mt-3 text-xs ${failed ? 'text-red-500' : 'text-content-primary'}`}
+          >
+            {message}
+          </p>
+        )}
+      </div>
+      <ConfirmDialog
+        isOpen={showWarning}
+        title="Export readable backup?"
+        description="This ZIP is plaintext and readable by anyone who can access it. It contains sensitive chats, documents, and images. Store it securely."
+        confirmLabel="I understand, create backup"
+        onConfirm={() => void createBackup()}
+        onCancel={() => setShowWarning(false)}
+      />
+    </div>
+  )
+}

--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -102,6 +102,7 @@ import { ConfirmDialog } from './components/confirm-dialog'
 import { normalizeChatFont, type ChatFont } from './hooks/use-chat-font'
 import { usePromptLibrary } from './hooks/use-prompt-library'
 import { MfaSettingsCard } from './mfa-settings-card'
+import { NativeBackupExport } from './native-backup-export'
 import {
   EMPTY_PRESET_EDITOR_STATE,
   PresetEditor,
@@ -3411,6 +3412,14 @@ ${encryptionKey.replace('key_', '')}
                         }
                       />
                     )}
+                    <NativeBackupExport
+                      available={Boolean(
+                        isSignedIn &&
+                        encryptionKey &&
+                        process.env.NEXT_PUBLIC_NATIVE_BACKUP_EXPORT_ENABLED ===
+                          'true',
+                      )}
+                    />
                   </div>
 
                   {/* Your Personal Encryption Key - Collapsible */}

--- a/src/services/native-backup/export.ts
+++ b/src/services/native-backup/export.ts
@@ -1,0 +1,86 @@
+import * as auth from '@/services/auth'
+import { SyncEnclaveError } from '@/services/sync-enclave'
+import { collectNativeBackupV1, NativeBackupCollectionError } from './collect'
+import { formatNativeBackupV1 } from './format'
+import {
+  NativeBackupWriterError,
+  writeNativeBackupArchive,
+  type NativeBackupArchiveResult,
+} from './write'
+
+export type NativeBackupExportProgress = 'collecting' | 'formatting' | 'writing'
+
+export interface NativeBackupExportDependencies {
+  collect: (signal: AbortSignal) => ReturnType<typeof collectNativeBackupV1>
+  format: typeof formatNativeBackupV1
+  write: typeof writeNativeBackupArchive
+  download: (result: NativeBackupArchiveResult) => void
+}
+
+const download = (result: NativeBackupArchiveResult) => {
+  if (result.kind !== 'blob') return
+  const url = URL.createObjectURL(result.blob)
+  const anchor = document.createElement('a')
+  anchor.href = url
+  anchor.download = result.filename
+  document.body.appendChild(anchor)
+  anchor.click()
+  anchor.remove()
+  URL.revokeObjectURL(url)
+}
+
+const defaults: NativeBackupExportDependencies = {
+  collect: (signal) => collectNativeBackupV1(undefined, signal),
+  format: formatNativeBackupV1,
+  write: writeNativeBackupArchive,
+  download,
+}
+
+export async function runNativeBackupExport(
+  signal: AbortSignal,
+  onProgress: (progress: NativeBackupExportProgress) => void,
+  dependencies: NativeBackupExportDependencies = defaults,
+): Promise<void> {
+  signal.throwIfAborted()
+  onProgress('collecting')
+  const collected = await dependencies.collect(signal)
+  signal.throwIfAborted()
+  onProgress('formatting')
+  const formatted = dependencies.format(collected)
+  signal.throwIfAborted()
+  onProgress('writing')
+  const result = await dependencies.write(formatted, { signal })
+  if (result.kind === 'blob') signal.throwIfAborted()
+  dependencies.download(result)
+}
+
+export function nativeBackupExportError(error: unknown): string {
+  if (error instanceof DOMException && error.name === 'AbortError')
+    return 'Backup canceled. No backup file was saved.'
+  if (
+    error instanceof NativeBackupWriterError &&
+    (error.code === 'compressed_limit' || error.code === 'uncompressed_limit')
+  )
+    return 'This backup is too large to save in your browser. Remove some large images or documents, then try again.'
+  if (error instanceof NativeBackupCollectionError) {
+    if (error.kind === 'limits')
+      return 'This backup is too large to create. Remove some large images or documents, then try again.'
+    if (error.kind === 'account')
+      return error.recordId === 'active'
+        ? 'Your account session is unavailable. Sign in again, then retry the backup.'
+        : 'Unlock your cloud encryption key on this device, then try again.'
+    return 'Some cloud data changed or went missing during export. Wait for Cloud Sync to finish, then try again.'
+  }
+  if (
+    error instanceof auth.AuthTokenUnavailableError ||
+    error instanceof auth.AuthTokenRefreshError ||
+    (error instanceof SyncEnclaveError && error.status === 401)
+  )
+    return 'Your account session is unavailable. Sign in again, then retry the backup.'
+  if (
+    error instanceof DOMException &&
+    (error.name === 'NotAllowedError' || error.name === 'SecurityError')
+  )
+    return 'Tinfoil could not save the backup. Allow file downloads for this site, then try again.'
+  return 'The backup could not be created. Check your connection and try again.'
+}

--- a/tests/components/native-backup-export.test.tsx
+++ b/tests/components/native-backup-export.test.tsx
@@ -1,0 +1,56 @@
+import { NativeBackupExport } from '@/components/chat/native-backup-export'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+describe('NativeBackupExport', () => {
+  it('hides export when its account, flag, or key gate is unavailable', () => {
+    render(<NativeBackupExport available={false} />)
+    expect(
+      screen.queryByRole('button', { name: 'Create Tinfoil Backup' }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('requires plaintext confirmation before export', async () => {
+    const runExport = vi.fn(async () => undefined)
+    render(<NativeBackupExport available runExport={runExport} />)
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Create Tinfoil Backup' }),
+    )
+    expect(runExport).not.toHaveBeenCalled()
+    expect(screen.getByText(/plaintext and readable/)).toHaveTextContent(
+      'sensitive chats, documents, and images',
+    )
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'I understand, create backup' }),
+    )
+    await waitFor(() => expect(runExport).toHaveBeenCalledOnce())
+    expect(await screen.findByText('Backup saved successfully.')).toBeVisible()
+  })
+
+  it('cancels an active export with its AbortController', async () => {
+    const runExport = vi.fn(
+      (signal: AbortSignal, onProgress: (value: 'collecting') => void) => {
+        onProgress('collecting')
+        return new Promise<void>((_resolve, reject) =>
+          signal.addEventListener('abort', () =>
+            reject(new DOMException('Canceled', 'AbortError')),
+          ),
+        )
+      },
+    )
+    render(<NativeBackupExport available runExport={runExport} />)
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Create Tinfoil Backup' }),
+    )
+    fireEvent.click(
+      screen.getByRole('button', { name: 'I understand, create backup' }),
+    )
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Cancel' }))
+
+    expect(await screen.findByText(/No backup file was saved/)).toBeVisible()
+    expect(runExport.mock.calls[0][0].aborted).toBe(true)
+  })
+})

--- a/tests/services/native-backup/export-cancellation.integration.test.ts
+++ b/tests/services/native-backup/export-cancellation.integration.test.ts
@@ -1,0 +1,85 @@
+import {
+  runNativeBackupExport,
+  type NativeBackupExportDependencies,
+} from '@/services/native-backup/export'
+import {
+  writeNativeBackupArchive,
+  type NativeBackupWriterDependencies,
+} from '@/services/native-backup/write'
+import { expect, it, vi } from 'vitest'
+
+const collectNativeBackupV1 = vi.hoisted(() => vi.fn())
+
+vi.mock('@/services/native-backup/collect', async (importOriginal) => ({
+  ...(await importOriginal()),
+  collectNativeBackupV1,
+}))
+
+it('propagates cancellation into the default collector', async () => {
+  const controller = new AbortController()
+  collectNativeBackupV1.mockImplementation(
+    (_dependencies: unknown, signal: AbortSignal) =>
+      new Promise((_resolve, reject) =>
+        signal.addEventListener('abort', () => reject(signal.reason), {
+          once: true,
+        }),
+      ),
+  )
+
+  const result = runNativeBackupExport(controller.signal, vi.fn())
+  await vi.waitFor(() => expect(collectNativeBackupV1).toHaveBeenCalled())
+  controller.abort()
+
+  await expect(result).rejects.toMatchObject({ name: 'AbortError' })
+  expect(collectNativeBackupV1).toHaveBeenCalledWith(
+    undefined,
+    controller.signal,
+  )
+})
+
+it('reports success when cancellation occurs during file close', async () => {
+  const controller = new AbortController()
+  const output = new WritableStream<Uint8Array>({
+    close: () => controller.abort(),
+  })
+  const writerDependencies: NativeBackupWriterDependencies = {
+    fileSystemAccessSupported: () => true,
+    createFileWritable: async () => output,
+    createBlobOutput: () => {
+      throw new Error('Blob output must not be used')
+    },
+    createZipWriter: (writable) => {
+      const writer = writable.getWriter()
+      return {
+        add: async (_path, bytes) => writer.write(bytes),
+        close: async () => writer.close(),
+      }
+    },
+    limits: {
+      file: { compressedBytes: 1024, uncompressedBytes: 1024 },
+      blob: { compressedBytes: 1024, uncompressedBytes: 1024 },
+    },
+  }
+  const download = vi.fn()
+  const dependencies = {
+    collect: async () => ({}),
+    format: () => ({
+      manifestBytes: new TextEncoder().encode(
+        '{"created_at":"2026-08-20T12:00:00.000Z"}',
+      ),
+      files: [],
+    }),
+    write: (input, options) =>
+      writeNativeBackupArchive(input, options, writerDependencies),
+    download,
+  } as NativeBackupExportDependencies
+
+  await expect(
+    runNativeBackupExport(controller.signal, vi.fn(), dependencies),
+  ).resolves.toBeUndefined()
+  expect(controller.signal.aborted).toBe(true)
+  expect(download).toHaveBeenCalledWith({
+    kind: 'file',
+    filename: 'tinfoil-backup-2026-08-20.zip',
+  })
+})

--- a/tests/services/native-backup/export.test.ts
+++ b/tests/services/native-backup/export.test.ts
@@ -1,0 +1,96 @@
+import { AuthTokenUnavailableError } from '@/services/auth'
+import { NativeBackupCollectionError } from '@/services/native-backup/collect'
+import {
+  nativeBackupExportError,
+  runNativeBackupExport,
+  type NativeBackupExportDependencies,
+} from '@/services/native-backup/export'
+import { NativeBackupWriterError } from '@/services/native-backup/write'
+import { SyncEnclaveError } from '@/services/sync-enclave'
+import { describe, expect, it, vi } from 'vitest'
+
+describe('native backup export orchestration', () => {
+  it('collects, formats, commits, and only then downloads', async () => {
+    const order: string[] = []
+    const dependencies = {
+      collect: vi.fn(async () => {
+        order.push('collect')
+        return { value: true }
+      }),
+      format: vi.fn(() => {
+        order.push('format')
+        return { manifestBytes: new Uint8Array(), files: [] }
+      }),
+      write: vi.fn(async () => {
+        order.push('write')
+        return { kind: 'file', filename: 'backup.zip' } as const
+      }),
+      download: vi.fn(() => order.push('download')),
+    } as unknown as NativeBackupExportDependencies
+    const progress: string[] = []
+
+    await runNativeBackupExport(
+      new AbortController().signal,
+      (value) => progress.push(value),
+      dependencies,
+    )
+
+    expect(order).toEqual(['collect', 'format', 'write', 'download'])
+    expect(progress).toEqual(['collecting', 'formatting', 'writing'])
+    expect(dependencies.collect).toHaveBeenCalledWith(expect.any(AbortSignal))
+  })
+
+  it('does not format or download after cancellation', async () => {
+    const controller = new AbortController()
+    const dependencies = {
+      collect: vi.fn(async () => {
+        controller.abort()
+        return {}
+      }),
+      format: vi.fn(),
+      write: vi.fn(),
+      download: vi.fn(),
+    } as unknown as NativeBackupExportDependencies
+
+    await expect(
+      runNativeBackupExport(controller.signal, vi.fn(), dependencies),
+    ).rejects.toMatchObject({ name: 'AbortError' })
+    expect(dependencies.format).not.toHaveBeenCalled()
+    expect(dependencies.download).not.toHaveBeenCalled()
+  })
+
+  it('returns actionable errors for expected failures', () => {
+    expect(
+      nativeBackupExportError(
+        new NativeBackupCollectionError('cloud chat', 'chat-1', 'missing'),
+      ),
+    ).toContain('changed or went missing')
+    expect(
+      nativeBackupExportError(
+        new NativeBackupWriterError('compressed_limit', 'too large'),
+      ),
+    ).toContain('too large')
+    expect(
+      nativeBackupExportError(new DOMException('Denied', 'NotAllowedError')),
+    ).toContain('Allow file downloads')
+    expect(
+      nativeBackupExportError(new DOMException('Canceled', 'AbortError')),
+    ).toContain('No backup file was saved')
+    expect(
+      nativeBackupExportError(
+        new NativeBackupCollectionError('account', 'active', 'unavailable'),
+      ),
+    ).toContain('Sign in again')
+    expect(
+      nativeBackupExportError(
+        new NativeBackupCollectionError('account', 'user-1', 'locked'),
+      ),
+    ).toContain('Unlock your cloud encryption key')
+    expect(
+      nativeBackupExportError(new AuthTokenUnavailableError('unavailable')),
+    ).toContain('Sign in again')
+    expect(nativeBackupExportError(new SyncEnclaveError('', 401))).toContain(
+      'Sign in again',
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- add a disabled-by-default native backup export flag
- require signed-in, unlocked state and explicit plaintext warning
- expose progress, cancellation, and structured complete-only errors

## Testing
- 1,865 unit tests
- typecheck and lint

## Rollout
Set `NEXT_PUBLIC_NATIVE_BACKUP_EXPORT_ENABLED=true` only after the stack merges and staff validation passes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a guarded native backup export that creates a plaintext ZIP of cloud and local data with progress and cancellation. Previously there was no export; now a “Create Tinfoil Backup” button appears in Settings only when signed in, the encryption key is unlocked, and `NEXT_PUBLIC_NATIVE_BACKUP_EXPORT_ENABLED` is true, with a mandatory plaintext warning and clear success/error messaging.

- Orchestrates export in three steps (collect → format → write) and only downloads after a successful write; exposes progress states and a cancel action that aborts the flow cleanly.
- Maps expected failures to actionable messages (canceled, size limits, auth/session, locked key, file permissions).
- Hides the entry point unless all gates pass; updates `.env.example`; integrates into the settings modal without affecting other settings.

**Rollout**
- Keep disabled by default. Enable by setting `NEXT_PUBLIC_NATIVE_BACKUP_EXPORT_ENABLED=true` after the stack merges and staff validation passes.
- No migrations. Users must be signed in with an unlocked key; ensure browser allows downloads.

<sup>Written for commit aeb38ee0e3ed7cfca2840ec3b47bede257988376. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/522?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

