### PR TITLE
chore: prepare release v1.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tinfoil-chat",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tinfoil-chat",
-      "version": "1.0.0",
+      "version": "1.0.2",
       "dependencies": {
         "@apple/mapkit-loader": "^0.2.1",
         "@braintree/sanitize-url": "^7.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tinfoil-chat",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "scripts": {
     "dev": "concurrently \"npm run dev:backend\" \"npm run dev:frontend\"",
     "dev:frontend": "next dev",


### PR DESCRIPTION
## Summary
- update package versions for v1.0.2
- prepare the matching release tag

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `tinfoil-chat` from 1.0.0 to 1.0.2 to prepare the v1.0.2 release. No code or behavior changes; only package metadata updated in package manifests.

- **Rollout**
  - After merge, create and push tag v1.0.2.

<sup>Written for commit 3d29bacc3e6cabae66f4711456251bbda6667d6a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/541?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

