### PR TITLE
feat: collect native backup data

### DIFF
--- a/src/services/cloud/cloud-storage.ts
+++ b/src/services/cloud/cloud-storage.ts
@@ -569,20 +569,6 @@ export class CloudStorageService {
     return results
   }
 
-  async loadChatImage(attachment: Attachment): Promise<Uint8Array | null> {
-    if (attachment.base64) return base64ToUint8Array(attachment.base64)
-    if (attachment.encryptionKey) {
-      return enclaveAttachmentGet({
-        id: attachment.id,
-        attKeyB64: attachment.encryptionKey,
-      })
-    }
-    const legacyKey = (attachment as Attachment & { key?: string }).key
-    return legacyKey
-      ? this.fetchLegacyAttachment(attachment.id, legacyKey)
-      : null
-  }
-
   // Part of the v0/v1 → v2 attachment migration. Safe to remove once
   // the controlplane `chat_attachments_legacy` table is drained and
   // no client (web or iOS) still depends on this fallback.

--- a/src/services/cloud/cloud-storage.ts
+++ b/src/services/cloud/cloud-storage.ts
@@ -569,6 +569,20 @@ export class CloudStorageService {
     return results
   }
 
+  async loadChatImage(attachment: Attachment): Promise<Uint8Array | null> {
+    if (attachment.base64) return base64ToUint8Array(attachment.base64)
+    if (attachment.encryptionKey) {
+      return enclaveAttachmentGet({
+        id: attachment.id,
+        attKeyB64: attachment.encryptionKey,
+      })
+    }
+    const legacyKey = (attachment as Attachment & { key?: string }).key
+    return legacyKey
+      ? this.fetchLegacyAttachment(attachment.id, legacyKey)
+      : null
+  }
+
   // Part of the v0/v1 → v2 attachment migration. Safe to remove once
   // the controlplane `chat_attachments_legacy` table is drained and
   // no client (web or iOS) still depends on this fallback.

--- a/src/services/native-backup/collect.ts
+++ b/src/services/native-backup/collect.ts
@@ -1,4 +1,4 @@
-import type { Attachment } from '@/components/chat/types'
+import type { Attachment, Message } from '@/components/chat/types'
 import { AUTH_ACTIVE_USER_ID } from '@/constants/storage-keys'
 import { authTokenManager } from '@/services/auth'
 import { requirePrimaryKeyB64 } from '@/services/cloud/cek-encoding'
@@ -21,7 +21,6 @@ import {
   sanitizeNativeBackupRelationships,
   type NativeBackupImageCandidate,
 } from './sanitize'
-
 const PAGE_SIZE = 500
 const CONCURRENCY = 4
 const encoder = new TextEncoder()
@@ -72,7 +71,11 @@ const defaults: NativeBackupCollectionDependencies = {
     return { items: page.conversations, next: page.nextContinuationToken }
   },
   getCloudChat: (id) => cloudStorage.downloadChat(id),
-  getCloudImage: (value) => cloudStorage.loadChatImage(value),
+  getCloudImage: async (value) => {
+    const message = { attachments: [value] } as Message
+    const encoded = (await cloudStorage.loadChatImages('', [message]))[value.id]
+    return encoded ? base64ToUint8Array(encoded) : null
+  },
   listProjects: async (continuationToken) => {
     const page = await projectStorage.listProjects({
       limit: PAGE_SIZE,
@@ -87,9 +90,14 @@ const defaults: NativeBackupCollectionDependencies = {
   getLocalChats: () => indexedDBStorage.getAllChats(),
   getLocalChat: (id) => indexedDBStorage.getChat(id),
 }
-
 function fail(kind: string, id: string, detail: string): never {
   throw new NativeBackupCollectionError(kind, id, detail)
+}
+async function wait<T>(s: AbortSignal | undefined, read: () => Promise<T>) {
+  s?.throwIfAborted()
+  const value = await read()
+  s?.throwIfAborted()
+  return value
 }
 const detail = (error: unknown) =>
   error instanceof Error ? error.message : String(error)
@@ -111,24 +119,32 @@ function unique<T extends Listed>(values: T[]): T[] {
   }
   return [...byId.values()]
 }
-async function pages<T extends Listed>(read: (token?: string) => Page<T>) {
+async function pages<T extends Listed>(
+  fn: (t?: string) => Page<T>,
+  s?: AbortSignal,
+) {
   const values: T[] = []
   let token: string | undefined
   do {
-    const page = await read(token)
+    const page = await wait(s, () => fn(token))
     values.push(...page.items)
     token = page.next
   } while (token)
   return unique(values)
 }
-async function mapLimit<T, R>(values: T[], read: (value: T) => Promise<R>) {
-  const output = new Array<R>(values.length)
+async function mapLimit<T, R>(
+  v: T[],
+  fn: (v: T) => Promise<R>,
+  s?: AbortSignal,
+) {
+  const output = new Array<R>(v.length)
   let next = 0
   await Promise.all(
-    Array.from({ length: Math.min(CONCURRENCY, values.length) }, async () => {
-      while (next < values.length) {
+    Array.from({ length: Math.min(CONCURRENCY, v.length) }, async () => {
+      while (next < v.length) {
+        s?.throwIfAborted()
         const index = next++
-        output[index] = await read(values[index])
+        output[index] = await wait(s, () => fn(v[index]))
       }
     }),
   )
@@ -151,17 +167,11 @@ class Budget {
   }
   chat(value: ReturnType<typeof sanitizeNativeBackupChat>): Pending {
     const bytes = jsonSize(value)
-    const attachments = value.messages.reduce(
+    const count = value.messages.reduce(
       (sum, item) => sum + (item.attachments?.length ?? 0),
       0,
     )
-    const pending: Pending = [
-      value.messages.length,
-      attachments,
-      bytes,
-      bytes,
-      1,
-    ]
+    const pending: Pending = [value.messages.length, count, bytes, bytes, 1]
     this.check(pending)
     return pending
   }
@@ -195,32 +205,34 @@ async function readRecord<T>(
   kind: string,
   id: string,
   read: () => Promise<T | null>,
+  signal?: AbortSignal,
 ) {
   try {
-    return (await read()) ?? fail(kind, id, 'record is missing or invalid')
+    const value = await wait(signal, read)
+    return value ?? fail(kind, id, 'record is missing or invalid')
   } catch (error) {
+    signal?.throwIfAborted()
     if (error instanceof NativeBackupCollectionError) throw error
     return fail(kind, id, `read failed: ${detail(error)}`)
   }
 }
-
 async function stable<T extends { syncVersion?: number }, I extends Listed>(
   kind: string,
   initial: I,
   read: () => Promise<T | null>,
   refresh: () => Promise<I[]>,
+  signal?: AbortSignal,
 ): Promise<{ value: T; item: I }> {
   let item = initial
   for (let attempt = 0; attempt < 2; attempt++) {
-    const value = await readRecord(kind, item.id, read)
+    const value = await readRecord(kind, item.id, read, signal)
     if (value.syncVersion === item.syncVersion) return { value, item }
     item =
-      unique(await refresh()).find(({ id }) => id === item.id) ??
+      unique(await wait(signal, refresh)).find(({ id }) => id === item.id) ??
       fail(kind, item.id, 'record is missing or invalid')
   }
   return fail(kind, item.id, 'version changed during collection')
 }
-
 async function timed<T extends { syncVersion?: number }, I extends Timed, R>(
   kind: string,
   item: I,
@@ -228,8 +240,9 @@ async function timed<T extends { syncVersion?: number }, I extends Timed, R>(
   refresh: () => Promise<I[]>,
   sanitize: (value: unknown) => R,
   budget: Budget,
+  signal?: AbortSignal,
 ) {
-  const current = await stable(kind, item, read, refresh)
+  const current = await stable(kind, item, read, refresh, signal)
   const value = valid(kind, item.id, () =>
     sanitize({
       ...current.value,
@@ -240,7 +253,6 @@ async function timed<T extends { syncVersion?: number }, I extends Timed, R>(
   budget.json(value)
   return value
 }
-
 function portable(chat: StoredChat, images?: NativeBackupImageCandidate[]) {
   return sanitizeNativeBackupChat(chat, (candidate) => {
     images?.push(candidate)
@@ -267,58 +279,89 @@ function localEligible(chat: StoredChat, userId: string) {
       'local'
   )
 }
-
 async function collectChat(
   chat: StoredChat,
   cloud: boolean,
   deps: NativeBackupCollectionDependencies,
   budget: Budget,
+  signal?: AbortSignal,
 ) {
   const candidates: NativeBackupImageCandidate[] = []
   const value = valid(cloud ? 'cloud chat' : 'local chat', chat.id, () =>
     portable(chat, candidates),
   )
   const pending = budget.chat(value)
-  const images = await mapLimit(candidates, async (candidate) => {
-    const message = chat.messages[candidate.messageIndex]
-    const attachment = message.attachments?.find(
-      ({ id }) => id === candidate.attachmentId,
-    )
-    const base64 =
-      candidate.legacyIndex !== undefined
-        ? message.imageData?.[candidate.legacyIndex]?.base64
-        : candidate.page !== undefined
-          ? attachment?.pages?.find(({ page }) => page === candidate.page)
-              ?.image
-          : attachment?.base64
-    let bytes: Uint8Array | null = null
-    try {
-      bytes = base64
-        ? base64ToUint8Array(base64)
-        : cloud && attachment
-          ? await deps.getCloudImage(attachment)
-          : null
-    } catch {
-      fail('image', candidate.sourceKey, 'image bytes are invalid')
-    }
-    if (!bytes) fail('image', candidate.sourceKey, 'image bytes are missing')
-    const metadata = valid('image', candidate.sourceKey, () =>
-      sanitizeNativeBackupImage({
-        ...candidate,
-        id: candidate.sourceKey,
-        sizeBytes: bytes.length,
-      }),
-    )
-    budget.image(pending, metadata, bytes)
-    return { metadata, bytes }
-  })
+  const images = await mapLimit(
+    candidates,
+    async (candidate) => {
+      const message = chat.messages[candidate.messageIndex]
+      const attachment = message.attachments?.find(
+        ({ id }) => id === candidate.attachmentId,
+      )
+      const base64 =
+        candidate.legacyIndex !== undefined
+          ? message.imageData?.[candidate.legacyIndex]?.base64
+          : candidate.page !== undefined
+            ? attachment?.pages?.find(({ page }) => page === candidate.page)
+                ?.image
+            : attachment?.base64
+      let bytes: Uint8Array | null = null
+      try {
+        bytes = base64
+          ? base64ToUint8Array(base64)
+          : cloud && attachment
+            ? await wait(signal, () => deps.getCloudImage(attachment))
+            : null
+      } catch {
+        signal?.throwIfAborted()
+        fail('image', candidate.sourceKey, 'image bytes are invalid')
+      }
+      if (!bytes) fail('image', candidate.sourceKey, 'image bytes are missing')
+      const metadata = valid('image', candidate.sourceKey, () =>
+        sanitizeNativeBackupImage({
+          ...candidate,
+          id: candidate.sourceKey,
+          sizeBytes: bytes.length,
+        }),
+      )
+      budget.image(pending, metadata, bytes)
+      return { metadata, bytes }
+    },
+    signal,
+  )
   return { chat: value, images, pending }
 }
-
+async function retryChat<K>(
+  kind: string,
+  id: string,
+  expected: K,
+  read: () => Promise<StoredChat | null>,
+  revision: (chat: StoredChat) => K,
+  eligible: (chat: StoredChat) => boolean,
+  refresh: (chat: StoredChat) => Promise<K>,
+  collect: (chat: StoredChat) => ReturnType<typeof collectChat>,
+  signal?: AbortSignal,
+) {
+  for (let attempt = 0; attempt < 2; attempt++) {
+    const chat = await readRecord(kind, id, read, signal)
+    const current = revision(chat)
+    if (current !== expected) {
+      expected = await wait(signal, () => refresh(chat))
+      continue
+    }
+    if (!eligible(chat)) return null
+    const result = await collect(chat)
+    const verify = await readRecord(kind, id, read, signal)
+    if (revision(verify) === current) return result
+    expected = await wait(signal, () => refresh(verify))
+  }
+  return fail(kind, id, 'version changed during collection')
+}
 export async function collectNativeBackupV1(
   deps: NativeBackupCollectionDependencies = defaults,
+  signal?: AbortSignal,
 ): Promise<NativeBackupV1Input> {
-  if (!(await deps.isAuthenticated()))
+  if (!(await wait(signal, () => deps.isAuthenticated())))
     fail('account', 'active', 'signed-in user is required')
   const userId = deps.activeUserId()
   if (!userId) fail('account', 'active', 'signed-in owner is unavailable')
@@ -327,109 +370,84 @@ export async function collectNativeBackupV1(
   } catch {
     fail('account', userId, 'cloud encryption key is locked or unavailable')
   }
-
   const [chatItems, projectItems, localSnapshots] = await Promise.all([
-    pages(deps.listChats),
-    pages(deps.listProjects),
-    deps.getLocalChats(),
+    pages(deps.listChats, signal),
+    pages(deps.listProjects, signal),
+    wait(signal, () => deps.getLocalChats()),
   ])
   const documentItems = unique(
-    (await mapLimit(projectItems, ({ id }) => deps.listDocuments(id))).flat(),
+    (
+      await mapLimit(projectItems, ({ id }) => deps.listDocuments(id), signal)
+    ).flat(),
   )
   const budget = new Budget()
   budget.entities(projectItems.length + documentItems.length)
-
-  const projects = await mapLimit(projectItems, (item) =>
-    timed(
-      'project',
-      item,
-      () => deps.getProject(item.id),
-      () => pages(deps.listProjects),
-      sanitizeNativeBackupProject,
-      budget,
-    ),
+  const projects = await mapLimit(
+    projectItems,
+    (item) =>
+      timed(
+        'project',
+        item,
+        () => deps.getProject(item.id),
+        () => pages(deps.listProjects, signal),
+        sanitizeNativeBackupProject,
+        budget,
+        signal,
+      ),
+    signal,
   )
-  const projectDocuments = await mapLimit(documentItems, (item) =>
-    timed(
-      'project document',
-      item,
-      () => deps.getDocument(item.projectId, item.id),
-      () => deps.listDocuments(item.projectId),
-      sanitizeNativeBackupProjectDocument,
-      budget,
-    ),
+  const projectDocuments = await mapLimit(
+    documentItems,
+    (item) =>
+      timed(
+        'project document',
+        item,
+        () => deps.getDocument(item.projectId, item.id),
+        () => deps.listDocuments(item.projectId),
+        sanitizeNativeBackupProjectDocument,
+        budget,
+        signal,
+      ),
+    signal,
   )
-
   const cloudResults = []
   for (const listed of chatItems) {
-    let item = listed
-    let result: Awaited<ReturnType<typeof collectChat>> | null = null
-    let excluded = false
-    for (let attempt = 0; attempt < 2; attempt++) {
-      const chat = await readRecord('cloud chat', item.id, () =>
-        deps.getCloudChat(item.id),
-      )
-      if (chat.syncVersion !== item.syncVersion) {
-        item =
-          (await pages(deps.listChats)).find(({ id }) => id === item.id) ??
-          fail('cloud chat', item.id, 'record is missing or invalid')
-        continue
-      }
-      if (classifyNativeBackupChat(chat, 'cloud') === null) {
-        excluded = true
-        break
-      }
-      result = await collectChat(chat, true, deps, budget)
-      const verify = await readRecord('cloud chat', item.id, () =>
-        deps.getCloudChat(item.id),
-      )
-      if (verify.syncVersion === chat.syncVersion) break
-      item =
-        (await pages(deps.listChats)).find(({ id }) => id === item.id) ??
-        fail('cloud chat', item.id, 'record is missing or invalid')
-      result = null
-    }
-    if (excluded) continue
-    if (!result)
-      fail('cloud chat', item.id, 'version changed during collection')
+    const result = await retryChat(
+      'cloud chat',
+      listed.id,
+      listed.syncVersion,
+      () => deps.getCloudChat(listed.id),
+      ({ syncVersion }) => syncVersion,
+      (chat) => classifyNativeBackupChat(chat, 'cloud') !== null,
+      async () =>
+        (await pages(deps.listChats, signal)).find(({ id }) => id === listed.id)
+          ?.syncVersion ??
+        fail('cloud chat', listed.id, 'record is missing or invalid'),
+      (chat) => collectChat(chat, true, deps, budget, signal),
+      signal,
+    )
+    if (!result) continue
     budget.commit(result.pending, true)
     cloudResults.push(result)
   }
-
   const localResults = []
   for (const snapshot of localSnapshots) {
     if (!localEligible(snapshot, userId)) continue
-    let expected = localToken(snapshot)
-    let result: Awaited<ReturnType<typeof collectChat>> | null = null
-    let excluded = false
-    for (let attempt = 0; attempt < 2; attempt++) {
-      const chat = await readRecord('local chat', snapshot.id, () =>
-        deps.getLocalChat(snapshot.id),
-      )
-      const token = localToken(chat)
-      if (token !== expected) {
-        expected = token
-        continue
-      }
-      if (!localEligible(chat, userId)) {
-        excluded = true
-        break
-      }
-      result = await collectChat(chat, false, deps, budget)
-      const verify = await readRecord('local chat', snapshot.id, () =>
-        deps.getLocalChat(snapshot.id),
-      )
-      if (localToken(verify) === token) break
-      expected = localToken(verify)
-      result = null
-    }
-    if (excluded) continue
-    if (!result)
-      fail('local chat', snapshot.id, 'version changed during collection')
+    const result = await retryChat(
+      'local chat',
+      snapshot.id,
+      localToken(snapshot),
+      () => deps.getLocalChat(snapshot.id),
+      localToken,
+      (chat) => localEligible(chat, userId),
+      async (chat) => localToken(chat),
+      (chat) => collectChat(chat, false, deps, budget, signal),
+      signal,
+    )
+    if (!result) continue
     budget.commit(result.pending, true)
     localResults.push(result)
   }
-
   const cloudChats = cloudResults.map(({ chat }) => chat)
   const localChats = localResults.map(({ chat }) => chat)
   const images = [...cloudResults, ...localResults].flatMap(
@@ -459,6 +477,7 @@ export async function collectNativeBackupV1(
     relationships,
     images,
   }
+  signal?.throwIfAborted()
   formatNativeBackupV1(input)
   return input
 }

--- a/src/services/native-backup/collect.ts
+++ b/src/services/native-backup/collect.ts
@@ -23,40 +23,26 @@ import {
 } from './sanitize'
 
 const PAGE_SIZE = 500
-const READ_CONCURRENCY = 4
-
-type ChatListItem = { id: string; syncVersion: number }
-type ProjectListItem = {
-  id: string
-  syncVersion: number
-  createdAt: string
-  updatedAt: string
-}
-type DocumentListItem = ProjectListItem & { projectId: string }
-
+const CONCURRENCY = 4
+const encoder = new TextEncoder()
+type Listed = { id: string; syncVersion: number }
+type Timed = Listed & { createdAt: string; updatedAt: string }
+type DocumentItem = Timed & { projectId: string }
+type Page<T> = Promise<{ items: T[]; next?: string }>
 export interface NativeBackupCollectionDependencies {
   isAuthenticated(): Promise<boolean>
   activeUserId(): string | null
   requireUnlockedCek(): void
-  listChats(token?: string): Promise<{
-    items: ChatListItem[]
-    next?: string
-  }>
+  listChats(token?: string): Page<Listed>
   getCloudChat(id: string): Promise<StoredChat | null>
-  getCloudImage(attachment: Attachment): Promise<Uint8Array | null>
-  listProjects(token?: string): Promise<{
-    items: ProjectListItem[]
-    next?: string
-  }>
+  getCloudImage(value: Attachment): Promise<Uint8Array | null>
+  listProjects(token?: string): Page<Timed>
   getProject(id: string): Promise<Project | null>
-  listDocuments(projectId: string): Promise<DocumentListItem[]>
+  listDocuments(projectId: string): Promise<DocumentItem[]>
   getDocument(projectId: string, id: string): Promise<ProjectDocument | null>
   getLocalChats(): Promise<StoredChat[]>
   getLocalChat(id: string): Promise<StoredChat | null>
-  randomUUID(): string
-  now(): Date
 }
-
 export class NativeBackupCollectionError extends Error {
   constructor(
     public readonly kind: string,
@@ -67,16 +53,14 @@ export class NativeBackupCollectionError extends Error {
     this.name = 'NativeBackupCollectionError'
   }
 }
-
-function activeUserId(): string | null {
+function activeUserId() {
   try {
     return localStorage.getItem(AUTH_ACTIVE_USER_ID)
   } catch {
     return null
   }
 }
-
-const defaultDependencies: NativeBackupCollectionDependencies = {
+const defaults: NativeBackupCollectionDependencies = {
   isAuthenticated: () => authTokenManager.isAuthenticated(),
   activeUserId,
   requireUnlockedCek: () => void requirePrimaryKeyB64(),
@@ -85,13 +69,10 @@ const defaultDependencies: NativeBackupCollectionDependencies = {
       limit: PAGE_SIZE,
       continuationToken,
     })
-    return {
-      items: page.conversations,
-      next: page.nextContinuationToken,
-    }
+    return { items: page.conversations, next: page.nextContinuationToken }
   },
   getCloudChat: (id) => cloudStorage.downloadChat(id),
-  getCloudImage: (attachment) => cloudStorage.loadChatImage(attachment),
+  getCloudImage: (value) => cloudStorage.loadChatImage(value),
   listProjects: async (continuationToken) => {
     const page = await projectStorage.listProjects({
       limit: PAGE_SIZE,
@@ -100,353 +81,359 @@ const defaultDependencies: NativeBackupCollectionDependencies = {
     return { items: page.projects, next: page.nextContinuationToken }
   },
   getProject: (id) => projectStorage.getProject(id),
-  listDocuments: async (projectId) =>
-    (await projectStorage.listDocuments(projectId)).documents,
+  listDocuments: async (id) =>
+    (await projectStorage.listDocuments(id)).documents,
   getDocument: (projectId, id) => projectStorage.getDocument(projectId, id),
   getLocalChats: () => indexedDBStorage.getAllChats(),
   getLocalChat: (id) => indexedDBStorage.getChat(id),
-  randomUUID: () => crypto.randomUUID(),
-  now: () => new Date(),
-}
-
-async function allPages<T>(
-  read: (token?: string) => Promise<{ items: T[]; next?: string }>,
-): Promise<T[]> {
-  const output: T[] = []
-  let token: string | undefined
-  do {
-    const page = await read(token)
-    output.push(...page.items)
-    token = page.next
-  } while (token)
-  return output
-}
-
-async function mapLimit<T, R>(
-  values: readonly T[],
-  read: (value: T) => Promise<R>,
-): Promise<R[]> {
-  const output = new Array<R>(values.length)
-  let next = 0
-  await Promise.all(
-    Array.from(
-      { length: Math.min(READ_CONCURRENCY, values.length) },
-      async () => {
-        while (next < values.length) {
-          const index = next++
-          output[index] = await read(values[index])
-        }
-      },
-    ),
-  )
-  return output
 }
 
 function fail(kind: string, id: string, detail: string): never {
   throw new NativeBackupCollectionError(kind, id, detail)
 }
-
+const detail = (error: unknown) =>
+  error instanceof Error ? error.message : String(error)
+const jsonSize = (value: unknown) =>
+  encoder.encode(JSON.stringify(value)).length
+function valid<T>(kind: string, id: string, parse: () => T): T {
+  try {
+    return parse()
+  } catch (error) {
+    if (error instanceof NativeBackupCollectionError) throw error
+    return fail(kind, id, `record is invalid: ${detail(error)}`)
+  }
+}
+function unique<T extends Listed>(values: T[]): T[] {
+  const byId = new Map<string, T>()
+  for (const value of values) {
+    const old = byId.get(value.id)
+    if (!old || value.syncVersion >= old.syncVersion) byId.set(value.id, value)
+  }
+  return [...byId.values()]
+}
+async function pages<T extends Listed>(read: (token?: string) => Page<T>) {
+  const values: T[] = []
+  let token: string | undefined
+  do {
+    const page = await read(token)
+    values.push(...page.items)
+    token = page.next
+  } while (token)
+  return unique(values)
+}
+async function mapLimit<T, R>(values: T[], read: (value: T) => Promise<R>) {
+  const output = new Array<R>(values.length)
+  let next = 0
+  await Promise.all(
+    Array.from({ length: Math.min(CONCURRENCY, values.length) }, async () => {
+      while (next < values.length) {
+        const index = next++
+        output[index] = await read(values[index])
+      }
+    }),
+  )
+  return output
+}
+type Pending = [number, number, number, number, number]
+const budgetLimits: Array<[string, number]> = [
+  ['message', NATIVE_BACKUP_LIMITS.messages],
+  ['attachment', NATIVE_BACKUP_LIMITS.attachments],
+  ['aggregate JSON size', NATIVE_BACKUP_LIMITS.aggregateJsonBytes],
+  ['archive size', NATIVE_BACKUP_LIMITS.archiveBytes],
+  ['archive entry', NATIVE_BACKUP_LIMITS.entries],
+]
+class Budget {
+  private used: Pending = [0, 0, 0, 0, 1]
+  private entityCount = 0
+  entities(count: number) {
+    this.entityCount += count
+    this.limit('entity', this.entityCount, NATIVE_BACKUP_LIMITS.entities)
+  }
+  chat(value: ReturnType<typeof sanitizeNativeBackupChat>): Pending {
+    const bytes = jsonSize(value)
+    const attachments = value.messages.reduce(
+      (sum, item) => sum + (item.attachments?.length ?? 0),
+      0,
+    )
+    const pending: Pending = [
+      value.messages.length,
+      attachments,
+      bytes,
+      bytes,
+      1,
+    ]
+    this.check(pending)
+    return pending
+  }
+  image(pending: Pending, metadata: unknown, bytes: Uint8Array) {
+    this.limit('image size', bytes.length, NATIVE_BACKUP_LIMITS.imageBytes)
+    const json = jsonSize(metadata)
+    pending[2] += json
+    pending[3] += json + bytes.length
+    pending[4] += 2
+    this.check(pending)
+  }
+  json(value: unknown) {
+    const bytes = jsonSize(value)
+    this.commit([0, 0, bytes, bytes, 1])
+  }
+  commit(value: Pending, entity = false) {
+    if (entity) this.entities(1)
+    this.check(value)
+    value.forEach((amount, index) => (this.used[index] += amount))
+  }
+  private check(value: Pending) {
+    budgetLimits.forEach(([label, limit], index) =>
+      this.limit(label, this.used[index] + value[index], limit),
+    )
+  }
+  private limit(label: string, value: number, maximum: number) {
+    if (value > maximum) fail('limits', 'collection', `${label} limit exceeded`)
+  }
+}
 async function readRecord<T>(
   kind: string,
   id: string,
   read: () => Promise<T | null>,
-): Promise<T> {
+) {
   try {
-    const value = await read()
-    return value ?? fail(kind, id, 'record is missing or invalid')
+    return (await read()) ?? fail(kind, id, 'record is missing or invalid')
   } catch (error) {
     if (error instanceof NativeBackupCollectionError) throw error
-    fail(kind, id, `read failed: ${errorDetail(error)}`)
+    return fail(kind, id, `read failed: ${detail(error)}`)
   }
 }
 
-async function stableCloudRecord<T extends { syncVersion?: number }>(
+async function stable<T extends { syncVersion?: number }, I extends Listed>(
   kind: string,
-  item: { id: string; syncVersion: number },
+  initial: I,
   read: () => Promise<T | null>,
-): Promise<T> {
-  let expected = item.syncVersion
+  refresh: () => Promise<I[]>,
+): Promise<{ value: T; item: I }> {
+  let item = initial
   for (let attempt = 0; attempt < 2; attempt++) {
     const value = await readRecord(kind, item.id, read)
-    if (value.syncVersion === expected) return value
-    expected = value.syncVersion ?? -1
+    if (value.syncVersion === item.syncVersion) return { value, item }
+    item =
+      unique(await refresh()).find(({ id }) => id === item.id) ??
+      fail(kind, item.id, 'record is missing or invalid')
   }
   return fail(kind, item.id, 'version changed during collection')
 }
 
-function errorDetail(error: unknown): string {
-  return error instanceof Error ? error.message : String(error)
+async function timed<T extends { syncVersion?: number }, I extends Timed, R>(
+  kind: string,
+  item: I,
+  read: () => Promise<T | null>,
+  refresh: () => Promise<I[]>,
+  sanitize: (value: unknown) => R,
+  budget: Budget,
+) {
+  const current = await stable(kind, item, read, refresh)
+  const value = valid(kind, item.id, () =>
+    sanitize({
+      ...current.value,
+      createdAt: current.item.createdAt,
+      updatedAt: current.item.updatedAt,
+    }),
+  )
+  budget.json(value)
+  return value
 }
 
-function localToken(chat: StoredChat): string {
-  return JSON.stringify({
-    id: chat.id,
-    title: chat.title,
-    titleState: chat.titleState,
-    messages: chat.messages,
-    createdAt: chat.createdAt,
-    updatedAt: chat.updatedAt,
-    projectId: chat.projectId,
-    presetId: chat.presetId,
-    model: chat.model,
-    webSearchEnabled: chat.webSearchEnabled,
-    isLocalOnly: chat.isLocalOnly,
-    isBlankChat: chat.isBlankChat,
-    isTemporary: chat.isTemporary,
-    syncUserId: chat.syncUserId,
-    clock: chat.clock,
-    writer: chat.writer,
+function portable(chat: StoredChat, images?: NativeBackupImageCandidate[]) {
+  return sanitizeNativeBackupChat(chat, (candidate) => {
+    images?.push(candidate)
+    return candidate.sourceKey
   })
 }
-
-type ImageSource = {
-  candidate: NativeBackupImageCandidate
-  base64?: string
-  attachment?: Attachment
+function localToken(chat: StoredChat) {
+  return JSON.stringify([
+    portable(chat),
+    chat.isLocalOnly,
+    chat.isBlankChat,
+    chat.isTemporary,
+    chat.syncUserId,
+    (chat as StoredChat & { userId?: string }).userId,
+  ])
 }
-
-function imageSources(chat: StoredChat): ImageSource[] {
-  const output: ImageSource[] = []
-  chat.messages.forEach((message, messageIndex) => {
-    for (const attachment of message.attachments ?? []) {
-      if (attachment.type === 'image') {
-        output.push({
-          candidate: {
-            sourceKey: `attachment:${chat.id}:${messageIndex}:${attachment.id}`,
-            chatId: chat.id,
-            messageIndex,
-            attachmentId: attachment.id,
-            fileName: attachment.fileName,
-            mimeType: attachment.mimeType ?? 'application/octet-stream',
-            description: attachment.description,
-          },
-          base64: attachment.base64,
-          attachment,
-        })
-      } else {
-        for (const page of attachment.pages ?? []) {
-          if (!page.image) continue
-          output.push({
-            candidate: {
-              sourceKey: `page:${chat.id}:${messageIndex}:${attachment.id}:${page.page}`,
-              chatId: chat.id,
-              messageIndex,
-              attachmentId: attachment.id,
-              page: page.page,
-              fileName: `${attachment.id}-page-${page.page}.jpg`,
-              mimeType: 'image/jpeg',
-            },
-            base64: page.image,
-          })
-        }
-      }
-    }
-    message.imageData?.forEach((image, legacyIndex) =>
-      output.push({
-        candidate: {
-          sourceKey: `legacy:${chat.id}:${messageIndex}:${legacyIndex}`,
-          chatId: chat.id,
-          messageIndex,
-          legacyIndex,
-          fileName: `legacy-image-${legacyIndex}`,
-          mimeType: image.mimeType,
-        },
-        base64: image.base64,
-      }),
-    )
-  })
-  return output
+function localEligible(chat: StoredChat, userId: string) {
+  const owned =
+    chat.syncUserId === userId ||
+    (chat as StoredChat & { userId?: string }).userId === userId
+  return (
+    chat.isLocalOnly === true &&
+    classifyNativeBackupChat(chat, owned ? 'signed_in' : 'anonymous') ===
+      'local'
+  )
 }
 
 async function collectChat(
   chat: StoredChat,
   cloud: boolean,
-  dependencies: NativeBackupCollectionDependencies,
+  deps: NativeBackupCollectionDependencies,
+  budget: Budget,
 ) {
-  const sources = imageSources(chat)
-  const images = await mapLimit(
-    sources,
-    async ({ candidate, base64, attachment }) => {
-      let bytes: Uint8Array | null = null
-      try {
-        bytes = base64
-          ? base64ToUint8Array(base64)
-          : cloud && attachment
-            ? await dependencies.getCloudImage(attachment)
-            : null
-      } catch {
-        fail('image', candidate.sourceKey, 'image bytes are invalid')
-      }
-      if (!bytes) fail('image', candidate.sourceKey, 'image bytes are missing')
-      if (bytes.length > NATIVE_BACKUP_LIMITS.imageBytes)
-        fail('image', candidate.sourceKey, 'image size limit exceeded')
-      const id = candidate.sourceKey
-      try {
-        return {
-          metadata: sanitizeNativeBackupImage({
-            ...candidate,
-            id,
-            sizeBytes: bytes.length,
-          }),
-          bytes,
-        }
-      } catch (error) {
-        fail(
-          'image',
-          candidate.sourceKey,
-          `record is invalid: ${errorDetail(error)}`,
-        )
-      }
-    },
+  const candidates: NativeBackupImageCandidate[] = []
+  const value = valid(cloud ? 'cloud chat' : 'local chat', chat.id, () =>
+    portable(chat, candidates),
   )
-  const imageIds = new Map(
-    images.map(({ metadata }) => [metadata.id, metadata.id]),
-  )
-  try {
-    return {
-      chat: sanitizeNativeBackupChat(chat, ({ sourceKey }) => {
-        const id = imageIds.get(sourceKey)
-        return id ?? fail('image', sourceKey, 'image bytes are missing')
-      }),
-      images,
-    }
-  } catch (error) {
-    if (error instanceof NativeBackupCollectionError) throw error
-    fail(
-      cloud ? 'cloud chat' : 'local chat',
-      chat.id,
-      `record is invalid: ${errorDetail(error)}`,
+  const pending = budget.chat(value)
+  const images = await mapLimit(candidates, async (candidate) => {
+    const message = chat.messages[candidate.messageIndex]
+    const attachment = message.attachments?.find(
+      ({ id }) => id === candidate.attachmentId,
     )
-  }
+    const base64 =
+      candidate.legacyIndex !== undefined
+        ? message.imageData?.[candidate.legacyIndex]?.base64
+        : candidate.page !== undefined
+          ? attachment?.pages?.find(({ page }) => page === candidate.page)
+              ?.image
+          : attachment?.base64
+    let bytes: Uint8Array | null = null
+    try {
+      bytes = base64
+        ? base64ToUint8Array(base64)
+        : cloud && attachment
+          ? await deps.getCloudImage(attachment)
+          : null
+    } catch {
+      fail('image', candidate.sourceKey, 'image bytes are invalid')
+    }
+    if (!bytes) fail('image', candidate.sourceKey, 'image bytes are missing')
+    const metadata = valid('image', candidate.sourceKey, () =>
+      sanitizeNativeBackupImage({
+        ...candidate,
+        id: candidate.sourceKey,
+        sizeBytes: bytes.length,
+      }),
+    )
+    budget.image(pending, metadata, bytes)
+    return { metadata, bytes }
+  })
+  return { chat: value, images, pending }
 }
 
 export async function collectNativeBackupV1(
-  dependencies: NativeBackupCollectionDependencies = defaultDependencies,
+  deps: NativeBackupCollectionDependencies = defaults,
 ): Promise<NativeBackupV1Input> {
-  if (!(await dependencies.isAuthenticated()))
+  if (!(await deps.isAuthenticated()))
     fail('account', 'active', 'signed-in user is required')
-  const userId = dependencies.activeUserId()
+  const userId = deps.activeUserId()
   if (!userId) fail('account', 'active', 'signed-in owner is unavailable')
   try {
-    dependencies.requireUnlockedCek()
+    deps.requireUnlockedCek()
   } catch {
     fail('account', userId, 'cloud encryption key is locked or unavailable')
   }
 
   const [chatItems, projectItems, localSnapshots] = await Promise.all([
-    allPages((token) => dependencies.listChats(token)),
-    allPages((token) => dependencies.listProjects(token)),
-    dependencies.getLocalChats(),
+    pages(deps.listChats),
+    pages(deps.listProjects),
+    deps.getLocalChats(),
   ])
-  const projects = await mapLimit(projectItems, async (item) => {
-    const project = await stableCloudRecord('project', item, () =>
-      dependencies.getProject(item.id),
-    )
-    try {
-      return sanitizeNativeBackupProject({
-        ...project,
-        createdAt: item.createdAt,
-        updatedAt: item.updatedAt,
-      })
-    } catch (error) {
-      fail('project', item.id, `record is invalid: ${errorDetail(error)}`)
-    }
-  })
-  const documentItems = (
-    await mapLimit(projectItems, (project) =>
-      dependencies.listDocuments(project.id),
-    )
-  ).flat()
-  const projectDocuments = await mapLimit(documentItems, async (item) => {
-    const document = await stableCloudRecord('project document', item, () =>
-      dependencies.getDocument(item.projectId, item.id),
-    )
-    try {
-      return sanitizeNativeBackupProjectDocument({
-        ...document,
-        createdAt: item.createdAt,
-        updatedAt: item.updatedAt,
-      })
-    } catch (error) {
-      fail(
-        'project document',
-        item.id,
-        `record is invalid: ${errorDetail(error)}`,
-      )
-    }
-  })
+  const documentItems = unique(
+    (await mapLimit(projectItems, ({ id }) => deps.listDocuments(id))).flat(),
+  )
+  const budget = new Budget()
+  budget.entities(projectItems.length + documentItems.length)
+
+  const projects = await mapLimit(projectItems, (item) =>
+    timed(
+      'project',
+      item,
+      () => deps.getProject(item.id),
+      () => pages(deps.listProjects),
+      sanitizeNativeBackupProject,
+      budget,
+    ),
+  )
+  const projectDocuments = await mapLimit(documentItems, (item) =>
+    timed(
+      'project document',
+      item,
+      () => deps.getDocument(item.projectId, item.id),
+      () => deps.listDocuments(item.projectId),
+      sanitizeNativeBackupProjectDocument,
+      budget,
+    ),
+  )
 
   const cloudResults = []
-  for (const item of chatItems) {
-    let expected = item.syncVersion
+  for (const listed of chatItems) {
+    let item = listed
     let result: Awaited<ReturnType<typeof collectChat>> | null = null
     let excluded = false
     for (let attempt = 0; attempt < 2; attempt++) {
       const chat = await readRecord('cloud chat', item.id, () =>
-        dependencies.getCloudChat(item.id),
+        deps.getCloudChat(item.id),
       )
-      if (chat.syncVersion !== expected) {
-        expected = chat.syncVersion ?? -1
+      if (chat.syncVersion !== item.syncVersion) {
+        item =
+          (await pages(deps.listChats)).find(({ id }) => id === item.id) ??
+          fail('cloud chat', item.id, 'record is missing or invalid')
         continue
       }
       if (classifyNativeBackupChat(chat, 'cloud') === null) {
         excluded = true
         break
       }
-      result = await collectChat(chat, true, dependencies)
+      result = await collectChat(chat, true, deps, budget)
       const verify = await readRecord('cloud chat', item.id, () =>
-        dependencies.getCloudChat(item.id),
+        deps.getCloudChat(item.id),
       )
       if (verify.syncVersion === chat.syncVersion) break
-      expected = verify.syncVersion ?? -1
+      item =
+        (await pages(deps.listChats)).find(({ id }) => id === item.id) ??
+        fail('cloud chat', item.id, 'record is missing or invalid')
       result = null
     }
     if (excluded) continue
     if (!result)
       fail('cloud chat', item.id, 'version changed during collection')
+    budget.commit(result.pending, true)
     cloudResults.push(result)
   }
 
   const localResults = []
   for (const snapshot of localSnapshots) {
-    const owner =
-      snapshot.syncUserId === userId ||
-      (snapshot as StoredChat & { userId?: string }).userId === userId
-        ? 'signed_in'
-        : 'anonymous'
-    if (
-      !snapshot.isLocalOnly ||
-      classifyNativeBackupChat(snapshot, owner) !== 'local'
-    )
-      continue
+    if (!localEligible(snapshot, userId)) continue
     let expected = localToken(snapshot)
     let result: Awaited<ReturnType<typeof collectChat>> | null = null
+    let excluded = false
     for (let attempt = 0; attempt < 2; attempt++) {
       const chat = await readRecord('local chat', snapshot.id, () =>
-        dependencies.getLocalChat(snapshot.id),
+        deps.getLocalChat(snapshot.id),
       )
       const token = localToken(chat)
       if (token !== expected) {
         expected = token
         continue
       }
-      result = await collectChat(chat, false, dependencies)
+      if (!localEligible(chat, userId)) {
+        excluded = true
+        break
+      }
+      result = await collectChat(chat, false, deps, budget)
       const verify = await readRecord('local chat', snapshot.id, () =>
-        dependencies.getLocalChat(snapshot.id),
+        deps.getLocalChat(snapshot.id),
       )
       if (localToken(verify) === token) break
       expected = localToken(verify)
       result = null
     }
+    if (excluded) continue
     if (!result)
       fail('local chat', snapshot.id, 'version changed during collection')
+    budget.commit(result.pending, true)
     localResults.push(result)
   }
 
   const cloudChats = cloudResults.map(({ chat }) => chat)
   const localChats = localResults.map(({ chat }) => chat)
   const images = [...cloudResults, ...localResults].flatMap(
-    ({ images: values }) => values,
+    ({ images }) => images,
   )
   const relationships = sanitizeNativeBackupRelationships({
     projectChats: [...cloudChats, ...localChats].flatMap((chat) =>
@@ -461,9 +448,10 @@ export async function collectNativeBackupV1(
       imageId: metadata.id,
     })),
   })
+  budget.json(relationships)
   const input: NativeBackupV1Input = {
-    backupId: dependencies.randomUUID(),
-    createdAt: dependencies.now().toISOString(),
+    backupId: crypto.randomUUID(),
+    createdAt: new Date().toISOString(),
     projects,
     projectDocuments,
     cloudChats,

--- a/src/services/native-backup/collect.ts
+++ b/src/services/native-backup/collect.ts
@@ -15,18 +15,8 @@ import {
 import { SyncEnclaveError } from '@/services/sync-enclave'
 import type { Project, ProjectDocument } from '@/types/project'
 import { base64ToUint8Array } from '@/utils/binary-codec'
-import { bytesToHex } from '@noble/hashes/utils.js'
-import {
-  NATIVE_BACKUP_FORMAT,
-  NATIVE_BACKUP_LIMITS,
-  NATIVE_BACKUP_VERSION,
-  type NativeBackupEntityKind,
-} from './constants'
-import {
-  assertNativeBackupSizeLimits,
-  type NativeBackupManifestV1,
-  type NativeBackupV1Input,
-} from './format'
+import { NATIVE_BACKUP_LIMITS } from './constants'
+import type { NativeBackupV1Input } from './format'
 import { detectNativeBackupImageMimeType } from './image-mime'
 import {
   classifyNativeBackupChat,
@@ -119,7 +109,6 @@ const detail = (error: unknown) =>
   error instanceof Error ? error.message : String(error)
 const jsonSize = (value: unknown) =>
   encoder.encode(JSON.stringify(value)).length
-const idComponent = (id: string) => `id-${bytesToHex(encoder.encode(id))}`
 function valid<T>(kind: string, id: string, parse: () => T): T {
   try {
     return parse()
@@ -220,68 +209,6 @@ class Budget {
     if (entity) this.entities(1)
     this.check(value)
     value.forEach((amount, index) => (this.used[index] += amount))
-  }
-  finalize(input: NativeBackupV1Input) {
-    const files: Array<{
-      path: string
-      kind: NativeBackupEntityKind
-      sizeBytes: number
-    }> = []
-    const add = (path: string, kind: NativeBackupEntityKind, value: unknown) =>
-      files.push({ path, kind, sizeBytes: jsonSize(value) })
-    for (const value of input.projects)
-      add(`projects/${idComponent(value.id)}.json`, 'projects', value)
-    for (const value of input.projectDocuments)
-      add(
-        `project_documents/${idComponent(value.projectId)}/${idComponent(value.id)}.json`,
-        'project_documents',
-        value,
-      )
-    for (const value of input.cloudChats)
-      add(`cloud_chats/${idComponent(value.id)}.json`, 'cloud_chats', value)
-    for (const value of input.localChats)
-      add(`local_chats/${idComponent(value.id)}.json`, 'local_chats', value)
-    add('relationships.json', 'relationships', input.relationships)
-    for (const { metadata, bytes } of input.images) {
-      const path = `images/${idComponent(metadata.id)}`
-      add(`${path}.json`, 'images', { ...metadata, sizeBytes: bytes.length })
-      files.push({
-        path: `${path}.bin`,
-        kind: 'images',
-        sizeBytes: bytes.length,
-      })
-    }
-    files.sort((left, right) => (left.path < right.path ? -1 : 1))
-    const manifest: NativeBackupManifestV1 = {
-      format: NATIVE_BACKUP_FORMAT,
-      version: NATIVE_BACKUP_VERSION,
-      backup_id: input.backupId,
-      created_at: input.createdAt,
-      complete: true,
-      counts: {
-        projects: input.projects.length,
-        project_documents: input.projectDocuments.length,
-        cloud_chats: input.cloudChats.length,
-        local_chats: input.localChats.length,
-        relationships:
-          input.relationships.projectChats.length +
-          input.relationships.projectDocuments.length +
-          input.relationships.chatImages.length,
-        images: input.images.length,
-        files: files.length,
-      },
-      notices: {
-        contains_plaintext: true,
-        documents_are_extracted_text_only: true,
-      },
-      files: files.map(({ path, kind, sizeBytes }) => ({
-        path,
-        kind,
-        sha256: '0'.repeat(64),
-        size_bytes: sizeBytes,
-      })),
-    }
-    assertNativeBackupSizeLimits(jsonSize(manifest), files)
   }
   private check(value: Pending) {
     budgetLimits.forEach(([label, limit], index) =>
@@ -591,6 +518,5 @@ export async function collectNativeBackupV1(
     images,
   }
   signal?.throwIfAborted()
-  budget.finalize(input)
   return input
 }

--- a/src/services/native-backup/collect.ts
+++ b/src/services/native-backup/collect.ts
@@ -1,6 +1,10 @@
 import type { Attachment, Message } from '@/components/chat/types'
 import { AUTH_ACTIVE_USER_ID } from '@/constants/storage-keys'
-import { authTokenManager } from '@/services/auth'
+import {
+  AuthTokenRefreshError,
+  AuthTokenUnavailableError,
+  authTokenManager,
+} from '@/services/auth'
 import { requirePrimaryKeyB64 } from '@/services/cloud/cek-encoding'
 import { cloudStorage } from '@/services/cloud/cloud-storage'
 import { projectStorage } from '@/services/cloud/project-storage'
@@ -8,10 +12,12 @@ import {
   indexedDBStorage,
   type StoredChat,
 } from '@/services/storage/indexed-db'
+import { SyncEnclaveError } from '@/services/sync-enclave'
 import type { Project, ProjectDocument } from '@/types/project'
 import { base64ToUint8Array } from '@/utils/binary-codec'
 import { NATIVE_BACKUP_LIMITS } from './constants'
 import { formatNativeBackupV1, type NativeBackupV1Input } from './format'
+import { detectNativeBackupImageMimeType } from './image-mime'
 import {
   classifyNativeBackupChat,
   sanitizeNativeBackupChat,
@@ -111,13 +117,25 @@ function valid<T>(kind: string, id: string, parse: () => T): T {
     return fail(kind, id, `record is invalid: ${detail(error)}`)
   }
 }
-function unique<T extends Listed>(values: T[]): T[] {
+function unique<T extends Listed>(
+  values: T[],
+  key: (value: T) => string = ({ id }) => id,
+): T[] {
   const byId = new Map<string, T>()
   for (const value of values) {
-    const old = byId.get(value.id)
-    if (!old || value.syncVersion >= old.syncVersion) byId.set(value.id, value)
+    const identity = key(value)
+    const old = byId.get(identity)
+    if (!old || value.syncVersion >= old.syncVersion) byId.set(identity, value)
   }
   return [...byId.values()]
+}
+function throwIfAuthenticationError(error: unknown) {
+  if (
+    error instanceof AuthTokenUnavailableError ||
+    error instanceof AuthTokenRefreshError ||
+    (error instanceof SyncEnclaveError && error.status === 401)
+  )
+    throw error
 }
 async function pages<T extends Listed>(
   fn: (t?: string) => Page<T>,
@@ -212,6 +230,7 @@ async function readRecord<T>(
     return value ?? fail(kind, id, 'record is missing or invalid')
   } catch (error) {
     signal?.throwIfAborted()
+    throwIfAuthenticationError(error)
     if (error instanceof NativeBackupCollectionError) throw error
     return fail(kind, id, `read failed: ${detail(error)}`)
   }
@@ -323,15 +342,24 @@ async function collectChat(
           : cloud && attachment
             ? await wait(signal, () => deps.getCloudImage(attachment))
             : null
-      } catch {
+      } catch (error) {
         signal?.throwIfAborted()
+        throwIfAuthenticationError(error)
         fail('image', candidate.sourceKey, 'image bytes are invalid')
       }
       if (!bytes) fail('image', candidate.sourceKey, 'image bytes are missing')
+      const mimeType =
+        detectNativeBackupImageMimeType(bytes) ??
+        fail('image', candidate.sourceKey, 'image type is unsupported')
+      if (candidate.legacyIndex !== undefined)
+        value.messages[candidate.messageIndex].imageData![
+          candidate.legacyIndex
+        ].mimeType = mimeType
       const metadata = valid('image', candidate.sourceKey, () =>
         sanitizeNativeBackupImage({
           ...candidate,
           id: candidate.sourceKey,
+          mimeType,
           sizeBytes: bytes.length,
         }),
       )
@@ -390,6 +418,7 @@ export async function collectNativeBackupV1(
     (
       await mapLimit(projectItems, ({ id }) => deps.listDocuments(id), signal)
     ).flat(),
+    ({ projectId, id }) => JSON.stringify([projectId, id]),
   )
   const budget = new Budget()
   budget.entities(projectItems.length + documentItems.length)

--- a/src/services/native-backup/collect.ts
+++ b/src/services/native-backup/collect.ts
@@ -1,0 +1,476 @@
+import type { Attachment } from '@/components/chat/types'
+import { AUTH_ACTIVE_USER_ID } from '@/constants/storage-keys'
+import { authTokenManager } from '@/services/auth'
+import { requirePrimaryKeyB64 } from '@/services/cloud/cek-encoding'
+import { cloudStorage } from '@/services/cloud/cloud-storage'
+import { projectStorage } from '@/services/cloud/project-storage'
+import {
+  indexedDBStorage,
+  type StoredChat,
+} from '@/services/storage/indexed-db'
+import type { Project, ProjectDocument } from '@/types/project'
+import { base64ToUint8Array } from '@/utils/binary-codec'
+import { NATIVE_BACKUP_LIMITS } from './constants'
+import { formatNativeBackupV1, type NativeBackupV1Input } from './format'
+import {
+  classifyNativeBackupChat,
+  sanitizeNativeBackupChat,
+  sanitizeNativeBackupImage,
+  sanitizeNativeBackupProject,
+  sanitizeNativeBackupProjectDocument,
+  sanitizeNativeBackupRelationships,
+  type NativeBackupImageCandidate,
+} from './sanitize'
+
+const PAGE_SIZE = 500
+const READ_CONCURRENCY = 4
+
+type ChatListItem = { id: string; syncVersion: number }
+type ProjectListItem = {
+  id: string
+  syncVersion: number
+  createdAt: string
+  updatedAt: string
+}
+type DocumentListItem = ProjectListItem & { projectId: string }
+
+export interface NativeBackupCollectionDependencies {
+  isAuthenticated(): Promise<boolean>
+  activeUserId(): string | null
+  requireUnlockedCek(): void
+  listChats(token?: string): Promise<{
+    items: ChatListItem[]
+    next?: string
+  }>
+  getCloudChat(id: string): Promise<StoredChat | null>
+  getCloudImage(attachment: Attachment): Promise<Uint8Array | null>
+  listProjects(token?: string): Promise<{
+    items: ProjectListItem[]
+    next?: string
+  }>
+  getProject(id: string): Promise<Project | null>
+  listDocuments(projectId: string): Promise<DocumentListItem[]>
+  getDocument(projectId: string, id: string): Promise<ProjectDocument | null>
+  getLocalChats(): Promise<StoredChat[]>
+  getLocalChat(id: string): Promise<StoredChat | null>
+  randomUUID(): string
+  now(): Date
+}
+
+export class NativeBackupCollectionError extends Error {
+  constructor(
+    public readonly kind: string,
+    public readonly recordId: string,
+    detail: string,
+  ) {
+    super(`Native backup collection failed for ${kind} ${recordId}: ${detail}`)
+    this.name = 'NativeBackupCollectionError'
+  }
+}
+
+function activeUserId(): string | null {
+  try {
+    return localStorage.getItem(AUTH_ACTIVE_USER_ID)
+  } catch {
+    return null
+  }
+}
+
+const defaultDependencies: NativeBackupCollectionDependencies = {
+  isAuthenticated: () => authTokenManager.isAuthenticated(),
+  activeUserId,
+  requireUnlockedCek: () => void requirePrimaryKeyB64(),
+  listChats: async (continuationToken) => {
+    const page = await cloudStorage.listChats({
+      limit: PAGE_SIZE,
+      continuationToken,
+    })
+    return {
+      items: page.conversations,
+      next: page.nextContinuationToken,
+    }
+  },
+  getCloudChat: (id) => cloudStorage.downloadChat(id),
+  getCloudImage: (attachment) => cloudStorage.loadChatImage(attachment),
+  listProjects: async (continuationToken) => {
+    const page = await projectStorage.listProjects({
+      limit: PAGE_SIZE,
+      continuationToken,
+    })
+    return { items: page.projects, next: page.nextContinuationToken }
+  },
+  getProject: (id) => projectStorage.getProject(id),
+  listDocuments: async (projectId) =>
+    (await projectStorage.listDocuments(projectId)).documents,
+  getDocument: (projectId, id) => projectStorage.getDocument(projectId, id),
+  getLocalChats: () => indexedDBStorage.getAllChats(),
+  getLocalChat: (id) => indexedDBStorage.getChat(id),
+  randomUUID: () => crypto.randomUUID(),
+  now: () => new Date(),
+}
+
+async function allPages<T>(
+  read: (token?: string) => Promise<{ items: T[]; next?: string }>,
+): Promise<T[]> {
+  const output: T[] = []
+  let token: string | undefined
+  do {
+    const page = await read(token)
+    output.push(...page.items)
+    token = page.next
+  } while (token)
+  return output
+}
+
+async function mapLimit<T, R>(
+  values: readonly T[],
+  read: (value: T) => Promise<R>,
+): Promise<R[]> {
+  const output = new Array<R>(values.length)
+  let next = 0
+  await Promise.all(
+    Array.from(
+      { length: Math.min(READ_CONCURRENCY, values.length) },
+      async () => {
+        while (next < values.length) {
+          const index = next++
+          output[index] = await read(values[index])
+        }
+      },
+    ),
+  )
+  return output
+}
+
+function fail(kind: string, id: string, detail: string): never {
+  throw new NativeBackupCollectionError(kind, id, detail)
+}
+
+async function readRecord<T>(
+  kind: string,
+  id: string,
+  read: () => Promise<T | null>,
+): Promise<T> {
+  try {
+    const value = await read()
+    return value ?? fail(kind, id, 'record is missing or invalid')
+  } catch (error) {
+    if (error instanceof NativeBackupCollectionError) throw error
+    fail(kind, id, `read failed: ${errorDetail(error)}`)
+  }
+}
+
+async function stableCloudRecord<T extends { syncVersion?: number }>(
+  kind: string,
+  item: { id: string; syncVersion: number },
+  read: () => Promise<T | null>,
+): Promise<T> {
+  let expected = item.syncVersion
+  for (let attempt = 0; attempt < 2; attempt++) {
+    const value = await readRecord(kind, item.id, read)
+    if (value.syncVersion === expected) return value
+    expected = value.syncVersion ?? -1
+  }
+  return fail(kind, item.id, 'version changed during collection')
+}
+
+function errorDetail(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function localToken(chat: StoredChat): string {
+  return JSON.stringify({
+    id: chat.id,
+    title: chat.title,
+    titleState: chat.titleState,
+    messages: chat.messages,
+    createdAt: chat.createdAt,
+    updatedAt: chat.updatedAt,
+    projectId: chat.projectId,
+    presetId: chat.presetId,
+    model: chat.model,
+    webSearchEnabled: chat.webSearchEnabled,
+    isLocalOnly: chat.isLocalOnly,
+    isBlankChat: chat.isBlankChat,
+    isTemporary: chat.isTemporary,
+    syncUserId: chat.syncUserId,
+    clock: chat.clock,
+    writer: chat.writer,
+  })
+}
+
+type ImageSource = {
+  candidate: NativeBackupImageCandidate
+  base64?: string
+  attachment?: Attachment
+}
+
+function imageSources(chat: StoredChat): ImageSource[] {
+  const output: ImageSource[] = []
+  chat.messages.forEach((message, messageIndex) => {
+    for (const attachment of message.attachments ?? []) {
+      if (attachment.type === 'image') {
+        output.push({
+          candidate: {
+            sourceKey: `attachment:${chat.id}:${messageIndex}:${attachment.id}`,
+            chatId: chat.id,
+            messageIndex,
+            attachmentId: attachment.id,
+            fileName: attachment.fileName,
+            mimeType: attachment.mimeType ?? 'application/octet-stream',
+            description: attachment.description,
+          },
+          base64: attachment.base64,
+          attachment,
+        })
+      } else {
+        for (const page of attachment.pages ?? []) {
+          if (!page.image) continue
+          output.push({
+            candidate: {
+              sourceKey: `page:${chat.id}:${messageIndex}:${attachment.id}:${page.page}`,
+              chatId: chat.id,
+              messageIndex,
+              attachmentId: attachment.id,
+              page: page.page,
+              fileName: `${attachment.id}-page-${page.page}.jpg`,
+              mimeType: 'image/jpeg',
+            },
+            base64: page.image,
+          })
+        }
+      }
+    }
+    message.imageData?.forEach((image, legacyIndex) =>
+      output.push({
+        candidate: {
+          sourceKey: `legacy:${chat.id}:${messageIndex}:${legacyIndex}`,
+          chatId: chat.id,
+          messageIndex,
+          legacyIndex,
+          fileName: `legacy-image-${legacyIndex}`,
+          mimeType: image.mimeType,
+        },
+        base64: image.base64,
+      }),
+    )
+  })
+  return output
+}
+
+async function collectChat(
+  chat: StoredChat,
+  cloud: boolean,
+  dependencies: NativeBackupCollectionDependencies,
+) {
+  const sources = imageSources(chat)
+  const images = await mapLimit(
+    sources,
+    async ({ candidate, base64, attachment }) => {
+      let bytes: Uint8Array | null = null
+      try {
+        bytes = base64
+          ? base64ToUint8Array(base64)
+          : cloud && attachment
+            ? await dependencies.getCloudImage(attachment)
+            : null
+      } catch {
+        fail('image', candidate.sourceKey, 'image bytes are invalid')
+      }
+      if (!bytes) fail('image', candidate.sourceKey, 'image bytes are missing')
+      if (bytes.length > NATIVE_BACKUP_LIMITS.imageBytes)
+        fail('image', candidate.sourceKey, 'image size limit exceeded')
+      const id = candidate.sourceKey
+      try {
+        return {
+          metadata: sanitizeNativeBackupImage({
+            ...candidate,
+            id,
+            sizeBytes: bytes.length,
+          }),
+          bytes,
+        }
+      } catch (error) {
+        fail(
+          'image',
+          candidate.sourceKey,
+          `record is invalid: ${errorDetail(error)}`,
+        )
+      }
+    },
+  )
+  const imageIds = new Map(
+    images.map(({ metadata }) => [metadata.id, metadata.id]),
+  )
+  try {
+    return {
+      chat: sanitizeNativeBackupChat(chat, ({ sourceKey }) => {
+        const id = imageIds.get(sourceKey)
+        return id ?? fail('image', sourceKey, 'image bytes are missing')
+      }),
+      images,
+    }
+  } catch (error) {
+    if (error instanceof NativeBackupCollectionError) throw error
+    fail(
+      cloud ? 'cloud chat' : 'local chat',
+      chat.id,
+      `record is invalid: ${errorDetail(error)}`,
+    )
+  }
+}
+
+export async function collectNativeBackupV1(
+  dependencies: NativeBackupCollectionDependencies = defaultDependencies,
+): Promise<NativeBackupV1Input> {
+  if (!(await dependencies.isAuthenticated()))
+    fail('account', 'active', 'signed-in user is required')
+  const userId = dependencies.activeUserId()
+  if (!userId) fail('account', 'active', 'signed-in owner is unavailable')
+  try {
+    dependencies.requireUnlockedCek()
+  } catch {
+    fail('account', userId, 'cloud encryption key is locked or unavailable')
+  }
+
+  const [chatItems, projectItems, localSnapshots] = await Promise.all([
+    allPages((token) => dependencies.listChats(token)),
+    allPages((token) => dependencies.listProjects(token)),
+    dependencies.getLocalChats(),
+  ])
+  const projects = await mapLimit(projectItems, async (item) => {
+    const project = await stableCloudRecord('project', item, () =>
+      dependencies.getProject(item.id),
+    )
+    try {
+      return sanitizeNativeBackupProject({
+        ...project,
+        createdAt: item.createdAt,
+        updatedAt: item.updatedAt,
+      })
+    } catch (error) {
+      fail('project', item.id, `record is invalid: ${errorDetail(error)}`)
+    }
+  })
+  const documentItems = (
+    await mapLimit(projectItems, (project) =>
+      dependencies.listDocuments(project.id),
+    )
+  ).flat()
+  const projectDocuments = await mapLimit(documentItems, async (item) => {
+    const document = await stableCloudRecord('project document', item, () =>
+      dependencies.getDocument(item.projectId, item.id),
+    )
+    try {
+      return sanitizeNativeBackupProjectDocument({
+        ...document,
+        createdAt: item.createdAt,
+        updatedAt: item.updatedAt,
+      })
+    } catch (error) {
+      fail(
+        'project document',
+        item.id,
+        `record is invalid: ${errorDetail(error)}`,
+      )
+    }
+  })
+
+  const cloudResults = []
+  for (const item of chatItems) {
+    let expected = item.syncVersion
+    let result: Awaited<ReturnType<typeof collectChat>> | null = null
+    let excluded = false
+    for (let attempt = 0; attempt < 2; attempt++) {
+      const chat = await readRecord('cloud chat', item.id, () =>
+        dependencies.getCloudChat(item.id),
+      )
+      if (chat.syncVersion !== expected) {
+        expected = chat.syncVersion ?? -1
+        continue
+      }
+      if (classifyNativeBackupChat(chat, 'cloud') === null) {
+        excluded = true
+        break
+      }
+      result = await collectChat(chat, true, dependencies)
+      const verify = await readRecord('cloud chat', item.id, () =>
+        dependencies.getCloudChat(item.id),
+      )
+      if (verify.syncVersion === chat.syncVersion) break
+      expected = verify.syncVersion ?? -1
+      result = null
+    }
+    if (excluded) continue
+    if (!result)
+      fail('cloud chat', item.id, 'version changed during collection')
+    cloudResults.push(result)
+  }
+
+  const localResults = []
+  for (const snapshot of localSnapshots) {
+    const owner =
+      snapshot.syncUserId === userId ||
+      (snapshot as StoredChat & { userId?: string }).userId === userId
+        ? 'signed_in'
+        : 'anonymous'
+    if (
+      !snapshot.isLocalOnly ||
+      classifyNativeBackupChat(snapshot, owner) !== 'local'
+    )
+      continue
+    let expected = localToken(snapshot)
+    let result: Awaited<ReturnType<typeof collectChat>> | null = null
+    for (let attempt = 0; attempt < 2; attempt++) {
+      const chat = await readRecord('local chat', snapshot.id, () =>
+        dependencies.getLocalChat(snapshot.id),
+      )
+      const token = localToken(chat)
+      if (token !== expected) {
+        expected = token
+        continue
+      }
+      result = await collectChat(chat, false, dependencies)
+      const verify = await readRecord('local chat', snapshot.id, () =>
+        dependencies.getLocalChat(snapshot.id),
+      )
+      if (localToken(verify) === token) break
+      expected = localToken(verify)
+      result = null
+    }
+    if (!result)
+      fail('local chat', snapshot.id, 'version changed during collection')
+    localResults.push(result)
+  }
+
+  const cloudChats = cloudResults.map(({ chat }) => chat)
+  const localChats = localResults.map(({ chat }) => chat)
+  const images = [...cloudResults, ...localResults].flatMap(
+    ({ images: values }) => values,
+  )
+  const relationships = sanitizeNativeBackupRelationships({
+    projectChats: [...cloudChats, ...localChats].flatMap((chat) =>
+      chat.projectId ? [{ projectId: chat.projectId, chatId: chat.id }] : [],
+    ),
+    projectDocuments: projectDocuments.map(({ projectId, id }) => ({
+      projectId,
+      documentId: id,
+    })),
+    chatImages: images.map(({ metadata }) => ({
+      chatId: metadata.chatId,
+      imageId: metadata.id,
+    })),
+  })
+  const input: NativeBackupV1Input = {
+    backupId: dependencies.randomUUID(),
+    createdAt: dependencies.now().toISOString(),
+    projects,
+    projectDocuments,
+    cloudChats,
+    localChats,
+    relationships,
+    images,
+  }
+  formatNativeBackupV1(input)
+  return input
+}

--- a/src/services/native-backup/collect.ts
+++ b/src/services/native-backup/collect.ts
@@ -15,8 +15,18 @@ import {
 import { SyncEnclaveError } from '@/services/sync-enclave'
 import type { Project, ProjectDocument } from '@/types/project'
 import { base64ToUint8Array } from '@/utils/binary-codec'
-import { NATIVE_BACKUP_LIMITS } from './constants'
-import { formatNativeBackupV1, type NativeBackupV1Input } from './format'
+import { bytesToHex } from '@noble/hashes/utils.js'
+import {
+  NATIVE_BACKUP_FORMAT,
+  NATIVE_BACKUP_LIMITS,
+  NATIVE_BACKUP_VERSION,
+  type NativeBackupEntityKind,
+} from './constants'
+import {
+  assertNativeBackupSizeLimits,
+  type NativeBackupManifestV1,
+  type NativeBackupV1Input,
+} from './format'
 import { detectNativeBackupImageMimeType } from './image-mime'
 import {
   classifyNativeBackupChat,
@@ -109,6 +119,7 @@ const detail = (error: unknown) =>
   error instanceof Error ? error.message : String(error)
 const jsonSize = (value: unknown) =>
   encoder.encode(JSON.stringify(value)).length
+const idComponent = (id: string) => `id-${bytesToHex(encoder.encode(id))}`
 function valid<T>(kind: string, id: string, parse: () => T): T {
   try {
     return parse()
@@ -209,6 +220,68 @@ class Budget {
     if (entity) this.entities(1)
     this.check(value)
     value.forEach((amount, index) => (this.used[index] += amount))
+  }
+  finalize(input: NativeBackupV1Input) {
+    const files: Array<{
+      path: string
+      kind: NativeBackupEntityKind
+      sizeBytes: number
+    }> = []
+    const add = (path: string, kind: NativeBackupEntityKind, value: unknown) =>
+      files.push({ path, kind, sizeBytes: jsonSize(value) })
+    for (const value of input.projects)
+      add(`projects/${idComponent(value.id)}.json`, 'projects', value)
+    for (const value of input.projectDocuments)
+      add(
+        `project_documents/${idComponent(value.projectId)}/${idComponent(value.id)}.json`,
+        'project_documents',
+        value,
+      )
+    for (const value of input.cloudChats)
+      add(`cloud_chats/${idComponent(value.id)}.json`, 'cloud_chats', value)
+    for (const value of input.localChats)
+      add(`local_chats/${idComponent(value.id)}.json`, 'local_chats', value)
+    add('relationships.json', 'relationships', input.relationships)
+    for (const { metadata, bytes } of input.images) {
+      const path = `images/${idComponent(metadata.id)}`
+      add(`${path}.json`, 'images', { ...metadata, sizeBytes: bytes.length })
+      files.push({
+        path: `${path}.bin`,
+        kind: 'images',
+        sizeBytes: bytes.length,
+      })
+    }
+    files.sort((left, right) => (left.path < right.path ? -1 : 1))
+    const manifest: NativeBackupManifestV1 = {
+      format: NATIVE_BACKUP_FORMAT,
+      version: NATIVE_BACKUP_VERSION,
+      backup_id: input.backupId,
+      created_at: input.createdAt,
+      complete: true,
+      counts: {
+        projects: input.projects.length,
+        project_documents: input.projectDocuments.length,
+        cloud_chats: input.cloudChats.length,
+        local_chats: input.localChats.length,
+        relationships:
+          input.relationships.projectChats.length +
+          input.relationships.projectDocuments.length +
+          input.relationships.chatImages.length,
+        images: input.images.length,
+        files: files.length,
+      },
+      notices: {
+        contains_plaintext: true,
+        documents_are_extracted_text_only: true,
+      },
+      files: files.map(({ path, kind, sizeBytes }) => ({
+        path,
+        kind,
+        sha256: '0'.repeat(64),
+        size_bytes: sizeBytes,
+      })),
+    }
+    assertNativeBackupSizeLimits(jsonSize(manifest), files)
   }
   private check(value: Pending) {
     budgetLimits.forEach(([label, limit], index) =>
@@ -518,6 +591,6 @@ export async function collectNativeBackupV1(
     images,
   }
   signal?.throwIfAborted()
-  formatNativeBackupV1(input)
+  budget.finalize(input)
   return input
 }

--- a/src/services/native-backup/collect.ts
+++ b/src/services/native-backup/collect.ts
@@ -259,9 +259,24 @@ function portable(chat: StoredChat, images?: NativeBackupImageCandidate[]) {
     return candidate.sourceKey
   })
 }
+function imagePayload(chat: StoredChat, candidate: NativeBackupImageCandidate) {
+  const message = chat.messages[candidate.messageIndex]
+  const attachment =
+    candidate.attachmentIndex === undefined
+      ? undefined
+      : message.attachments?.[candidate.attachmentIndex]
+  return candidate.legacyIndex !== undefined
+    ? message.imageData?.[candidate.legacyIndex]?.base64
+    : candidate.page !== undefined
+      ? attachment?.pages?.find(({ page }) => page === candidate.page)?.image
+      : attachment?.base64
+}
 function localToken(chat: StoredChat) {
+  const images: NativeBackupImageCandidate[] = []
+  const value = valid('local chat', chat.id, () => portable(chat, images))
   return JSON.stringify([
-    portable(chat),
+    value,
+    images.map((candidate) => [candidate, imagePayload(chat, candidate)]),
     chat.isLocalOnly,
     chat.isBlankChat,
     chat.isTemporary,
@@ -294,17 +309,13 @@ async function collectChat(
   const images = await mapLimit(
     candidates,
     async (candidate) => {
-      const message = chat.messages[candidate.messageIndex]
-      const attachment = message.attachments?.find(
-        ({ id }) => id === candidate.attachmentId,
-      )
-      const base64 =
-        candidate.legacyIndex !== undefined
-          ? message.imageData?.[candidate.legacyIndex]?.base64
-          : candidate.page !== undefined
-            ? attachment?.pages?.find(({ page }) => page === candidate.page)
-                ?.image
-            : attachment?.base64
+      const attachment =
+        candidate.attachmentIndex === undefined
+          ? undefined
+          : chat.messages[candidate.messageIndex].attachments?.[
+              candidate.attachmentIndex
+            ]
+      const base64 = imagePayload(chat, candidate)
       let bytes: Uint8Array | null = null
       try {
         bytes = base64

--- a/src/services/native-backup/format.ts
+++ b/src/services/native-backup/format.ts
@@ -113,9 +113,7 @@ function parseJson(bytes: Uint8Array, label: string): unknown {
 const idComponent = (id: string) => `id-${bytesToHex(encoder.encode(id))}`
 const hash = (bytes: Uint8Array) => bytesToHex(sha256(bytes))
 const relationshipCount = (value: NativeBackupRelationships) =>
-  value.projectChats.length +
-  value.projectDocuments.length +
-  value.chatImages.length
+  Object.values(value).reduce((count, relations) => count + relations.length, 0)
 
 function expectedPathKind(path: string): NativeBackupEntityKind | null {
   if (path === 'relationships.json') return 'relationships'

--- a/src/services/native-backup/format.ts
+++ b/src/services/native-backup/format.ts
@@ -65,6 +65,8 @@ export interface NativeBackupManifestV1 {
   }>
 }
 
+export type NativeBackupV1Input = NativeBackupFormatInput
+
 const manifestSchema: z.ZodType<NativeBackupManifestV1> = strict({
   format: z.literal(NATIVE_BACKUP_FORMAT),
   version: z.literal(NATIVE_BACKUP_VERSION),

--- a/src/services/native-backup/format.ts
+++ b/src/services/native-backup/format.ts
@@ -113,7 +113,9 @@ function parseJson(bytes: Uint8Array, label: string): unknown {
 const idComponent = (id: string) => `id-${bytesToHex(encoder.encode(id))}`
 const hash = (bytes: Uint8Array) => bytesToHex(sha256(bytes))
 const relationshipCount = (value: NativeBackupRelationships) =>
-  Object.values(value).reduce((count, relations) => count + relations.length, 0)
+  value.projectChats.length +
+  value.projectDocuments.length +
+  value.chatImages.length
 
 function expectedPathKind(path: string): NativeBackupEntityKind | null {
   if (path === 'relationships.json') return 'relationships'

--- a/src/services/native-backup/index.ts
+++ b/src/services/native-backup/index.ts
@@ -1,3 +1,4 @@
+export * from './collect'
 export * from './constants'
 export * from './image-mime'
 export * from './format'

--- a/tests/services/native-backup/collect-cancellation.test.ts
+++ b/tests/services/native-backup/collect-cancellation.test.ts
@@ -1,0 +1,141 @@
+import type { NativeBackupCollectionDependencies } from '@/services/native-backup'
+import { collectNativeBackupV1 } from '@/services/native-backup'
+import type { StoredChat } from '@/services/storage/indexed-db'
+
+const timestamp = '2026-08-20T12:00:00.000Z'
+
+function dependencies(
+  overrides: Partial<NativeBackupCollectionDependencies> = {},
+): NativeBackupCollectionDependencies {
+  return {
+    isAuthenticated: async () => true,
+    activeUserId: () => 'user',
+    requireUnlockedCek: () => {},
+    listChats: async () => ({ items: [] }),
+    getCloudChat: async () => null,
+    getCloudImage: async () => null,
+    listProjects: async () => ({ items: [] }),
+    getProject: async () => null,
+    listDocuments: async () => [],
+    getDocument: async () => null,
+    getLocalChats: async () => [],
+    getLocalChat: async () => null,
+    ...overrides,
+  }
+}
+
+function cloudChat(): StoredChat {
+  return {
+    id: 'chat',
+    title: 'Chat',
+    messages: [
+      {
+        role: 'user',
+        content: 'image',
+        timestamp: new Date(timestamp),
+        attachments: Array.from({ length: 6 }, (_, index) => ({
+          id: `image-${index}`,
+          type: 'image' as const,
+          fileName: `image-${index}.png`,
+          encryptionKey: 'key',
+        })),
+      },
+    ],
+    createdAt: timestamp,
+    updatedAt: timestamp,
+    lastAccessedAt: 0,
+    syncVersion: 1,
+  }
+}
+
+describe('native backup collection cancellation', () => {
+  it('does not start collection for an already-aborted signal', async () => {
+    const controller = new AbortController()
+    const reason = new DOMException('Canceled', 'AbortError')
+    const isAuthenticated = vi.fn().mockResolvedValue(true)
+    controller.abort(reason)
+
+    await expect(
+      collectNativeBackupV1(
+        dependencies({ isAuthenticated }),
+        controller.signal,
+      ),
+    ).rejects.toBe(reason)
+    expect(isAuthenticated).not.toHaveBeenCalled()
+  })
+
+  it('stops pagination immediately after an awaited page aborts', async () => {
+    const controller = new AbortController()
+    const reason = new DOMException('Canceled', 'AbortError')
+    const getCloudChat = vi.fn()
+    const listChats = vi.fn().mockImplementation(async () => {
+      controller.abort(reason)
+      return { items: [], next: 'another-page' }
+    })
+
+    await expect(
+      collectNativeBackupV1(
+        dependencies({ listChats, getCloudChat }),
+        controller.signal,
+      ),
+    ).rejects.toBe(reason)
+    expect(listChats).toHaveBeenCalledTimes(1)
+    expect(getCloudChat).not.toHaveBeenCalled()
+  })
+
+  it('does not schedule more bounded document workers after abort', async () => {
+    const controller = new AbortController()
+    const reason = new DOMException('Canceled', 'AbortError')
+    const getProject = vi.fn()
+    const listDocuments = vi.fn().mockImplementation(async () => {
+      controller.abort(reason)
+      return []
+    })
+    const projects = Array.from({ length: 8 }, (_, index) => ({
+      id: `project-${index}`,
+      syncVersion: 1,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    }))
+
+    await expect(
+      collectNativeBackupV1(
+        dependencies({
+          listProjects: async () => ({ items: projects }),
+          listDocuments,
+          getProject,
+        }),
+        controller.signal,
+      ),
+    ).rejects.toBe(reason)
+    expect(listDocuments).toHaveBeenCalledTimes(1)
+    expect(listDocuments).toHaveBeenCalledWith('project-0')
+    expect(getProject).not.toHaveBeenCalled()
+  })
+
+  it('stops image reads and never returns partial input after abort', async () => {
+    const controller = new AbortController()
+    const reason = new DOMException('Canceled', 'AbortError')
+    const chat = cloudChat()
+    const getCloudImage = vi.fn().mockImplementation(async () => {
+      controller.abort(reason)
+      return new Uint8Array([1])
+    })
+    const getCloudChat = vi.fn().mockResolvedValue(chat)
+
+    await expect(
+      collectNativeBackupV1(
+        dependencies({
+          listChats: async () => ({
+            items: [{ id: chat.id, syncVersion: 1 }],
+          }),
+          getCloudChat,
+          getCloudImage,
+        }),
+        controller.signal,
+      ),
+    ).rejects.toBe(reason)
+    expect(getCloudImage).toHaveBeenCalledTimes(1)
+    expect(getCloudChat).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tests/services/native-backup/collect-limits.test.ts
+++ b/tests/services/native-backup/collect-limits.test.ts
@@ -18,39 +18,52 @@ const localChat: StoredChat = {
   id: 'local',
   title: 'Local',
   messages: [
-    { role: 'user', content: 'one', timestamp: new Date(timestamp) },
+    {
+      role: 'user',
+      content: 'one',
+      timestamp: new Date(timestamp),
+      attachments: [
+        {
+          id: 'image',
+          type: 'image',
+          fileName: 'image.png',
+          encryptionKey: 'key',
+        },
+      ],
+    },
     { role: 'assistant', content: 'two', timestamp: new Date(timestamp) },
   ],
   createdAt: timestamp,
   updatedAt: timestamp,
   lastAccessedAt: 0,
-  isLocalOnly: true,
-  syncUserId: 'user',
+  syncVersion: 1,
 }
 
 describe('native backup collection limits', () => {
   it('preflights aggregate record counts before returning input', async () => {
     const { collectNativeBackupV1 } =
       await import('@/services/native-backup/collect')
+    const getCloudImage = vi.fn().mockResolvedValue(new Uint8Array([1]))
     const dependencies: NativeBackupCollectionDependencies = {
       isAuthenticated: async () => true,
       activeUserId: () => 'user',
       requireUnlockedCek: () => {},
-      listChats: async () => ({ items: [] }),
-      getCloudChat: async () => null,
-      getCloudImage: async () => null,
+      listChats: async () => ({
+        items: [{ id: localChat.id, syncVersion: 1 }],
+      }),
+      getCloudChat: async () => localChat,
+      getCloudImage,
       listProjects: async () => ({ items: [] }),
       getProject: async () => null,
       listDocuments: async () => [],
       getDocument: async () => null,
-      getLocalChats: async () => [localChat],
-      getLocalChat: async () => localChat,
-      randomUUID: () => '123e4567-e89b-42d3-a456-426614174000',
-      now: () => new Date(timestamp),
+      getLocalChats: async () => [],
+      getLocalChat: async () => null,
     }
 
     await expect(collectNativeBackupV1(dependencies)).rejects.toThrow(
       'message limit exceeded',
     )
+    expect(getCloudImage).not.toHaveBeenCalled()
   })
 })

--- a/tests/services/native-backup/collect-limits.test.ts
+++ b/tests/services/native-backup/collect-limits.test.ts
@@ -1,0 +1,56 @@
+import type { NativeBackupCollectionDependencies } from '@/services/native-backup/collect'
+import type { StoredChat } from '@/services/storage/indexed-db'
+
+vi.mock('@/services/native-backup/constants', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@/services/native-backup/constants')>()
+  return {
+    ...actual,
+    NATIVE_BACKUP_LIMITS: {
+      ...actual.NATIVE_BACKUP_LIMITS,
+      messages: 1,
+    },
+  }
+})
+
+const timestamp = '2026-08-20T12:00:00.000Z'
+const localChat: StoredChat = {
+  id: 'local',
+  title: 'Local',
+  messages: [
+    { role: 'user', content: 'one', timestamp: new Date(timestamp) },
+    { role: 'assistant', content: 'two', timestamp: new Date(timestamp) },
+  ],
+  createdAt: timestamp,
+  updatedAt: timestamp,
+  lastAccessedAt: 0,
+  isLocalOnly: true,
+  syncUserId: 'user',
+}
+
+describe('native backup collection limits', () => {
+  it('preflights aggregate record counts before returning input', async () => {
+    const { collectNativeBackupV1 } =
+      await import('@/services/native-backup/collect')
+    const dependencies: NativeBackupCollectionDependencies = {
+      isAuthenticated: async () => true,
+      activeUserId: () => 'user',
+      requireUnlockedCek: () => {},
+      listChats: async () => ({ items: [] }),
+      getCloudChat: async () => null,
+      getCloudImage: async () => null,
+      listProjects: async () => ({ items: [] }),
+      getProject: async () => null,
+      listDocuments: async () => [],
+      getDocument: async () => null,
+      getLocalChats: async () => [localChat],
+      getLocalChat: async () => localChat,
+      randomUUID: () => '123e4567-e89b-42d3-a456-426614174000',
+      now: () => new Date(timestamp),
+    }
+
+    await expect(collectNativeBackupV1(dependencies)).rejects.toThrow(
+      'message limit exceeded',
+    )
+  })
+})

--- a/tests/services/native-backup/collect-limits.test.ts
+++ b/tests/services/native-backup/collect-limits.test.ts
@@ -40,7 +40,7 @@ const localChat: StoredChat = {
 }
 
 describe('native backup collection limits', () => {
-  it('preflights aggregate record counts before returning input', async () => {
+  it('guards message counts before reading attachments', async () => {
     const { collectNativeBackupV1 } =
       await import('@/services/native-backup/collect')
     const getCloudImage = vi.fn().mockResolvedValue(new Uint8Array([1]))

--- a/tests/services/native-backup/collect.test.ts
+++ b/tests/services/native-backup/collect.test.ts
@@ -4,6 +4,7 @@ import {
   NATIVE_BACKUP_LIMITS,
   NativeBackupCollectionError,
   collectNativeBackupV1,
+  formatNativeBackupV1,
   type NativeBackupCollectionDependencies,
 } from '@/services/native-backup'
 import type { StoredChat } from '@/services/storage/indexed-db'
@@ -279,6 +280,7 @@ describe('native backup collection', () => {
         },
       ],
     })
+    expect(() => formatNativeBackupV1(result)).not.toThrow()
   })
 
   it('keeps documents with the same id in different projects', async () => {

--- a/tests/services/native-backup/collect.test.ts
+++ b/tests/services/native-backup/collect.test.ts
@@ -1,0 +1,383 @@
+import type { Attachment } from '@/components/chat/types'
+import {
+  NATIVE_BACKUP_LIMITS,
+  NativeBackupCollectionError,
+  collectNativeBackupV1,
+  type NativeBackupCollectionDependencies,
+} from '@/services/native-backup'
+import type { StoredChat } from '@/services/storage/indexed-db'
+import type { Project, ProjectDocument } from '@/types/project'
+
+const timestamp = '2026-08-20T12:00:00.000Z'
+
+function chat(overrides: Partial<StoredChat> = {}): StoredChat {
+  return {
+    id: 'chat',
+    title: 'Chat',
+    messages: [],
+    createdAt: timestamp,
+    updatedAt: timestamp,
+    lastAccessedAt: 0,
+    syncVersion: 1,
+    ...overrides,
+  }
+}
+
+function project(overrides: Partial<Project> = {}): Project {
+  return {
+    id: 'project',
+    name: 'Project',
+    description: '',
+    systemInstructions: 'Be concise',
+    color: 'blue',
+    memory: [
+      {
+        id: 'fact',
+        fact: 'Likes tea',
+        category: 'preference',
+        confidence: 1,
+        date: timestamp,
+      },
+    ],
+    createdAt: timestamp,
+    updatedAt: timestamp,
+    syncVersion: 1,
+    ...overrides,
+  }
+}
+
+function document(overrides: Partial<ProjectDocument> = {}): ProjectDocument {
+  return {
+    id: 'document',
+    projectId: 'project',
+    filename: 'notes.txt',
+    contentType: 'text/plain',
+    sizeBytes: 4,
+    syncVersion: 1,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+    content: 'text',
+    ...overrides,
+  }
+}
+
+function dependencies(
+  overrides: Partial<NativeBackupCollectionDependencies> = {},
+): NativeBackupCollectionDependencies {
+  return {
+    isAuthenticated: async () => true,
+    activeUserId: () => 'user',
+    requireUnlockedCek: () => {},
+    listChats: async () => ({ items: [] }),
+    getCloudChat: async () => null,
+    getCloudImage: async () => null,
+    listProjects: async () => ({ items: [] }),
+    getProject: async () => null,
+    listDocuments: async () => [],
+    getDocument: async () => null,
+    getLocalChats: async () => [],
+    getLocalChat: async () => null,
+    randomUUID: () => '123e4567-e89b-42d3-a456-426614174000',
+    now: () => new Date(timestamp),
+    ...overrides,
+  }
+}
+
+describe('native backup collection', () => {
+  it('paginates all cloud chats and projects', async () => {
+    const firstChat = chat({ id: 'chat-1' })
+    const secondChat = chat({ id: 'chat-2' })
+    const firstProject = project({ id: 'project-1' })
+    const secondProject = project({ id: 'project-2' })
+    const listChats = vi
+      .fn()
+      .mockResolvedValueOnce({
+        items: [{ id: firstChat.id, syncVersion: 1 }],
+        next: 'chat-page-2',
+      })
+      .mockResolvedValueOnce({
+        items: [{ id: secondChat.id, syncVersion: 1 }],
+      })
+    const listProjects = vi
+      .fn()
+      .mockResolvedValueOnce({
+        items: [
+          {
+            id: firstProject.id,
+            syncVersion: 1,
+            createdAt: timestamp,
+            updatedAt: timestamp,
+          },
+        ],
+        next: 'project-page-2',
+      })
+      .mockResolvedValueOnce({
+        items: [
+          {
+            id: secondProject.id,
+            syncVersion: 1,
+            createdAt: timestamp,
+            updatedAt: timestamp,
+          },
+        ],
+      })
+
+    const result = await collectNativeBackupV1(
+      dependencies({
+        listChats,
+        listProjects,
+        getCloudChat: async (id) =>
+          id === firstChat.id ? firstChat : secondChat,
+        getProject: async (id) =>
+          id === firstProject.id ? firstProject : secondProject,
+      }),
+    )
+
+    expect(listChats).toHaveBeenNthCalledWith(2, 'chat-page-2')
+    expect(listProjects).toHaveBeenNthCalledWith(2, 'project-page-2')
+    expect(result.cloudChats.map(({ id }) => id)).toEqual(['chat-1', 'chat-2'])
+    expect(result.projects.map(({ id }) => id)).toEqual([
+      'project-1',
+      'project-2',
+    ])
+  })
+
+  it('includes only signed-in-owner local-only chats', async () => {
+    const included = chat({
+      id: 'included',
+      isLocalOnly: true,
+      syncUserId: 'user',
+    })
+    const cloudCache = chat({ id: 'cloud-cache', syncUserId: 'user' })
+    const anonymous = chat({ id: 'anonymous', isLocalOnly: true })
+    const otherOwner = chat({
+      id: 'other-owner',
+      isLocalOnly: true,
+      syncUserId: 'other',
+    })
+    const temporary = chat({
+      id: 'temporary',
+      isLocalOnly: true,
+      syncUserId: 'user',
+      isTemporary: true,
+    })
+    const blank = chat({
+      id: 'blank',
+      isLocalOnly: true,
+      syncUserId: 'user',
+      isBlankChat: true,
+    })
+    const values = [
+      included,
+      cloudCache,
+      anonymous,
+      otherOwner,
+      temporary,
+      blank,
+    ]
+
+    const result = await collectNativeBackupV1(
+      dependencies({
+        getLocalChats: async () => values,
+        getLocalChat: async (id) => values.find((value) => value.id === id)!,
+      }),
+    )
+
+    expect(result.localChats.map(({ id }) => id)).toEqual(['included'])
+  })
+
+  it('retrieves document content and cloud and local images with relationships', async () => {
+    const imageAttachment: Attachment = {
+      id: 'cloud-image',
+      type: 'image',
+      fileName: 'cloud.png',
+      mimeType: 'image/png',
+      encryptionKey: 'key',
+    }
+    const cloudChat = chat({
+      id: 'cloud-chat',
+      projectId: 'project',
+      messages: [
+        {
+          role: 'user',
+          content: 'cloud',
+          timestamp: new Date(timestamp),
+          attachments: [imageAttachment],
+        },
+      ],
+    })
+    const localChat = chat({
+      id: 'local-chat',
+      isLocalOnly: true,
+      syncUserId: 'user',
+      messages: [
+        {
+          role: 'user',
+          content: 'local',
+          timestamp: new Date(timestamp),
+          imageData: [{ base64: 'BAU=', mimeType: 'image/png' }],
+        },
+      ],
+    })
+    const doc = document()
+
+    const result = await collectNativeBackupV1(
+      dependencies({
+        listChats: async () => ({
+          items: [{ id: cloudChat.id, syncVersion: 1 }],
+        }),
+        getCloudChat: async () => cloudChat,
+        getCloudImage: async () => new Uint8Array([1, 2, 3]),
+        listProjects: async () => ({
+          items: [
+            {
+              id: 'project',
+              syncVersion: 1,
+              createdAt: timestamp,
+              updatedAt: timestamp,
+            },
+          ],
+        }),
+        getProject: async () => project(),
+        listDocuments: async () => [
+          {
+            id: doc.id,
+            projectId: doc.projectId,
+            syncVersion: 1,
+            createdAt: timestamp,
+            updatedAt: timestamp,
+          },
+        ],
+        getDocument: async () => doc,
+        getLocalChats: async () => [localChat],
+        getLocalChat: async () => localChat,
+      }),
+    )
+
+    expect(result.projectDocuments[0].extractedText).toBe('text')
+    expect(result.projects[0]).toMatchObject({
+      color: 'blue',
+      memory: project().memory,
+    })
+    expect(result.images.map(({ bytes }) => [...bytes])).toEqual([
+      [1, 2, 3],
+      [4, 5],
+    ])
+    expect(result.relationships).toEqual({
+      projectChats: [{ projectId: 'project', chatId: 'cloud-chat' }],
+      projectDocuments: [{ projectId: 'project', documentId: 'document' }],
+      chatImages: [
+        {
+          chatId: 'cloud-chat',
+          imageId: 'attachment:cloud-chat:0:cloud-image',
+        },
+        {
+          chatId: 'local-chat',
+          imageId: 'legacy:local-chat:0:0',
+        },
+      ],
+    })
+  })
+
+  it('retries one changed record and fails a persistently changing record', async () => {
+    const stable = chat({ syncVersion: 2 })
+    const getStable = vi.fn().mockResolvedValue(stable)
+    await collectNativeBackupV1(
+      dependencies({
+        listChats: async () => ({ items: [{ id: stable.id, syncVersion: 1 }] }),
+        getCloudChat: getStable,
+      }),
+    )
+    expect(getStable).toHaveBeenCalledTimes(3)
+
+    let version = 1
+    await expect(
+      collectNativeBackupV1(
+        dependencies({
+          listChats: async () => ({ items: [{ id: 'chat', syncVersion: 1 }] }),
+          getCloudChat: async () => chat({ syncVersion: version++ }),
+        }),
+      ),
+    ).rejects.toThrow('cloud chat chat: version changed during collection')
+  })
+
+  it('fails the whole collection with missing record and image details', async () => {
+    await expect(
+      collectNativeBackupV1(
+        dependencies({
+          listProjects: async () => ({
+            items: [
+              {
+                id: 'missing-project',
+                syncVersion: 1,
+                createdAt: timestamp,
+                updatedAt: timestamp,
+              },
+            ],
+          }),
+        }),
+      ),
+    ).rejects.toMatchObject({
+      kind: 'project',
+      recordId: 'missing-project',
+    } satisfies Partial<NativeBackupCollectionError>)
+
+    const missingImage = chat({
+      messages: [
+        {
+          role: 'user',
+          content: '',
+          timestamp: new Date(timestamp),
+          attachments: [
+            { id: 'missing', type: 'image', fileName: 'missing.png' },
+          ],
+        },
+      ],
+    })
+    await expect(
+      collectNativeBackupV1(
+        dependencies({
+          listChats: async () => ({
+            items: [{ id: missingImage.id, syncVersion: 1 }],
+          }),
+          getCloudChat: async () => missingImage,
+        }),
+      ),
+    ).rejects.toThrow(
+      'image attachment:chat:0:missing: image bytes are missing',
+    )
+  })
+
+  it('preflights per-image limits', async () => {
+    const oversized = chat({
+      messages: [
+        {
+          role: 'user',
+          content: '',
+          timestamp: new Date(timestamp),
+          attachments: [
+            {
+              id: 'large',
+              type: 'image',
+              fileName: 'large.png',
+              encryptionKey: 'key',
+            },
+          ],
+        },
+      ],
+    })
+
+    await expect(
+      collectNativeBackupV1(
+        dependencies({
+          listChats: async () => ({
+            items: [{ id: oversized.id, syncVersion: 1 }],
+          }),
+          getCloudChat: async () => oversized,
+          getCloudImage: async () =>
+            new Uint8Array(NATIVE_BACKUP_LIMITS.imageBytes + 1),
+        }),
+      ),
+    ).rejects.toThrow('image size limit exceeded')
+  })
+})

--- a/tests/services/native-backup/collect.test.ts
+++ b/tests/services/native-backup/collect.test.ts
@@ -267,7 +267,7 @@ describe('native backup collection', () => {
       chatImages: [
         {
           chatId: 'cloud-chat',
-          imageId: 'attachment:cloud-chat:0:cloud-image',
+          imageId: '["attachment","cloud-chat",0,0,"cloud-image"]',
         },
         {
           chatId: 'local-chat',
@@ -323,6 +323,64 @@ describe('native backup collection', () => {
 
     expect(result.localChats).toEqual([])
     expect(getLocalChat).toHaveBeenCalledTimes(3)
+  })
+
+  it('detects local image changes during collection', async () => {
+    const local = (base64: string) =>
+      chat({
+        isLocalOnly: true,
+        syncUserId: 'user',
+        messages: [
+          {
+            role: 'user',
+            content: 'image',
+            timestamp: new Date(timestamp),
+            attachments: [
+              {
+                id: 'image',
+                type: 'image',
+                fileName: 'image.png',
+                mimeType: 'image/png',
+                base64,
+              },
+            ],
+          },
+        ],
+      })
+    const getLocalChat = vi
+      .fn()
+      .mockResolvedValueOnce(local('AQ=='))
+      .mockResolvedValueOnce(local('Ag=='))
+      .mockResolvedValueOnce(local('Aw=='))
+      .mockResolvedValueOnce(local('BA=='))
+
+    await expect(
+      collectNativeBackupV1(
+        dependencies({
+          getLocalChats: async () => [local('AQ==')],
+          getLocalChat,
+        }),
+      ),
+    ).rejects.toThrow('local chat chat: version changed during collection')
+  })
+
+  it('adds record context to malformed local chat errors', async () => {
+    const malformed = chat({
+      isLocalOnly: true,
+      syncUserId: 'user',
+      createdAt: null as unknown as string,
+    })
+
+    await expect(
+      collectNativeBackupV1(
+        dependencies({
+          getLocalChats: async () => [malformed],
+          getLocalChat: async () => malformed,
+        }),
+      ),
+    ).rejects.toThrow(
+      'local chat chat: record is invalid: Invalid backup timestamp',
+    )
   })
 
   it('refreshes authoritative timestamps when a listed version changes', async () => {
@@ -459,7 +517,7 @@ describe('native backup collection', () => {
         }),
       ),
     ).rejects.toThrow(
-      'image attachment:chat:0:missing: image bytes are missing',
+      'image ["attachment","chat",0,0,"missing"]: image bytes are missing',
     )
   })
 

--- a/tests/services/native-backup/collect.test.ts
+++ b/tests/services/native-backup/collect.test.ts
@@ -1,4 +1,5 @@
 import type { Attachment } from '@/components/chat/types'
+import { AuthTokenUnavailableError } from '@/services/auth'
 import {
   NATIVE_BACKUP_LIMITS,
   NativeBackupCollectionError,
@@ -9,6 +10,9 @@ import type { StoredChat } from '@/services/storage/indexed-db'
 import type { Project, ProjectDocument } from '@/types/project'
 
 const timestamp = '2026-08-20T12:00:00.000Z'
+const png = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10])
+const pngBase64 = (suffix?: number) =>
+  btoa(String.fromCharCode(...png, ...(suffix === undefined ? [] : [suffix])))
 
 function chat(overrides: Partial<StoredChat> = {}): StoredChat {
   return {
@@ -213,7 +217,7 @@ describe('native backup collection', () => {
           role: 'user',
           content: 'local',
           timestamp: new Date(timestamp),
-          imageData: [{ base64: 'BAU=', mimeType: 'image/png' }],
+          imageData: [{ base64: pngBase64(), mimeType: 'image/png' }],
         },
       ],
     })
@@ -225,7 +229,7 @@ describe('native backup collection', () => {
           items: [{ id: cloudChat.id, syncVersion: 1 }],
         }),
         getCloudChat: async () => cloudChat,
-        getCloudImage: async () => new Uint8Array([1, 2, 3]),
+        getCloudImage: async () => png,
         listProjects: async () => ({
           items: [
             {
@@ -258,8 +262,8 @@ describe('native backup collection', () => {
       memory: project().memory,
     })
     expect(result.images.map(({ bytes }) => [...bytes])).toEqual([
-      [1, 2, 3],
-      [4, 5],
+      [...png],
+      [...png],
     ])
     expect(result.relationships).toEqual({
       projectChats: [{ projectId: 'project', chatId: 'cloud-chat' }],
@@ -275,6 +279,46 @@ describe('native backup collection', () => {
         },
       ],
     })
+  })
+
+  it('keeps documents with the same id in different projects', async () => {
+    const projects = [
+      project({ id: 'project-1' }),
+      project({ id: 'project-2' }),
+    ]
+    const documents = projects.map(({ id: projectId }) =>
+      document({ id: 'shared-document', projectId }),
+    )
+
+    const result = await collectNativeBackupV1(
+      dependencies({
+        listProjects: async () => ({
+          items: projects.map(({ id, syncVersion, createdAt, updatedAt }) => ({
+            id,
+            syncVersion,
+            createdAt,
+            updatedAt,
+          })),
+        }),
+        getProject: async (id) => projects.find((value) => value.id === id)!,
+        listDocuments: async (projectId) =>
+          documents
+            .filter((value) => value.projectId === projectId)
+            .map(({ id, projectId, syncVersion, createdAt, updatedAt }) => ({
+              id,
+              projectId,
+              syncVersion,
+              createdAt,
+              updatedAt,
+            })),
+        getDocument: async (projectId, id) =>
+          documents.find(
+            (value) => value.projectId === projectId && value.id === id,
+          )!,
+      }),
+    )
+
+    expect(result.projectDocuments).toHaveLength(2)
   })
 
   it('retries one changed record and fails a persistently changing record', async () => {
@@ -349,15 +393,15 @@ describe('native backup collection', () => {
       })
     const getLocalChat = vi
       .fn()
-      .mockResolvedValueOnce(local('AQ=='))
-      .mockResolvedValueOnce(local('Ag=='))
-      .mockResolvedValueOnce(local('Aw=='))
-      .mockResolvedValueOnce(local('BA=='))
+      .mockResolvedValueOnce(local(pngBase64(1)))
+      .mockResolvedValueOnce(local(pngBase64(2)))
+      .mockResolvedValueOnce(local(pngBase64(3)))
+      .mockResolvedValueOnce(local(pngBase64(4)))
 
     await expect(
       collectNativeBackupV1(
         dependencies({
-          getLocalChats: async () => [local('AQ==')],
+          getLocalChats: async () => [local(pngBase64(1))],
           getLocalChat,
         }),
       ),
@@ -521,6 +565,23 @@ describe('native backup collection', () => {
     )
   })
 
+  it('preserves authentication failures while reading cloud records', async () => {
+    const error = new AuthTokenUnavailableError('signed out')
+
+    await expect(
+      collectNativeBackupV1(
+        dependencies({
+          listChats: async () => ({
+            items: [{ id: 'chat', syncVersion: 1 }],
+          }),
+          getCloudChat: async () => {
+            throw error
+          },
+        }),
+      ),
+    ).rejects.toBe(error)
+  })
+
   it('preflights per-image limits', async () => {
     const oversized = chat({
       messages: [
@@ -547,8 +608,11 @@ describe('native backup collection', () => {
             items: [{ id: oversized.id, syncVersion: 1 }],
           }),
           getCloudChat: async () => oversized,
-          getCloudImage: async () =>
-            new Uint8Array(NATIVE_BACKUP_LIMITS.imageBytes + 1),
+          getCloudImage: async () => {
+            const bytes = new Uint8Array(NATIVE_BACKUP_LIMITS.imageBytes + 1)
+            bytes.set(png)
+            return bytes
+          },
         }),
       ),
     ).rejects.toThrow('image size limit exceeded')

--- a/tests/services/native-backup/collect.test.ts
+++ b/tests/services/native-backup/collect.test.ts
@@ -77,8 +77,6 @@ function dependencies(
     getDocument: async () => null,
     getLocalChats: async () => [],
     getLocalChat: async () => null,
-    randomUUID: () => '123e4567-e89b-42d3-a456-426614174000',
-    now: () => new Date(timestamp),
     ...overrides,
   }
 }
@@ -282,9 +280,13 @@ describe('native backup collection', () => {
   it('retries one changed record and fails a persistently changing record', async () => {
     const stable = chat({ syncVersion: 2 })
     const getStable = vi.fn().mockResolvedValue(stable)
+    const listStable = vi
+      .fn()
+      .mockResolvedValueOnce({ items: [{ id: stable.id, syncVersion: 1 }] })
+      .mockResolvedValue({ items: [{ id: stable.id, syncVersion: 2 }] })
     await collectNativeBackupV1(
       dependencies({
-        listChats: async () => ({ items: [{ id: stable.id, syncVersion: 1 }] }),
+        listChats: listStable,
         getCloudChat: getStable,
       }),
     )
@@ -299,6 +301,119 @@ describe('native backup collection', () => {
         }),
       ),
     ).rejects.toThrow('cloud chat chat: version changed during collection')
+  })
+
+  it('revalidates local ownership and eligibility after a changed read', async () => {
+    const eligible = chat({ isLocalOnly: true, syncUserId: 'user' })
+    const ineligible = chat({
+      isLocalOnly: true,
+      syncUserId: 'other-user',
+    })
+    const getLocalChat = vi
+      .fn()
+      .mockResolvedValueOnce(eligible)
+      .mockResolvedValue(ineligible)
+
+    const result = await collectNativeBackupV1(
+      dependencies({
+        getLocalChats: async () => [eligible],
+        getLocalChat,
+      }),
+    )
+
+    expect(result.localChats).toEqual([])
+    expect(getLocalChat).toHaveBeenCalledTimes(3)
+  })
+
+  it('refreshes authoritative timestamps when a listed version changes', async () => {
+    const oldTimestamp = '2026-08-19T12:00:00.000Z'
+    const listProjects = vi
+      .fn()
+      .mockResolvedValueOnce({
+        items: [
+          {
+            id: 'project',
+            syncVersion: 1,
+            createdAt: oldTimestamp,
+            updatedAt: oldTimestamp,
+          },
+        ],
+      })
+      .mockResolvedValue({
+        items: [
+          {
+            id: 'project',
+            syncVersion: 2,
+            createdAt: timestamp,
+            updatedAt: timestamp,
+          },
+        ],
+      })
+
+    const result = await collectNativeBackupV1(
+      dependencies({
+        listProjects,
+        getProject: async () => project({ syncVersion: 2 }),
+      }),
+    )
+
+    expect(result.projects[0]).toMatchObject({
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    })
+    expect(listProjects).toHaveBeenCalledTimes(2)
+  })
+
+  it('deduplicates mutable paginated rows at their latest versions', async () => {
+    const listChats = vi
+      .fn()
+      .mockResolvedValueOnce({
+        items: [{ id: 'chat', syncVersion: 1 }],
+        next: 'next',
+      })
+      .mockResolvedValueOnce({ items: [{ id: 'chat', syncVersion: 2 }] })
+    const listProjects = vi
+      .fn()
+      .mockResolvedValueOnce({
+        items: [
+          {
+            id: 'project',
+            syncVersion: 1,
+            createdAt: timestamp,
+            updatedAt: timestamp,
+          },
+        ],
+        next: 'next',
+      })
+      .mockResolvedValueOnce({
+        items: [
+          {
+            id: 'project',
+            syncVersion: 2,
+            createdAt: timestamp,
+            updatedAt: timestamp,
+          },
+        ],
+      })
+    const getCloudChat = vi.fn().mockResolvedValue(chat({ syncVersion: 2 }))
+    const getProject = vi.fn().mockResolvedValue(project({ syncVersion: 2 }))
+    const listDocuments = vi.fn().mockResolvedValue([])
+
+    const result = await collectNativeBackupV1(
+      dependencies({
+        listChats,
+        listProjects,
+        getCloudChat,
+        getProject,
+        listDocuments,
+      }),
+    )
+
+    expect(result.cloudChats).toHaveLength(1)
+    expect(result.projects).toHaveLength(1)
+    expect(getCloudChat).toHaveBeenCalledTimes(2)
+    expect(getProject).toHaveBeenCalledTimes(1)
+    expect(listDocuments).toHaveBeenCalledTimes(1)
   })
 
   it('fails the whole collection with missing record and image details', async () => {


### PR DESCRIPTION
## Summary
- enumerate authoritative cloud and account-owned local data
- collect documents and images with bounded concurrency and cancellation
- include reviewed local-image fingerprint and sanitizer-context fixes

## Testing
- unit tests, typecheck, and lint

## Dependency
- stacked on native backup manifest branch