### PR TITLE
fix: clear all local data after sign out

### DIFF
--- a/src/services/storage/indexed-db.ts
+++ b/src/services/storage/indexed-db.ts
@@ -1150,81 +1150,46 @@ export class IndexedDBStorage {
     this.db = null
     db?.close()
 
-    const reset = this.ensureDB().then(
-      (resetDb) =>
-        new Promise<void>((resolve, reject) => {
-          const transaction = resetDb.transaction(
-            [
-              CHATS_STORE,
-              PROJECTS_STORE,
-              ATTACHMENT_PAYLOADS_STORE,
-              CHAT_SUMMARIES_STORE,
-              SYNC_STATE_STORE,
-              REMOTE_CHAT_STATE_STORE,
-              SYNC_OUTBOX_STORE,
-            ],
-            'readwrite',
-          )
-          const timeout = window.setTimeout(() => {
-            try {
-              transaction.abort()
-            } finally {
-              reject(
-                new Error('Timed out resetting IndexedDB for account change'),
-              )
-            }
-          }, ACCOUNT_CHANGE_RESET_TIMEOUT_MS)
+    const reset = this.ensureDB().then((resetDb) => {
+      const storeNames = Array.from(resetDb.objectStoreNames)
+      return new Promise<void>((resolve, reject) => {
+        const transaction = resetDb.transaction(storeNames, 'readwrite')
+        const timeout = window.setTimeout(() => {
+          try {
+            transaction.abort()
+          } finally {
+            reject(
+              new Error('Timed out resetting IndexedDB for account change'),
+            )
+          }
+        }, ACCOUNT_CHANGE_RESET_TIMEOUT_MS)
 
-          transaction.oncomplete = () => {
-            clearTimeout(timeout)
-            resolve()
-          }
-          transaction.onerror = () => {
-            clearTimeout(timeout)
-            reject(new Error('Failed to reset IndexedDB for account change'))
-          }
-          transaction.onabort = () => {
-            clearTimeout(timeout)
-            reject(new Error('IndexedDB account reset was aborted'))
-          }
+        transaction.oncomplete = () => {
+          clearTimeout(timeout)
+          resolve()
+        }
+        transaction.onerror = () => {
+          clearTimeout(timeout)
+          reject(new Error('Failed to reset IndexedDB for account change'))
+        }
+        transaction.onabort = () => {
+          clearTimeout(timeout)
+          reject(new Error('IndexedDB account reset was aborted'))
+        }
 
-          const chatsRequest = transaction.objectStore(CHATS_STORE).clear()
-          chatsRequest.onerror = () => {
-            clearTimeout(timeout)
-            reject(new Error('Failed to clear chats for account change'))
-          }
-          const projectsRequest = transaction
-            .objectStore(PROJECTS_STORE)
-            .clear()
-          projectsRequest.onerror = () => {
-            clearTimeout(timeout)
-            reject(new Error('Failed to clear projects for account change'))
-          }
-          const payloadsRequest = transaction
-            .objectStore(ATTACHMENT_PAYLOADS_STORE)
-            .clear()
-          payloadsRequest.onerror = () => {
+        for (const storeName of storeNames) {
+          const clearRequest = transaction.objectStore(storeName).clear()
+          clearRequest.onerror = () => {
             clearTimeout(timeout)
             reject(
               new Error(
-                'Failed to clear attachment payloads for account change',
+                `Failed to clear IndexedDB store ${storeName} for account change`,
               ),
             )
           }
-          const summariesRequest = transaction
-            .objectStore(CHAT_SUMMARIES_STORE)
-            .clear()
-          summariesRequest.onerror = () => {
-            clearTimeout(timeout)
-            reject(
-              new Error('Failed to clear chat summaries for account change'),
-            )
-          }
-          transaction.objectStore(SYNC_STATE_STORE).clear()
-          transaction.objectStore(REMOTE_CHAT_STATE_STORE).clear()
-          transaction.objectStore(SYNC_OUTBOX_STORE).clear()
-        }),
-    )
+        }
+      })
+    })
 
     const trackedReset = reset
     this.accountResetPromise = trackedReset

--- a/src/services/storage/indexed-db.ts
+++ b/src/services/storage/indexed-db.ts
@@ -1151,7 +1151,9 @@ export class IndexedDBStorage {
     db?.close()
 
     const reset = this.ensureDB().then((resetDb) => {
-      const storeNames = Array.from(resetDb.objectStoreNames)
+      const storeNames = Array.from(resetDb.objectStoreNames).filter(
+        (storeName) => storeName !== MIGRATIONS_STORE,
+      )
       return new Promise<void>((resolve, reject) => {
         const transaction = resetDb.transaction(storeNames, 'readwrite')
         const timeout = window.setTimeout(() => {

--- a/src/utils/signout-cleanup.ts
+++ b/src/utils/signout-cleanup.ts
@@ -119,11 +119,6 @@ async function clearAllUserData(options: ClearUserDataOptions): Promise<void> {
         localStorage.removeItem(key)
       }
     }
-    window.dispatchEvent(
-      new CustomEvent(PINNED_CHAT_IDS_CHANGED_EVENT, {
-        detail: { pinnedChatIds: [] },
-      }),
-    )
   } catch {
     // best-effort — don't let localStorage failures skip remaining cleanup
   }
@@ -188,6 +183,11 @@ export async function performSignoutCleanup(opts?: {
       context: 'signoutCleanup',
       preserveEncryptionKey: preserveKey,
     })
+    window.dispatchEvent(
+      new CustomEvent(PINNED_CHAT_IDS_CHANGED_EVENT, {
+        detail: { pinnedChatIds: [] },
+      }),
+    )
 
     logInfo(
       `Signout cleanup completed${preserveKey ? ' (encryption key preserved)' : ''}`,

--- a/src/utils/signout-cleanup.ts
+++ b/src/utils/signout-cleanup.ts
@@ -1,4 +1,5 @@
 import { resetRendererRegistry } from '@/components/chat/renderers'
+import { PINNED_CHAT_IDS_CHANGED_EVENT } from '@/constants/settings-events'
 import {
   AUTH_ACCOUNT_RESET_FAILED,
   AUTH_ACTIVE_USER_ID,
@@ -118,6 +119,11 @@ async function clearAllUserData(options: ClearUserDataOptions): Promise<void> {
         localStorage.removeItem(key)
       }
     }
+    window.dispatchEvent(
+      new CustomEvent(PINNED_CHAT_IDS_CHANGED_EVENT, {
+        detail: { pinnedChatIds: [] },
+      }),
+    )
   } catch {
     // best-effort — don't let localStorage failures skip remaining cleanup
   }

--- a/src/utils/signout-cleanup.ts
+++ b/src/utils/signout-cleanup.ts
@@ -179,15 +179,18 @@ export async function performSignoutCleanup(opts?: {
       },
     )
 
-    await clearAllUserData({
-      context: 'signoutCleanup',
-      preserveEncryptionKey: preserveKey,
-    })
-    window.dispatchEvent(
-      new CustomEvent(PINNED_CHAT_IDS_CHANGED_EVENT, {
-        detail: { pinnedChatIds: [] },
-      }),
-    )
+    try {
+      await clearAllUserData({
+        context: 'signoutCleanup',
+        preserveEncryptionKey: preserveKey,
+      })
+    } finally {
+      window.dispatchEvent(
+        new CustomEvent(PINNED_CHAT_IDS_CHANGED_EVENT, {
+          detail: { pinnedChatIds: [] },
+        }),
+      )
+    }
 
     logInfo(
       `Signout cleanup completed${preserveKey ? ' (encryption key preserved)' : ''}`,

--- a/tests/services/storage/indexed-db-account-reset.test.ts
+++ b/tests/services/storage/indexed-db-account-reset.test.ts
@@ -30,29 +30,22 @@ describe('IndexedDBStorage account reset', () => {
     const clearRemoteState = vi.fn(() => ({ onerror: null }))
     const clearOutbox = vi.fn(() => ({ onerror: null }))
     const clearMigrations = vi.fn(() => ({ onerror: null }))
+    const clearByStoreName = new Map([
+      ['chats', clear],
+      ['projects', clearProjects],
+      ['attachmentPayloads', clearPayloads],
+      ['chatSummaries', clearSummaries],
+      ['sync_state', clearSyncState],
+      ['remote_chat_state', clearRemoteState],
+      ['sync_outbox', clearOutbox],
+      ['migrations', clearMigrations],
+    ])
     const transaction: FakeResetTransaction = {
       oncomplete: null,
       onerror: null,
       onabort: null,
       abort: vi.fn(),
-      objectStore: (storeName) => ({
-        clear:
-          storeName === 'chats'
-            ? clear
-            : storeName === 'projects'
-              ? clearProjects
-              : storeName === 'attachmentPayloads'
-                ? clearPayloads
-                : storeName === 'chatSummaries'
-                  ? clearSummaries
-                  : storeName === 'sync_state'
-                    ? clearSyncState
-                    : storeName === 'remote_chat_state'
-                      ? clearRemoteState
-                      : storeName === 'sync_outbox'
-                        ? clearOutbox
-                        : clearMigrations,
-      }),
+      objectStore: (storeName) => ({ clear: clearByStoreName.get(storeName)! }),
     }
     const resetDb = {
       objectStoreNames: [
@@ -125,7 +118,7 @@ describe('IndexedDBStorage account reset', () => {
     expect(clearSyncState).toHaveBeenCalledTimes(1)
     expect(clearRemoteState).toHaveBeenCalledTimes(1)
     expect(clearOutbox).toHaveBeenCalledTimes(1)
-    expect(clearMigrations).toHaveBeenCalledTimes(1)
+    expect(clearMigrations).not.toHaveBeenCalled()
     await completeReset(transaction)
     await reset
   })

--- a/tests/services/storage/indexed-db-account-reset.test.ts
+++ b/tests/services/storage/indexed-db-account-reset.test.ts
@@ -29,6 +29,7 @@ describe('IndexedDBStorage account reset', () => {
     const clearSyncState = vi.fn(() => ({ onerror: null }))
     const clearRemoteState = vi.fn(() => ({ onerror: null }))
     const clearOutbox = vi.fn(() => ({ onerror: null }))
+    const clearMigrations = vi.fn(() => ({ onerror: null }))
     const transaction: FakeResetTransaction = {
       oncomplete: null,
       onerror: null,
@@ -48,10 +49,22 @@ describe('IndexedDBStorage account reset', () => {
                     ? clearSyncState
                     : storeName === 'remote_chat_state'
                       ? clearRemoteState
-                      : clearOutbox,
+                      : storeName === 'sync_outbox'
+                        ? clearOutbox
+                        : clearMigrations,
       }),
     }
     const resetDb = {
+      objectStoreNames: [
+        'chats',
+        'projects',
+        'attachmentPayloads',
+        'chatSummaries',
+        'sync_state',
+        'remote_chat_state',
+        'sync_outbox',
+        'migrations',
+      ],
       transaction: vi.fn(() => transaction),
     }
     vi.spyOn(storage as any, 'ensureDB').mockResolvedValue(resetDb)
@@ -63,6 +76,7 @@ describe('IndexedDBStorage account reset', () => {
       clearSyncState,
       clearRemoteState,
       clearOutbox,
+      clearMigrations,
       transaction,
     }
   }
@@ -92,6 +106,7 @@ describe('IndexedDBStorage account reset', () => {
       clearSyncState,
       clearRemoteState,
       clearOutbox,
+      clearMigrations,
       transaction,
     } = prepareReset(storage)
     const close = vi.fn()
@@ -110,6 +125,7 @@ describe('IndexedDBStorage account reset', () => {
     expect(clearSyncState).toHaveBeenCalledTimes(1)
     expect(clearRemoteState).toHaveBeenCalledTimes(1)
     expect(clearOutbox).toHaveBeenCalledTimes(1)
+    expect(clearMigrations).toHaveBeenCalledTimes(1)
     await completeReset(transaction)
     await reset
   })

--- a/tests/utils/signout-cleanup.test.ts
+++ b/tests/utils/signout-cleanup.test.ts
@@ -80,6 +80,26 @@ vi.mock('@/utils/error-handling', () => ({
 }))
 
 describe('performSignoutCleanup', () => {
+  async function withPinnedChatChanges(
+    action: () => Promise<void>,
+    assertion: (handlePinnedChatsChanged: ReturnType<typeof vi.fn>) => void,
+  ): Promise<void> {
+    const handlePinnedChatsChanged = vi.fn()
+    window.addEventListener(
+      PINNED_CHAT_IDS_CHANGED_EVENT,
+      handlePinnedChatsChanged,
+    )
+    try {
+      await action()
+      assertion(handlePinnedChatsChanged)
+    } finally {
+      window.removeEventListener(
+        PINNED_CHAT_IDS_CHANGED_EVENT,
+        handlePinnedChatsChanged,
+      )
+    }
+  }
+
   beforeEach(() => {
     vi.clearAllMocks()
     localStorage.clear()
@@ -106,42 +126,18 @@ describe('performSignoutCleanup', () => {
 
   it('clears pinned chats from storage and active UI state', async () => {
     localStorage.setItem(USER_PREFS_PINNED_CHAT_IDS, '["chat-a"]')
-    const handlePinnedChatsChanged = vi.fn()
-    window.addEventListener(
-      PINNED_CHAT_IDS_CHANGED_EVENT,
-      handlePinnedChatsChanged,
-    )
 
-    try {
-      await performSignoutCleanup()
-
+    await withPinnedChatChanges(performSignoutCleanup, (handle) => {
       expect(localStorage.getItem(USER_PREFS_PINNED_CHAT_IDS)).toBeNull()
-      expect(handlePinnedChatsChanged).toHaveBeenCalledTimes(1)
-    } finally {
-      window.removeEventListener(
-        PINNED_CHAT_IDS_CHANGED_EVENT,
-        handlePinnedChatsChanged,
-      )
-    }
+      expect(handle).toHaveBeenCalledTimes(1)
+    })
   })
 
   it('does not dispatch pinned-chat changes during an account switch', async () => {
-    const handlePinnedChatsChanged = vi.fn()
-    window.addEventListener(
-      PINNED_CHAT_IDS_CHANGED_EVENT,
-      handlePinnedChatsChanged,
+    await withPinnedChatChanges(
+      () => performUserSwitchCleanup('user_new'),
+      (handle) => expect(handle).not.toHaveBeenCalled(),
     )
-
-    try {
-      await performUserSwitchCleanup('user_new')
-
-      expect(handlePinnedChatsChanged).not.toHaveBeenCalled()
-    } finally {
-      window.removeEventListener(
-        PINNED_CHAT_IDS_CHANGED_EVENT,
-        handlePinnedChatsChanged,
-      )
-    }
   })
 
   it('clears the encryption key and every user data cache', async () => {
@@ -196,7 +192,10 @@ describe('performSignoutCleanup', () => {
     )
     localStorage.setItem(AUTH_ACTIVE_USER_ID, 'user_123')
 
-    await expect(performSignoutCleanup()).rejects.toThrow('reset failed')
+    await withPinnedChatChanges(
+      () => expect(performSignoutCleanup()).rejects.toThrow('reset failed'),
+      (handle) => expect(handle).toHaveBeenCalledTimes(1),
+    )
 
     expect(localStorage.getItem(AUTH_ACTIVE_USER_ID)).toBe('user_123')
   })

--- a/tests/utils/signout-cleanup.test.ts
+++ b/tests/utils/signout-cleanup.test.ts
@@ -1,8 +1,10 @@
 import { resetRendererRegistry } from '@/components/chat/renderers'
+import { PINNED_CHAT_IDS_CHANGED_EVENT } from '@/constants/settings-events'
 import {
   AUTH_ACCOUNT_RESET_FAILED,
   AUTH_ACTIVE_USER_ID,
   SETTINGS_HAS_SEEN_ONBOARDING,
+  USER_PREFS_PINNED_CHAT_IDS,
 } from '@/constants/storage-keys'
 import { cloudSync } from '@/services/cloud/cloud-sync'
 import { resetEditClockCache } from '@/services/cloud/edit-clock'
@@ -100,6 +102,24 @@ describe('performSignoutCleanup', () => {
     await performSignoutCleanup()
 
     expect(sessionStorage.getItem('session-data')).toBeNull()
+  })
+
+  it('clears pinned chats from storage and active UI state', async () => {
+    localStorage.setItem(USER_PREFS_PINNED_CHAT_IDS, '["chat-a"]')
+    const handlePinnedChatsChanged = vi.fn()
+    window.addEventListener(
+      PINNED_CHAT_IDS_CHANGED_EVENT,
+      handlePinnedChatsChanged,
+    )
+
+    await performSignoutCleanup()
+
+    expect(localStorage.getItem(USER_PREFS_PINNED_CHAT_IDS)).toBeNull()
+    expect(handlePinnedChatsChanged).toHaveBeenCalledTimes(1)
+    window.removeEventListener(
+      PINNED_CHAT_IDS_CHANGED_EVENT,
+      handlePinnedChatsChanged,
+    )
   })
 
   it('clears the encryption key and every user data cache', async () => {

--- a/tests/utils/signout-cleanup.test.ts
+++ b/tests/utils/signout-cleanup.test.ts
@@ -112,14 +112,36 @@ describe('performSignoutCleanup', () => {
       handlePinnedChatsChanged,
     )
 
-    await performSignoutCleanup()
+    try {
+      await performSignoutCleanup()
 
-    expect(localStorage.getItem(USER_PREFS_PINNED_CHAT_IDS)).toBeNull()
-    expect(handlePinnedChatsChanged).toHaveBeenCalledTimes(1)
-    window.removeEventListener(
+      expect(localStorage.getItem(USER_PREFS_PINNED_CHAT_IDS)).toBeNull()
+      expect(handlePinnedChatsChanged).toHaveBeenCalledTimes(1)
+    } finally {
+      window.removeEventListener(
+        PINNED_CHAT_IDS_CHANGED_EVENT,
+        handlePinnedChatsChanged,
+      )
+    }
+  })
+
+  it('does not dispatch pinned-chat changes during an account switch', async () => {
+    const handlePinnedChatsChanged = vi.fn()
+    window.addEventListener(
       PINNED_CHAT_IDS_CHANGED_EVENT,
       handlePinnedChatsChanged,
     )
+
+    try {
+      await performUserSwitchCleanup('user_new')
+
+      expect(handlePinnedChatsChanged).not.toHaveBeenCalled()
+    } finally {
+      window.removeEventListener(
+        PINNED_CHAT_IDS_CHANGED_EVENT,
+        handlePinnedChatsChanged,
+      )
+    }
   })
 
   it('clears the encryption key and every user data cache', async () => {


### PR DESCRIPTION
## Summary
- clear every IndexedDB object store during sign-out and account changes
- remove pinned chats from active UI state as local storage is cleared
- add regression coverage for complete IndexedDB and pinned-chat cleanup

## Testing
- `npx vitest run tests/services/storage/indexed-db-account-reset.test.ts tests/utils/signout-cleanup.test.ts tests/hooks/use-pinned-chats.test.ts`
- `npx eslint src/services/storage/indexed-db.ts src/utils/signout-cleanup.ts tests/services/storage/indexed-db-account-reset.test.ts tests/utils/signout-cleanup.test.ts`
- `npx prettier --check src/services/storage/indexed-db.ts src/utils/signout-cleanup.ts tests/services/storage/indexed-db-account-reset.test.ts tests/utils/signout-cleanup.test.ts`

## Notes
- `npx tsc --noEmit` remains blocked by existing passkey-kit export and zip.js resolution errors in unrelated files.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clears all local data on sign out and isolates account-switch cleanup to avoid cross-account UI resets. Previously we cleared a fixed subset of IndexedDB stores and reset pinned chats during account changes; now we clear every store except the migrations store and only reset pinned chats on sign out, even when cleanup fails.

- Enumerates IndexedDB `objectStoreNames` and clears them in a single readwrite transaction, skipping the `migrations` store.
- On sign out, removes pinned chats from `localStorage` and dispatches `PINNED_CHAT_IDS_CHANGED_EVENT` with an empty list; during account switch, does not dispatch or alter pinned chats. The event still fires if sign-out cleanup throws.
- Adds regression tests for complete IndexedDB cleanup (excluding `migrations`) and for sign-out-only pinned-chat reset, including failure cases.

<sup>Written for commit 598e61d11c8c1123dcd3bf7b184f2916a897894b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/538?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

