### PR TITLE
feat: add guarded native backup restore

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,4 @@ NEXT_PUBLIC_DEV=false
 # Only necessary if local dev mode is on.
 NEXT_PUBLIC_DEV_API_KEY=your-tinfoil-api-key-here
 NEXT_PUBLIC_NATIVE_BACKUP_EXPORT_ENABLED=false
+NEXT_PUBLIC_NATIVE_BACKUP_RESTORE_ENABLED=false

--- a/src/components/chat/native-backup-restore.tsx
+++ b/src/components/chat/native-backup-restore.tsx
@@ -1,0 +1,137 @@
+// prettier-ignore
+import { NATIVE_RESTORE_KINDS,restoreNativeBackup,type NativeRestoreResult } from '@/services/native-backup/orchestrate'
+import { useEffect, useRef, useState } from 'react'
+
+export function NativeBackupRestore({
+  available,
+  ownerId,
+  onChatsUpdated,
+  runRestore = restoreNativeBackup,
+}: {
+  available?: boolean
+  ownerId?: string
+  onChatsUpdated?: () => void
+  runRestore?: typeof restoreNativeBackup
+}) {
+  const input = useRef<HTMLInputElement>(null)
+  const controller = useRef<AbortController | null>(null)
+  const started = useRef(false)
+  const dismissed = useRef(false)
+  const [busy, setBusy] = useState(false)
+  const [phase, setPhase] = useState('uploading')
+  const [result, setResult] = useState<NativeRestoreResult | null>(null)
+  const [message, setMessage] = useState<string | null>(null)
+
+  // prettier-ignore
+  useEffect(() => () => { if (!started.current) controller.current?.abort() }, [])
+
+  const restore = async (file: File) => {
+    if (!ownerId) return
+    const current = new AbortController()
+    controller.current = current
+    started.current = false
+    dismissed.current = false
+    setBusy(true)
+    setResult(null)
+    setMessage(null)
+    try {
+      const next = await runRestore(file, ownerId, current.signal, {
+        onStarted: (status) => {
+          started.current = true
+          setPhase(status.phase ?? 'running')
+        },
+        // prettier-ignore
+        onPhase: (value) => { if (!dismissed.current && value) setPhase(value) },
+      })
+      if (!dismissed.current) setResult(next)
+      if (!dismissed.current)
+        setMessage(
+          next.state === 'pending'
+            ? "The cloud restore is still running. We'll email you when it finishes. No local chats were restored; reselect this archive afterward to restore them."
+            : next.state === 'failed'
+              ? 'The cloud restore failed. No local chats were restored.'
+              : next.state === 'partial'
+                ? 'Backup restored with warnings.'
+                : 'Backup restored successfully.',
+        )
+      if (next.state === 'completed' || next.state === 'partial')
+        onChatsUpdated?.()
+    } catch (cause) {
+      if (!current.signal.aborted && !dismissed.current)
+        setMessage(cause instanceof Error ? cause.message : 'Restore failed')
+    } finally {
+      if (controller.current === current) controller.current = null
+      setBusy(false)
+      if (input.current) input.current.value = ''
+    }
+  }
+
+  if (!available) return null
+
+  return (
+    <div className="rounded-lg border border-border-subtle bg-surface-sidebar p-4">
+      <p className="font-aeonik-fono text-xs text-amber-600">
+        Warning: plaintext backup with sensitive data. Use a trusted archive.
+      </p>
+      <input
+        ref={input}
+        type="file"
+        accept=".zip,application/zip"
+        className="hidden"
+        onChange={(event) => {
+          const file = event.target.files?.[0]
+          if (file) void restore(file)
+        }}
+      />
+      <button
+        type="button"
+        disabled={busy}
+        onClick={() => input.current?.click()}
+        className="mt-3 flex w-full items-center justify-center gap-2 rounded-lg border border-border-subtle px-4 py-2.5 text-sm font-medium transition-colors hover:bg-surface-chat disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        Restore Tinfoil Backup
+      </button>
+      {busy && !dismissed.current && (
+        <div className="mt-3 flex items-center justify-between text-xs text-content-muted">
+          {/* prettier-ignore */}
+          <span>{started.current ? `Enclave restore: ${phase}...` : 'Validating and uploading...'}</span>
+          <button
+            type="button"
+            className="font-medium text-content-primary hover:underline"
+            onClick={() => {
+              if (!started.current) return controller.current?.abort()
+              dismissed.current = true
+              // prettier-ignore
+              setMessage("The enclave restore continues. We'll email you when it finishes.")
+            }}
+          >
+            {started.current ? 'Close' : 'Cancel'}
+          </button>
+        </div>
+      )}
+      {message && (
+        <p className="mt-3 text-xs text-content-primary" role="status">
+          {message}
+        </p>
+      )}
+      {result && result.state !== 'pending' && (
+        <ul className="mt-2 space-y-1 text-xs text-content-muted">
+          {NATIVE_RESTORE_KINDS.map((kind) => {
+            const value = result.report[kind]
+            return (
+              <li key={kind}>
+                {kind.replaceAll('_', ' ')}: {value.imported} imported,{' '}
+                {value.skipped} skipped, {value.failed} failed, {value.blocked}{' '}
+                blocked
+                {value.warnings.length > 0 &&
+                  `, warnings: ${value.warnings.join('; ')}`}
+                {value.errors.length > 0 &&
+                  `, errors: ${value.errors.join('; ')}`}
+              </li>
+            )
+          })}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -103,6 +103,7 @@ import { normalizeChatFont, type ChatFont } from './hooks/use-chat-font'
 import { usePromptLibrary } from './hooks/use-prompt-library'
 import { MfaSettingsCard } from './mfa-settings-card'
 import { NativeBackupExport } from './native-backup-export'
+import { NativeBackupRestore } from './native-backup-restore'
 import {
   EMPTY_PRESET_EDITOR_STATE,
   PresetEditor,
@@ -114,6 +115,8 @@ import type { Attachment, Chat } from './types'
 const CHARS = '0123456789ABCDEF!@#$%^&*()_+<>?/'
 
 const DASHBOARD_URL = 'https://dash.tinfoil.sh'
+const NATIVE_RESTORE_ENABLED =
+  process.env.NEXT_PUBLIC_NATIVE_BACKUP_RESTORE_ENABLED === 'true'
 
 const DELETE_ALL_CHATS_CONFIRM_PHRASE = 'delete all chats'
 const DELETE_ALL_PROJECTS_CONFIRM_PHRASE = 'delete all projects'
@@ -3419,6 +3422,13 @@ ${encryptionKey.replace('key_', '')}
                         process.env.NEXT_PUBLIC_NATIVE_BACKUP_EXPORT_ENABLED ===
                           'true',
                       )}
+                    />
+                    <NativeBackupRestore
+                      available={Boolean(
+                        isSignedIn && encryptionKey && NATIVE_RESTORE_ENABLED,
+                      )}
+                      ownerId={user?.id}
+                      onChatsUpdated={onChatsUpdated}
                     />
                   </div>
 

--- a/src/components/chat/types.ts
+++ b/src/components/chat/types.ts
@@ -190,6 +190,7 @@ export type Chat = {
   isBlankChat?: boolean
   // Local-only flag - true for chats that should never sync to cloud
   isLocalOnly?: boolean
+  syncUserId?: string
   // Temporary flag - true for ephemeral chats that are never persisted anywhere
   isTemporary?: boolean
   // Pending save flag - true while initial save is in progress

--- a/src/services/chat-import/off-device-import.ts
+++ b/src/services/chat-import/off-device-import.ts
@@ -41,7 +41,10 @@ async function readChunk(file: File, index: number): Promise<Uint8Array> {
   return new Uint8Array(await file.slice(start, end).arrayBuffer())
 }
 
-async function hashFileByChunk(file: File): Promise<{
+async function hashFileByChunk(
+  file: File,
+  signal?: AbortSignal,
+): Promise<{
   archiveSha256: string
   chunkSha256s: string[]
 }> {
@@ -50,6 +53,7 @@ async function hashFileByChunk(file: File): Promise<{
   const chunkSha256s: string[] = []
 
   for (let index = 0; index < totalChunks; index++) {
+    signal?.throwIfAborted()
     const chunk = await readChunk(file, index)
     archiveHash.update(chunk)
     chunkSha256s.push(bytesToHex(sha256(chunk)))
@@ -64,6 +68,7 @@ async function hashFileByChunk(file: File): Promise<{
 export async function runOffDeviceImport(
   source: ImportSource,
   file: File,
+  options: { signal?: AbortSignal } = {},
 ): Promise<OffDeviceImportResult> {
   if (file.size === 0) {
     throw new Error('The export file is empty')
@@ -72,30 +77,37 @@ export async function runOffDeviceImport(
     throw new Error('The export file is too large')
   }
 
+  const signalArg = options.signal ? ([options.signal] as const) : []
   const totalChunks = Math.ceil(file.size / IMPORT_CHUNK_BYTES)
-  const { archiveSha256, chunkSha256s } = await hashFileByChunk(file)
+  const { archiveSha256, chunkSha256s } = await hashFileByChunk(
+    file,
+    options.signal,
+  )
 
-  const { job_id, upload_id } = await importCreate({
-    source,
-    totalBytes: file.size,
-    totalChunks,
-    archiveSha256,
-  })
+  const { job_id, upload_id } = await importCreate(
+    { source, totalBytes: file.size, totalChunks, archiveSha256 },
+    ...signalArg,
+  )
 
   for (let index = 0; index < totalChunks; index++) {
+    options.signal?.throwIfAborted()
     const chunk = await readChunk(file, index)
-    await importUploadChunk({
-      uploadId: upload_id,
-      chunkIndex: index,
-      chunkSha256: chunkSha256s[index],
-      data: chunk,
-    })
+    await importUploadChunk(
+      {
+        uploadId: upload_id,
+        chunkIndex: index,
+        chunkSha256: chunkSha256s[index],
+        data: chunk,
+      },
+      ...signalArg,
+    )
   }
 
-  const status = await importStart({
-    jobId: job_id,
-    keyB64: requirePrimaryKeyB64(),
-  })
+  options.signal?.throwIfAborted()
+  const status = await importStart(
+    { jobId: job_id, keyB64: requirePrimaryKeyB64() },
+    ...signalArg,
+  )
 
   return { jobId: job_id, status }
 }

--- a/src/services/native-backup/orchestrate.ts
+++ b/src/services/native-backup/orchestrate.ts
@@ -1,0 +1,210 @@
+import type { Chat } from '@/components/chat/types'
+import { runOffDeviceImport } from '@/services/chat-import/off-device-import'
+import { chatStorage } from '@/services/storage/chat-storage'
+// prettier-ignore
+import { importStatus,type ImportStatusResponse } from '@/services/sync-enclave/sync-api'
+import { uint8ArrayToBase64 } from '@/utils/binary-codec'
+import { sha256 } from '@noble/hashes/sha2.js'
+import { bytesToHex } from '@noble/hashes/utils.js'
+import {
+  forEachNativeBackupLocalImage,
+  validateAndPackageNativeBackup,
+  type ValidatedNativeRestore,
+} from './restore'
+import type { NativeBackupImage } from './schemas'
+
+const POLL_INTERVAL_MS = 1500
+const MAX_POLL_ATTEMPTS = 20
+// prettier-ignore
+export const NATIVE_RESTORE_KINDS = ['projects', 'project_documents', 'cloud_chats', 'local_chats', 'attachments'] as const
+export type NativeRestoreKind = (typeof NATIVE_RESTORE_KINDS)[number]
+// prettier-ignore
+export type NativeRestoreCount = { imported: number; skipped: number; failed: number; blocked: number; warnings: string[]; errors: string[] }
+// prettier-ignore
+export type NativeRestoreResult = { state: 'completed' | 'partial' | 'failed' | 'pending'; jobId?: string; report: Record<NativeRestoreKind, NativeRestoreCount> }
+// prettier-ignore
+type Dependencies = { validate: typeof validateAndPackageNativeBackup; upload: typeof runOffDeviceImport; status: typeof importStatus; forEachImage: typeof forEachNativeBackupLocalImage; getChat(id: string): Promise<Chat | null>; saveChat(chat: Chat, skipCloudSync?: boolean): Promise<Chat>; wait(ms: number, signal: AbortSignal): Promise<void> }
+// prettier-ignore
+type RestoreEvents = { onStarted?(status: ImportStatusResponse): void; onPhase?(phase?: string): void }
+
+const defaults: Dependencies = {
+  validate: validateAndPackageNativeBackup,
+  upload: runOffDeviceImport,
+  status: importStatus,
+  forEachImage: forEachNativeBackupLocalImage,
+  getChat: chatStorage.getChat.bind(chatStorage),
+  saveChat: chatStorage.saveChat.bind(chatStorage),
+  wait: (ms, signal) =>
+    new Promise((resolve, reject) => {
+      const timer = window.setTimeout(resolve, ms)
+      signal.addEventListener(
+        'abort',
+        () => {
+          clearTimeout(timer)
+          reject(signal.reason)
+        },
+        { once: true },
+      )
+    }),
+}
+
+function emptyReport(): NativeRestoreResult['report'] {
+  // prettier-ignore
+  return Object.fromEntries(
+    NATIVE_RESTORE_KINDS.map((kind) => [kind, { imported: 0, skipped: 0, failed: 0, blocked: 0, warnings: [], errors: [] }]),
+  ) as unknown as NativeRestoreResult['report']
+}
+
+// prettier-ignore
+function destinationChatId(ownerId: string, backupId: string, sourceId: string) {
+  const input = new TextEncoder().encode(`${ownerId}\0${backupId}\0${sourceId}`)
+  return `native-${bytesToHex(sha256(input))}`
+}
+
+function applyImage(chat: Chat, image: NativeBackupImage, bytes: Uint8Array) {
+  const message = chat.messages[image.messageIndex]
+  const base64 = uint8ArrayToBase64(bytes)
+  if (image.legacyIndex !== undefined) {
+    message.imageData![image.legacyIndex] = { base64, mimeType: image.mimeType }
+    return
+  }
+  const index =
+    message.attachments?.findIndex(({ id }) => id === image.attachmentId) ?? -1
+  const attachment = message.attachments?.[index]
+  if (!attachment) throw new Error('Backup image attachment is missing')
+  if (image.page !== undefined) {
+    const page = attachment.pages?.find(({ page }) => page === image.page)
+    if (!page) throw new Error('Backup image page is missing')
+    page.image = base64
+  } else {
+    // prettier-ignore
+    message.attachments![index] = { id: attachment.id, type: 'image', fileName: image.fileName, mimeType: image.mimeType, fileSize: image.sizeBytes, description: image.description, base64 }
+  }
+}
+
+function applyCloudReport(
+  status: ImportStatusResponse,
+  report: NativeRestoreResult['report'],
+) {
+  // prettier-ignore
+  const aliases: Record<string, NativeRestoreKind> = { project: 'projects', document: 'project_documents', chat: 'cloud_chats' }
+  for (const [kind, outcome] of Object.entries(status.counts ?? {})) {
+    const target = aliases[kind]
+    if (target) Object.assign(report[target], outcome)
+  }
+  report.attachments.warnings.push(...(status.warnings ?? []))
+  report.cloud_chats.errors.push(...(status.errors ?? []))
+  if (status.status === 'failed' && !status.counts)
+    report.cloud_chats.failed = status.failed
+}
+
+async function restoreLocalChats(
+  validated: ValidatedNativeRestore,
+  ownerId: string,
+  projectMap: Record<string, string>,
+  report: NativeRestoreResult['report'],
+  signal: AbortSignal,
+  dependencies: Dependencies,
+) {
+  for (const source of validated.local.chats) {
+    signal.throwIfAborted()
+    const id = destinationChatId(ownerId, validated.backup.backup_id, source.id)
+    const existing = await dependencies.getChat(id)
+    if (existing) {
+      const bucket = existing.syncUserId === ownerId ? 'skipped' : 'blocked'
+      report.local_chats[bucket]++
+      // prettier-ignore
+      report.attachments[bucket] += validated.local.images.filter(({ metadata }) => metadata.chatId === source.id).length
+      continue
+    }
+    let projectId = source.projectId ? projectMap[source.projectId] : undefined
+    if (source.projectId && !projectId) {
+      report.local_chats.warnings.push(
+        `Restored "${source.title}" without its unavailable project.`,
+      )
+      projectId = undefined
+    }
+    const sourceImages = validated.local.images.filter(
+      ({ metadata }) => metadata.chatId === source.id,
+    )
+    try {
+      const chat = {
+        ...source,
+        id,
+        projectId,
+        // prettier-ignore
+        messages: source.messages.map((message) => ({ ...message, timestamp: new Date(message.timestamp), attachments: message.attachments?.map((attachment) => attachment.type === 'document' ? { ...attachment, pages: attachment.pages?.map(({ imageId: _imageId, ...page }) => ({ ...page, image: '' })) } : attachment) })),
+        createdAt: new Date(source.createdAt),
+        isLocalOnly: true,
+        syncUserId: ownerId,
+      } as unknown as Chat
+      // prettier-ignore
+      await dependencies.forEachImage(sourceImages, ({ metadata, bytes }) => applyImage(chat, metadata, bytes), { signal })
+      await dependencies.saveChat(chat, true)
+      report.local_chats.imported++
+      report.attachments.imported += sourceImages.length
+    } catch {
+      signal.throwIfAborted()
+      report.local_chats.failed++
+      report.attachments.failed += sourceImages.length
+    }
+  }
+}
+
+export async function restoreNativeBackup(
+  file: File,
+  ownerId: string,
+  signal: AbortSignal,
+  events: RestoreEvents = {},
+  dependencies: Dependencies = defaults,
+): Promise<NativeRestoreResult> {
+  if (!ownerId.trim()) throw new Error('Sign in before restoring a backup')
+  const report = emptyReport()
+  const validated = await dependencies.validate(file, { signal })
+  let status: ImportStatusResponse | null = null
+  let jobId: string | undefined
+  if (validated.cloud) {
+    const { upload } = validated.cloud
+    try {
+      // prettier-ignore
+      const packageFile = upload.kind === 'blob' ? new File([upload.blob], upload.filename, { type: 'application/zip' }) : await upload.handle.getFile()
+      const started = await dependencies.upload('tinfoil_backup', packageFile, {
+        signal,
+      })
+      jobId = started.jobId
+      status = started.status
+      events.onStarted?.(status)
+      events.onPhase?.(status.phase)
+      for (
+        let attempt = 0;
+        status.status !== 'completed' &&
+        status.status !== 'failed' &&
+        attempt < MAX_POLL_ATTEMPTS;
+        attempt++
+      ) {
+        await dependencies.wait(POLL_INTERVAL_MS, signal)
+        status = await dependencies.status(jobId, signal)
+        events.onPhase?.(status.phase)
+      }
+    } finally {
+      if (upload.kind === 'file') await upload.cleanup()
+    }
+    applyCloudReport(status!, report)
+    if (status!.status !== 'completed' && status!.status !== 'failed')
+      return { state: 'pending', jobId, report }
+    if (status!.status === 'failed') return { state: 'failed', jobId, report }
+  }
+  await restoreLocalChats(
+    validated,
+    ownerId,
+    status?.project_mappings ?? {},
+    report,
+    signal,
+    dependencies,
+  )
+  const partial = Object.values(report).some(
+    ({ failed, blocked, warnings, errors }) =>
+      failed || blocked || warnings.length || errors.length,
+  )
+  return { state: partial ? 'partial' : 'completed', jobId, report }
+}

--- a/src/services/sync-enclave/sync-api.ts
+++ b/src/services/sync-enclave/sync-api.ts
@@ -394,7 +394,7 @@ export interface SearchReindexStatusResponse {
 /*  Off-device chat import                                                    */
 /* -------------------------------------------------------------------------- */
 
-export type ImportSource = 'chatgpt' | 'claude' | 'tinfoil'
+export type ImportSource = 'chatgpt' | 'claude' | 'tinfoil' | 'tinfoil_backup'
 
 export type ImportJobStatus =
   'idle' | 'staging' | 'running' | 'completed' | 'failed'
@@ -431,10 +431,17 @@ export interface ImportStartRequest {
 
 export interface ImportStatusResponse {
   status: ImportJobStatus
+  phase?: string
   imported: number
   failed: number
   total: number
+  counts?: Record<
+    string,
+    { imported: number; skipped: number; failed: number; blocked: number }
+  >
+  warnings?: string[]
   errors?: string[]
+  project_mappings?: Record<string, string>
   job_id?: string
 }
 
@@ -446,27 +453,39 @@ export interface ImportStatusResponse {
  */
 export async function importCreate(
   req: ImportCreateRequest,
+  signal?: AbortSignal,
 ): Promise<ImportCreateResponse> {
   const client = await getSyncEnclaveClient()
-  return client.post<ImportCreateResponse>('/v1/import/create', {
-    source: req.source,
-    total_bytes: req.totalBytes,
-    total_chunks: req.totalChunks,
-    archive_sha256: req.archiveSha256,
-  })
+  return client.post<ImportCreateResponse>(
+    '/v1/import/create',
+    {
+      source: req.source,
+      total_bytes: req.totalBytes,
+      total_chunks: req.totalChunks,
+      archive_sha256: req.archiveSha256,
+    },
+    undefined,
+    { signal },
+  )
 }
 
 /** Stage one archive chunk. Replaying the same index+hash is idempotent. */
 export async function importUploadChunk(
   req: ImportUploadChunkRequest,
+  signal?: AbortSignal,
 ): Promise<OKResponse> {
   const client = await getSyncEnclaveClient()
-  return client.post<OKResponse>('/v1/import/upload', {
-    upload_id: req.uploadId,
-    chunk_index: req.chunkIndex,
-    chunk_sha256: req.chunkSha256,
-    data: bytesToB64(req.data),
-  })
+  return client.post<OKResponse>(
+    '/v1/import/upload',
+    {
+      upload_id: req.uploadId,
+      chunk_index: req.chunkIndex,
+      chunk_sha256: req.chunkSha256,
+      data: bytesToB64(req.data),
+    },
+    undefined,
+    { signal },
+  )
 }
 
 /**
@@ -476,22 +495,29 @@ export async function importUploadChunk(
  */
 export async function importStart(
   req: ImportStartRequest,
+  signal?: AbortSignal,
 ): Promise<ImportStatusResponse> {
   const client = await getSyncEnclaveClient()
-  return client.post<ImportStatusResponse>('/v1/import/start', {
-    job_id: req.jobId,
-    key: req.keyB64,
-  })
+  return client.post<ImportStatusResponse>(
+    '/v1/import/start',
+    { job_id: req.jobId, key: req.keyB64 },
+    undefined,
+    { signal },
+  )
 }
 
 /** Poll an import job's progress while the tab stays open. */
 export async function importStatus(
   jobId: string,
+  signal?: AbortSignal,
 ): Promise<ImportStatusResponse> {
   const client = await getSyncEnclaveClient()
-  const resp = await client.post<ImportStatusResponse>('/v1/import/status', {
-    job_id: jobId,
-  })
+  const resp = await client.post<ImportStatusResponse>(
+    '/v1/import/status',
+    { job_id: jobId },
+    undefined,
+    { signal },
+  )
   return { ...resp, errors: resp.errors ?? [] }
 }
 

--- a/tests/components/native-backup-restore.test.tsx
+++ b/tests/components/native-backup-restore.test.tsx
@@ -1,0 +1,162 @@
+import { NativeBackupRestore } from '@/components/chat/native-backup-restore'
+import type { NativeRestoreResult } from '@/services/native-backup/orchestrate'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+const report = {
+  projects: {
+    imported: 1,
+    skipped: 0,
+    failed: 0,
+    blocked: 0,
+    warnings: [],
+    errors: [],
+  },
+  project_documents: {
+    imported: 0,
+    skipped: 0,
+    failed: 0,
+    blocked: 0,
+    warnings: [],
+    errors: [],
+  },
+  cloud_chats: {
+    imported: 0,
+    skipped: 0,
+    failed: 0,
+    blocked: 0,
+    warnings: [],
+    errors: [],
+  },
+  local_chats: {
+    imported: 1,
+    skipped: 0,
+    failed: 0,
+    blocked: 0,
+    warnings: [],
+    errors: [],
+  },
+  attachments: {
+    imported: 0,
+    skipped: 0,
+    failed: 0,
+    blocked: 0,
+    warnings: [],
+    errors: [],
+  },
+} satisfies NativeRestoreResult['report']
+
+function selectArchive(container: HTMLElement) {
+  const input = container.querySelector('input[type="file"]')!
+  fireEvent.change(input, {
+    target: { files: [new File(['backup'], 'backup.zip')] },
+  })
+}
+
+describe('NativeBackupRestore', () => {
+  it('honors its availability gate and displays the plaintext warning', () => {
+    const { rerender } = render(
+      <NativeBackupRestore available={false} ownerId="owner" />,
+    )
+    expect(
+      screen.queryByRole('button', { name: 'Restore Tinfoil Backup' }),
+    ).not.toBeInTheDocument()
+    rerender(<NativeBackupRestore available ownerId="owner" />)
+    expect(screen.getByText(/plaintext backup/)).toBeVisible()
+  })
+
+  it('reports partial restores by kind without unqualified success', async () => {
+    const runRestore = vi.fn(async () => ({
+      state: 'partial' as const,
+      report: {
+        ...report,
+        attachments: {
+          ...report.attachments,
+          warnings: ['thumbnail unavailable'],
+        },
+      },
+    }))
+    const updated = vi.fn()
+    const { container } = render(
+      <NativeBackupRestore
+        available
+        ownerId="owner"
+        runRestore={runRestore}
+        onChatsUpdated={updated}
+      />,
+    )
+    selectArchive(container)
+
+    expect(
+      await screen.findByText('Backup restored with warnings.'),
+    ).toBeVisible()
+    expect(
+      screen.getByText(/attachments:.*thumbnail unavailable/i),
+    ).toBeVisible()
+    expect(screen.queryByText('Backup restored successfully.')).toBeNull()
+    expect(updated).toHaveBeenCalledOnce()
+  })
+
+  it('explains pending local restore and allows cancellation', async () => {
+    const runRestore = vi.fn(
+      (_file: File, _owner: string, signal: AbortSignal) =>
+        new Promise<NativeRestoreResult>((resolve, reject) => {
+          signal.addEventListener('abort', () => reject(signal.reason))
+          queueMicrotask(() => resolve({ state: 'pending', report }))
+        }),
+    )
+    const first = render(
+      <NativeBackupRestore available ownerId="owner" runRestore={runRestore} />,
+    )
+    selectArchive(first.container)
+    expect(
+      await screen.findByText(/No local chats were restored/),
+    ).toHaveTextContent('reselect this archive')
+
+    const neverFinishes = vi.fn(
+      (_file: File, _owner: string, signal: AbortSignal) =>
+        new Promise<NativeRestoreResult>((_resolve, reject) =>
+          signal.addEventListener('abort', () => reject(signal.reason)),
+        ),
+    )
+    first.unmount()
+    const second = render(
+      <NativeBackupRestore
+        available
+        ownerId="owner"
+        runRestore={neverFinishes}
+      />,
+    )
+    selectArchive(second.container)
+    fireEvent.click(await screen.findByRole('button', { name: 'Cancel' }))
+    await waitFor(() =>
+      expect(neverFinishes.mock.calls[0][2].aborted).toBe(true),
+    )
+  })
+
+  it('closes without aborting after the enclave restore starts', async () => {
+    let finish!: (result: NativeRestoreResult) => void
+    const runRestore = vi.fn(
+      (
+        _file: File,
+        _owner: string,
+        _signal: AbortSignal,
+        events: { onStarted(status: any): void },
+      ) => {
+        events.onStarted({ status: 'running', phase: 'projects' })
+        return new Promise<NativeRestoreResult>((resolve) => (finish = resolve))
+      },
+    )
+    const { container } = render(
+      <NativeBackupRestore available ownerId="owner" runRestore={runRestore} />,
+    )
+    selectArchive(container)
+    fireEvent.click(await screen.findByRole('button', { name: 'Close' }))
+
+    expect(runRestore.mock.calls[0][2].aborted).toBe(false)
+    expect(screen.getByText(/enclave restore continues/i)).toHaveTextContent(
+      "We'll email you",
+    )
+    finish({ state: 'pending', report })
+  })
+})

--- a/tests/fixtures/native-backup-import-status.json
+++ b/tests/fixtures/native-backup-import-status.json
@@ -1,0 +1,16 @@
+{
+  "status": "completed",
+  "phase": "complete",
+  "imported": 3,
+  "failed": 1,
+  "total": 5,
+  "counts": {
+    "project": { "imported": 1, "skipped": 0, "failed": 0, "blocked": 0 },
+    "document": { "imported": 1, "skipped": 0, "failed": 0, "blocked": 1 },
+    "chat": { "imported": 1, "skipped": 0, "failed": 1, "blocked": 0 }
+  },
+  "warnings": ["attachment omitted"],
+  "errors": ["chat failed"],
+  "project_mappings": { "source-project": "destination-project" },
+  "job_id": "job-1"
+}

--- a/tests/services/native-backup/orchestrate.test.ts
+++ b/tests/services/native-backup/orchestrate.test.ts
@@ -1,0 +1,299 @@
+import { restoreNativeBackup } from '@/services/native-backup/orchestrate'
+import type { ValidatedNativeRestore } from '@/services/native-backup/restore'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const sourceFile = new File(['plaintext'], 'backup.zip')
+const cloudFile = new File(['cloud-only'], 'cloud.zip')
+const localChat = {
+  id: 'source-chat',
+  title: 'Local chat',
+  messages: [
+    {
+      role: 'user' as const,
+      content: 'hello',
+      timestamp: '2026-01-01T00:00:00.000Z',
+    },
+  ],
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  projectId: 'source-project',
+}
+
+function validated(cloud = true): ValidatedNativeRestore {
+  return {
+    backup: { backup_id: 'backup-1' } as ValidatedNativeRestore['backup'],
+    local: {
+      chats: [localChat],
+      relationships: {
+        projectChats: [{ projectId: 'source-project', chatId: 'source-chat' }],
+        projectDocuments: [],
+        chatImages: [],
+      },
+      images: [],
+    },
+    cloud: cloud
+      ? {
+          manifest: {
+            format: 'tinfoil-native-cloud-import',
+            version: 1,
+            source_backup_id: 'backup-1',
+            counts: { projects: 1, documents: 0, chats: 0, blobs: 0 },
+            entities: [],
+            blobs: [],
+          },
+          upload: {
+            kind: 'blob',
+            blob: cloudFile,
+            filename: 'cloud.zip',
+            sizeBytes: cloudFile.size,
+          },
+        }
+      : null,
+  }
+}
+
+describe('restoreNativeBackup', () => {
+  let saveChat: ReturnType<typeof vi.fn>
+  let dependencies: any
+
+  beforeEach(() => {
+    saveChat = vi.fn(async (chat) => chat)
+    dependencies = {
+      validate: vi.fn(async () => validated()),
+      upload: vi.fn(async () => ({
+        jobId: 'job-1',
+        status: {
+          status: 'completed',
+          imported: 1,
+          failed: 0,
+          total: 1,
+          project_mappings: { 'source-project': 'destination-project' },
+        },
+      })),
+      status: vi.fn(),
+      forEachImage: vi.fn(async () => undefined),
+      getChat: vi.fn(async () => null),
+      saveChat,
+      wait: vi.fn(async () => undefined),
+    }
+  })
+
+  it('uploads only the cloud package and restores local chats with mapped projects', async () => {
+    const result = await restoreNativeBackup(
+      sourceFile,
+      'destination-owner',
+      new AbortController().signal,
+      {},
+      dependencies,
+    )
+
+    expect(dependencies.upload).toHaveBeenCalledWith(
+      'tinfoil_backup',
+      expect.objectContaining({ name: 'cloud.zip' }),
+      expect.any(Object),
+    )
+    expect(dependencies.upload.mock.calls[0][1]).not.toBe(sourceFile)
+    expect(saveChat.mock.calls[0][0]).toMatchObject({
+      projectId: 'destination-project',
+      syncUserId: 'destination-owner',
+      isLocalOnly: true,
+    })
+    expect(result.state).toBe('completed')
+  })
+
+  it('uses deterministic owner-scoped IDs and skips an existing owner row', async () => {
+    dependencies.validate.mockResolvedValue(validated(false))
+    await restoreNativeBackup(
+      sourceFile,
+      'owner-a',
+      new AbortController().signal,
+      {},
+      dependencies,
+    )
+    const id = saveChat.mock.calls[0][0].id
+    dependencies.getChat.mockResolvedValue({ id, syncUserId: 'owner-a' })
+    const result = await restoreNativeBackup(
+      sourceFile,
+      'owner-a',
+      new AbortController().signal,
+      {},
+      dependencies,
+    )
+    dependencies.getChat.mockResolvedValue(null)
+    await restoreNativeBackup(
+      sourceFile,
+      'owner-b',
+      new AbortController().signal,
+      {},
+      dependencies,
+    )
+
+    expect(result.report.local_chats.skipped).toBe(1)
+    expect(saveChat.mock.calls[1][0].id).not.toBe(id)
+  })
+
+  it('uses service counts for an idempotent cloud restore', async () => {
+    dependencies.upload.mockResolvedValue({
+      jobId: 'job-1',
+      status: {
+        status: 'completed',
+        imported: 0,
+        failed: 0,
+        total: 1,
+        counts: {
+          project: { imported: 0, skipped: 1, failed: 0, blocked: 0 },
+        },
+      },
+    })
+
+    const result = await restoreNativeBackup(
+      sourceFile,
+      'owner-a',
+      new AbortController().signal,
+      {},
+      dependencies,
+    )
+
+    expect(result.report.projects).toMatchObject({ imported: 0, skipped: 1 })
+  })
+
+  it('streams local images and counts attachments after each chat outcome', async () => {
+    const value = validated(false)
+    value.local.chats[0].messages[0].attachments = [
+      { id: 'attachment-1', type: 'image', imageId: 'image-1' },
+      { id: 'attachment-2', type: 'image', imageId: 'image-2' },
+    ]
+    value.local.images = [1, 2].map((number) => ({
+      metadata: {
+        id: `image-${number}`,
+        chatId: 'source-chat',
+        messageIndex: 0,
+        attachmentId: `attachment-${number}`,
+        fileName: `image-${number}.png`,
+        mimeType: 'image/png',
+      },
+      source: {
+        file: sourceFile,
+        path: `image-${number}`,
+        sizeBytes: 1,
+        sha256: 'hash',
+      },
+    }))
+    dependencies.validate.mockResolvedValue(value)
+    let active = 0
+    let peak = 0
+    dependencies.forEachImage.mockImplementation(
+      async (images: any[], consume: any) => {
+        for (const image of images) {
+          active++
+          peak = Math.max(peak, active)
+          await consume({
+            metadata: image.metadata,
+            bytes: new Uint8Array([image.metadata.id === 'image-1' ? 1 : 2]),
+          })
+          active--
+        }
+      },
+    )
+
+    const imported = await restoreNativeBackup(
+      sourceFile,
+      'owner-a',
+      new AbortController().signal,
+      {},
+      dependencies,
+    )
+    const id = saveChat.mock.calls[0][0].id
+    dependencies.getChat.mockResolvedValue({ id, syncUserId: 'owner-a' })
+    const skipped = await restoreNativeBackup(
+      sourceFile,
+      'owner-a',
+      new AbortController().signal,
+      {},
+      dependencies,
+    )
+    dependencies.getChat.mockResolvedValue(null)
+    saveChat.mockRejectedValueOnce(new Error('save failed'))
+    const failed = await restoreNativeBackup(
+      sourceFile,
+      'owner-b',
+      new AbortController().signal,
+      {},
+      dependencies,
+    )
+
+    expect(peak).toBe(1)
+    expect(saveChat.mock.calls[0][0].messages[0].attachments).toMatchObject([
+      { id: 'attachment-1', base64: 'AQ==' },
+      { id: 'attachment-2', base64: 'Ag==' },
+    ])
+    expect(imported.report.attachments.imported).toBe(2)
+    expect(skipped.report.attachments.skipped).toBe(2)
+    expect(failed.report.attachments.failed).toBe(2)
+    expect(dependencies.forEachImage).toHaveBeenCalledTimes(2)
+  })
+
+  it.each(['running', 'failed'] as const)(
+    'does not restore local chats when the cloud job is %s',
+    async (status) => {
+      dependencies.upload.mockResolvedValue({
+        jobId: 'job-1',
+        status: { status, imported: 0, failed: 0, total: 1 },
+      })
+      dependencies.status.mockResolvedValue({
+        status,
+        imported: 0,
+        failed: status === 'failed' ? 1 : 0,
+        total: 1,
+      })
+
+      const result = await restoreNativeBackup(
+        sourceFile,
+        'owner-a',
+        new AbortController().signal,
+        {},
+        dependencies,
+      )
+
+      expect(result.state).toBe(status === 'running' ? 'pending' : 'failed')
+      expect(saveChat).not.toHaveBeenCalled()
+    },
+  )
+
+  it('detaches chats from failed projects and treats warnings as partial', async () => {
+    dependencies.upload.mockResolvedValue({
+      jobId: 'job-1',
+      status: {
+        status: 'completed',
+        imported: 0,
+        failed: 1,
+        total: 1,
+        counts: {
+          chat: { imported: 0, skipped: 0, failed: 1, blocked: 0 },
+        },
+        warnings: ['thumbnail unavailable'],
+        errors: ['chat failed'],
+        phase: 'complete',
+      },
+    })
+
+    const onPhase = vi.fn()
+    const result = await restoreNativeBackup(
+      sourceFile,
+      'owner-a',
+      new AbortController().signal,
+      { onPhase },
+      dependencies,
+    )
+
+    expect(saveChat.mock.calls[0][0].projectId).toBeUndefined()
+    expect(result.report.local_chats.warnings).toHaveLength(1)
+    expect(result.report.cloud_chats.failed).toBe(1)
+    expect(result.report.cloud_chats.errors).toEqual(['chat failed'])
+    expect(result.report.attachments.warnings).toEqual([
+      'thumbnail unavailable',
+    ])
+    expect(onPhase).toHaveBeenCalledWith('complete')
+    expect(result.state).toBe('partial')
+  })
+})

--- a/tests/services/sync-enclave/import-status-contract.test.ts
+++ b/tests/services/sync-enclave/import-status-contract.test.ts
@@ -1,0 +1,29 @@
+import type { ImportStatusResponse } from '@/services/sync-enclave/sync-api'
+import { describe, expect, it } from 'vitest'
+import fixture from '../../fixtures/native-backup-import-status.json'
+
+describe('native backup import status contract', () => {
+  it('matches the confidential-sync response exactly', () => {
+    const status = fixture as ImportStatusResponse
+    expect(Object.keys(status)).toEqual([
+      'status',
+      'phase',
+      'imported',
+      'failed',
+      'total',
+      'counts',
+      'warnings',
+      'errors',
+      'project_mappings',
+      'job_id',
+    ])
+    expect(Object.keys(status.counts ?? {})).toEqual([
+      'project',
+      'document',
+      'chat',
+    ])
+    expect(status.project_mappings).toEqual({
+      'source-project': 'destination-project',
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- add disabled-by-default native restore orchestration and settings UI
- restore cloud data through the enclave and local chats only after authoritative mappings
- report terminal, pending, partial, and attachment-warning outcomes accurately

## Testing
- 1,883 unit tests
- typecheck and lint

## Rollout
Set `NEXT_PUBLIC_NATIVE_BACKUP_RESTORE_ENABLED=true` only after export validation and confidential-sync fixture PR #41.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a disabled-by-default native backup restore flow with a settings UI. Previously restore was unavailable; now users can upload a `.zip`, the app restores cloud data through the sync enclave, then restores local-only chats once server project mappings are available, reporting pending/partial/failed outcomes and attachment warnings.

- Uses deterministic chat IDs scoped to owner and backup; existing owner rows are skipped, mismatched rows are blocked. Local chats are saved as `isLocalOnly` with `syncUserId`.
- Uploads a packaged cloud import as source `tinfoil_backup`, polls `/import/status`, merges `counts`, `warnings`, `errors`, and `project_mappings` into a per-kind report.
- Aborts pre-start uploads on cancel; after the enclave job starts, Close only dismisses UI while the job continues. Local restore runs only on completed cloud imports; pending returns early with guidance.

**Review notes**
- UI: new `NativeBackupRestore` in settings, gated by `NEXT_PUBLIC_NATIVE_BACKUP_RESTORE_ENABLED`. Shows plaintext warning, progress phase, per-kind results.
- Orchestration: `restoreNativeBackup` validates, uploads, polls, applies server counts, then restores local chats with mapped projects; streams and applies images per message/attachment/page.
- API: `ImportSource` adds `tinfoil_backup`. `importCreate`, `importUploadChunk`, `importStart`, and `importStatus` accept `AbortSignal`. `ImportStatusResponse` adds `phase`, `counts`, `warnings`, and `project_mappings`.
- Types/storage: `Chat` adds optional `syncUserId` to mark restored local chats. No data migration required.

**Rollout**
- Keep `NEXT_PUBLIC_NATIVE_BACKUP_RESTORE_ENABLED=false`. Enable only after the sync API supports `tinfoil_backup` with `phase`, `counts`, and `project_mappings`, and export validation is in place.

<sup>Written for commit db2d4244873b6d44262cbf8ef6d6cb14c7e5e2e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/524?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

