### PR TITLE
feat: make release version updates repeatable

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 - [Development](#development)
   - [Quick Start](#quick-start)
   - [Local Testing & Dev Mode](#local-testing--dev-mode)
+- [Releases](#releases)
 - [Reporting Vulnerabilities](#reporting-vulnerabilities)
 
 ## Built With
@@ -92,6 +93,23 @@ Learn more about the security model:
 ### Local Testing & Dev Mode
 
 For running the app against a local model router (bypassing attestation and encryption), see **[LOCAL_TESTING.md](./LOCAL_TESTING.md)**.
+
+## Releases
+
+Prepare a release from an up-to-date `main` branch:
+
+```bash
+npm run release -- prepare 1.0.2
+```
+
+This updates `package.json` and `package-lock.json`, then opens a pull request. After the pull request merges, publish its matching tag:
+
+```bash
+git switch main
+npm run release -- publish 1.0.2
+```
+
+Pushing the tag starts the GitHub release workflow.
 
 ## Reporting Vulnerabilities
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "lint": "eslint .",
     "format": "prettier --write .",
     "prepare": "husky install",
+    "release": "node scripts/release.mjs",
     "find-unused": "ts-unused-exports tsconfig.json",
     "test": "vitest run && playwright test",
     "test:unit": "vitest",

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -1,0 +1,196 @@
+import { execFileSync, spawnSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+
+const MAIN_BRANCH = 'main'
+const REMOTE = 'origin'
+const REMOTE_MAIN_REF = `refs/remotes/${REMOTE}/${MAIN_BRANCH}`
+const PREPARE_COMMAND = 'prepare'
+const PUBLISH_COMMAND = 'publish'
+const VERSION_PATTERN =
+  /^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)(\.(0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*))?$/
+
+function run(command, args, captureOutput = false) {
+  return execFileSync(command, args, {
+    encoding: 'utf8',
+    stdio: captureOutput ? ['ignore', 'pipe', 'pipe'] : 'inherit',
+  }).trim()
+}
+
+function readPackageVersion() {
+  return JSON.parse(readFileSync('package.json', 'utf8')).version
+}
+
+function requireCleanMain() {
+  if (run('git', ['status', '--porcelain'], true)) {
+    throw new Error(
+      'The working tree must be clean before a release operation.',
+    )
+  }
+
+  const branch = run('git', ['branch', '--show-current'], true)
+
+  if (branch !== MAIN_BRANCH) {
+    throw new Error(`Releases must be prepared from ${MAIN_BRANCH}.`)
+  }
+
+  run('git', ['pull', '--ff-only', REMOTE, MAIN_BRANCH])
+
+  const headCommit = run('git', ['rev-parse', 'HEAD'], true)
+  const remoteMainCommit = run('git', ['rev-parse', REMOTE_MAIN_REF], true)
+
+  if (headCommit !== remoteMainCommit) {
+    throw new Error(`Local ${MAIN_BRANCH} must match ${REMOTE}/${MAIN_BRANCH}.`)
+  }
+}
+
+function requireAvailableTag(releaseTag, allowLocalTagAtHead = false) {
+  const localTag = spawnSync(
+    'git',
+    ['show-ref', '--verify', '--quiet', `refs/tags/${releaseTag}`],
+    { encoding: 'utf8' },
+  )
+
+  if (localTag.status === 0) {
+    if (!allowLocalTagAtHead) {
+      throw new Error(`Tag ${releaseTag} already exists locally.`)
+    }
+
+    const tagCommit = run(
+      'git',
+      ['rev-parse', `refs/tags/${releaseTag}^{commit}`],
+      true,
+    )
+    const headCommit = run('git', ['rev-parse', 'HEAD'], true)
+
+    if (tagCommit !== headCommit) {
+      throw new Error(`Local tag ${releaseTag} does not point to HEAD.`)
+    }
+  }
+
+  if (localTag.status !== 0 && localTag.status !== 1) {
+    throw new Error(localTag.stderr.trim() || 'Unable to inspect local tags.')
+  }
+
+  const remoteTag = spawnSync(
+    'git',
+    ['ls-remote', '--exit-code', '--tags', REMOTE, `refs/tags/${releaseTag}`],
+    { encoding: 'utf8' },
+  )
+
+  if (remoteTag.status === 0) {
+    throw new Error(`Tag ${releaseTag} already exists on ${REMOTE}.`)
+  }
+
+  if (remoteTag.status !== 2) {
+    throw new Error(remoteTag.stderr.trim() || 'Unable to inspect remote tags.')
+  }
+
+  return localTag.status === 0
+}
+
+function prepareRelease(requestedVersion) {
+  requireCleanMain()
+  run('gh', ['auth', 'status'])
+
+  const normalizedVersion = requestedVersion.replace(/^v/, '')
+
+  if (!VERSION_PATTERN.test(normalizedVersion)) {
+    throw new Error(`Invalid release version: ${requestedVersion}.`)
+  }
+
+  const releaseTag = `v${normalizedVersion}`
+  requireAvailableTag(releaseTag)
+
+  const releaseBranch = `chore/release-${releaseTag}`
+  run('git', ['switch', '-c', releaseBranch])
+
+  const npmReleaseTag = run(
+    'npm',
+    ['version', normalizedVersion, '--no-git-tag-version'],
+    true,
+  )
+  const packageVersion = readPackageVersion()
+
+  if (npmReleaseTag !== releaseTag || packageVersion !== normalizedVersion) {
+    throw new Error(`npm returned an unexpected release tag: ${npmReleaseTag}.`)
+  }
+
+  run('node', ['scripts/check-release-settings.mjs', releaseTag])
+  run('git', ['add', 'package.json', 'package-lock.json'])
+  run('git', ['commit', '-m', `chore: prepare release ${releaseTag}`])
+  run('git', ['push', '-u', REMOTE, releaseBranch])
+
+  const pullRequestUrl = run(
+    'gh',
+    [
+      'pr',
+      'create',
+      '--base',
+      MAIN_BRANCH,
+      '--head',
+      releaseBranch,
+      '--title',
+      `chore: prepare release ${releaseTag}`,
+      '--body',
+      `## Summary\n- update package versions for ${releaseTag}\n- prepare the matching release tag`,
+    ],
+    true,
+  )
+
+  process.stdout.write(
+    `Release PR created: ${pullRequestUrl}\nAfter it merges, run: git switch main && npm run release -- publish ${packageVersion}\n`,
+  )
+}
+
+function publishRelease(requestedVersion) {
+  requireCleanMain()
+
+  const packageVersion = readPackageVersion()
+  const normalizedVersion = requestedVersion.replace(/^v/, '')
+
+  if (normalizedVersion !== packageVersion) {
+    throw new Error(
+      `Requested version ${normalizedVersion} does not match package version ${packageVersion}.`,
+    )
+  }
+
+  const releaseTag = `v${packageVersion}`
+  const localTagExists = requireAvailableTag(releaseTag, true)
+  run('node', ['scripts/check-release-settings.mjs', releaseTag])
+
+  if (!localTagExists) {
+    run('git', ['tag', '-a', releaseTag, '-m', releaseTag])
+  }
+
+  run('git', ['push', REMOTE, `refs/tags/${releaseTag}`])
+  process.stdout.write(`Published ${releaseTag}.\n`)
+}
+
+function printUsage() {
+  process.stdout.write(
+    'Usage:\n  npm run release -- prepare <version>\n  npm run release -- publish <version>\n',
+  )
+}
+
+const [command, requestedVersion] = process.argv.slice(2)
+
+if (command === '--help' || command === '-h') {
+  printUsage()
+} else if (!requestedVersion) {
+  printUsage()
+  process.exitCode = 1
+} else {
+  try {
+    if (command === PREPARE_COMMAND) {
+      prepareRelease(requestedVersion)
+    } else if (command === PUBLISH_COMMAND) {
+      publishRelease(requestedVersion)
+    } else {
+      throw new Error(`Unknown release command: ${command}.`)
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    process.stderr.write(`${message}\n`)
+    process.exitCode = 1
+  }
+}

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -10,10 +10,12 @@ const VERSION_PATTERN =
   /^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)(\.(0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*))?$/
 
 function run(command, args, captureOutput = false) {
-  return execFileSync(command, args, {
+  const output = execFileSync(command, args, {
     encoding: 'utf8',
     stdio: captureOutput ? ['ignore', 'pipe', 'pipe'] : 'inherit',
-  }).trim()
+  })
+
+  return captureOutput ? output.trim() : ''
 }
 
 function readPackageVersion() {


### PR DESCRIPTION
## Summary
- add a local release command that updates package metadata and opens a version PR
- publish exactly one matching tag after the version PR merges
- verify clean, current `main` and prevent duplicate or mismatched tags
- document the two-step release flow

## Testing
- `node --check scripts/release.mjs`
- `npm run release -- --help`
- `node scripts/check-release-settings.mjs v1.0.0`
- `npm run lint -- --no-warn-ignored scripts/release.mjs`
- `npx prettier --check README.md package.json scripts/release.mjs`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a repeatable two-step release workflow that prepares a version PR and publishes exactly one matching Git tag. It standardizes releases from a clean, up-to-date `main`, fixes CLI invocation so `npm run release -- …` works, and prevents duplicate or mismatched tags.

- `npm run release -- prepare <version>`: validates SemVer (with or without leading `v`), checks `gh` auth, verifies clean and synced `main`, verifies the tag does not exist, runs `scripts/check-release-settings.mjs`, updates `package.json`/`package-lock.json`, commits on `chore/release-v<version>`, pushes, and opens a PR via `gh`.
- `npm run release -- publish <version>`: requires `<version>` to match `package.json`, ensures the tag is absent or at `HEAD`, re-checks release settings, creates an annotated tag if needed, and pushes it to trigger the GitHub release workflow.

**Rollout**
- Ensure `gh` is installed and authenticated.
- Prepare from a clean `main`: `npm run release -- prepare <version>`.
- After the version PR merges, switch to `main` and publish: `npm run release -- publish <version>`.

<sup>Written for commit d0d4e959185ade645b11ba578140254b5ce2236c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/540?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

