### PR TITLE
Prevent crashes when thought panels collapse

### DIFF
--- a/src/components/chat/renderers/components/ThoughtProcess.tsx
+++ b/src/components/chat/renderers/components/ThoughtProcess.tsx
@@ -233,15 +233,17 @@ export const ThoughtProcess = memo(function ThoughtProcess({
 
   // Reset max height when thinking stops
   useEffect(() => {
-    if (!isThinking && contentRef.current) {
-      setContentHeight(contentRef.current.scrollHeight)
+    const content = contentRef.current
+    if (!isThinking && content) {
+      setContentHeight(content.scrollHeight)
     }
   }, [isThinking])
 
   // Measure content height for smooth animation
   useLayoutEffect(() => {
-    if (contentRef.current) {
-      const measuredHeight = contentRef.current.scrollHeight
+    const content = contentRef.current
+    if (content) {
+      const measuredHeight = content.scrollHeight
       setContentHeight((prevHeight) =>
         // Same never-shrink guard as the ResizeObserver below: this effect
         // re-runs on every streaming chunk, and shrinking mid-stream causes
@@ -249,19 +251,20 @@ export const ThoughtProcess = memo(function ThoughtProcess({
         isThinking ? Math.max(prevHeight, measuredHeight) : measuredHeight,
       )
       const resizeObserver = new ResizeObserver(() => {
-        if (contentRef.current) {
-          setContentHeight((prevHeight) => {
-            const newHeight = contentRef.current!.scrollHeight
-            // During streaming (isThinking), only allow height to grow, never shrink
-            // This prevents scroll resets when content temporarily contracts
-            if (isThinking) {
-              return Math.max(prevHeight, newHeight)
-            }
-            return newHeight
-          })
-        }
+        const currentContent = contentRef.current
+        if (!currentContent) return
+
+        const newHeight = currentContent.scrollHeight
+        setContentHeight((prevHeight) => {
+          // During streaming (isThinking), only allow height to grow, never shrink
+          // This prevents scroll resets when content temporarily contracts
+          if (isThinking) {
+            return Math.max(prevHeight, newHeight)
+          }
+          return newHeight
+        })
       })
-      resizeObserver.observe(contentRef.current)
+      resizeObserver.observe(content)
       return () => resizeObserver.disconnect()
     }
   }, [thoughts, isThinking, isExpanded, renderContent])


### PR DESCRIPTION
## Summary
- capture thought-content elements before measuring their height
- read resize measurements before scheduling React state updates
- prevent deferred updates from dereferencing a cleared DOM ref after collapse or unmount

## Testing
- `npx vitest run tests/components/chat` (47 files, 452 tests)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents crashes when a thought panel collapses or unmounts mid-stream by stabilizing DOM measurements and guarding cleared refs. Previously the layout effect and ResizeObserver could dereference a cleared `contentRef` and crash; now we read measurements before enqueuing updates and exit safely if the ref is gone.

- Snapshot `contentRef.current` into a local `content` for measurement and observation; observe/disconnect the stable node.
- In the observer, re-read `contentRef.current`, return if missing, then update height using the existing no-shrink guard while `isThinking`.
- No prop or API changes. Smooth expand/collapse preserved and scroll resets avoided mid-stream.

<sup>Written for commit 17eb76946659f1bcf6b973f9bb42fc37e3dcf014. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/535?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

