### PR TITLE
Fix long chat replies jumping out of view

### DIFF
--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -119,6 +119,11 @@ import { AskSidebar } from './ask-sidebar'
 import { ChatAnnouncer } from './chat-announcer'
 import { ChatInput } from './chat-input'
 import { ChatMessages } from './chat-messages'
+import {
+  getChatContentBottomScrollTop,
+  getChatSpacerHeight,
+  getDistanceFromChatContentBottom,
+} from './chat-scroll'
 import { ChatSidebar } from './chat-sidebar'
 import { PromptPresetSuggestions } from './components/prompt-preset-suggestions'
 import { CONSTANTS } from './constants'
@@ -830,13 +835,18 @@ export function ChatInterface({
   const scrollToBottom = useCallback((smooth = true) => {
     if (scrollContainerRef.current) {
       const el = scrollContainerRef.current
+      const top = getChatContentBottomScrollTop(
+        el.scrollHeight,
+        el.clientHeight,
+        getChatSpacerHeight(el),
+      )
       if (smooth) {
         el.scrollTo({
-          top: el.scrollHeight,
+          top,
           behavior: 'smooth',
         })
       } else {
-        el.scrollTop = el.scrollHeight
+        el.scrollTop = top
       }
     }
   }, [])
@@ -3088,14 +3098,14 @@ export function ChatInterface({
     const el = scrollContainerRef.current
     if (!el) return
 
-    // Check if spacer is present and get its height
-    const spacer = el.querySelector('[data-spacer]') as HTMLElement | null
-    const spacerHeight = spacer?.offsetHeight || 0
-
     // Show button when user has scrolled up from the bottom by more than threshold
     // Subtract spacer height since it's empty space, not content
-    const distanceFromBottom =
-      el.scrollHeight - el.scrollTop - el.clientHeight - spacerHeight
+    const distanceFromBottom = getDistanceFromChatContentBottom(
+      el.scrollHeight,
+      el.scrollTop,
+      el.clientHeight,
+      getChatSpacerHeight(el),
+    )
     const SCROLL_THRESHOLD = 200
 
     setShowScrollButton(distanceFromBottom > SCROLL_THRESHOLD)

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -3229,8 +3229,12 @@ export function ChatInterface({
       wasThinkingBefore &&
       scrolledForContentStartKeyRef.current !== key
     ) {
-      const distanceFromBottom =
-        el.scrollHeight - el.scrollTop - el.clientHeight
+      const distanceFromBottom = getDistanceFromChatContentBottom(
+        el.scrollHeight,
+        el.scrollTop,
+        el.clientHeight,
+        getChatSpacerHeight(el),
+      )
       const ANCHOR_THRESHOLD = 140
       const isNearBottom = distanceFromBottom <= ANCHOR_THRESHOLD
       if (isNearBottom) {

--- a/src/components/chat/chat-messages.tsx
+++ b/src/components/chat/chat-messages.tsx
@@ -20,6 +20,7 @@ import React, {
   useRef,
   useState,
 } from 'react'
+import { canRemoveChatSpacerWithoutJump } from './chat-scroll'
 import { CONSTANTS } from './constants'
 import { ensureTimeline } from './ensure-timeline'
 import type { ReasoningEffort } from './hooks/use-reasoning-effort'
@@ -322,8 +323,8 @@ export function ChatMessages({
   const [mounted, setMounted] = useState(false)
   const [showSpacer, setShowSpacer] = useState(false)
   const prevMessageCountRef = React.useRef(messages.length)
-  const prevShowScrollButtonRef = React.useRef(showScrollButton)
   const messageCountWhenSpacerSetRef = React.useRef<number | null>(null)
+  const spacerRef = React.useRef<HTMLDivElement>(null)
   const printRef = useRef<HTMLDivElement>(null)
   const printReadyResolverRef = useRef<(() => void) | null>(null)
   const [printRequested, setPrintRequested] = useState(false)
@@ -385,19 +386,30 @@ export function ChatMessages({
     messageCountWhenSpacerSetRef.current = null
   }, [chatId]) // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Reset spacer when scroll-to-bottom button appears (user scrolled up)
+  // Reset spacer after an active response has grown beyond the viewport
   React.useEffect(() => {
-    const buttonJustAppeared =
-      showScrollButton && !prevShowScrollButtonRef.current
     const spacerSetForCurrentMessage =
       messageCountWhenSpacerSetRef.current === messages.length
+    const spacer = spacerRef.current
+    const scrollContainer = spacer?.closest(
+      '[data-scroll-container="main"]',
+    ) as HTMLElement | null
 
-    // Only reset if button transitioned to visible and we're not on the same message that triggered the spacer
-    if (buttonJustAppeared && !spacerSetForCurrentMessage) {
+    if (
+      !isStreamingResponse &&
+      !spacerSetForCurrentMessage &&
+      spacer &&
+      scrollContainer &&
+      canRemoveChatSpacerWithoutJump(
+        scrollContainer.scrollHeight,
+        scrollContainer.scrollTop,
+        scrollContainer.clientHeight,
+        spacer.offsetHeight,
+      )
+    ) {
       setShowSpacer(false)
     }
-    prevShowScrollButtonRef.current = showScrollButton
-  }, [showScrollButton, messages.length])
+  }, [showScrollButton, messages.length, isStreamingResponse])
 
   // Get the current model - always defined since config must load
   const currentModel = useMemo(() => {
@@ -744,6 +756,7 @@ export function ChatMessages({
           fade above the input area, not a full 70dvh of empty space. */}
         {showSpacer && (
           <div
+            ref={spacerRef}
             data-spacer
             className="flex-shrink-0"
             style={{

--- a/src/components/chat/chat-scroll.ts
+++ b/src/components/chat/chat-scroll.ts
@@ -1,0 +1,33 @@
+export function getChatSpacerHeight(container: HTMLElement): number {
+  const spacer = container.querySelector('[data-spacer]') as HTMLElement | null
+  return spacer?.offsetHeight ?? 0
+}
+
+export function getChatContentBottomScrollTop(
+  scrollHeight: number,
+  clientHeight: number,
+  spacerHeight: number,
+): number {
+  return Math.max(0, scrollHeight - clientHeight - spacerHeight)
+}
+
+export function canRemoveChatSpacerWithoutJump(
+  scrollHeight: number,
+  scrollTop: number,
+  clientHeight: number,
+  spacerHeight: number,
+): boolean {
+  return (
+    scrollTop <=
+    getChatContentBottomScrollTop(scrollHeight, clientHeight, spacerHeight)
+  )
+}
+
+export function getDistanceFromChatContentBottom(
+  scrollHeight: number,
+  scrollTop: number,
+  clientHeight: number,
+  spacerHeight: number,
+): number {
+  return scrollHeight - scrollTop - clientHeight - spacerHeight
+}

--- a/tests/components/chat/chat-messages-scroll-spacer.test.tsx
+++ b/tests/components/chat/chat-messages-scroll-spacer.test.tsx
@@ -1,0 +1,149 @@
+import { ChatMessages } from '@/components/chat/chat-messages'
+import type { Message } from '@/components/chat/types'
+import { render } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/config/models', () => ({
+  findSelectableModel: (_id: string, models: unknown[]) => models[0],
+}))
+
+vi.mock('@/components/chat/renderers/client', () => ({
+  getRendererRegistry: () => ({
+    getMessageRenderer: () => ({
+      render: ({ message }: { message: Message }) => (
+        <div>{message.content}</div>
+      ),
+    }),
+  }),
+}))
+
+vi.mock('@/hooks/use-chat-print', () => ({
+  useChatPrint: () => undefined,
+}))
+
+vi.mock('@/components/chat/PrintableChat', () => ({
+  PrintableChat: () => null,
+}))
+
+const models = [{ id: 'model-1', contextWindowTokens: 1000 }] as any
+
+function message(role: Message['role'], turnId: string): Message {
+  return {
+    role,
+    turnId,
+    content: `${role} message`,
+    timestamp: new Date(),
+  }
+}
+
+function props(messages: Message[]) {
+  return {
+    chatId: 'chat-1',
+    messages,
+    isDarkMode: false,
+    models,
+    selectedModel: 'model-1',
+  }
+}
+
+function conversation(
+  messages: Message[],
+  options: { isStreamingResponse?: boolean; showScrollButton?: boolean } = {},
+) {
+  return (
+    <div data-scroll-container="main">
+      <ChatMessages {...props(messages)} {...options} />
+    </div>
+  )
+}
+
+function setScrollLayout(
+  container: HTMLElement,
+  spacer: HTMLElement,
+  layout: { scrollHeight: number; scrollTop: number; clientHeight: number },
+) {
+  Object.defineProperties(container, {
+    scrollHeight: { configurable: true, value: layout.scrollHeight },
+    scrollTop: { configurable: true, value: layout.scrollTop },
+    clientHeight: { configurable: true, value: layout.clientHeight },
+  })
+  Object.defineProperty(spacer, 'offsetHeight', {
+    configurable: true,
+    value: 500,
+  })
+}
+
+describe('ChatMessages scroll spacer', () => {
+  it('keeps the prompt anchor stable while a long response streams', () => {
+    const initialMessages = [
+      message('user', 'old-user'),
+      message('assistant', 'old-assistant'),
+    ]
+    const { container, rerender } = render(conversation(initialMessages))
+
+    const messagesWithPrompt = [
+      ...initialMessages,
+      message('user', 'active-user'),
+    ]
+    rerender(conversation(messagesWithPrompt))
+    expect(container.querySelector('[data-spacer]')).toBeInTheDocument()
+
+    const streamingMessages = [
+      ...messagesWithPrompt,
+      message('assistant', 'active-assistant'),
+    ]
+    rerender(
+      conversation(streamingMessages, {
+        isStreamingResponse: true,
+        showScrollButton: true,
+      }),
+    )
+    expect(container.querySelector('[data-spacer]')).toBeInTheDocument()
+
+    rerender(conversation(streamingMessages, { isStreamingResponse: true }))
+    expect(container.querySelector('[data-spacer]')).toBeInTheDocument()
+
+    setScrollLayout(
+      container.querySelector('[data-scroll-container="main"]')!,
+      container.querySelector('[data-spacer]')!,
+      { scrollHeight: 2400, scrollTop: 900, clientHeight: 800 },
+    )
+    rerender(conversation(streamingMessages))
+    expect(container.querySelector('[data-spacer]')).not.toBeInTheDocument()
+  })
+
+  it('does not treat an existing scroll button as response overflow', () => {
+    const initialMessages = [
+      message('user', 'old-user'),
+      message('assistant', 'old-assistant'),
+    ]
+    const { container, rerender } = render(
+      conversation(initialMessages, { showScrollButton: true }),
+    )
+
+    const messagesWithPrompt = [
+      ...initialMessages,
+      message('user', 'active-user'),
+    ]
+    rerender(conversation(messagesWithPrompt, { showScrollButton: true }))
+
+    const streamingMessages = [
+      ...messagesWithPrompt,
+      message('assistant', 'active-assistant'),
+    ]
+    rerender(
+      conversation(streamingMessages, {
+        isStreamingResponse: true,
+        showScrollButton: true,
+      }),
+    )
+    setScrollLayout(
+      container.querySelector('[data-scroll-container="main"]')!,
+      container.querySelector('[data-spacer]')!,
+      { scrollHeight: 1400, scrollTop: 500, clientHeight: 800 },
+    )
+    rerender(conversation(streamingMessages, { showScrollButton: true }))
+
+    expect(container.querySelector('[data-spacer]')).toBeInTheDocument()
+  })
+})

--- a/tests/components/chat/chat-scroll.test.ts
+++ b/tests/components/chat/chat-scroll.test.ts
@@ -1,0 +1,21 @@
+import {
+  canRemoveChatSpacerWithoutJump,
+  getChatContentBottomScrollTop,
+  getDistanceFromChatContentBottom,
+} from '@/components/chat/chat-scroll'
+import { describe, expect, it } from 'vitest'
+
+describe('chat scrolling', () => {
+  it('targets the end of conversation content instead of the spacer', () => {
+    expect(getChatContentBottomScrollTop(2400, 800, 500)).toBe(1100)
+  })
+
+  it('measures distance from conversation content instead of the spacer', () => {
+    expect(getDistanceFromChatContentBottom(2400, 900, 800, 500)).toBe(200)
+  })
+
+  it('only removes the spacer when the viewport will not be clamped', () => {
+    expect(canRemoveChatSpacerWithoutJump(2400, 900, 800, 500)).toBe(true)
+    expect(canRemoveChatSpacerWithoutJump(1400, 500, 800, 500)).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- keep the prompt anchor spacer in place while long replies stream
- remove the spacer only when doing so cannot clamp or jump the viewport
- make scroll-to-bottom target conversation content rather than spacer space

## Testing
- `npx vitest run tests/components/chat/chat-scroll.test.ts tests/components/chat/chat-messages-scroll-spacer.test.tsx tests/components/chat/chat-messages-archive-boundary.test.tsx tests/components/chat/chat-messages-recovery.test.tsx`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents long streaming replies and post-thinking replies from jumping the chat viewport. Previously we scrolled to spacer space and removed the spacer too early; now we target the end of conversation content and only remove the spacer when it won’t clamp or jump the viewport.

- Adds `src/components/chat/chat-scroll.ts` helpers: `getChatSpacerHeight`, `getChatContentBottomScrollTop`, `getDistanceFromChatContentBottom`, `canRemoveChatSpacerWithoutJump`.
- `ChatInterface.scrollToBottom` scrolls to content bottom (subtracts spacer). Scroll-button visibility and near-bottom checks use distance from content bottom; after “thinking” ends, new replies auto-anchor if the user is near bottom.
- `ChatMessages` keeps the spacer while a response streams and removes it only when `canRemoveChatSpacerWithoutJump(...)` permits; uses a spacer ref and the nearest `[data-scroll-container="main"]`.
- Tests cover spacer lifecycle, thinking-to-reply anchoring, and scroll math: `chat-messages-scroll-spacer.test.tsx`, `chat-scroll.test.ts`.

<sup>Written for commit 82db11dbca3c624dbdef8c8bc36cf462326a7aa4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/533?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

