### PR TITLE
feat: validate native backup restores

### DIFF
--- a/src/services/native-backup/format.ts
+++ b/src/services/native-backup/format.ts
@@ -96,6 +96,9 @@ const manifestSchema: z.ZodType<NativeBackupManifestV1> = strict({
   ),
 })
 
+export const parseNativeBackupManifestV1 = (bytes: Uint8Array) =>
+  manifestSchema.parse(parseJson(bytes, MANIFEST_PATH))
+
 function fail(message: string): never {
   throw new Error(`Invalid native backup: ${message}`)
 }
@@ -279,7 +282,7 @@ function exactRelations(values: string[], wanted: Set<string>, name: string) {
     fail(`${name} relationships do not match entities`)
 }
 
-function assertSemanticContent(
+export function assertSemanticContent(
   projects: NativeBackupProject[],
   documents: NativeBackupProjectDocument[],
   chats: NativeBackupChat[],

--- a/src/services/native-backup/index.ts
+++ b/src/services/native-backup/index.ts
@@ -1,6 +1,7 @@
 export * from './collect'
 export * from './constants'
 export * from './format'
+export * from './restore'
 export * from './sanitize'
 export * from './schemas'
 export * from './write'

--- a/src/services/native-backup/restore.ts
+++ b/src/services/native-backup/restore.ts
@@ -1,0 +1,494 @@
+import { uint8ArrayToBase64 } from '@/utils/binary-codec'
+import { sha256 } from '@noble/hashes/sha2.js'
+import { bytesToHex } from '@noble/hashes/utils.js'
+import {
+  BlobReader,
+  BlobWriter,
+  Uint8ArrayReader,
+  Uint8ArrayWriter,
+  ZipReader,
+  ZipWriter,
+} from '@zip.js/zip.js'
+import { NATIVE_BACKUP_ENTITY_KINDS, NATIVE_BACKUP_LIMITS } from './constants'
+import {
+  assertSemanticContent,
+  parseNativeBackupManifestV1,
+  type NativeBackupManifestV1,
+} from './format'
+import {
+  NativeBackupChatSchema,
+  NativeBackupImageSchema,
+  NativeBackupProjectDocumentSchema,
+  NativeBackupProjectSchema,
+  NativeBackupRelationshipsSchema,
+  type NativeBackupChat,
+  type NativeBackupImage,
+  type NativeBackupProject,
+  type NativeBackupProjectDocument,
+  type NativeBackupRelationships,
+} from './schemas'
+const MANIFEST_PATH = 'manifest.json'
+const MAX_MANIFEST_BYTES = 32 * 1024 * 1024
+const MAX_ENTRY_BYTES = 256 * 1024 * 1024
+const MAX_UNCOMPRESSED_BYTES = 1024 * 1024 * 1024
+const MAX_CLOUD_ENTITY_BYTES = 256 * 1024 * 1024
+const BLOB_OUTPUT_BYTES = 128 * 1024 * 1024
+const FILE_OUTPUT_BYTES = 512 * 1024 * 1024
+const encoder = new TextEncoder()
+const decoder = new TextDecoder('utf-8', { fatal: true })
+// prettier-ignore
+export type NativeRestoreEntry = { path: string; directory: boolean; encrypted: boolean; compressedSize: number; uncompressedSize: number; read(signal?: AbortSignal): Promise<{ bytes: Uint8Array; release(): void }> }
+// prettier-ignore
+export type NativeRestoreArchive = { entries: NativeRestoreEntry[]; close(): Promise<void> }
+// prettier-ignore
+export type NativeRestoreDependencies = { openArchive(file: File): Promise<NativeRestoreArchive> }
+// prettier-ignore
+export type NativeCloudImportManifestV1 = { format: 'tinfoil-native-cloud-import'; version: 1; source_backup_id: string; counts: { projects: number; documents: number; chats: number; blobs: number }; entities: Array<{ kind: 'project' | 'document' | 'chat'; source_id: string; project_source_id?: string; path: string; sha256: string; size_bytes: number }>; blobs: Array<{ path: string; sha256: string; size_bytes: number }> }
+// prettier-ignore
+export type NativeCloudUpload = { kind: 'blob'; blob: Blob; filename: string; sizeBytes: number } | { kind: 'file'; handle: FileSystemFileHandle; filename: string; sizeBytes: number; cleanup(): Promise<void> }
+// prettier-ignore
+export type NativeBackupImageSource = { metadata: NativeBackupImage; source: { file: File; path: string; sizeBytes: number; sha256: string } }
+// prettier-ignore
+export type ValidatedNativeRestore = { backup: NativeBackupManifestV1; local: { chats: NativeBackupChat[]; relationships: NativeBackupRelationships; images: NativeBackupImageSource[] }; cloud: { manifest: NativeCloudImportManifestV1; upload: NativeCloudUpload } | null }
+// prettier-ignore
+type ParsedBackup = { backup: NativeBackupManifestV1; projects: NativeBackupProject[]; documents: NativeBackupProjectDocument[]; cloudChats: NativeBackupChat[]; localChats: NativeBackupChat[]; relationships: NativeBackupRelationships; images: Array<{ metadata: NativeBackupImage; entry: NativeRestoreEntry; sha256: string }> }
+function fail(message: string): never {
+  throw new Error(`Invalid native backup restore: ${message}`)
+}
+const hash = (bytes: Uint8Array) => bytesToHex(sha256(bytes))
+const jsonBytes = (value: unknown) => encoder.encode(JSON.stringify(value))
+const idComponent = (id: string) => `id-${bytesToHex(encoder.encode(id))}`
+function parse(bytes: Uint8Array, path: string): unknown {
+  try {
+    return JSON.parse(decoder.decode(bytes))
+  } catch {
+    return fail(`${path} is not valid UTF-8 JSON`)
+  }
+}
+// prettier-ignore
+async function openZip(file: File): Promise<NativeRestoreArchive> {
+  const reader = new ZipReader(new BlobReader(file), { strictness: 'strict', useWebWorkers: false })
+  try {
+    const entries = await reader.getEntries()
+    return {
+      entries: entries.map((entry) => ({
+        path: entry.filename, directory: entry.directory, encrypted: entry.encrypted,
+        compressedSize: entry.compressedSize, uncompressedSize: entry.uncompressedSize,
+        read: async (signal) => {
+          if (entry.directory) fail('directory entries are not allowed')
+          const bytes = await entry.getData(new Uint8ArrayWriter(), {
+            signal, useWebWorkers: false,
+            onprogress: (size) => { if (size > entry.uncompressedSize) fail(`inflated entry: ${entry.filename}`) },
+          })
+          return { bytes, release: () => undefined }
+        },
+      })),
+      close: () => reader.close(),
+    }
+  } catch (error) { await reader.close(); throw error }
+}
+const defaults: NativeRestoreDependencies = { openArchive: openZip }
+function knownPath(path: string): boolean {
+  // prettier-ignore
+  return (
+    path === MANIFEST_PATH || path === 'relationships.json' || /^(projects|cloud_chats|local_chats)\/id-[0-9a-f]+\.json$/.test(path) || /^project_documents\/id-[0-9a-f]+\/id-[0-9a-f]+\.json$/.test(path) || /^images\/id-[0-9a-f]+\.(json|bin)$/.test(path)
+  )
+}
+function checkEntries(entries: NativeRestoreEntry[]) {
+  if (entries.length > NATIVE_BACKUP_LIMITS.entries)
+    fail('entry limit exceeded')
+  const byPath = new Map<string, NativeRestoreEntry>()
+  let compressed = 0
+  let uncompressed = 0
+  for (const entry of entries) {
+    if (
+      entry.directory ||
+      entry.encrypted ||
+      !knownPath(entry.path) ||
+      byPath.has(entry.path)
+    )
+      fail('archive contains an invalid, unknown, or duplicate entry')
+    // prettier-ignore
+    const limit =
+      entry.path === MANIFEST_PATH ? MAX_MANIFEST_BYTES : entry.path.endsWith('.bin') ? NATIVE_BACKUP_LIMITS.imageBytes : MAX_ENTRY_BYTES
+    if (entry.uncompressedSize > limit)
+      fail(`entry is too large: ${entry.path}`)
+    compressed += entry.compressedSize
+    uncompressed += entry.uncompressedSize
+    if (compressed > NATIVE_BACKUP_LIMITS.archiveBytes)
+      fail('compressed size limit exceeded')
+    if (uncompressed > MAX_UNCOMPRESSED_BYTES)
+      fail('uncompressed size limit exceeded')
+    byPath.set(entry.path, entry)
+  }
+  return byPath
+}
+// prettier-ignore
+async function readEntry<T>(entry: NativeRestoreEntry, expected: { size_bytes: number; sha256: string }, signal: AbortSignal | undefined, consume: (bytes: Uint8Array) => T | Promise<T>): Promise<T> {
+  signal?.throwIfAborted()
+  const retained = await entry.read(signal)
+  try {
+    if (retained.bytes.length !== entry.uncompressedSize || retained.bytes.length !== expected.size_bytes) fail(`size mismatch for ${entry.path}`)
+    if (hash(retained.bytes) !== expected.sha256) fail(`hash mismatch for ${entry.path}`)
+    return await consume(retained.bytes)
+  } finally {
+    retained.release()
+  }
+}
+async function parseArchive(
+  byPath: Map<string, NativeRestoreEntry>,
+  signal?: AbortSignal,
+): Promise<ParsedBackup> {
+  const manifestEntry = byPath.get(MANIFEST_PATH) ?? fail('manifest is missing')
+  const manifestRead = await manifestEntry.read(signal)
+  let backup: NativeBackupManifestV1
+  try {
+    if (manifestRead.bytes.length !== manifestEntry.uncompressedSize)
+      fail('manifest size mismatch')
+    backup = parseNativeBackupManifestV1(manifestRead.bytes)
+  } finally {
+    manifestRead.release()
+  }
+  const listed = new Map(backup.files.map((file) => [file.path, file]))
+  if (listed.size !== backup.files.length || listed.size + 1 !== byPath.size)
+    fail('file list mismatch')
+  let jsonSize = manifestEntry.uncompressedSize
+  for (const file of backup.files) {
+    const entry = byPath.get(file.path) ?? fail(`missing entry ${file.path}`)
+    if (entry.uncompressedSize !== file.size_bytes)
+      fail(`size mismatch for ${file.path}`)
+    if (file.path !== MANIFEST_PATH && !knownPath(file.path))
+      fail(`invalid path ${file.path}`)
+    if (!file.path.endsWith('.bin')) jsonSize += file.size_bytes
+  }
+  if (jsonSize > NATIVE_BACKUP_LIMITS.aggregateJsonBytes)
+    fail('aggregate JSON size limit exceeded')
+  for (const path of byPath.keys())
+    if (path !== MANIFEST_PATH && !listed.has(path))
+      fail(`unlisted entry ${path}`)
+  const projects: NativeBackupProject[] = []
+  const documents: NativeBackupProjectDocument[] = []
+  const cloudChats: NativeBackupChat[] = []
+  const localChats: NativeBackupChat[] = []
+  const imageMetadata: Array<{ metadata: NativeBackupImage; sha256: string }> =
+    []
+  let relationships: NativeBackupRelationships | undefined
+  for (const file of backup.files) {
+    if (file.path.endsWith('.bin')) continue
+    const entry = byPath.get(file.path)!
+    await readEntry(entry, file, signal, (bytes) => {
+      const value = parse(bytes, file.path)
+      if (file.kind === 'projects') {
+        const project = NativeBackupProjectSchema.parse(value)
+        if (file.path !== `projects/${idComponent(project.id)}.json`)
+          fail('project path mismatch')
+        projects.push(project)
+      } else if (file.kind === 'project_documents') {
+        const document = NativeBackupProjectDocumentSchema.parse(value)
+        if (
+          file.path !==
+          `project_documents/${idComponent(document.projectId)}/${idComponent(document.id)}.json`
+        )
+          fail('document path mismatch')
+        documents.push(document)
+      } else if (file.kind === 'cloud_chats' || file.kind === 'local_chats') {
+        const chat = NativeBackupChatSchema.parse(value)
+        if (file.path !== `${file.kind}/${idComponent(chat.id)}.json`)
+          fail('chat path mismatch')
+        ;(file.kind === 'cloud_chats' ? cloudChats : localChats).push(chat)
+      } else if (file.kind === 'relationships') {
+        if (relationships || file.path !== 'relationships.json')
+          fail('relationships path mismatch')
+        relationships = NativeBackupRelationshipsSchema.parse(value)
+      } else if (file.kind === 'images') {
+        const metadata = NativeBackupImageSchema.parse(value)
+        if (file.path !== `images/${idComponent(metadata.id)}.json`)
+          fail('image path mismatch')
+        const binary =
+          listed.get(`images/${idComponent(metadata.id)}.bin`) ??
+          fail('image bytes are missing')
+        imageMetadata.push({ metadata, sha256: binary.sha256 })
+      } else fail(`invalid kind for ${file.path}`)
+    })
+  }
+  const relationValue = relationships ?? fail('relationships are missing')
+  const images = imageMetadata.map(({ metadata, sha256 }) => {
+    const path = `images/${idComponent(metadata.id)}.bin`
+    const entry = byPath.get(path) ?? fail('image bytes are missing')
+    if (
+      metadata.sizeBytes !== undefined &&
+      metadata.sizeBytes !== entry.uncompressedSize
+    )
+      fail('image size mismatch')
+    return { metadata, entry, sha256 }
+  })
+  if (
+    backup.files.filter(
+      ({ kind, path }) => kind === 'images' && path.endsWith('.bin'),
+    ).length !== images.length
+  )
+    fail('image metadata is missing')
+  const allChats = [...cloudChats, ...localChats]
+  assertSemanticContent(
+    projects,
+    documents,
+    allChats,
+    relationValue,
+    images.map(({ metadata }) => metadata),
+  )
+  // prettier-ignore
+  const counts = {
+    projects: projects.length, project_documents: documents.length, cloud_chats: cloudChats.length, local_chats: localChats.length, relationships: Object.values(relationValue).reduce((sum, values) => sum + values.length, 0), images: images.length, files: backup.files.length,
+  }
+  for (const key of [...NATIVE_BACKUP_ENTITY_KINDS, 'files'] as const)
+    if (backup.counts[key] !== counts[key]) fail(`count mismatch for ${key}`)
+  if (
+    projects.length + documents.length + allChats.length >
+    NATIVE_BACKUP_LIMITS.entities
+  )
+    fail('entity limit exceeded')
+  // prettier-ignore
+  return { backup, projects, documents, cloudChats, localChats, relationships: relationValue, images }
+}
+function imageMime(bytes: Uint8Array): string | null {
+  const has = (...values: number[]) =>
+    values.every((value, index) => bytes[index] === value)
+  if (bytes.length >= 8 && has(137, 80, 78, 71, 13, 10, 26, 10))
+    return 'image/png'
+  if (bytes.length >= 3 && has(255, 216, 255)) return 'image/jpeg'
+  const text = (start: number, end: number) =>
+    decoder.decode(bytes.subarray(start, end))
+  if (bytes.length >= 6 && ['GIF87a', 'GIF89a'].includes(text(0, 6)))
+    return 'image/gif'
+  if (bytes.length >= 12 && text(0, 4) === 'RIFF' && text(8, 12) === 'WEBP')
+    return 'image/webp'
+  if (bytes.length >= 2 && has(66, 77)) return 'image/bmp'
+  return null
+}
+// prettier-ignore
+type CloudSink = { add(path: string, bytes: Uint8Array): Promise<void>; finish(): Promise<NativeCloudUpload>; abort(reason?: unknown): Promise<void> }
+async function createCloudSink(
+  backupId: string,
+  signal?: AbortSignal,
+): Promise<CloudSink> {
+  // prettier-ignore
+  const storage = navigator.storage as StorageManager & { getDirectory?: () => Promise<FileSystemDirectoryHandle> }
+  const outputName = `native-import-${backupId}-${crypto.randomUUID()}.zip`
+  let root: FileSystemDirectoryHandle | null = null
+  let handle: FileSystemFileHandle | null = null
+  let target: WritableStreamDefaultWriter<Uint8Array> | null = null
+  let committed = false
+  try {
+    root = storage?.getDirectory ? await storage.getDirectory() : null
+    handle = root
+      ? await root.getFileHandle(outputName, { create: true })
+      : null
+    const blobWriter = handle ? null : new BlobWriter('application/zip')
+    const writable = handle
+      ? await handle.createWritable()
+      : blobWriter!.writable
+    target = writable.getWriter()
+    const limit = handle ? FILE_OUTPUT_BYTES : BLOB_OUTPUT_BYTES
+    let size = 0
+    const bounded = new WritableStream<Uint8Array>({
+      async write(chunk) {
+        if (size + chunk.length > limit) fail('cloud ZIP output limit exceeded')
+        size += chunk.length
+        await target!.write(chunk)
+      },
+      abort: (reason) => target!.abort(reason),
+    })
+    const zip = new ZipWriter(bounded, {
+      bufferedWrite: false,
+      preventClose: true,
+      signal,
+      useWebWorkers: false,
+    })
+    const abort = async (reason?: unknown) => {
+      if (committed) return
+      await target!.abort(reason).catch(() => undefined)
+      if (root) await root.removeEntry(outputName).catch(() => undefined)
+    }
+    return {
+      add: async (path, bytes) => {
+        signal?.throwIfAborted()
+        await zip.add(path, new Uint8ArrayReader(bytes))
+      },
+      finish: async () => {
+        await zip.close(undefined, { preventClose: true })
+        signal?.throwIfAborted()
+        await target!.close()
+        committed = true
+        // prettier-ignore
+        if (handle) return { kind: 'file', handle, filename: 'tinfoil-cloud-import.zip', sizeBytes: size, cleanup: () => root!.removeEntry(outputName) }
+        // prettier-ignore
+        return { kind: 'blob', blob: await blobWriter!.getData(), filename: 'tinfoil-cloud-import.zip', sizeBytes: size }
+      },
+      abort,
+    }
+  } catch (error) {
+    if (target) await target.abort(error).catch(() => undefined)
+    if (root) await root.removeEntry(outputName).catch(() => undefined)
+    throw error
+  }
+}
+export async function validateAndPackageNativeBackup(
+  file: File,
+  options: {
+    signal?: AbortSignal
+    dependencies?: NativeRestoreDependencies
+  } = {},
+): Promise<ValidatedNativeRestore> {
+  if (file.size > NATIVE_BACKUP_LIMITS.archiveBytes)
+    fail('archive is too large')
+  options.signal?.throwIfAborted()
+  const archive = await (options.dependencies ?? defaults).openArchive(file)
+  let sink: CloudSink | null = null
+  try {
+    const value = await parseArchive(
+      checkEntries(archive.entries),
+      options.signal,
+    )
+    const localIds = new Set(value.localChats.map(({ id }) => id))
+    const hasCloud =
+      value.projects.length + value.documents.length + value.cloudChats.length >
+      0
+    if (hasCloud)
+      sink = await createCloudSink(value.backup.backup_id, options.signal)
+    const localImages: NativeBackupImageSource[] = []
+    const blobs: NativeCloudImportManifestV1['blobs'] = []
+    // prettier-ignore
+    const readImage = async <T>(image: ParsedBackup['images'][number], consume: (bytes: Uint8Array) => T | Promise<T>) => readEntry(image.entry, { size_bytes: image.entry.uncompressedSize, sha256: image.sha256 }, options.signal, async (bytes) => {
+      const mime = imageMime(bytes)
+      if (!mime || mime !== image.metadata.mimeType.split(';', 1)[0].trim() || !image.metadata.fileName.trim()) fail(`image is malformed: ${image.metadata.id}`)
+      return consume(bytes)
+    })
+    for (const image of value.images.filter(({ metadata }) =>
+      localIds.has(metadata.chatId),
+    )) {
+      await readImage(image, (bytes) => {
+        // prettier-ignore
+        localImages.push({ metadata: image.metadata, source: { file, path: image.entry.path, sizeBytes: bytes.length, sha256: image.sha256 } })
+      })
+    }
+    let cloud: ValidatedNativeRestore['cloud'] = null
+    if (sink) {
+      const entities: NativeCloudImportManifestV1['entities'] = []
+      let entityBytes = 0
+      const add = async (
+        kind: 'project' | 'document' | 'chat',
+        sourceId: string,
+        payload: unknown,
+        projectSourceId?: string,
+      ) => {
+        const path = `entities/${kind}/${entities.length}.json`
+        const bytes = jsonBytes(payload)
+        entityBytes += bytes.length
+        if (
+          bytes.length > MAX_CLOUD_ENTITY_BYTES ||
+          entityBytes > MAX_CLOUD_ENTITY_BYTES
+        )
+          fail('cloud entity JSON limit exceeded')
+        // prettier-ignore
+        entities.push({ kind, source_id: sourceId, ...(projectSourceId ? { project_source_id: projectSourceId } : {}), path, sha256: hash(bytes), size_bytes: bytes.length })
+        await sink!.add(path, bytes)
+      }
+      for (const project of value.projects) {
+        if (!project.name.trim()) fail('project name is empty')
+        const {
+          id,
+          createdAt: _createdAt,
+          updatedAt: _updatedAt,
+          ...payload
+        } = project
+        await add('project', id, payload)
+      }
+      for (const document of value.documents) {
+        if (!document.filename.trim() || !document.contentType.trim())
+          fail('document field is empty')
+        // prettier-ignore
+        await add('document', document.id, { filename: document.filename, contentType: document.contentType, sourceSizeBytes: document.sizeBytes, sizeBytes: document.sizeBytes, content: document.extractedText }, document.projectId)
+      }
+      for (const chat of value.cloudChats) {
+        // prettier-ignore
+        const cloudImages = new Map<string, { metadata: NativeBackupImage; path?: string; base64?: string }>()
+        for (const image of value.images.filter(
+          ({ metadata }) => metadata.chatId === chat.id,
+        ))
+          await readImage(image, async (bytes) => {
+            const direct =
+              image.metadata.page === undefined &&
+              image.metadata.legacyIndex === undefined
+            const path = direct ? `blobs/${blobs.length}` : undefined
+            if (path) {
+              blobs.push({
+                path,
+                sha256: image.sha256,
+                size_bytes: bytes.length,
+              })
+              await sink!.add(path, bytes)
+            }
+            // prettier-ignore
+            cloudImages.set(image.metadata.id, { metadata: image.metadata, path, ...(!path ? { base64: uint8ArrayToBase64(bytes) } : {}) })
+          })
+        // prettier-ignore
+        const messages = chat.messages.map((message) => ({
+          ...message,
+          imageData: message.imageData?.map(({ imageId, mimeType }) => ({ base64: cloudImages.get(imageId)?.base64 ?? fail(`missing image ${imageId}`), mimeType })),
+          attachments: message.attachments?.map((attachment) => {
+            if (attachment.type === 'image') {
+              const image = cloudImages.get(attachment.imageId) ?? fail(`missing image ${attachment.imageId}`)
+              return { id: attachment.id, type: 'image', fileName: image.metadata.fileName, mimeType: image.metadata.mimeType, fileSize: image.metadata.sizeBytes, ...(image.metadata.description ? { description: image.metadata.description } : {}), archivePath: image.path }
+            }
+            if (!attachment.fileName.trim())
+              fail('document attachment filename is empty')
+            return { ...attachment, pages: attachment.pages?.map(({ imageId, ...page }) => imageId ? { ...page, image: cloudImages.get(imageId)?.base64 ?? fail(`missing image ${imageId}`) } : page) }
+          }),
+        }))
+        const { id, projectId, messages: _messages, ...payload } = chat
+        await add(
+          'chat',
+          id,
+          { ...payload, messages, isLocalOnly: false },
+          projectId,
+        )
+      }
+      // prettier-ignore
+      const manifest: NativeCloudImportManifestV1 = {
+        format: 'tinfoil-native-cloud-import', version: 1, source_backup_id: value.backup.backup_id, counts: { projects: value.projects.length, documents: value.documents.length, chats: value.cloudChats.length, blobs: blobs.length }, entities, blobs,
+      }
+      await sink.add(MANIFEST_PATH, jsonBytes(manifest))
+      const upload = await sink.finish()
+      cloud = { manifest, upload }
+    }
+    // prettier-ignore
+    return { backup: value.backup, local: { chats: value.localChats, relationships: { projectChats: value.relationships.projectChats.filter(({ chatId }) => localIds.has(chatId)), projectDocuments: [], chatImages: value.relationships.chatImages.filter(({ chatId }) => localIds.has(chatId)) }, images: localImages }, cloud }
+  } catch (error) {
+    await sink?.abort(error)
+    options.signal?.throwIfAborted()
+    throw error
+  } finally {
+    await archive.close()
+  }
+}
+// prettier-ignore
+export async function forEachNativeBackupLocalImage(images: NativeBackupImageSource[], consume: (image: { metadata: NativeBackupImage; bytes: Uint8Array }) => void | Promise<void>, options: { signal?: AbortSignal; dependencies?: NativeRestoreDependencies } = {}): Promise<void> {
+  if (!images.length) return
+  const file = images[0].source.file
+  if (file.size > NATIVE_BACKUP_LIMITS.archiveBytes) fail('archive is too large')
+  options.signal?.throwIfAborted()
+  const archive = await (options.dependencies ?? defaults).openArchive(file)
+  try {
+    const entries = checkEntries(archive.entries)
+    for (const image of images) {
+      const source = image.source
+      if (source.file !== file || source.sizeBytes > NATIVE_BACKUP_LIMITS.imageBytes || source.path !== `images/${idComponent(image.metadata.id)}.bin`) fail('invalid local image source')
+      const entry = entries.get(source.path) ?? fail('local image entry is missing')
+      await readEntry(entry, { size_bytes: source.sizeBytes, sha256: source.sha256 }, options.signal, async (bytes) => {
+        if (imageMime(bytes) !== image.metadata.mimeType.split(';', 1)[0].trim()) fail(`image is malformed: ${image.metadata.id}`)
+        await consume({ metadata: image.metadata, bytes })
+        options.signal?.throwIfAborted()
+      })
+    }
+  } finally { await archive.close() }
+}

--- a/tests/fixtures/native-cloud-import-v1.json
+++ b/tests/fixtures/native-cloud-import-v1.json
@@ -1,0 +1,64 @@
+{
+  "source_backup_id": "123e4567-e89b-42d3-a456-426614174000",
+  "entities": [
+    {
+      "kind": "project",
+      "source_id": "project-1",
+      "payload": {
+        "name": "Research",
+        "description": "Description",
+        "systemInstructions": "Be exact",
+        "color": "#123456",
+        "memory": []
+      }
+    },
+    {
+      "kind": "document",
+      "source_id": "document-1",
+      "project_source_id": "project-1",
+      "payload": {
+        "filename": "paper.pdf",
+        "contentType": "application/pdf",
+        "sourceSizeBytes": 9000,
+        "sizeBytes": 9000,
+        "content": "Extracted text"
+      }
+    },
+    {
+      "kind": "chat",
+      "source_id": "cloud-1",
+      "project_source_id": "project-1",
+      "payload": {
+        "title": "Cloud chat",
+        "titleState": "manual",
+        "messages": [
+          {
+            "role": "user",
+            "content": "hello",
+            "attachments": [
+              {
+                "id": "cloud-image",
+                "type": "image",
+                "fileName": "photo.png",
+                "mimeType": "image/png",
+                "fileSize": 72,
+                "archivePath": "blobs/0"
+              }
+            ],
+            "timestamp": "2026-08-20T12:00:00.000Z"
+          }
+        ],
+        "createdAt": "2026-08-20T12:00:00.000Z",
+        "updatedAt": "2026-08-20T12:00:00.000Z",
+        "model": "gpt-oss-120b",
+        "isLocalOnly": false
+      }
+    }
+  ],
+  "blobs": [
+    {
+      "path": "blobs/0",
+      "base64": "iVBORw0KGgpCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJC"
+    }
+  ]
+}

--- a/tests/services/native-backup/restore.test.ts
+++ b/tests/services/native-backup/restore.test.ts
@@ -1,0 +1,460 @@
+import {
+  NATIVE_BACKUP_LIMITS,
+  forEachNativeBackupLocalImage,
+  formatNativeBackupV1,
+  validateAndPackageNativeBackup,
+  type NativeBackupFileEntry,
+  type NativeBackupFormatInput,
+  type NativeRestoreArchive,
+} from '@/services/native-backup'
+import { base64ToUint8Array } from '@/utils/binary-codec'
+import {
+  BlobReader,
+  BlobWriter,
+  Uint8ArrayReader,
+  Uint8ArrayWriter,
+  ZipReader,
+  ZipWriter,
+} from '@zip.js/zip.js'
+import contract from '../../fixtures/native-cloud-import-v1.json'
+
+const timestamp = '2026-08-20T12:00:00.000Z'
+const png = base64ToUint8Array(contract.blobs[0].base64)
+
+function backupInput(): NativeBackupFormatInput {
+  return {
+    backupId: contract.source_backup_id,
+    createdAt: timestamp,
+    projects: [
+      {
+        id: 'project-1',
+        name: 'Research',
+        description: 'Description',
+        systemInstructions: 'Be exact',
+        color: '#123456',
+        memory: [],
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      },
+    ],
+    projectDocuments: [
+      {
+        id: 'document-1',
+        projectId: 'project-1',
+        filename: 'paper.pdf',
+        contentType: 'application/pdf',
+        sizeBytes: 9000,
+        extractedText: 'Extracted text',
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      },
+    ],
+    cloudChats: [
+      {
+        id: 'cloud-1',
+        title: 'Cloud chat',
+        titleState: 'manual',
+        messages: [
+          {
+            role: 'user',
+            content: 'hello',
+            timestamp,
+            attachments: [
+              { id: 'cloud-image', type: 'image', imageId: 'cloud-image' },
+            ],
+          },
+        ],
+        createdAt: timestamp,
+        updatedAt: timestamp,
+        projectId: 'project-1',
+        model: 'gpt-oss-120b',
+      },
+    ],
+    localChats: [
+      {
+        id: 'local-1',
+        title: 'Local chat',
+        messages: [
+          {
+            role: 'user',
+            content: 'local',
+            timestamp,
+            attachments: [
+              { id: 'local-image', type: 'image', imageId: 'local-image' },
+            ],
+          },
+        ],
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      },
+    ],
+    relationships: {
+      projectChats: [{ projectId: 'project-1', chatId: 'cloud-1' }],
+      projectDocuments: [{ projectId: 'project-1', documentId: 'document-1' }],
+      chatImages: [
+        { chatId: 'cloud-1', imageId: 'cloud-image' },
+        { chatId: 'local-1', imageId: 'local-image' },
+      ],
+    },
+    images: [
+      {
+        metadata: {
+          id: 'cloud-image',
+          chatId: 'cloud-1',
+          messageIndex: 0,
+          attachmentId: 'cloud-image',
+          fileName: 'photo.png',
+          mimeType: 'image/png',
+        },
+        bytes: png,
+      },
+      {
+        metadata: {
+          id: 'local-image',
+          chatId: 'local-1',
+          messageIndex: 0,
+          attachmentId: 'local-image',
+          fileName: 'local.png',
+          mimeType: 'image/png',
+        },
+        bytes: png,
+      },
+    ],
+  }
+}
+
+async function zip(
+  manifestBytes: Uint8Array,
+  files: readonly NativeBackupFileEntry[],
+  extra: Array<[string, Uint8Array]> = [],
+) {
+  const output = new BlobWriter('application/zip')
+  const writer = new ZipWriter(output, { useWebWorkers: false })
+  for (const [path, bytes] of [
+    ['manifest.json', manifestBytes] as const,
+    ...files.map(({ path, bytes }) => [path, bytes] as const),
+    ...extra,
+  ])
+    await writer.add(path, new Uint8ArrayReader(bytes))
+  await writer.close()
+  return new File([await output.getData()], 'backup.zip', {
+    type: 'application/zip',
+  })
+}
+
+async function unzip(blob: Blob) {
+  const reader = new ZipReader(new BlobReader(blob), { useWebWorkers: false })
+  const files = new Map<string, Uint8Array>()
+  try {
+    for (const entry of await reader.getEntries()) {
+      if (!entry.directory)
+        files.set(
+          entry.filename,
+          await entry.getData(new Uint8ArrayWriter(), { useWebWorkers: false }),
+        )
+    }
+  } finally {
+    await reader.close()
+  }
+  return files
+}
+
+describe('native backup restore validation and cloud packaging', () => {
+  it('partitions local records and matches the deployed semantic contract', async () => {
+    const formatted = formatNativeBackupV1(backupInput())
+    const result = await validateAndPackageNativeBackup(
+      await zip(formatted.manifestBytes, formatted.files),
+    )
+
+    expect(result.local.chats.map(({ id }) => id)).toEqual(['local-1'])
+    expect(result.local.images.map(({ metadata }) => metadata.id)).toEqual([
+      'local-image',
+    ])
+    expect(result.local.relationships.projectChats).toEqual([])
+    expect(result.cloud?.manifest.counts).toEqual({
+      projects: 1,
+      documents: 1,
+      chats: 1,
+      blobs: 1,
+    })
+    expect(result.cloud?.upload.kind).toBe('blob')
+
+    const files = await unzip((result.cloud!.upload as { blob: Blob }).blob)
+    const semantic = {
+      source_backup_id: result.cloud!.manifest.source_backup_id,
+      entities: result.cloud!.manifest.entities.map((entity) => ({
+        kind: entity.kind,
+        source_id: entity.source_id,
+        ...(entity.project_source_id
+          ? { project_source_id: entity.project_source_id }
+          : {}),
+        payload: JSON.parse(new TextDecoder().decode(files.get(entity.path))),
+      })),
+      blobs: result.cloud!.manifest.blobs.map((blob) => ({
+        path: blob.path,
+        base64: btoa(String.fromCharCode(...files.get(blob.path)!)),
+      })),
+    }
+    expect(semantic).toEqual(contract)
+    expect(JSON.stringify(semantic)).not.toMatch(
+      /encryptionKey|codeExecutionAccessToken|syncUserId|local-1/,
+    )
+  })
+
+  it('rejects incomplete, tampered, unknown, and malformed archives', async () => {
+    const formatted = formatNativeBackupV1(backupInput())
+    const manifest = JSON.parse(
+      new TextDecoder().decode(formatted.manifestBytes),
+    )
+    manifest.complete = false
+    await expect(
+      validateAndPackageNativeBackup(
+        await zip(
+          new TextEncoder().encode(JSON.stringify(manifest)),
+          formatted.files,
+        ),
+      ),
+    ).rejects.toThrow()
+
+    const tampered = formatted.files.map((file, index) =>
+      index ? file : { ...file, bytes: new Uint8Array([1]) },
+    )
+    await expect(
+      validateAndPackageNativeBackup(
+        await zip(formatted.manifestBytes, tampered),
+      ),
+    ).rejects.toThrow('size mismatch')
+
+    await expect(
+      validateAndPackageNativeBackup(
+        await zip(formatted.manifestBytes, formatted.files, [
+          ['tmp/partial', new Uint8Array()],
+        ]),
+      ),
+    ).rejects.toThrow('invalid, unknown, or duplicate')
+
+    const malformedInput = backupInput()
+    malformedInput.images[0].bytes = new Uint8Array([0, 1, 2, 3])
+    const malformed = formatNativeBackupV1(malformedInput)
+    await expect(
+      validateAndPackageNativeBackup(
+        await zip(malformed.manifestBytes, malformed.files),
+      ),
+    ).rejects.toThrow('image is malformed')
+  })
+
+  it('checks outer and per-entry limits without calling File.arrayBuffer', async () => {
+    const arrayBuffer = vi.fn()
+    const oversized = {
+      size: NATIVE_BACKUP_LIMITS.archiveBytes + 1,
+      arrayBuffer,
+    } as unknown as File
+    await expect(validateAndPackageNativeBackup(oversized)).rejects.toThrow(
+      'archive is too large',
+    )
+    expect(arrayBuffer).not.toHaveBeenCalled()
+
+    const formatted = formatNativeBackupV1(backupInput())
+    const large = new Uint8Array(NATIVE_BACKUP_LIMITS.imageBytes + 1)
+    await expect(
+      validateAndPackageNativeBackup(
+        await zip(
+          formatted.manifestBytes,
+          formatted.files.filter(
+            ({ path }) => path !== 'images/id-636c6f75642d696d616765.bin',
+          ),
+          [['images/id-636c6f75642d696d616765.bin', large]],
+        ),
+      ),
+    ).rejects.toThrow('entry is too large')
+  })
+
+  it('releases each image before reading the next and returns source descriptors', async () => {
+    const input = backupInput()
+    input.localChats[0].messages[0].attachments!.push({
+      id: 'local-image-2',
+      type: 'image',
+      imageId: 'local-image-2',
+    })
+    input.relationships.chatImages.push({
+      chatId: 'local-1',
+      imageId: 'local-image-2',
+    })
+    input.images.push({
+      metadata: {
+        id: 'local-image-2',
+        chatId: 'local-1',
+        messageIndex: 0,
+        attachmentId: 'local-image-2',
+        fileName: 'local-2.png',
+        mimeType: 'image/png',
+      },
+      bytes: png,
+    })
+    const formatted = formatNativeBackupV1(input)
+    const source = new File([], 'backup.zip')
+    let heldImageBytes = 0
+    let peakImageBytes = 0
+    const imageReads: string[] = []
+    const values = [
+      { path: 'manifest.json', bytes: formatted.manifestBytes },
+      ...formatted.files,
+    ]
+    const archive: NativeRestoreArchive = {
+      entries: values.map(({ path, bytes }) => ({
+        path,
+        directory: false,
+        encrypted: false,
+        compressedSize: bytes.length,
+        uncompressedSize: bytes.length,
+        read: async () => {
+          const image = path.endsWith('.bin')
+          if (image) {
+            imageReads.push(path)
+            heldImageBytes += bytes.length
+            peakImageBytes = Math.max(peakImageBytes, heldImageBytes)
+          }
+          return {
+            bytes,
+            release: () => {
+              if (image) heldImageBytes -= bytes.length
+            },
+          }
+        },
+      })),
+      close: async () => undefined,
+    }
+
+    const result = await validateAndPackageNativeBackup(source, {
+      dependencies: { openArchive: async () => archive },
+    })
+
+    expect(peakImageBytes).toBe(png.length)
+    expect(heldImageBytes).toBe(0)
+    expect(result.local.images[0].source).toMatchObject({
+      file: source,
+      path: expect.stringMatching(/\.bin$/),
+      sizeBytes: png.length,
+    })
+    expect(result.local.images[0]).not.toHaveProperty('bytes')
+
+    heldImageBytes = 0
+    peakImageBytes = 0
+    imageReads.length = 0
+    const sequence: string[] = []
+    await forEachNativeBackupLocalImage(
+      result.local.images,
+      async ({ metadata, bytes }) => {
+        expect(heldImageBytes).toBe(bytes.length)
+        sequence.push(metadata.id)
+        await Promise.resolve()
+      },
+      { dependencies: { openArchive: async () => archive } },
+    )
+    expect(sequence).toEqual(['local-image', 'local-image-2'])
+    expect(imageReads).toHaveLength(2)
+    expect(peakImageBytes).toBe(png.length)
+    expect(heldImageBytes).toBe(0)
+
+    imageReads.length = 0
+    const controller = new AbortController()
+    await expect(
+      forEachNativeBackupLocalImage(
+        result.local.images,
+        () => controller.abort(),
+        {
+          signal: controller.signal,
+          dependencies: { openArchive: async () => archive },
+        },
+      ),
+    ).rejects.toMatchObject({ name: 'AbortError' })
+    expect(imageReads).toHaveLength(1)
+    expect(heldImageBytes).toBe(0)
+  })
+
+  it('removes OPFS output when setup or pre-commit cancellation fails', async () => {
+    const formatted = formatNativeBackupV1(backupInput())
+    const file = await zip(formatted.manifestBytes, formatted.files)
+    const original = Object.getOwnPropertyDescriptor(navigator, 'storage')
+    const removeEntry = vi.fn(async () => undefined)
+    const root = {
+      removeEntry,
+      getFileHandle: vi.fn(async () => ({
+        createWritable: vi.fn(async () => {
+          throw new Error('setup failed')
+        }),
+      })),
+    }
+    Object.defineProperty(navigator, 'storage', {
+      configurable: true,
+      value: { getDirectory: async () => root },
+    })
+    try {
+      await expect(validateAndPackageNativeBackup(file)).rejects.toThrow(
+        'setup failed',
+      )
+      expect(removeEntry).toHaveBeenCalledTimes(1)
+
+      removeEntry.mockClear()
+      const controller = new AbortController()
+      root.getFileHandle.mockResolvedValue({
+        createWritable: vi.fn(
+          async () =>
+            new WritableStream<Uint8Array>({
+              write() {
+                controller.abort()
+              },
+            }),
+        ),
+      })
+      await expect(
+        validateAndPackageNativeBackup(file, { signal: controller.signal }),
+      ).rejects.toMatchObject({ name: 'AbortError' })
+      expect(removeEntry).toHaveBeenCalledTimes(1)
+    } finally {
+      if (original) Object.defineProperty(navigator, 'storage', original)
+      else Reflect.deleteProperty(navigator, 'storage')
+    }
+  })
+
+  it('returns committed OPFS output when cancellation occurs during commit', async () => {
+    const formatted = formatNativeBackupV1(backupInput())
+    const file = await zip(formatted.manifestBytes, formatted.files)
+    const original = Object.getOwnPropertyDescriptor(navigator, 'storage')
+    const controller = new AbortController()
+    const removeEntry = vi.fn(async () => undefined)
+    const handle = {
+      createWritable: vi.fn(
+        async () =>
+          new WritableStream<Uint8Array>({
+            close() {
+              controller.abort()
+            },
+          }),
+      ),
+    }
+    Object.defineProperty(navigator, 'storage', {
+      configurable: true,
+      value: {
+        getDirectory: async () => ({
+          getFileHandle: async () => handle,
+          removeEntry,
+        }),
+      },
+    })
+    try {
+      const result = await validateAndPackageNativeBackup(file, {
+        signal: controller.signal,
+      })
+      expect(controller.signal.aborted).toBe(true)
+      expect(result.cloud?.upload).toMatchObject({ kind: 'file', handle })
+      expect(removeEntry).not.toHaveBeenCalled()
+      if (result.cloud?.upload.kind === 'file')
+        await result.cloud.upload.cleanup()
+      expect(removeEntry).toHaveBeenCalledTimes(1)
+    } finally {
+      if (original) Object.defineProperty(navigator, 'storage', original)
+      else Reflect.deleteProperty(navigator, 'storage')
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- stream-validate native backup archives and partition local/cloud records
- build the exact deployed confidential-sync import package
- stream local images one at a time and clean OPFS output on failure

## Testing
- 1,871 unit tests
- typecheck and lint
- compatible with confidential-sync contract fixture PR #41

## Dependency
- stacked on guarded native export UI

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validates and packages native backup restores, partitioning local data and building a cloud import ZIP that matches the v1 restore/import contract. Previously, restores were unvalidated; now we stream-validate archives, enforce limits, and ensure semantic integrity, with abort-safe output handling.

- Focus review on `src/services/native-backup/restore.ts` (new): stream-validates ZIP entries and hashes, enforces size/entity limits, validates JSON structure, partitions local vs. cloud entities, and constructs the cloud import ZIP (OPFS when available) with `manifest.json`, entities, and blobs.
- Exposes new APIs: `validateAndPackageNativeBackup` and `forEachNativeBackupLocalImage`; also exports `parseNativeBackupManifestV1` and `assertSemanticContent`. `index.ts` re-exports `restore`.
- Side effects: strict validation may reject malformed, unknown, or oversized archives; local images are read one at a time to bound memory; OPFS output is cleaned up on setup/pre-commit failures and returned on post-commit aborts.

<sup>Written for commit 8a3c6740bc7e9d702762a53fc5ca8d7bdc33b92d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/523?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

