### PR TITLE
fix: clarify what happens when messages are edited

### DIFF
--- a/src/components/chat/renderers/default/DefaultMessageRenderer.tsx
+++ b/src/components/chat/renderers/default/DefaultMessageRenderer.tsx
@@ -611,7 +611,10 @@ const DefaultMessageComponent = ({
                   <div className="mt-3 flex items-center justify-between">
                     <div className="hidden items-center gap-2 text-sm text-content-muted sm:flex">
                       <InformationCircleIcon className="h-4 w-4 shrink-0" />
-                      <span>All messages after this point will be removed</span>
+                      <span>
+                        Editing this message will restart the conversation from
+                        this point.
+                      </span>
                     </div>
                     <div className="flex flex-1 justify-end gap-2">
                       <button


### PR DESCRIPTION
## Summary
- clarify that editing a message restarts the conversation from that point
- replace the previous destructive-sounding removal warning

## Testing
- `npx prettier --check src/components/chat/renderers/default/DefaultMessageRenderer.tsx`
- `npm run lint -- --no-warn-ignored src/components/chat/renderers/default/DefaultMessageRenderer.tsx`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the edit warning in the default chat message renderer to match actual behavior; no behavior change. Replaces “All messages after this point will be removed” with “Editing this message will restart the conversation from this point.”

<sup>Written for commit ec7f3aa9c103cca962cdd38d021ea04987361213. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/539?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

