### PR TITLE
feat: define native backup schema

### DIFF
--- a/src/services/native-backup/constants.ts
+++ b/src/services/native-backup/constants.ts
@@ -1,0 +1,13 @@
+export const NATIVE_BACKUP_FORMAT = 'tinfoil-native-backup' as const
+export const NATIVE_BACKUP_VERSION = 1 as const
+
+export const NATIVE_BACKUP_ENTITY_KINDS = [
+  'projects',
+  'project_documents',
+  'cloud_chats',
+  'local_chats',
+  'relationships',
+  'images',
+] as const
+
+export type NativeBackupEntityKind = (typeof NATIVE_BACKUP_ENTITY_KINDS)[number]

--- a/src/services/native-backup/image-mime.ts
+++ b/src/services/native-backup/image-mime.ts
@@ -1,0 +1,22 @@
+import type { NATIVE_BACKUP_IMAGE_MIME_TYPES } from './schemas'
+
+export type NativeBackupImageMimeType =
+  (typeof NATIVE_BACKUP_IMAGE_MIME_TYPES)[number]
+
+export function detectNativeBackupImageMimeType(
+  bytes: Uint8Array,
+): NativeBackupImageMimeType | null {
+  const has = (...values: number[]) =>
+    values.every((value, index) => bytes[index] === value)
+  if (bytes.length >= 8 && has(137, 80, 78, 71, 13, 10, 26, 10))
+    return 'image/png'
+  if (bytes.length >= 3 && has(255, 216, 255)) return 'image/jpeg'
+  const text = (start: number, end: number) =>
+    String.fromCharCode(...bytes.subarray(start, end))
+  if (bytes.length >= 6 && ['GIF87a', 'GIF89a'].includes(text(0, 6)))
+    return 'image/gif'
+  if (bytes.length >= 12 && text(0, 4) === 'RIFF' && text(8, 12) === 'WEBP')
+    return 'image/webp'
+  if (bytes.length >= 2 && has(66, 77)) return 'image/bmp'
+  return null
+}

--- a/src/services/native-backup/index.ts
+++ b/src/services/native-backup/index.ts
@@ -1,3 +1,4 @@
 export * from './constants'
+export * from './image-mime'
 export * from './sanitize'
 export * from './schemas'

--- a/src/services/native-backup/index.ts
+++ b/src/services/native-backup/index.ts
@@ -1,0 +1,3 @@
+export * from './constants'
+export * from './sanitize'
+export * from './schemas'

--- a/src/services/native-backup/sanitize.ts
+++ b/src/services/native-backup/sanitize.ts
@@ -53,6 +53,10 @@ const iso = (value: unknown): string => {
     throw new Error('Invalid backup timestamp')
   return parsed.toISOString()
 }
+const imageMimeType = (value: unknown) =>
+  schemas.NativeBackupImageMimeSchema.parse(
+    String(value).split(';', 1)[0].trim().toLowerCase(),
+  )
 
 export function sanitizeNativeBackupProject(value: unknown) {
   const source = row(value)
@@ -153,9 +157,13 @@ function cleanAttachments(
           attachmentIndex,
           attachmentId,
           fileName: String(attachment.fileName),
-          mimeType: String(attachment.mimeType ?? 'application/octet-stream'),
+          mimeType: imageMimeType(
+            attachment.mimeType ?? 'application/octet-stream',
+          ),
           sizeBytes:
-            typeof attachment.fileSize === 'number'
+            typeof attachment.fileSize === 'number' &&
+            Number.isInteger(attachment.fileSize) &&
+            attachment.fileSize >= 0
               ? attachment.fileSize
               : undefined,
           description:
@@ -234,9 +242,9 @@ function cleanMessage(
           messageIndex,
           legacyIndex,
           fileName: `legacy-image-${legacyIndex}`,
-          mimeType: String(image.mimeType),
+          mimeType: imageMimeType(image.mimeType),
         }),
-        mimeType: image.mimeType,
+        mimeType: imageMimeType(image.mimeType),
       }
     }),
     timestamp: iso(source.timestamp),

--- a/src/services/native-backup/sanitize.ts
+++ b/src/services/native-backup/sanitize.ts
@@ -11,6 +11,7 @@ export interface NativeBackupImageCandidate {
   legacyIndex?: number
   fileName: string
   mimeType: string
+  sizeBytes?: number
   description?: string
 }
 export type NativeBackupImageCollector = (
@@ -39,6 +40,12 @@ const pick = (source: Row, keys: readonly string[]): Row =>
       .map((key) => [key, source[key]]),
   )
 const iso = (value: unknown): string => {
+  if (
+    !(value instanceof Date) &&
+    typeof value !== 'string' &&
+    typeof value !== 'number'
+  )
+    throw new Error('Invalid backup timestamp')
   const parsed =
     value instanceof Date ? value : new Date(value as string | number)
   if (Number.isNaN(parsed.getTime()))
@@ -127,18 +134,28 @@ function cleanAttachments(
   messageIndex: number,
   collectImage: NativeBackupImageCollector,
 ) {
-  return rows(value).map((attachment) => {
+  return rows(value).map((attachment, attachmentIndex) => {
     const attachmentId = String(attachment.id)
     if (attachment.type === 'image') {
       return {
         ...pick(attachment, keys('id type')),
         imageId: collectImage({
-          sourceKey: `attachment:${chatId}:${messageIndex}:${attachmentId}`,
+          sourceKey: JSON.stringify([
+            'attachment',
+            chatId,
+            messageIndex,
+            attachmentIndex,
+            attachmentId,
+          ]),
           chatId,
           messageIndex,
           attachmentId,
           fileName: String(attachment.fileName),
           mimeType: String(attachment.mimeType ?? 'application/octet-stream'),
+          sizeBytes:
+            typeof attachment.fileSize === 'number'
+              ? attachment.fileSize
+              : undefined,
           description:
             typeof attachment.description === 'string'
               ? attachment.description
@@ -151,14 +168,22 @@ function cleanAttachments(
         attachment,
         keys('id type fileName mimeType textContent description fileSize'),
       ),
-      pages: list(attachment.pages, (value) => {
+      pages: list(attachment.pages, (value, pageIndex) => {
         const page = row(value)
         const pageNumber = Number(page.page)
         return {
           ...pick(page, keys('page text is_scanned')),
           imageId: page.image
             ? collectImage({
-                sourceKey: `page:${chatId}:${messageIndex}:${attachmentId}:${pageNumber}`,
+                sourceKey: JSON.stringify([
+                  'page',
+                  chatId,
+                  messageIndex,
+                  attachmentIndex,
+                  attachmentId,
+                  pageIndex,
+                  pageNumber,
+                ]),
                 chatId,
                 messageIndex,
                 attachmentId,

--- a/src/services/native-backup/sanitize.ts
+++ b/src/services/native-backup/sanitize.ts
@@ -1,0 +1,287 @@
+import * as schemas from './schemas'
+
+type Row = Record<string, unknown>
+type Cleaner = (value: unknown, index: number) => unknown
+export interface NativeBackupImageCandidate {
+  sourceKey: string
+  chatId: string
+  messageIndex: number
+  attachmentId?: string
+  page?: number
+  legacyIndex?: number
+  fileName: string
+  mimeType: string
+  description?: string
+}
+export type NativeBackupImageCollector = (
+  candidate: NativeBackupImageCandidate,
+) => string
+
+function row(value: unknown): Row {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('Native backup records must be objects')
+  }
+  return value as Row
+}
+function rows(value: unknown): Row[] {
+  if (value === undefined) return []
+  if (!Array.isArray(value))
+    throw new Error('Native backup collections must be arrays')
+  return value.map(row)
+}
+const list = (value: unknown, clean: Cleaner) =>
+  value === undefined ? undefined : rows(value).map(clean)
+const keys = (value: string) => value.split(' ')
+const pick = (source: Row, keys: readonly string[]): Row =>
+  Object.fromEntries(
+    keys
+      .filter((key) => source[key] !== undefined)
+      .map((key) => [key, source[key]]),
+  )
+const iso = (value: unknown): string => {
+  const parsed =
+    value instanceof Date ? value : new Date(value as string | number)
+  if (Number.isNaN(parsed.getTime()))
+    throw new Error('Invalid backup timestamp')
+  return parsed.toISOString()
+}
+
+export function sanitizeNativeBackupProject(value: unknown) {
+  const source = row(value)
+  return schemas.NativeBackupProjectSchema.parse({
+    ...pick(source, keys('id name color')),
+    description: source.description ?? '',
+    systemInstructions: source.systemInstructions ?? '',
+    memory: rows(source.memory).map((value) => {
+      const fact = row(value)
+      return {
+        ...pick(fact, keys('id fact category confidence')),
+        date: iso(fact.date),
+      }
+    }),
+    createdAt: iso(source.createdAt),
+    updatedAt: iso(source.updatedAt),
+  })
+}
+
+export function sanitizeNativeBackupProjectDocument(value: unknown) {
+  const source = row(value)
+  return schemas.NativeBackupProjectDocumentSchema.parse({
+    ...pick(source, keys('id projectId filename contentType sizeBytes')),
+    extractedText: source.content ?? source.extractedText ?? '',
+    createdAt: iso(source.createdAt),
+    updatedAt: iso(source.updatedAt),
+  })
+}
+
+const cleanSource = (value: unknown) => pick(row(value), keys('title url'))
+const cleanFetch = (value: unknown) => pick(row(value), keys('id url status'))
+const cleanCodeCall = (value: unknown) =>
+  pick(row(value), keys('id toolName arguments status output'))
+const cleanSearch = (value: unknown) => {
+  const source = row(value)
+  return {
+    ...pick(source, keys('query status reason')),
+    sources: list(source.sources, cleanSource),
+  }
+}
+const cleanCitation = (value: unknown) => {
+  const source = row(value)
+  return {
+    type: source.type,
+    url_citation: pick(
+      row(source.url_citation),
+      keys('title url start_index end_index'),
+    ),
+  }
+}
+const timelineFields: Record<string, readonly string[]> = {
+  thinking: keys('type id content isThinking duration'),
+  web_search: keys('type id'),
+  url_fetches: keys('type id'),
+  content: keys('type id content'),
+  code_exec: keys('type id'),
+  tool_call: keys('type id toolCallId name arguments resolvedAt'),
+}
+function cleanTimeline(value: unknown): unknown {
+  const source = row(value)
+  const fields = timelineFields[String(source.type)]
+  if (!fields) throw new Error('Unsupported native backup timeline block')
+  const output = pick(source, fields)
+  if (source.type === 'web_search') output.state = cleanSearch(source.state)
+  if (source.type === 'url_fetches') {
+    output.fetches = rows(source.fetches).map(cleanFetch)
+  }
+  if (source.type === 'code_exec') {
+    output.calls = rows(source.calls).map(cleanCodeCall)
+  }
+  if (source.type === 'tool_call' && source.resolution !== undefined) {
+    output.resolution = pick(row(source.resolution), keys('text data'))
+  }
+  return output
+}
+
+function cleanAttachments(
+  value: unknown,
+  chatId: string,
+  messageIndex: number,
+  collectImage: NativeBackupImageCollector,
+) {
+  return rows(value).map((attachment) => {
+    const attachmentId = String(attachment.id)
+    if (attachment.type === 'image') {
+      return {
+        ...pick(attachment, keys('id type')),
+        imageId: collectImage({
+          sourceKey: `attachment:${chatId}:${messageIndex}:${attachmentId}`,
+          chatId,
+          messageIndex,
+          attachmentId,
+          fileName: String(attachment.fileName),
+          mimeType: String(attachment.mimeType ?? 'application/octet-stream'),
+          description:
+            typeof attachment.description === 'string'
+              ? attachment.description
+              : undefined,
+        }),
+      }
+    }
+    return {
+      ...pick(
+        attachment,
+        keys('id type fileName mimeType textContent description fileSize'),
+      ),
+      pages: list(attachment.pages, (value) => {
+        const page = row(value)
+        const pageNumber = Number(page.page)
+        return {
+          ...pick(page, keys('page text is_scanned')),
+          imageId: page.image
+            ? collectImage({
+                sourceKey: `page:${chatId}:${messageIndex}:${attachmentId}:${pageNumber}`,
+                chatId,
+                messageIndex,
+                attachmentId,
+                page: pageNumber,
+                fileName: `${attachmentId}-page-${pageNumber}.jpg`,
+                mimeType: 'image/jpeg',
+              })
+            : undefined,
+        }
+      }),
+    }
+  })
+}
+
+const messageFields = keys(
+  'role content turnId modelDisplayName documentContent multimodalText thoughts isThinking thinkingDuration isError isRateLimitError isHourlyRateLimitError webSearchBeforeThinking searchReasoning quote',
+)
+function cleanMessage(
+  value: unknown,
+  chatId: string,
+  messageIndex: number,
+  collectImage: NativeBackupImageCollector,
+) {
+  const source = row(value)
+  return {
+    ...pick(source, messageFields),
+    attachments:
+      source.attachments === undefined
+        ? undefined
+        : cleanAttachments(
+            source.attachments,
+            chatId,
+            messageIndex,
+            collectImage,
+          ),
+    documents: list(source.documents, (value) =>
+      pick(row(value), keys('name')),
+    ),
+    imageData: list(source.imageData, (value, legacyIndex) => {
+      const image = row(value)
+      return {
+        imageId: collectImage({
+          sourceKey: `legacy:${chatId}:${messageIndex}:${legacyIndex}`,
+          chatId,
+          messageIndex,
+          legacyIndex,
+          fileName: `legacy-image-${legacyIndex}`,
+          mimeType: String(image.mimeType),
+        }),
+        mimeType: image.mimeType,
+      }
+    }),
+    timestamp: iso(source.timestamp),
+    urlFetches: list(source.urlFetches, cleanFetch),
+    webSearch:
+      source.webSearch === undefined
+        ? undefined
+        : cleanSearch(source.webSearch),
+    annotations: list(source.annotations, cleanCitation),
+    timeline: list(source.timeline, cleanTimeline),
+    toolCalls: list(source.toolCalls, (value) =>
+      pick(row(value), keys('id name arguments')),
+    ),
+    codeExecCalls: list(source.codeExecCalls, cleanCodeCall),
+  }
+}
+
+const missingImageCollector: NativeBackupImageCollector = () => {
+  throw new Error('Native backup image collector is required')
+}
+export function sanitizeNativeBackupChat(
+  value: unknown,
+  collectImage: NativeBackupImageCollector = missingImageCollector,
+) {
+  const source = row(value)
+  const chatId = String(source.id)
+  return schemas.NativeBackupChatSchema.parse({
+    ...pick(
+      source,
+      keys('id title titleState projectId presetId model webSearchEnabled'),
+    ),
+    messages: rows(source.messages).map((message, index) =>
+      cleanMessage(message, chatId, index, collectImage),
+    ),
+    createdAt: iso(source.createdAt),
+    updatedAt: iso(source.updatedAt ?? source.createdAt),
+  })
+}
+
+export function classifyNativeBackupChat(
+  value: unknown,
+  owner: 'cloud' | 'signed_in' | 'anonymous',
+): 'cloud' | 'local' | null {
+  const source = row(value)
+  if (source.isTemporary === true || source.isBlankChat === true) return null
+  if (owner === 'cloud') return 'cloud'
+  return owner === 'signed_in' ? 'local' : null
+}
+
+const cleanRelationship = (keys: readonly string[]) => (value: unknown) =>
+  pick(row(value), keys)
+export function sanitizeNativeBackupRelationships(value: unknown) {
+  const source = row(value)
+  return schemas.NativeBackupRelationshipsSchema.parse({
+    projectChats: rows(source.projectChats).map(
+      cleanRelationship(keys('projectId chatId')),
+    ),
+    projectDocuments: rows(source.projectDocuments).map(
+      cleanRelationship(keys('projectId documentId')),
+    ),
+    chatImages: rows(source.chatImages).map(
+      cleanRelationship(keys('chatId imageId')),
+    ),
+  })
+}
+
+export function sanitizeNativeBackupImage(value: unknown) {
+  return schemas.NativeBackupImageSchema.parse(
+    pick(
+      row(value),
+      keys(
+        'id chatId messageIndex attachmentId page legacyIndex fileName mimeType sizeBytes description',
+      ),
+    ),
+  )
+}

--- a/src/services/native-backup/sanitize.ts
+++ b/src/services/native-backup/sanitize.ts
@@ -53,11 +53,6 @@ const iso = (value: unknown): string => {
     throw new Error('Invalid backup timestamp')
   return parsed.toISOString()
 }
-const imageMimeType = (value: unknown) =>
-  schemas.NativeBackupImageMimeSchema.parse(
-    String(value).split(';', 1)[0].trim().toLowerCase(),
-  )
-
 export function sanitizeNativeBackupProject(value: unknown) {
   const source = row(value)
   return schemas.NativeBackupProjectSchema.parse({
@@ -157,9 +152,7 @@ function cleanAttachments(
           attachmentIndex,
           attachmentId,
           fileName: String(attachment.fileName),
-          mimeType: imageMimeType(
-            attachment.mimeType ?? 'application/octet-stream',
-          ),
+          mimeType: String(attachment.mimeType ?? 'application/octet-stream'),
           sizeBytes:
             typeof attachment.fileSize === 'number' &&
             Number.isInteger(attachment.fileSize) &&
@@ -242,9 +235,9 @@ function cleanMessage(
           messageIndex,
           legacyIndex,
           fileName: `legacy-image-${legacyIndex}`,
-          mimeType: imageMimeType(image.mimeType),
+          mimeType: String(image.mimeType),
         }),
-        mimeType: imageMimeType(image.mimeType),
+        mimeType: image.mimeType,
       }
     }),
     timestamp: iso(source.timestamp),

--- a/src/services/native-backup/sanitize.ts
+++ b/src/services/native-backup/sanitize.ts
@@ -12,7 +12,6 @@ export interface NativeBackupImageCandidate {
   legacyIndex?: number
   fileName: string
   mimeType: string
-  sizeBytes?: number
   description?: string
 }
 export type NativeBackupImageCollector = (
@@ -153,12 +152,6 @@ function cleanAttachments(
           attachmentId,
           fileName: String(attachment.fileName),
           mimeType: String(attachment.mimeType ?? 'application/octet-stream'),
-          sizeBytes:
-            typeof attachment.fileSize === 'number' &&
-            Number.isInteger(attachment.fileSize) &&
-            attachment.fileSize >= 0
-              ? attachment.fileSize
-              : undefined,
           description:
             typeof attachment.description === 'string'
               ? attachment.description

--- a/src/services/native-backup/sanitize.ts
+++ b/src/services/native-backup/sanitize.ts
@@ -6,6 +6,7 @@ export interface NativeBackupImageCandidate {
   sourceKey: string
   chatId: string
   messageIndex: number
+  attachmentIndex?: number
   attachmentId?: string
   page?: number
   legacyIndex?: number
@@ -149,6 +150,7 @@ function cleanAttachments(
           ]),
           chatId,
           messageIndex,
+          attachmentIndex,
           attachmentId,
           fileName: String(attachment.fileName),
           mimeType: String(attachment.mimeType ?? 'application/octet-stream'),
@@ -186,6 +188,7 @@ function cleanAttachments(
                 ]),
                 chatId,
                 messageIndex,
+                attachmentIndex,
                 attachmentId,
                 page: pageNumber,
                 fileName: `${attachmentId}-page-${pageNumber}.jpg`,

--- a/src/services/native-backup/schemas.ts
+++ b/src/services/native-backup/schemas.ts
@@ -1,0 +1,193 @@
+import { z } from 'zod'
+
+const id = z.string().min(1).max(256)
+const date = z.string().datetime({ offset: true })
+const optionalString = z.string().optional()
+const strict = <T extends z.ZodRawShape>(shape: T) => z.object(shape).strict()
+
+export const NativeBackupJsonSchema: z.ZodType<unknown> = z.lazy(() =>
+  z.union([
+    z.string(),
+    z.number().finite(),
+    z.boolean(),
+    z.null(),
+    z.array(NativeBackupJsonSchema),
+    z.record(z.string(), NativeBackupJsonSchema),
+  ]),
+)
+
+const source = strict({ title: z.string(), url: z.string() })
+const search = strict({
+  query: optionalString,
+  status: z.enum(['searching', 'completed', 'failed', 'blocked']),
+  sources: z.array(source).optional(),
+  reason: optionalString,
+})
+const fetchState = strict({
+  id,
+  url: z.string(),
+  status: z.enum(['fetching', 'completed', 'failed']),
+})
+const citation = strict({
+  type: z.literal('url_citation'),
+  url_citation: strict({
+    title: z.string(),
+    url: z.string(),
+    start_index: z.number().int().nonnegative().optional(),
+    end_index: z.number().int().nonnegative().optional(),
+  }),
+})
+const codeCall = strict({
+  id,
+  toolName: z.string(),
+  arguments: z.record(z.string(), NativeBackupJsonSchema).optional(),
+  status: z.enum(['running', 'completed', 'failed']),
+  output: optionalString,
+})
+const timeline = z.discriminatedUnion('type', [
+  strict({
+    type: z.literal('thinking'),
+    id,
+    content: z.string(),
+    isThinking: z.boolean(),
+    duration: z.number().nonnegative().optional(),
+  }),
+  strict({ type: z.literal('web_search'), id, state: search }),
+  strict({
+    type: z.literal('url_fetches'),
+    id,
+    fetches: z.array(fetchState),
+  }),
+  strict({ type: z.literal('content'), id, content: z.string() }),
+  strict({
+    type: z.literal('tool_call'),
+    id,
+    toolCallId: id,
+    name: z.string(),
+    arguments: z.string(),
+    resolvedAt: z.number().optional(),
+    resolution: strict({
+      text: z.string(),
+      data: NativeBackupJsonSchema.optional(),
+    }).optional(),
+  }),
+  strict({ type: z.literal('code_exec'), id, calls: z.array(codeCall) }),
+])
+const documentPage = strict({
+  page: z.number().int().nonnegative(),
+  text: z.string(),
+  is_scanned: z.boolean(),
+  imageId: id.optional(),
+})
+const attachment = z.discriminatedUnion('type', [
+  strict({
+    id,
+    type: z.literal('document'),
+    fileName: z.string(),
+    mimeType: optionalString,
+    textContent: optionalString,
+    description: optionalString,
+    fileSize: z.number().int().nonnegative().optional(),
+    pages: z.array(documentPage).optional(),
+  }),
+  strict({ id, type: z.literal('image'), imageId: id }),
+])
+
+export const NativeBackupMessageSchema = strict({
+  role: z.enum(['user', 'assistant']),
+  content: z.string(),
+  turnId: optionalString,
+  modelDisplayName: optionalString,
+  attachments: z.array(attachment).optional(),
+  documentContent: optionalString,
+  multimodalText: optionalString,
+  documents: z.array(strict({ name: z.string() })).optional(),
+  imageData: z.array(strict({ imageId: id, mimeType: z.string() })).optional(),
+  timestamp: date,
+  thoughts: optionalString,
+  isThinking: z.boolean().optional(),
+  thinkingDuration: z.number().nonnegative().optional(),
+  isError: z.boolean().optional(),
+  isRateLimitError: z.boolean().optional(),
+  isHourlyRateLimitError: z.boolean().optional(),
+  urlFetches: z.array(fetchState).optional(),
+  webSearch: search.optional(),
+  webSearchBeforeThinking: z.boolean().optional(),
+  annotations: z.array(citation).optional(),
+  searchReasoning: optionalString,
+  quote: optionalString,
+  timeline: z.array(timeline).optional(),
+  toolCalls: z
+    .array(strict({ id, name: z.string(), arguments: z.string() }))
+    .optional(),
+  codeExecCalls: z.array(codeCall).optional(),
+})
+
+export const NativeBackupProjectSchema = strict({
+  id,
+  name: z.string(),
+  description: z.string(),
+  systemInstructions: z.string(),
+  color: optionalString,
+  memory: z.array(
+    strict({
+      id,
+      fact: z.string(),
+      date,
+      category: z.string(),
+      confidence: z.number().min(0).max(1),
+    }),
+  ),
+  createdAt: date,
+  updatedAt: date,
+})
+export const NativeBackupProjectDocumentSchema = strict({
+  id,
+  projectId: id,
+  filename: z.string(),
+  contentType: z.string(),
+  sizeBytes: z.number().int().nonnegative(),
+  extractedText: z.string(),
+  createdAt: date,
+  updatedAt: date,
+})
+export const NativeBackupChatSchema = strict({
+  id,
+  title: z.string(),
+  titleState: z.enum(['placeholder', 'generated', 'manual']).optional(),
+  messages: z.array(NativeBackupMessageSchema),
+  createdAt: date,
+  updatedAt: date,
+  projectId: id.optional(),
+  presetId: id.optional(),
+  model: optionalString,
+  webSearchEnabled: z.boolean().optional(),
+})
+export const NativeBackupRelationshipsSchema = strict({
+  projectChats: z.array(strict({ projectId: id, chatId: id })),
+  projectDocuments: z.array(strict({ projectId: id, documentId: id })),
+  chatImages: z.array(strict({ chatId: id, imageId: id })),
+})
+export const NativeBackupImageSchema = strict({
+  id,
+  chatId: id,
+  messageIndex: z.number().int().nonnegative(),
+  attachmentId: id.optional(),
+  page: z.number().int().nonnegative().optional(),
+  legacyIndex: z.number().int().nonnegative().optional(),
+  fileName: z.string(),
+  mimeType: z.string(),
+  sizeBytes: z.number().int().nonnegative().optional(),
+  description: optionalString,
+})
+
+export type NativeBackupProject = z.infer<typeof NativeBackupProjectSchema>
+export type NativeBackupProjectDocument = z.infer<
+  typeof NativeBackupProjectDocumentSchema
+>
+export type NativeBackupMessage = z.infer<typeof NativeBackupMessageSchema>
+export type NativeBackupChat = z.infer<typeof NativeBackupChatSchema>
+export type NativeBackupRelationships = z.infer<
+  typeof NativeBackupRelationshipsSchema
+>
+export type NativeBackupImage = z.infer<typeof NativeBackupImageSchema>

--- a/src/services/native-backup/schemas.ts
+++ b/src/services/native-backup/schemas.ts
@@ -65,7 +65,7 @@ const timeline = z.discriminatedUnion('type', [
     toolCallId: id,
     name: z.string(),
     arguments: z.string(),
-    resolvedAt: z.number().optional(),
+    resolvedAt: z.number().finite().optional(),
     resolution: strict({
       text: z.string(),
       data: NativeBackupJsonSchema.optional(),
@@ -158,7 +158,7 @@ export const NativeBackupChatSchema = strict({
   messages: z.array(NativeBackupMessageSchema),
   createdAt: date,
   updatedAt: date,
-  projectId: id.optional(),
+  projectId: id.nullable().optional(),
   presetId: id.optional(),
   model: optionalString,
   webSearchEnabled: z.boolean().optional(),

--- a/src/services/native-backup/schemas.ts
+++ b/src/services/native-backup/schemas.ts
@@ -5,6 +5,17 @@ const date = z.string().datetime({ offset: true })
 const optionalString = z.string().optional()
 const strict = <T extends z.ZodRawShape>(shape: T) => z.object(shape).strict()
 
+export const NATIVE_BACKUP_IMAGE_MIME_TYPES = [
+  'image/png',
+  'image/jpeg',
+  'image/gif',
+  'image/webp',
+  'image/bmp',
+] as const
+export const NativeBackupImageMimeSchema = z.enum(
+  NATIVE_BACKUP_IMAGE_MIME_TYPES,
+)
+
 export const NativeBackupJsonSchema: z.ZodType<unknown> = z.lazy(() =>
   z.union([
     z.string(),
@@ -176,7 +187,7 @@ export const NativeBackupImageSchema = strict({
   page: z.number().int().nonnegative().optional(),
   legacyIndex: z.number().int().nonnegative().optional(),
   fileName: z.string(),
-  mimeType: z.string(),
+  mimeType: NativeBackupImageMimeSchema,
   sizeBytes: z.number().int().nonnegative().optional(),
   description: optionalString,
 })

--- a/tests/fixtures/native-backup-schema-v1.json
+++ b/tests/fixtures/native-backup-schema-v1.json
@@ -1,0 +1,238 @@
+{
+  "project": {
+    "id": "project-1",
+    "name": "Research",
+    "description": "Portable project",
+    "systemInstructions": "Cite sources",
+    "color": "teal",
+    "memory": [
+      {
+        "id": "fact-1",
+        "fact": "Prefer primary sources",
+        "date": "2026-08-01T09:00:00.000Z",
+        "category": "preference",
+        "confidence": 0.9,
+        "apiKey": "fact-api-key"
+      }
+    ],
+    "createdAt": "2026-08-01T08:00:00.000Z",
+    "updatedAt": "2026-08-10T08:00:00.000Z",
+    "cek": "project-cek",
+    "syncUserId": "project-sync-id"
+  },
+  "document": {
+    "id": "document-1",
+    "projectId": "project-1",
+    "filename": "paper.pdf",
+    "contentType": "application/pdf",
+    "sizeBytes": 2048,
+    "content": "Extracted paper text",
+    "createdAt": "2026-08-02T08:00:00.000Z",
+    "updatedAt": "2026-08-02T08:00:00.000Z",
+    "attachmentKey": "document-key",
+    "originalBytes": "document-bytes"
+  },
+  "chat": {
+    "id": "chat-1",
+    "title": "Evidence",
+    "titleState": "manual",
+    "createdAt": "2026-08-03T08:00:00.000Z",
+    "updatedAt": "2026-08-03T09:00:00.000Z",
+    "projectId": "project-1",
+    "presetId": "preset-1",
+    "model": "gpt-oss-120b",
+    "webSearchEnabled": true,
+    "messages": [
+      {
+        "role": "assistant",
+        "content": "Answer with evidence.",
+        "turnId": "turn-1",
+        "modelDisplayName": "Open Model",
+        "timestamp": "2026-08-03T08:01:00.000Z",
+        "thoughts": "Compare sources",
+        "isThinking": false,
+        "thinkingDuration": 1.5,
+        "isError": true,
+        "isRateLimitError": false,
+        "isHourlyRateLimitError": false,
+        "webSearchBeforeThinking": true,
+        "searchReasoning": "Need a primary source",
+        "documentContent": "Legacy document text",
+        "multimodalText": "Legacy multimodal text",
+        "documents": [{ "name": "legacy.txt", "attachmentKey": "legacy-key" }],
+        "imageData": [
+          { "base64": "legacy-image-bytes", "mimeType": "image/webp" }
+        ],
+        "quote": "What supports this?",
+        "webSearch": {
+          "query": "primary source",
+          "status": "completed",
+          "sources": [{ "title": "Source", "url": "https://example.com" }],
+          "reason": "Evidence"
+        },
+        "urlFetches": [
+          {
+            "id": "fetch-1",
+            "url": "https://example.com",
+            "status": "completed"
+          }
+        ],
+        "annotations": [
+          {
+            "type": "url_citation",
+            "url_citation": {
+              "title": "Source",
+              "url": "https://example.com",
+              "start_index": 0,
+              "end_index": 6
+            }
+          }
+        ],
+        "timeline": [
+          {
+            "type": "thinking",
+            "id": "thinking-1",
+            "content": "Inspect evidence",
+            "isThinking": false,
+            "duration": 1.5
+          },
+          {
+            "type": "tool_call",
+            "id": "tool-block-1",
+            "toolCallId": "tool-1",
+            "name": "render_quote",
+            "arguments": "{\"quote\":\"Evidence\"}",
+            "resolvedAt": 1770000000000,
+            "resolution": {
+              "text": "Accepted",
+              "data": { "nested": { "custom_key": [1, true, null] } },
+              "accessToken": "resolution-token"
+            }
+          },
+          {
+            "type": "content",
+            "id": "content-1",
+            "content": "Answer with evidence."
+          },
+          {
+            "type": "code_exec",
+            "id": "code-block-1",
+            "calls": [
+              {
+                "id": "code-1",
+                "toolName": "python",
+                "arguments": {
+                  "code": "print(1)",
+                  "options": { "precision": 2 }
+                },
+                "status": "completed",
+                "output": "1",
+                "apiKey": "code-api-key"
+              }
+            ]
+          }
+        ],
+        "toolCalls": [
+          {
+            "id": "tool-1",
+            "name": "render_quote",
+            "arguments": "{\"quote\":\"Evidence\"}",
+            "accessToken": "tool-token"
+          }
+        ],
+        "codeExecCalls": [
+          {
+            "id": "code-1",
+            "toolName": "python",
+            "arguments": { "code": "print(1)", "options": { "precision": 2 } },
+            "status": "completed",
+            "output": "1"
+          }
+        ],
+        "attachments": [
+          {
+            "id": "image-1",
+            "type": "image",
+            "fileName": "chart.png",
+            "mimeType": "image/png",
+            "description": "A chart",
+            "base64": "image-bytes",
+            "thumbnailBase64": "thumbnail-bytes",
+            "encryptionKey": "image-key"
+          },
+          {
+            "id": "document-attachment-1",
+            "type": "document",
+            "fileName": "scan.pdf",
+            "mimeType": "application/pdf",
+            "fileSize": 4096,
+            "textContent": "Extracted text",
+            "pages": [
+              {
+                "page": 1,
+                "text": "Page text",
+                "image": "page-bytes",
+                "is_scanned": true
+              }
+            ],
+            "attachmentKey": "attachment-key"
+          }
+        ],
+        "codeExecutionAccessToken": "message-token"
+      }
+    ],
+    "pendingRecoveries": [{ "ciphertext": "recovery-secret" }],
+    "syncUserId": "chat-sync-id",
+    "clock": 99,
+    "writer": "transient-writer",
+    "codeExecutionAccessToken": "chat-token"
+  },
+  "relationships": {
+    "projectChats": [
+      {
+        "projectId": "project-1",
+        "chatId": "chat-1",
+        "syncId": "relation-sync-id"
+      }
+    ],
+    "projectDocuments": [
+      { "projectId": "project-1", "documentId": "document-1" }
+    ],
+    "chatImages": [{ "chatId": "chat-1", "imageId": "image-descriptor-1" }]
+  },
+  "image": {
+    "id": "image-descriptor-1",
+    "chatId": "chat-1",
+    "messageIndex": 0,
+    "attachmentId": "image-1",
+    "fileName": "chart.png",
+    "mimeType": "image/png",
+    "sizeBytes": 1234,
+    "description": "A chart",
+    "attachmentKey": "descriptor-key"
+  },
+  "forbiddenValues": [
+    "fact-api-key",
+    "project-cek",
+    "project-sync-id",
+    "document-key",
+    "document-bytes",
+    "legacy-key",
+    "legacy-image-bytes",
+    "resolution-token",
+    "code-api-key",
+    "tool-token",
+    "image-bytes",
+    "thumbnail-bytes",
+    "image-key",
+    "page-bytes",
+    "attachment-key",
+    "message-token",
+    "recovery-secret",
+    "chat-sync-id",
+    "transient-writer",
+    "chat-token",
+    "relation-sync-id",
+    "descriptor-key"
+  ]
+}

--- a/tests/services/native-backup/schema.test.ts
+++ b/tests/services/native-backup/schema.test.ts
@@ -177,6 +177,30 @@ describe('native backup v1 schema', () => {
     expect(candidates[0].sourceKey).not.toBe(candidates[1].sourceKey)
   })
 
+  it('forwards only valid image sizes and supported image types', () => {
+    const candidates: Array<{ sizeBytes?: number }> = []
+    const value = structuredClone(fixture.chat)
+    value.messages[0].attachments = [
+      {
+        id: 'image',
+        type: 'image',
+        fileName: 'image.png',
+        mimeType: 'image/png',
+        fileSize: Number.NaN,
+      },
+    ]
+    value.messages[0].imageData = []
+
+    sanitizeNativeBackupChat(value, (candidate) => {
+      candidates.push(candidate)
+      return 'image'
+    })
+    expect(candidates[0].sizeBytes).toBeUndefined()
+
+    value.messages[0].attachments[0].mimeType = 'image/avif'
+    expect(() => sanitizeNativeBackupChat(value, () => 'image')).toThrow()
+  })
+
   it('classifies only eligible signed-in local chats', () => {
     expect(classifyNativeBackupChat(fixture.chat, 'cloud')).toBe('cloud')
     expect(classifyNativeBackupChat(fixture.chat, 'signed_in')).toBe('local')

--- a/tests/services/native-backup/schema.test.ts
+++ b/tests/services/native-backup/schema.test.ts
@@ -110,6 +110,71 @@ describe('native backup v1 schema', () => {
         chatImages: {},
       }),
     ).toThrow('collections must be arrays')
+    expect(() =>
+      sanitizeNativeBackupChat(
+        { ...fixture.chat, createdAt: null },
+        () => 'image',
+      ),
+    ).toThrow('Invalid backup timestamp')
+    expect(() =>
+      NativeBackupChatSchema.parse({
+        ...sanitizedFixture().chat,
+        messages: [
+          {
+            ...sanitizedFixture().chat.messages[0],
+            timeline: [
+              {
+                type: 'tool_call',
+                id: 'call',
+                toolCallId: 'call',
+                name: 'tool',
+                arguments: '{}',
+                resolvedAt: Number.POSITIVE_INFINITY,
+              },
+            ],
+          },
+        ],
+      }),
+    ).toThrow()
+  })
+
+  it('preserves nullable projects and distinct image occurrences', () => {
+    const candidates: Array<{ sourceKey: string; sizeBytes?: number }> = []
+    const chat = sanitizeNativeBackupChat(
+      {
+        ...fixture.chat,
+        projectId: null,
+        messages: [
+          {
+            ...fixture.chat.messages[0],
+            attachments: [
+              {
+                id: 'shared:id',
+                type: 'image',
+                fileName: 'first.png',
+                mimeType: 'image/png',
+                fileSize: 123,
+              },
+              {
+                id: 'shared:id',
+                type: 'image',
+                fileName: 'second.png',
+                mimeType: 'image/png',
+              },
+            ],
+            imageData: [],
+          },
+        ],
+      },
+      (candidate) => {
+        candidates.push(candidate)
+        return `image-${candidates.length}`
+      },
+    )
+
+    expect(chat.projectId).toBeNull()
+    expect(candidates[0].sizeBytes).toBe(123)
+    expect(candidates[0].sourceKey).not.toBe(candidates[1].sourceKey)
   })
 
   it('classifies only eligible signed-in local chats', () => {

--- a/tests/services/native-backup/schema.test.ts
+++ b/tests/services/native-backup/schema.test.ts
@@ -1,0 +1,132 @@
+import {
+  NATIVE_BACKUP_ENTITY_KINDS,
+  NATIVE_BACKUP_FORMAT,
+  NATIVE_BACKUP_VERSION,
+  NativeBackupChatSchema,
+  classifyNativeBackupChat,
+  sanitizeNativeBackupChat,
+  sanitizeNativeBackupImage,
+  sanitizeNativeBackupProject,
+  sanitizeNativeBackupProjectDocument,
+  sanitizeNativeBackupRelationships,
+} from '@/services/native-backup'
+import fixture from '../../fixtures/native-backup-schema-v1.json'
+
+function sanitizedFixture() {
+  const candidates: unknown[] = []
+  const chat = sanitizeNativeBackupChat(fixture.chat, (candidate) => {
+    candidates.push(candidate)
+    return `image-${candidates.length}`
+  })
+  return {
+    project: sanitizeNativeBackupProject(fixture.project),
+    document: sanitizeNativeBackupProjectDocument(fixture.document),
+    chat,
+    relationships: sanitizeNativeBackupRelationships(fixture.relationships),
+    image: sanitizeNativeBackupImage(fixture.image),
+    candidates,
+  }
+}
+
+describe('native backup v1 schema', () => {
+  it('defines the portable format and entity kinds', () => {
+    expect(NATIVE_BACKUP_FORMAT).toBe('tinfoil-native-backup')
+    expect(NATIVE_BACKUP_VERSION).toBe(1)
+    expect(NATIVE_BACKUP_ENTITY_KINDS).toEqual([
+      'projects',
+      'project_documents',
+      'cloud_chats',
+      'local_chats',
+      'relationships',
+      'images',
+    ])
+  })
+
+  it('preserves semantic fields while stripping secrets and transient state', () => {
+    const output = sanitizedFixture()
+
+    expect(output.project).toMatchObject({
+      color: 'teal',
+      memory: [{ confidence: 0.9 }],
+    })
+    expect(output.document.extractedText).toBe('Extracted paper text')
+    expect(output.chat).toMatchObject({
+      presetId: 'preset-1',
+      messages: [
+        {
+          thoughts: 'Compare sources',
+          isError: true,
+          webSearchBeforeThinking: true,
+          quote: 'What supports this?',
+          annotations: [{ url_citation: { title: 'Source' } }],
+          attachments: [
+            { type: 'image', imageId: 'image-1' },
+            { type: 'document', pages: [{ imageId: 'image-2' }] },
+          ],
+          imageData: [{ imageId: 'image-3', mimeType: 'image/webp' }],
+        },
+      ],
+    })
+    expect(output.relationships.projectChats).toEqual([
+      { projectId: 'project-1', chatId: 'chat-1' },
+    ])
+    expect(output.image).toMatchObject({
+      fileName: 'chart.png',
+      sizeBytes: 1234,
+    })
+    expect(output.candidates).toHaveLength(3)
+    const serialized = JSON.stringify(output)
+    for (const secret of fixture.forbiddenValues)
+      expect(serialized).not.toContain(secret)
+  })
+
+  it('preserves arbitrary JSON only in tool arguments and resolution data', () => {
+    const message = sanitizedFixture().chat.messages[0]
+
+    expect(message.timeline?.[1]).toMatchObject({
+      resolution: { data: { nested: { custom_key: [1, true, null] } } },
+    })
+    expect(message.codeExecCalls?.[0].arguments).toEqual({
+      code: 'print(1)',
+      options: { precision: 2 },
+    })
+    expect(JSON.stringify(message)).not.toContain('resolution-token')
+  })
+
+  it('rejects malformed nested records and unknown portable fields', () => {
+    const malformed = structuredClone(fixture.chat)
+    malformed.messages[0].annotations[0].url_citation.url =
+      42 as unknown as string
+    expect(() => sanitizeNativeBackupChat(malformed, () => 'image')).toThrow()
+    expect(() =>
+      NativeBackupChatSchema.parse({
+        ...sanitizedFixture().chat,
+        accessToken: 'secret',
+      }),
+    ).toThrow()
+    expect(() =>
+      sanitizeNativeBackupRelationships({
+        ...fixture.relationships,
+        chatImages: {},
+      }),
+    ).toThrow('collections must be arrays')
+  })
+
+  it('classifies only eligible signed-in local chats', () => {
+    expect(classifyNativeBackupChat(fixture.chat, 'cloud')).toBe('cloud')
+    expect(classifyNativeBackupChat(fixture.chat, 'signed_in')).toBe('local')
+    expect(classifyNativeBackupChat(fixture.chat, 'anonymous')).toBeNull()
+    expect(
+      classifyNativeBackupChat(
+        { ...fixture.chat, isTemporary: true },
+        'signed_in',
+      ),
+    ).toBeNull()
+    expect(
+      classifyNativeBackupChat(
+        { ...fixture.chat, isBlankChat: true },
+        'signed_in',
+      ),
+    ).toBeNull()
+  })
+})

--- a/tests/services/native-backup/schema.test.ts
+++ b/tests/services/native-backup/schema.test.ts
@@ -139,7 +139,7 @@ describe('native backup v1 schema', () => {
   })
 
   it('preserves nullable projects and distinct image occurrences', () => {
-    const candidates: Array<{ sourceKey: string; sizeBytes?: number }> = []
+    const candidates: Array<{ sourceKey: string }> = []
     const chat = sanitizeNativeBackupChat(
       {
         ...fixture.chat,
@@ -173,30 +173,10 @@ describe('native backup v1 schema', () => {
     )
 
     expect(chat.projectId).toBeNull()
-    expect(candidates[0].sizeBytes).toBe(123)
     expect(candidates[0].sourceKey).not.toBe(candidates[1].sourceKey)
   })
 
-  it('forwards only valid image sizes and supported image types', () => {
-    const candidates: Array<{ sizeBytes?: number }> = []
-    const value = structuredClone(fixture.chat)
-    value.messages[0].attachments = [
-      {
-        id: 'image',
-        type: 'image',
-        fileName: 'image.png',
-        mimeType: 'image/png',
-        fileSize: Number.NaN,
-      },
-    ]
-    value.messages[0].imageData = []
-
-    sanitizeNativeBackupChat(value, (candidate) => {
-      candidates.push(candidate)
-      return 'image'
-    })
-    expect(candidates[0].sizeBytes).toBeUndefined()
-
+  it('accepts only supported image types', () => {
     expect(() =>
       sanitizeNativeBackupImage({ ...fixture.image, mimeType: 'image/avif' }),
     ).toThrow()

--- a/tests/services/native-backup/schema.test.ts
+++ b/tests/services/native-backup/schema.test.ts
@@ -197,8 +197,9 @@ describe('native backup v1 schema', () => {
     })
     expect(candidates[0].sizeBytes).toBeUndefined()
 
-    value.messages[0].attachments[0].mimeType = 'image/avif'
-    expect(() => sanitizeNativeBackupChat(value, () => 'image')).toThrow()
+    expect(() =>
+      sanitizeNativeBackupImage({ ...fixture.image, mimeType: 'image/avif' }),
+    ).toThrow()
   })
 
   it('classifies only eligible signed-in local chats', () => {


### PR DESCRIPTION
## Summary
- define strict portable schemas for projects, documents, chats, messages, and images
- preserve supported tool, thought, citation, quote, and document fields
- strip keys, tokens, sync identifiers, and transient state

## Testing
- 1,822 unit tests
- typecheck and lint

## Scope
Format schema only; no archive writing, UI, restore, auth, or passkey changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defines a portable v1 native backup schema and sanitizers that preserve meaningful project/chat data while stripping secrets and transient state. Simplifies the image candidate API and adds shared image MIME detection while keeping image metadata restorable.

- Exposes `NATIVE_BACKUP_FORMAT`, `NATIVE_BACKUP_VERSION`, and `NATIVE_BACKUP_ENTITY_KINDS`. Adds strict Zod schemas and `sanitize*` utilities that whitelist fields, normalize timestamps to ISO (accept Date/string/number), map document `content`→`extractedText`, default chat `updatedAt` to `createdAt` when missing, and enforce strict validation (only tool arguments and tool resolution data admit arbitrary JSON). `classifyNativeBackupChat` returns `cloud`, `local`, or `null` based on owner and temporary/blank flags.
- `sanitizeNativeBackupChat` requires an image collector; attachments, document pages, and legacy `imageData` emit candidates with positional `sourceKey`s so repeated attachment IDs become distinct. The candidate payload is simplified to `fileName`, `mimeType`, and optional `description` (no `sizeBytes`). `sanitizeNativeBackupImage` preserves `fileName`, `mimeType`, optional `sizeBytes`/`description`, and restricts `mimeType` to `NATIVE_BACKUP_IMAGE_MIME_TYPES`. Exports `detectNativeBackupImageMimeType(bytes)` to identify supported image types.

<sup>Written for commit 8c7854caf0b6ff6acadad4dee7afe1e9d39e4caf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/525?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

