### PR TITLE
feat: merge release preparation automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,14 +99,14 @@ For running the app against a local model router (bypassing attestation and encr
 Prepare a release from an up-to-date `main` branch:
 
 ```bash
-npm run release -- prepare 1.0.2
+npm run release -- prepare 1.0.3
 ```
 
-This updates `package.json` and `package-lock.json`, then opens a pull request. After the pull request merges, publish its matching tag:
+This updates `package.json` and `package-lock.json`, then opens and immediately squash-merges a pull request. Publish its matching tag:
 
 ```bash
 git switch main
-npm run release -- publish 1.0.2
+npm run release -- publish 1.0.3
 ```
 
 Pushing the tag starts the GitHub release workflow.

--- a/README.md
+++ b/README.md
@@ -96,20 +96,36 @@ For running the app against a local model router (bypassing attestation and encr
 
 ## Releases
 
-Prepare a release from an up-to-date `main` branch:
+Releases use a two-step local command so package versions are committed before the matching tag is created. Start with a clean `main` branch and an authenticated GitHub CLI (`gh auth status`).
+
+### 1. Prepare the version
 
 ```bash
+git switch main
 npm run release -- prepare 1.0.3
 ```
 
-This updates `package.json` and `package-lock.json`, then opens and immediately squash-merges a pull request. Publish its matching tag:
+The command:
+
+1. Updates `package.json` and `package-lock.json`.
+2. Creates and pushes a release branch.
+3. Opens a version pull request.
+4. Verifies the pull request head and immediately squash-merges it.
+
+The merge does not wait for CI checks. If it fails, the command prints the pull request URL and a manual recovery command.
+
+### 2. Publish the tag
+
+After preparation finishes, publish the same version:
 
 ```bash
 git switch main
 npm run release -- publish 1.0.3
 ```
 
-Pushing the tag starts the GitHub release workflow.
+This updates local `main`, verifies the committed package version, creates one annotated tag, and pushes only that tag. The tag push starts the GitHub workflow that publishes the release and generated release notes.
+
+Do not use `git push --tags`; GitHub does not emit workflow events when more than three tags are pushed together. If a valid tag misses its release, run the **Create Release** workflow manually with that tag.
 
 ## Reporting Vulnerabilities
 

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -120,6 +120,7 @@ function prepareRelease(requestedVersion) {
   run('node', ['scripts/check-release-settings.mjs', releaseTag])
   run('git', ['add', 'package.json', 'package-lock.json'])
   run('git', ['commit', '-m', `chore: prepare release ${releaseTag}`])
+  const releaseCommit = run('git', ['rev-parse', 'HEAD'], true)
   run('git', ['push', '-u', REMOTE, releaseBranch])
 
   const pullRequestUrl = run(
@@ -139,8 +140,27 @@ function prepareRelease(requestedVersion) {
     true,
   )
 
+  process.stdout.write(`Release PR created: ${pullRequestUrl}\n`)
+
+  try {
+    run('gh', [
+      'pr',
+      'merge',
+      pullRequestUrl,
+      '--squash',
+      '--delete-branch',
+      '--match-head-commit',
+      releaseCommit,
+    ])
+  } catch (error) {
+    process.stderr.write(
+      `Automatic merge failed. Run: gh pr merge ${pullRequestUrl} --squash --delete-branch --match-head-commit ${releaseCommit}\n`,
+    )
+    throw error
+  }
+
   process.stdout.write(
-    `Release PR created: ${pullRequestUrl}\nAfter it merges, run: git switch main && npm run release -- publish ${packageVersion}\n`,
+    `Release PR merged: ${pullRequestUrl}\nRun: git switch main && npm run release -- publish ${packageVersion}\n`,
   )
 }
 


### PR DESCRIPTION
## Summary
- immediately squash-merge generated version pull requests
- verify the pull request head before merging
- print a manual recovery command if automatic merging fails
- update release documentation for the streamlined flow

## Testing
- `node --check scripts/release.mjs`
- `npm run release -- --help`
- `npm run lint -- --no-warn-ignored scripts/release.mjs`
- `npx prettier --check README.md scripts/release.mjs`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically squash-merges the release preparation PR during `npm run release -- prepare`, verifying the head commit and deleting the branch. This replaces the manual merge step and does not wait for CI; on failure, the script prints a recovery `gh pr merge` command.

- Uses `gh pr merge --squash --delete-branch --match-head-commit <commit>`; confirm this matches repo merge policy and branch protection.
- Requires authenticated `gh` in the release environment; if merging is blocked, run the printed recovery command.
- Updates README with the two-step flow, CI bypass note, and tag-push guidance: publish pushes a single annotated tag; do not use `git push --tags`.

<sup>Written for commit 03c6a7669c5262f473b5441d831b7af399970b30. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/542?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

