### PR TITLE
feat: add native backup manifest

### DIFF
--- a/src/services/native-backup/constants.ts
+++ b/src/services/native-backup/constants.ts
@@ -1,6 +1,16 @@
 export const NATIVE_BACKUP_FORMAT = 'tinfoil-native-backup' as const
 export const NATIVE_BACKUP_VERSION = 1 as const
 
+export const NATIVE_BACKUP_LIMITS = {
+  archiveBytes: 512 * 1024 * 1024,
+  entries: 50_000,
+  entities: 100_000,
+  messages: 2_000_000,
+  attachments: 100_000,
+  imageBytes: 32 * 1024 * 1024,
+  aggregateJsonBytes: 256 * 1024 * 1024,
+} as const
+
 export const NATIVE_BACKUP_ENTITY_KINDS = [
   'projects',
   'project_documents',

--- a/src/services/native-backup/format.ts
+++ b/src/services/native-backup/format.ts
@@ -1,0 +1,516 @@
+import { sha256 } from '@noble/hashes/sha2.js'
+import { bytesToHex } from '@noble/hashes/utils.js'
+import { z } from 'zod'
+import {
+  NATIVE_BACKUP_ENTITY_KINDS,
+  NATIVE_BACKUP_FORMAT,
+  NATIVE_BACKUP_LIMITS,
+  NATIVE_BACKUP_VERSION,
+  type NativeBackupEntityKind,
+} from './constants'
+import {
+  NativeBackupChatSchema,
+  NativeBackupImageSchema,
+  NativeBackupProjectDocumentSchema,
+  NativeBackupProjectSchema,
+  NativeBackupRelationshipsSchema,
+  type NativeBackupChat,
+  type NativeBackupImage,
+  type NativeBackupProject,
+  type NativeBackupProjectDocument,
+  type NativeBackupRelationships,
+} from './schemas'
+
+const MANIFEST_PATH = 'manifest.json'
+const encoder = new TextEncoder()
+const decoder = new TextDecoder('utf-8', { fatal: true })
+const sha256Schema = z.string().regex(/^[0-9a-f]{64}$/)
+const countSchema = z.number().int().nonnegative()
+
+export interface NativeBackupFileEntry {
+  path: string
+  kind: NativeBackupEntityKind
+  bytes: Uint8Array
+}
+
+export interface NativeBackupImageInput {
+  metadata: NativeBackupImage
+  bytes: Uint8Array
+}
+
+export interface NativeBackupFormatInput {
+  backupId: string
+  createdAt: string
+  projects: readonly NativeBackupProject[]
+  projectDocuments: readonly NativeBackupProjectDocument[]
+  cloudChats: readonly NativeBackupChat[]
+  localChats: readonly NativeBackupChat[]
+  relationships: NativeBackupRelationships
+  images: readonly NativeBackupImageInput[]
+}
+
+export interface NativeBackupManifestFile {
+  path: string
+  kind: NativeBackupEntityKind
+  sha256: string
+  size_bytes: number
+}
+
+export interface NativeBackupManifestV1 {
+  format: typeof NATIVE_BACKUP_FORMAT
+  version: typeof NATIVE_BACKUP_VERSION
+  backup_id: string
+  created_at: string
+  complete: true
+  counts: Record<NativeBackupEntityKind, number> & { files: number }
+  notices: {
+    contains_plaintext: true
+    documents_are_extracted_text_only: true
+  }
+  files: NativeBackupManifestFile[]
+}
+
+const manifestSchema = z
+  .object({
+    format: z.literal(NATIVE_BACKUP_FORMAT),
+    version: z.literal(NATIVE_BACKUP_VERSION),
+    backup_id: z.string().uuid(),
+    created_at: z.string().datetime({ offset: true }),
+    complete: z.literal(true),
+    counts: z
+      .object({
+        projects: countSchema,
+        project_documents: countSchema,
+        cloud_chats: countSchema,
+        local_chats: countSchema,
+        relationships: countSchema,
+        images: countSchema,
+        files: countSchema,
+      })
+      .strict(),
+    notices: z
+      .object({
+        contains_plaintext: z.literal(true),
+        documents_are_extracted_text_only: z.literal(true),
+      })
+      .strict(),
+    files: z.array(
+      z
+        .object({
+          path: z.string(),
+          kind: z.enum(NATIVE_BACKUP_ENTITY_KINDS),
+          sha256: sha256Schema,
+          size_bytes: countSchema,
+        })
+        .strict(),
+    ),
+  })
+  .strict()
+
+function fail(message: string): never {
+  throw new Error(`Invalid native backup: ${message}`)
+}
+
+function jsonBytes(value: unknown): Uint8Array {
+  return encoder.encode(JSON.stringify(value))
+}
+
+function parseJson(bytes: Uint8Array, label: string): unknown {
+  try {
+    return JSON.parse(decoder.decode(bytes))
+  } catch {
+    return fail(`${label} is not valid UTF-8 JSON`)
+  }
+}
+
+function idComponent(id: string): string {
+  return `id-${bytesToHex(encoder.encode(id))}`
+}
+
+function hash(bytes: Uint8Array): string {
+  return bytesToHex(sha256(bytes))
+}
+
+function safePath(path: string): boolean {
+  if (!path || path.length > 4096 || path.includes('\\') || path.includes('\0'))
+    return false
+  if (path.startsWith('/') || path.endsWith('/') || path.includes('//'))
+    return false
+  return path.split('/').every((part) => part !== '.' && part !== '..')
+}
+
+function expectedPathKind(path: string): NativeBackupEntityKind | null {
+  if (path === 'relationships.json') return 'relationships'
+  const match =
+    /^(projects|project_documents|cloud_chats|local_chats)\/id-[0-9a-f]+(?:\/id-[0-9a-f]+)?\.json$/.exec(
+      path,
+    )
+  if (match) return match[1] as NativeBackupEntityKind
+  if (/^images\/id-[0-9a-f]+\.(json|bin)$/.test(path)) return 'images'
+  return null
+}
+
+function zipUpperBound(path: string, size: number): number {
+  const pathBytes = encoder.encode(path).length
+  return size + Math.ceil(size / 16_383) * 5 + 104 + pathBytes * 2
+}
+
+function assertArchiveLimits(
+  manifestBytes: Uint8Array,
+  files: NativeBackupFileEntry[],
+) {
+  if (files.length + 1 > NATIVE_BACKUP_LIMITS.entries)
+    fail('archive entry limit exceeded')
+  let total = 22 + zipUpperBound(MANIFEST_PATH, manifestBytes.length)
+  for (const file of files) total += zipUpperBound(file.path, file.bytes.length)
+  if (total > NATIVE_BACKUP_LIMITS.archiveBytes)
+    fail('archive size limit exceeded')
+}
+
+function sortedUnique<T extends { id: string }>(
+  values: readonly T[],
+  label: string,
+) {
+  const sorted = [...values].sort((a, b) =>
+    idComponent(a.id) < idComponent(b.id)
+      ? -1
+      : idComponent(a.id) > idComponent(b.id)
+        ? 1
+        : 0,
+  )
+  for (let index = 1; index < sorted.length; index++)
+    if (sorted[index - 1].id === sorted[index].id) fail(`duplicate ${label} id`)
+  return sorted
+}
+
+function addJson(
+  files: NativeBackupFileEntry[],
+  path: string,
+  kind: NativeBackupEntityKind,
+  value: unknown,
+) {
+  files.push({ path, kind, bytes: jsonBytes(value) })
+}
+
+export function formatNativeBackupV1(input: NativeBackupFormatInput): {
+  manifestBytes: Uint8Array
+  files: NativeBackupFileEntry[]
+} {
+  z.string().uuid().parse(input.backupId)
+  z.string().datetime({ offset: true }).parse(input.createdAt)
+  const projects = sortedUnique(
+    input.projects.map((value) => NativeBackupProjectSchema.parse(value)),
+    'project',
+  )
+  const documents = sortedUnique(
+    input.projectDocuments.map((value) =>
+      NativeBackupProjectDocumentSchema.parse(value),
+    ),
+    'project document',
+  )
+  const cloudChats = sortedUnique(
+    input.cloudChats.map((value) => NativeBackupChatSchema.parse(value)),
+    'cloud chat',
+  )
+  const localChats = sortedUnique(
+    input.localChats.map((value) => NativeBackupChatSchema.parse(value)),
+    'local chat',
+  )
+  const chatIds = new Set(cloudChats.map(({ id }) => id))
+  for (const { id } of localChats) {
+    if (chatIds.has(id))
+      fail('chat ids must be unique across cloud and local chats')
+    chatIds.add(id)
+  }
+  const images = sortedUnique(
+    input.images.map(({ metadata, bytes }) => ({
+      ...NativeBackupImageSchema.parse(metadata),
+      sizeBytes: bytes.length,
+      bytes,
+    })),
+    'image',
+  )
+  const relationships = NativeBackupRelationshipsSchema.parse(
+    input.relationships,
+  )
+  const files: NativeBackupFileEntry[] = []
+  for (const value of projects)
+    addJson(files, `projects/${idComponent(value.id)}.json`, 'projects', value)
+  for (const value of documents)
+    addJson(
+      files,
+      `project_documents/${idComponent(value.projectId)}/${idComponent(value.id)}.json`,
+      'project_documents',
+      value,
+    )
+  for (const value of cloudChats)
+    addJson(
+      files,
+      `cloud_chats/${idComponent(value.id)}.json`,
+      'cloud_chats',
+      value,
+    )
+  for (const value of localChats)
+    addJson(
+      files,
+      `local_chats/${idComponent(value.id)}.json`,
+      'local_chats',
+      value,
+    )
+  addJson(files, 'relationships.json', 'relationships', relationships)
+  for (const { bytes, ...metadata } of images) {
+    const base = `images/${idComponent(metadata.id)}`
+    addJson(files, `${base}.json`, 'images', metadata)
+    files.push({ path: `${base}.bin`, kind: 'images', bytes })
+  }
+  files.sort((a, b) => (a.path < b.path ? -1 : 1))
+  const counts = {
+    projects: projects.length,
+    project_documents: documents.length,
+    cloud_chats: cloudChats.length,
+    local_chats: localChats.length,
+    relationships: 1,
+    images: images.length,
+    files: files.length,
+  }
+  const manifest: NativeBackupManifestV1 = {
+    format: NATIVE_BACKUP_FORMAT,
+    version: NATIVE_BACKUP_VERSION,
+    backup_id: input.backupId,
+    created_at: input.createdAt,
+    complete: true,
+    counts,
+    notices: {
+      contains_plaintext: true,
+      documents_are_extracted_text_only: true,
+    },
+    files: files.map(({ path, kind, bytes }) => ({
+      path,
+      kind,
+      sha256: hash(bytes),
+      size_bytes: bytes.length,
+    })),
+  }
+  const manifestBytes = jsonBytes(manifest)
+  assertValidNativeBackupV1(manifestBytes, files)
+  return { manifestBytes, files }
+}
+
+function relationKey(left: string, right: string) {
+  return `${left}\0${right}`
+}
+
+function exactRelations(actual: string[], expected: string[], label: string) {
+  if (new Set(actual).size !== actual.length)
+    fail(`duplicate ${label} relationship`)
+  if (
+    actual.length !== expected.length ||
+    actual.some((value) => !expected.includes(value))
+  )
+    fail(`${label} relationships do not match entities`)
+}
+
+function assertSemanticContent(
+  projects: NativeBackupProject[],
+  documents: NativeBackupProjectDocument[],
+  chats: NativeBackupChat[],
+  relationships: NativeBackupRelationships,
+  images: NativeBackupImage[],
+) {
+  const projectIds = new Set(projects.map(({ id }) => id))
+  const chatIds = new Set(chats.map(({ id }) => id))
+  const documentIds = new Set(documents.map(({ id }) => id))
+  const imageIds = new Set(images.map(({ id }) => id))
+  if (projectIds.size !== projects.length || chatIds.size !== chats.length)
+    fail('duplicate entity id')
+  if (documentIds.size !== documents.length || imageIds.size !== images.length)
+    fail('duplicate entity id')
+  const expectedDocuments = documents.map(({ projectId, id }) => {
+    if (!projectIds.has(projectId)) fail('document references unknown project')
+    return relationKey(projectId, id)
+  })
+  const expectedChats = chats.flatMap(({ id, projectId }) => {
+    if (!projectId) return []
+    if (!projectIds.has(projectId)) fail('chat references unknown project')
+    return [relationKey(projectId, id)]
+  })
+  exactRelations(
+    relationships.projectDocuments.map(({ projectId, documentId }) => {
+      if (!projectIds.has(projectId) || !documentIds.has(documentId))
+        fail('project document relationship references unknown entity')
+      return relationKey(projectId, documentId)
+    }),
+    expectedDocuments,
+    'project document',
+  )
+  exactRelations(
+    relationships.projectChats.map(({ projectId, chatId }) => {
+      if (!projectIds.has(projectId) || !chatIds.has(chatId))
+        fail('project chat relationship references unknown entity')
+      return relationKey(projectId, chatId)
+    }),
+    expectedChats,
+    'project chat',
+  )
+  exactRelations(
+    relationships.chatImages.map(({ chatId, imageId }) => {
+      if (!chatIds.has(chatId) || !imageIds.has(imageId))
+        fail('chat image relationship references unknown entity')
+      return relationKey(chatId, imageId)
+    }),
+    images.map(({ chatId, id }) => relationKey(chatId, id)),
+    'chat image',
+  )
+  let messages = 0
+  let attachments = 0
+  const referencedImages = new Set<string>()
+  const imageById = new Map(images.map((image) => [image.id, image]))
+  for (const chat of chats) {
+    messages += chat.messages.length
+    chat.messages.forEach((message, messageIndex) => {
+      const referenceImage = (
+        imageId: string,
+        location: Pick<
+          NativeBackupImage,
+          'attachmentId' | 'page' | 'legacyIndex'
+        >,
+      ) => {
+        const image = imageById.get(imageId)
+        if (!image || referencedImages.has(imageId))
+          fail('message has an invalid or duplicate image reference')
+        if (
+          image.chatId !== chat.id ||
+          image.messageIndex !== messageIndex ||
+          image.attachmentId !== location.attachmentId ||
+          image.page !== location.page ||
+          image.legacyIndex !== location.legacyIndex
+        )
+          fail('image descriptor does not match its message reference')
+        referencedImages.add(imageId)
+      }
+      attachments += message.attachments?.length ?? 0
+      for (const attachment of message.attachments ?? []) {
+        if (attachment.type === 'image')
+          referenceImage(attachment.imageId, { attachmentId: attachment.id })
+        for (const page of attachment.type === 'document'
+          ? (attachment.pages ?? [])
+          : [])
+          if (page.imageId)
+            referenceImage(page.imageId, {
+              attachmentId: attachment.id,
+              page: page.page,
+            })
+      }
+      for (const [legacyIndex, image] of (message.imageData ?? []).entries())
+        referenceImage(image.imageId, { legacyIndex })
+    })
+  }
+  if (referencedImages.size !== images.length)
+    fail('image is not referenced by a message')
+  if (messages > NATIVE_BACKUP_LIMITS.messages) fail('message limit exceeded')
+  if (attachments > NATIVE_BACKUP_LIMITS.attachments)
+    fail('attachment limit exceeded')
+}
+
+export function assertValidNativeBackupV1(
+  manifestBytes: Uint8Array,
+  files: readonly NativeBackupFileEntry[],
+): NativeBackupManifestV1 {
+  const manifest = manifestSchema.parse(parseJson(manifestBytes, MANIFEST_PATH))
+  const listed = new Map(manifest.files.map((file) => [file.path, file]))
+  if (
+    listed.size !== manifest.files.length ||
+    files.length !== manifest.files.length
+  )
+    fail('file list contains missing or duplicate paths')
+  const seenPaths = new Set<string>()
+  let aggregateJsonBytes = manifestBytes.length
+  const projects: NativeBackupProject[] = []
+  const documents: NativeBackupProjectDocument[] = []
+  const chats: NativeBackupChat[] = []
+  const relationships: NativeBackupRelationships[] = []
+  const images: NativeBackupImage[] = []
+  const imageBytes = new Map<string, number>()
+  for (const file of files) {
+    if (seenPaths.has(file.path)) fail(`duplicate path ${file.path}`)
+    seenPaths.add(file.path)
+    const metadata = listed.get(file.path)
+    const expectedKind = safePath(file.path) && expectedPathKind(file.path)
+    if (
+      !metadata ||
+      !expectedKind ||
+      metadata.kind !== file.kind ||
+      file.kind !== expectedKind
+    )
+      fail(`invalid or unlisted path ${file.path}`)
+    if (
+      metadata.size_bytes !== file.bytes.length ||
+      metadata.sha256 !== hash(file.bytes)
+    )
+      fail(`size or hash mismatch for ${file.path}`)
+    if (file.path.endsWith('.bin')) {
+      if (file.bytes.length > NATIVE_BACKUP_LIMITS.imageBytes)
+        fail('image size limit exceeded')
+      imageBytes.set(file.path.slice(0, -4), file.bytes.length)
+      continue
+    }
+    aggregateJsonBytes += file.bytes.length
+    const value = parseJson(file.bytes, file.path)
+    if (file.kind === 'projects') {
+      const project = NativeBackupProjectSchema.parse(value)
+      if (file.path !== `projects/${idComponent(project.id)}.json`)
+        fail('project path does not match its id')
+      projects.push(project)
+    }
+    if (file.kind === 'project_documents') {
+      const document = NativeBackupProjectDocumentSchema.parse(value)
+      if (
+        file.path !==
+        `project_documents/${idComponent(document.projectId)}/${idComponent(document.id)}.json`
+      )
+        fail('project document path does not match its ids')
+      documents.push(document)
+    }
+    if (file.kind === 'cloud_chats' || file.kind === 'local_chats') {
+      const chat = NativeBackupChatSchema.parse(value)
+      if (file.path !== `${file.kind}/${idComponent(chat.id)}.json`)
+        fail('chat path does not match its id')
+      chats.push(chat)
+    }
+    if (file.kind === 'relationships')
+      relationships.push(NativeBackupRelationshipsSchema.parse(value))
+    if (file.kind === 'images') {
+      const image = NativeBackupImageSchema.parse(value)
+      if (file.path !== `images/${idComponent(image.id)}.json`)
+        fail('image path does not match its id')
+      images.push(image)
+    }
+  }
+  if (aggregateJsonBytes > NATIVE_BACKUP_LIMITS.aggregateJsonBytes)
+    fail('aggregate JSON size limit exceeded')
+  if (relationships.length !== 1)
+    fail('exactly one relationships file is required')
+  for (const image of images) {
+    const size = imageBytes.get(`images/${idComponent(image.id)}`)
+    if (size === undefined || image.sizeBytes !== size)
+      fail('image bytes are missing or mismatched')
+  }
+  if (imageBytes.size !== images.length) fail('image metadata is missing')
+  const actualCounts = {
+    projects: projects.length,
+    project_documents: documents.length,
+    cloud_chats: files.filter(({ kind }) => kind === 'cloud_chats').length,
+    local_chats: files.filter(({ kind }) => kind === 'local_chats').length,
+    relationships: relationships.length,
+    images: images.length,
+    files: files.length,
+  }
+  for (const key of [...NATIVE_BACKUP_ENTITY_KINDS, 'files'] as const)
+    if (manifest.counts[key] !== actualCounts[key])
+      fail(`count mismatch for ${key}`)
+  const entities = projects.length + documents.length + chats.length
+  if (entities > NATIVE_BACKUP_LIMITS.entities) fail('entity limit exceeded')
+  assertSemanticContent(projects, documents, chats, relationships[0], images)
+  assertArchiveLimits(manifestBytes, [...files])
+  return manifest as NativeBackupManifestV1
+}

--- a/src/services/native-backup/format.ts
+++ b/src/services/native-backup/format.ts
@@ -24,7 +24,6 @@ import {
 const MANIFEST_PATH = 'manifest.json'
 const encoder = new TextEncoder()
 const decoder = new TextDecoder('utf-8', { fatal: true })
-const sha256Schema = z.string().regex(/^[0-9a-f]{64}$/)
 const countSchema = z.number().int().nonnegative()
 
 export interface NativeBackupFileEntry {
@@ -49,27 +48,6 @@ export interface NativeBackupFormatInput {
   images: readonly NativeBackupImageInput[]
 }
 
-export interface NativeBackupManifestFile {
-  path: string
-  kind: NativeBackupEntityKind
-  sha256: string
-  size_bytes: number
-}
-
-export interface NativeBackupManifestV1 {
-  format: typeof NATIVE_BACKUP_FORMAT
-  version: typeof NATIVE_BACKUP_VERSION
-  backup_id: string
-  created_at: string
-  complete: true
-  counts: Record<NativeBackupEntityKind, number> & { files: number }
-  notices: {
-    contains_plaintext: true
-    documents_are_extracted_text_only: true
-  }
-  files: NativeBackupManifestFile[]
-}
-
 const manifestSchema = z
   .object({
     format: z.literal(NATIVE_BACKUP_FORMAT),
@@ -77,17 +55,10 @@ const manifestSchema = z
     backup_id: z.string().uuid(),
     created_at: z.string().datetime({ offset: true }),
     complete: z.literal(true),
-    counts: z
-      .object({
-        projects: countSchema,
-        project_documents: countSchema,
-        cloud_chats: countSchema,
-        local_chats: countSchema,
-        relationships: countSchema,
-        images: countSchema,
-        files: countSchema,
-      })
-      .strict(),
+    counts: z.record(
+      z.enum([...NATIVE_BACKUP_ENTITY_KINDS, 'files']),
+      countSchema,
+    ),
     notices: z
       .object({
         contains_plaintext: z.literal(true),
@@ -99,13 +70,15 @@ const manifestSchema = z
         .object({
           path: z.string(),
           kind: z.enum(NATIVE_BACKUP_ENTITY_KINDS),
-          sha256: sha256Schema,
+          sha256: z.string().regex(/^[0-9a-f]{64}$/),
           size_bytes: countSchema,
         })
         .strict(),
     ),
   })
   .strict()
+
+export type NativeBackupManifestV1 = z.infer<typeof manifestSchema>
 
 function fail(message: string): never {
   throw new Error(`Invalid native backup: ${message}`)

--- a/src/services/native-backup/format.ts
+++ b/src/services/native-backup/format.ts
@@ -25,6 +25,7 @@ const MANIFEST_PATH = 'manifest.json'
 const encoder = new TextEncoder()
 const decoder = new TextDecoder('utf-8', { fatal: true })
 const countSchema = z.number().int().nonnegative()
+const strict = <T extends z.ZodRawShape>(shape: T) => z.object(shape).strict()
 
 export interface NativeBackupFileEntry {
   path: string
@@ -48,45 +49,56 @@ export interface NativeBackupFormatInput {
   images: readonly NativeBackupImageInput[]
 }
 
-const manifestSchema = z
-  .object({
-    format: z.literal(NATIVE_BACKUP_FORMAT),
-    version: z.literal(NATIVE_BACKUP_VERSION),
-    backup_id: z.string().uuid(),
-    created_at: z.string().datetime({ offset: true }),
-    complete: z.literal(true),
-    counts: z.record(
-      z.enum([...NATIVE_BACKUP_ENTITY_KINDS, 'files']),
-      countSchema,
-    ),
-    notices: z
-      .object({
-        contains_plaintext: z.literal(true),
-        documents_are_extracted_text_only: z.literal(true),
-      })
-      .strict(),
-    files: z.array(
-      z
-        .object({
-          path: z.string(),
-          kind: z.enum(NATIVE_BACKUP_ENTITY_KINDS),
-          sha256: z.string().regex(/^[0-9a-f]{64}$/),
-          size_bytes: countSchema,
-        })
-        .strict(),
-    ),
-  })
-  .strict()
+export interface NativeBackupManifestV1 {
+  format: typeof NATIVE_BACKUP_FORMAT
+  version: typeof NATIVE_BACKUP_VERSION
+  backup_id: string
+  created_at: string
+  complete: true
+  counts: Record<NativeBackupEntityKind, number> & { files: number }
+  notices: { contains_plaintext: true; documents_are_extracted_text_only: true }
+  files: Array<{
+    path: string
+    kind: NativeBackupEntityKind
+    sha256: string
+    size_bytes: number
+  }>
+}
 
-export type NativeBackupManifestV1 = z.infer<typeof manifestSchema>
+const manifestSchema: z.ZodType<NativeBackupManifestV1> = strict({
+  format: z.literal(NATIVE_BACKUP_FORMAT),
+  version: z.literal(NATIVE_BACKUP_VERSION),
+  backup_id: z.string().uuid(),
+  created_at: z.string().datetime({ offset: true }),
+  complete: z.literal(true),
+  counts: strict({
+    projects: countSchema,
+    project_documents: countSchema,
+    cloud_chats: countSchema,
+    local_chats: countSchema,
+    relationships: countSchema,
+    images: countSchema,
+    files: countSchema,
+  }),
+  notices: strict({
+    contains_plaintext: z.literal(true),
+    documents_are_extracted_text_only: z.literal(true),
+  }),
+  files: z.array(
+    strict({
+      path: z.string(),
+      kind: z.enum(NATIVE_BACKUP_ENTITY_KINDS),
+      sha256: z.string().regex(/^[0-9a-f]{64}$/),
+      size_bytes: countSchema,
+    }),
+  ),
+})
 
 function fail(message: string): never {
   throw new Error(`Invalid native backup: ${message}`)
 }
 
-function jsonBytes(value: unknown): Uint8Array {
-  return encoder.encode(JSON.stringify(value))
-}
+const jsonBytes = (value: unknown) => encoder.encode(JSON.stringify(value))
 
 function parseJson(bytes: Uint8Array, label: string): unknown {
   try {
@@ -96,21 +108,12 @@ function parseJson(bytes: Uint8Array, label: string): unknown {
   }
 }
 
-function idComponent(id: string): string {
-  return `id-${bytesToHex(encoder.encode(id))}`
-}
-
-function hash(bytes: Uint8Array): string {
-  return bytesToHex(sha256(bytes))
-}
-
-function safePath(path: string): boolean {
-  if (!path || path.length > 4096 || path.includes('\\') || path.includes('\0'))
-    return false
-  if (path.startsWith('/') || path.endsWith('/') || path.includes('//'))
-    return false
-  return path.split('/').every((part) => part !== '.' && part !== '..')
-}
+const idComponent = (id: string) => `id-${bytesToHex(encoder.encode(id))}`
+const hash = (bytes: Uint8Array) => bytesToHex(sha256(bytes))
+const relationshipCount = (value: NativeBackupRelationships) =>
+  value.projectChats.length +
+  value.projectDocuments.length +
+  value.chatImages.length
 
 function expectedPathKind(path: string): NativeBackupEntityKind | null {
   if (path === 'relationships.json') return 'relationships'
@@ -129,30 +132,26 @@ function zipUpperBound(path: string, size: number): number {
 }
 
 function assertArchiveLimits(
-  manifestBytes: Uint8Array,
+  manifest: Uint8Array,
   files: NativeBackupFileEntry[],
 ) {
   if (files.length + 1 > NATIVE_BACKUP_LIMITS.entries)
     fail('archive entry limit exceeded')
-  let total = 22 + zipUpperBound(MANIFEST_PATH, manifestBytes.length)
+  let total = 22 + zipUpperBound(MANIFEST_PATH, manifest.length)
   for (const file of files) total += zipUpperBound(file.path, file.bytes.length)
   if (total > NATIVE_BACKUP_LIMITS.archiveBytes)
     fail('archive size limit exceeded')
 }
 
 function sortedUnique<T extends { id: string }>(
-  values: readonly T[],
-  label: string,
+  items: readonly T[],
+  name: string,
 ) {
-  const sorted = [...values].sort((a, b) =>
-    idComponent(a.id) < idComponent(b.id)
-      ? -1
-      : idComponent(a.id) > idComponent(b.id)
-        ? 1
-        : 0,
+  const sorted = [...items].sort((a, b) =>
+    idComponent(a.id).localeCompare(idComponent(b.id)),
   )
   for (let index = 1; index < sorted.length; index++)
-    if (sorted[index - 1].id === sorted[index].id) fail(`duplicate ${label} id`)
+    if (sorted[index - 1].id === sorted[index].id) fail(`duplicate ${name} id`)
   return sorted
 }
 
@@ -242,7 +241,7 @@ export function formatNativeBackupV1(input: NativeBackupFormatInput): {
     project_documents: documents.length,
     cloud_chats: cloudChats.length,
     local_chats: localChats.length,
-    relationships: 1,
+    relationships: relationshipCount(relationships),
     images: images.length,
     files: files.length,
   }
@@ -269,18 +268,13 @@ export function formatNativeBackupV1(input: NativeBackupFormatInput): {
   return { manifestBytes, files }
 }
 
-function relationKey(left: string, right: string) {
-  return `${left}\0${right}`
-}
+const relationKey = (left: string, right: string) => `${left}\0${right}`
 
-function exactRelations(actual: string[], expected: string[], label: string) {
-  if (new Set(actual).size !== actual.length)
-    fail(`duplicate ${label} relationship`)
-  if (
-    actual.length !== expected.length ||
-    actual.some((value) => !expected.includes(value))
-  )
-    fail(`${label} relationships do not match entities`)
+function exactRelations(values: string[], wanted: Set<string>, name: string) {
+  const actual = new Set(values)
+  if (actual.size !== values.length) fail(`duplicate ${name} relationship`)
+  if (actual.size !== wanted.size || values.some((value) => !wanted.has(value)))
+    fail(`${name} relationships do not match entities`)
 }
 
 function assertSemanticContent(
@@ -298,15 +292,20 @@ function assertSemanticContent(
     fail('duplicate entity id')
   if (documentIds.size !== documents.length || imageIds.size !== images.length)
     fail('duplicate entity id')
-  const expectedDocuments = documents.map(({ projectId, id }) => {
-    if (!projectIds.has(projectId)) fail('document references unknown project')
-    return relationKey(projectId, id)
-  })
-  const expectedChats = chats.flatMap(({ id, projectId }) => {
-    if (!projectId) return []
-    if (!projectIds.has(projectId)) fail('chat references unknown project')
-    return [relationKey(projectId, id)]
-  })
+  const expectedDocuments = new Set(
+    documents.map(({ projectId, id }) => {
+      if (!projectIds.has(projectId))
+        fail('document references unknown project')
+      return relationKey(projectId, id)
+    }),
+  )
+  const expectedChats = new Set(
+    chats.flatMap(({ id, projectId }) => {
+      if (!projectId) return []
+      if (!projectIds.has(projectId)) fail('chat references unknown project')
+      return [relationKey(projectId, id)]
+    }),
+  )
   exactRelations(
     relationships.projectDocuments.map(({ projectId, documentId }) => {
       if (!projectIds.has(projectId) || !documentIds.has(documentId))
@@ -331,7 +330,7 @@ function assertSemanticContent(
         fail('chat image relationship references unknown entity')
       return relationKey(chatId, imageId)
     }),
-    images.map(({ chatId, id }) => relationKey(chatId, id)),
+    new Set(images.map(({ chatId, id }) => relationKey(chatId, id))),
     'chat image',
   )
   let messages = 0
@@ -408,7 +407,7 @@ export function assertValidNativeBackupV1(
     if (seenPaths.has(file.path)) fail(`duplicate path ${file.path}`)
     seenPaths.add(file.path)
     const metadata = listed.get(file.path)
-    const expectedKind = safePath(file.path) && expectedPathKind(file.path)
+    const expectedKind = expectedPathKind(file.path)
     if (
       !metadata ||
       !expectedKind ||
@@ -474,7 +473,7 @@ export function assertValidNativeBackupV1(
     project_documents: documents.length,
     cloud_chats: files.filter(({ kind }) => kind === 'cloud_chats').length,
     local_chats: files.filter(({ kind }) => kind === 'local_chats').length,
-    relationships: relationships.length,
+    relationships: relationshipCount(relationships[0]),
     images: images.length,
     files: files.length,
   }

--- a/src/services/native-backup/index.ts
+++ b/src/services/native-backup/index.ts
@@ -1,3 +1,4 @@
 export * from './constants'
+export * from './format'
 export * from './sanitize'
 export * from './schemas'

--- a/tests/fixtures/native-backup-manifest-v1.json
+++ b/tests/fixtures/native-backup-manifest-v1.json
@@ -1,0 +1,64 @@
+{
+  "format": "tinfoil-native-backup",
+  "version": 1,
+  "backup_id": "123e4567-e89b-42d3-a456-426614174000",
+  "created_at": "2026-08-20T12:00:00.000Z",
+  "complete": true,
+  "counts": {
+    "projects": 1,
+    "project_documents": 1,
+    "cloud_chats": 1,
+    "local_chats": 1,
+    "relationships": 1,
+    "images": 1,
+    "files": 7
+  },
+  "notices": {
+    "contains_plaintext": true,
+    "documents_are_extracted_text_only": true
+  },
+  "files": [
+    {
+      "path": "cloud_chats/id-63.json",
+      "kind": "cloud_chats",
+      "sha256": "e45e95d49f827552a7dd625f7285a85b7cb739c77d78e492c9524c3d092aec62",
+      "size_bytes": 262
+    },
+    {
+      "path": "images/id-69.bin",
+      "kind": "images",
+      "sha256": "054edec1d0211f624fed0cbca9d4f9400b0e491c43742af2c5b0abebf0c990d8",
+      "size_bytes": 4
+    },
+    {
+      "path": "images/id-69.json",
+      "kind": "images",
+      "sha256": "8f5787c4a9394731df921261c33376ebeaa31e13637092107961d2c15c06ca4b",
+      "size_bytes": 119
+    },
+    {
+      "path": "local_chats/id-6c.json",
+      "kind": "local_chats",
+      "sha256": "16dd6b0c1d82eb445260c17b6bc5dd912a510eb844156d6f30a9c084a71c9689",
+      "size_bytes": 118
+    },
+    {
+      "path": "project_documents/id-70/id-64.json",
+      "kind": "project_documents",
+      "sha256": "2314b5db7954813f560e10db2da83e041e2dd379552d569684c6ae08dbeae0d8",
+      "size_bytes": 197
+    },
+    {
+      "path": "projects/id-70.json",
+      "kind": "projects",
+      "sha256": "fc8b32e08ebb5b834c4b62c27f0593846fb94f83b0925b6ad673dd34d9b478f8",
+      "size_bytes": 152
+    },
+    {
+      "path": "relationships.json",
+      "kind": "relationships",
+      "sha256": "6d04be019bc2a27dfac46ad9f900b0ea471ed53a47acd7a43b297eca68eb859f",
+      "size_bytes": 149
+    }
+  ]
+}

--- a/tests/fixtures/native-backup-manifest-v1.json
+++ b/tests/fixtures/native-backup-manifest-v1.json
@@ -9,7 +9,7 @@
     "project_documents": 1,
     "cloud_chats": 1,
     "local_chats": 1,
-    "relationships": 1,
+    "relationships": 3,
     "images": 1,
     "files": 7
   },

--- a/tests/services/native-backup/format.test.ts
+++ b/tests/services/native-backup/format.test.ts
@@ -1,0 +1,210 @@
+import {
+  NATIVE_BACKUP_LIMITS,
+  assertValidNativeBackupV1,
+  formatNativeBackupV1,
+  type NativeBackupFormatInput,
+} from '@/services/native-backup'
+import goldenManifest from '../../fixtures/native-backup-manifest-v1.json'
+
+const timestamp = '2026-08-20T12:00:00.000Z'
+
+function input(): NativeBackupFormatInput {
+  return {
+    backupId: '123e4567-e89b-42d3-a456-426614174000',
+    createdAt: timestamp,
+    projects: [
+      {
+        id: 'p',
+        name: 'P',
+        description: '',
+        systemInstructions: '',
+        memory: [],
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      },
+    ],
+    projectDocuments: [
+      {
+        id: 'd',
+        projectId: 'p',
+        filename: 'paper.pdf',
+        contentType: 'application/pdf',
+        sizeBytes: 10,
+        extractedText: 'text',
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      },
+    ],
+    cloudChats: [
+      {
+        id: 'c',
+        title: 'Cloud',
+        messages: [
+          {
+            role: 'user',
+            content: 'hello',
+            attachments: [{ id: 'a', type: 'image', imageId: 'i' }],
+            timestamp,
+          },
+        ],
+        createdAt: timestamp,
+        updatedAt: timestamp,
+        projectId: 'p',
+      },
+    ],
+    localChats: [
+      {
+        id: 'l',
+        title: 'Local',
+        messages: [],
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      },
+    ],
+    relationships: {
+      projectChats: [{ projectId: 'p', chatId: 'c' }],
+      projectDocuments: [{ projectId: 'p', documentId: 'd' }],
+      chatImages: [{ chatId: 'c', imageId: 'i' }],
+    },
+    images: [
+      {
+        metadata: {
+          id: 'i',
+          chatId: 'c',
+          messageIndex: 0,
+          attachmentId: 'a',
+          fileName: 'pixel.png',
+          mimeType: 'image/png',
+        },
+        bytes: new Uint8Array([0, 1, 2, 3]),
+      },
+    ],
+  }
+}
+
+describe('native backup v1 manifest', () => {
+  it('matches the semantic golden manifest with deterministic hashes and counts', () => {
+    const first = formatNativeBackupV1(input())
+    const second = formatNativeBackupV1(input())
+
+    expect(JSON.parse(new TextDecoder().decode(first.manifestBytes))).toEqual(
+      goldenManifest,
+    )
+    expect(first.files.map(({ path }) => path)).toEqual(
+      goldenManifest.files.map(({ path }) => path),
+    )
+    expect(second.manifestBytes).toEqual(first.manifestBytes)
+    expect(assertValidNativeBackupV1(first.manifestBytes, first.files)).toEqual(
+      goldenManifest,
+    )
+  })
+
+  it('requires matching image metadata, bytes, and message references', () => {
+    const missingBytes = { ...input(), images: [] }
+    expect(() => formatNativeBackupV1(missingBytes)).toThrow(
+      'chat image relationship references unknown entity',
+    )
+
+    const wrongLocation = input()
+    wrongLocation.images[0].metadata.messageIndex = 1
+    expect(() => formatNativeBackupV1(wrongLocation)).toThrow(
+      'image descriptor does not match its message reference',
+    )
+  })
+
+  it('enforces parser-aligned image and archive safety limits', () => {
+    expect(NATIVE_BACKUP_LIMITS.archiveBytes).toBe(512 * 1024 * 1024)
+    expect(NATIVE_BACKUP_LIMITS.aggregateJsonBytes).toBe(256 * 1024 * 1024)
+    const valid = input()
+    const oversized = {
+      ...valid,
+      images: [
+        {
+          ...valid.images[0],
+          bytes: new Uint8Array(NATIVE_BACKUP_LIMITS.imageBytes + 1),
+        },
+      ],
+    }
+    expect(() => formatNativeBackupV1(oversized)).toThrow(
+      'image size limit exceeded',
+    )
+
+    const archiveLimited = input()
+    const maxImage = new Uint8Array(NATIVE_BACKUP_LIMITS.imageBytes)
+    const imageIds = Array.from({ length: 16 }, (_, index) => `i-${index}`)
+    archiveLimited.cloudChats[0].messages[0].attachments = imageIds.map(
+      (imageId) => ({ id: `a-${imageId}`, type: 'image', imageId }),
+    )
+    archiveLimited.relationships.chatImages = imageIds.map((imageId) => ({
+      chatId: 'c',
+      imageId,
+    }))
+    archiveLimited.images = imageIds.map((imageId) => ({
+      metadata: {
+        id: imageId,
+        chatId: 'c',
+        messageIndex: 0,
+        attachmentId: `a-${imageId}`,
+        fileName: `${imageId}.png`,
+        mimeType: 'image/png',
+      },
+      bytes: maxImage,
+    }))
+    expect(() => formatNativeBackupV1(archiveLimited)).toThrow(
+      'archive size limit exceeded',
+    )
+  })
+
+  it('rejects unsafe or noncanonical paths', () => {
+    const formatted = formatNativeBackupV1(input())
+    const manifest = JSON.parse(
+      new TextDecoder().decode(formatted.manifestBytes),
+    )
+    const project = formatted.files.find(({ kind }) => kind === 'projects')!
+    project.path = 'projects/../project.json'
+    manifest.files.find(
+      ({ kind }: { kind: string }) => kind === 'projects',
+    ).path = project.path
+
+    expect(() =>
+      assertValidNativeBackupV1(
+        new TextEncoder().encode(JSON.stringify(manifest)),
+        formatted.files,
+      ),
+    ).toThrow('invalid or unlisted path')
+  })
+
+  it('detects content, hash, size, count, and completeness tampering', () => {
+    const formatted = formatNativeBackupV1(input())
+    const tamperedFiles = formatted.files.map((file) => ({
+      ...file,
+      bytes: new Uint8Array(file.bytes),
+    }))
+    tamperedFiles[0].bytes[0] ^= 1
+    expect(() =>
+      assertValidNativeBackupV1(formatted.manifestBytes, tamperedFiles),
+    ).toThrow('size or hash mismatch')
+
+    type MutableManifest = {
+      counts: { images: number }
+      complete: boolean
+      files: unknown[]
+    }
+    for (const mutation of [
+      (manifest: MutableManifest) => manifest.counts.images++,
+      (manifest: MutableManifest) => (manifest.complete = false),
+      (manifest: MutableManifest) => manifest.files.pop(),
+    ]) {
+      const manifest = JSON.parse(
+        new TextDecoder().decode(formatted.manifestBytes),
+      ) as MutableManifest
+      mutation(manifest)
+      expect(() =>
+        assertValidNativeBackupV1(
+          new TextEncoder().encode(JSON.stringify(manifest)),
+          formatted.files,
+        ),
+      ).toThrow()
+    }
+  })
+})

--- a/tests/services/native-backup/format.test.ts
+++ b/tests/services/native-backup/format.test.ts
@@ -3,6 +3,7 @@ import {
   assertValidNativeBackupV1,
   formatNativeBackupV1,
   type NativeBackupFormatInput,
+  type NativeBackupManifestV1,
 } from '@/services/native-backup'
 import goldenManifest from '../../fixtures/native-backup-manifest-v1.json'
 
@@ -97,7 +98,53 @@ describe('native backup v1 manifest', () => {
     expect(assertValidNativeBackupV1(first.manifestBytes, first.files)).toEqual(
       goldenManifest,
     )
+    expectTypeOf<NativeBackupManifestV1['counts']>().toMatchTypeOf<{
+      projects: number
+      project_documents: number
+      cloud_chats: number
+      local_chats: number
+      relationships: number
+      images: number
+      files: number
+    }>()
   })
+
+  it('validates near-limit relationship sets without quadratic membership scans', () => {
+    const nearLimit = input()
+    const count = 24_000
+    nearLimit.projects = Array.from({ length: count }, (_, index) => ({
+      id: `p-${index}`,
+      name: `Project ${index}`,
+      description: '',
+      systemInstructions: '',
+      memory: [],
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    }))
+    nearLimit.projectDocuments = nearLimit.projects.map((project, index) => ({
+      id: `d-${index}`,
+      projectId: project.id,
+      filename: `${index}.txt`,
+      contentType: 'text/plain',
+      sizeBytes: 1,
+      extractedText: 'x',
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    }))
+    nearLimit.cloudChats[0].projectId = nearLimit.projects[0].id
+    nearLimit.relationships.projectChats[0].projectId = nearLimit.projects[0].id
+    nearLimit.relationships.projectDocuments = nearLimit.projectDocuments.map(
+      ({ id, projectId }) => ({ projectId, documentId: id }),
+    )
+
+    const formatted = formatNativeBackupV1(nearLimit)
+    const manifest = assertValidNativeBackupV1(
+      formatted.manifestBytes,
+      formatted.files,
+    )
+    expect(manifest.counts.files).toBe(48_005)
+    expect(manifest.counts.relationships).toBe(24_002)
+  }, 30_000)
 
   it('requires matching image metadata, bytes, and message references', () => {
     const missingBytes = { ...input(), images: [] }
@@ -153,7 +200,7 @@ describe('native backup v1 manifest', () => {
     expect(() => formatNativeBackupV1(archiveLimited)).toThrow(
       'archive size limit exceeded',
     )
-  })
+  }, 15_000)
 
   it('rejects unsafe or noncanonical paths', () => {
     const formatted = formatNativeBackupV1(input())
@@ -186,12 +233,13 @@ describe('native backup v1 manifest', () => {
     ).toThrow('size or hash mismatch')
 
     type MutableManifest = {
-      counts: { images: number }
+      counts: { images: number; relationships?: number }
       complete: boolean
       files: unknown[]
     }
     for (const mutation of [
       (manifest: MutableManifest) => manifest.counts.images++,
+      (manifest: MutableManifest) => delete manifest.counts.relationships,
       (manifest: MutableManifest) => (manifest.complete = false),
       (manifest: MutableManifest) => manifest.files.pop(),
     ]) {


### PR DESCRIPTION
## Summary
- add complete-only manifest, deterministic layout, hashes, counts, and image bytes
- enforce safe paths and conservative parser-compatible limits
- validate tampering and near-limit relationship sets efficiently

## Testing
- 1,828 unit tests
- typecheck and lint

## Dependency
- stacked on native backup schema

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a native backup v1 manifest generator and validator that produce a deterministic file list with per-file SHA-256 hashes and strict counts. This prevents path/content tampering and enforces parser-aligned size and count limits.

- Introduces limits (`archiveBytes`, `aggregateJsonBytes`, `entries`, `entities`, `messages`, `attachments`, `imageBytes`) and validates against them, including a ZIP entry upper bound for the whole archive.
- Provides formatNativeBackupV1 and assertValidNativeBackupV1:
  - Canonical paths: projects/id-<hex>.json, project_documents/<project>/id-<doc>.json, cloud_chats/local_chats/id-<hex>.json, relationships.json, images/id-<hex>.json and .bin.
  - Manifest includes format/version, backup_id, created_at, complete: true, counts, notices, and files with path/kind/sha256/size_bytes.
  - Ensures unique IDs (cloud/local chats cannot collide), exact relationship sets, and that image metadata, bytes (sizeBytes), and message references match.
- Exports the new APIs from native-backup index and adds deterministic “golden” tests for counts, hashes, limits, tamper and path safety.

- Migration:
  - Backup producers must emit complete backups only; partial exports are rejected.
  - Use formatNativeBackupV1 to generate manifest.json and files, and ensure chat IDs are unique across cloud and local.
  - Respect size/count limits; oversize images or archives will fail validation.

<sup>Written for commit fb163f3662892e7f896d607f779bc9671b526209. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/526?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

