### PR TITLE
fix: allow missed releases to be retried

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,18 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing version tag to release
+        required: true
+        type: string
 
 permissions:
   contents: write
+
+env:
+  RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
 
 jobs:
   release:
@@ -15,13 +24,16 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ env.RELEASE_TAG }}
 
       - name: Check release settings
-        run: node scripts/check-release-settings.mjs "${GITHUB_REF_NAME}"
+        run: node scripts/check-release-settings.mjs "${RELEASE_TAG}"
 
       - name: Create Release
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65
         with:
+          tag_name: ${{ env.RELEASE_TAG }}
           generate_release_notes: true
           draft: false
-          prerelease: ${{ contains(github.ref_name, '-') }}
+          prerelease: ${{ contains(env.RELEASE_TAG, '-') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ env.RELEASE_TAG }}
+          ref: refs/tags/${{ env.RELEASE_TAG }}
 
       - name: Check release settings
         run: node scripts/check-release-settings.mjs "${RELEASE_TAG}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          if [[ ! "${RELEASE_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+          if [[ ! "${RELEASE_TAG}" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)(\.(0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*))?$ ]]; then
             printf 'Invalid release tag: %s\n' "${RELEASE_TAG}" >&2
             exit 1
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,16 +12,27 @@ on:
         type: string
 
 permissions:
-  contents: write
+  contents: read
 
 env:
   RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
 
 jobs:
-  release:
-    name: Create Release
+  validate:
+    name: Validate Release
     runs-on: ubuntu-latest
     steps:
+      - name: Check release tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [[ ! "${RELEASE_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            printf 'Invalid release tag: %s\n' "${RELEASE_TAG}" >&2
+            exit 1
+          fi
+
+          gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${RELEASE_TAG}" >/dev/null
+
       - name: Checkout code
         uses: actions/checkout@v4
         with:
@@ -30,6 +41,13 @@ jobs:
       - name: Check release settings
         run: node scripts/check-release-settings.mjs "${RELEASE_TAG}"
 
+  release:
+    name: Create Release
+    needs: validate
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
       - name: Create Release
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65
         with:


### PR DESCRIPTION
## Summary
- keep automatic releases for individual `v*` tag pushes
- add a manual tag input to recover when GitHub suppresses bulk tag events
- check out, validate, and publish the explicitly selected tag

## Testing
- `actionlint .github/workflows/release.yml`
- `npx prettier --check .github/workflows/release.yml`
- `node scripts/check-release-settings.mjs v1.0.0`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows missed releases to be retried when GitHub suppresses bulk tag events. Auto-releases still run on `v*` tags; manual retries now require an existing tag and reject malformed versions.

- Adds `workflow_dispatch` with required `tag`; sets `RELEASE_TAG` to `${{ inputs.tag || github.ref_name }}`.
- Validates `RELEASE_TAG` format (`vMAJOR.MINOR.PATCH[-pre]`) and existence via `gh`; checks out `refs/tags/${RELEASE_TAG}` and runs `scripts/check-release-settings.mjs`.
- Splits into `validate` and `release` jobs; defaults to `contents: read` and grants `contents: write` only to the `release` job.
- Uses `softprops/action-gh-release` with `tag_name: ${{ env.RELEASE_TAG }}`; sets `prerelease` when `RELEASE_TAG` contains a hyphen.
- To backfill a missed release: run the workflow manually and enter an existing `v*` tag.

<sup>Written for commit 624373e6132d8f15efc243fe552bf141e322cbac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/537?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

