### PR TITLE
Improve sign-in persistence and chat performance

### DIFF
--- a/src/components/auth-cleanup-handler.tsx
+++ b/src/components/auth-cleanup-handler.tsx
@@ -2,11 +2,15 @@ import { SignoutConfirmationModal } from '@/components/modals/signout-confirmati
 import {
   ACCOUNT_RESET_FAILED_EVENT,
   AUTH_ACTIVE_USER_CHANGED_EVENT,
+  AUTH_SIGNOUT_CLEARED_EVENT,
+  AUTH_SIGNOUT_REQUESTED_EVENT,
 } from '@/constants/auth-events'
 import {
   AUTH_ACCOUNT_RESET_FAILED,
   AUTH_ACTIVE_USER_ID,
+  AUTH_SIGNOUT_REQUESTED_AT,
 } from '@/constants/storage-keys'
+import { hasRecentExplicitSignoutIntent } from '@/utils/auth-signout-intent'
 import { logError, logInfo } from '@/utils/error-handling'
 import {
   deleteEncryptionKey,
@@ -37,6 +41,8 @@ export function AuthCleanupHandler() {
     retryStorage: boolean
   } | null>(null)
   const [cleanupRetrying, setCleanupRetrying] = useState(false)
+  const [hasExplicitSignoutIntent, setHasExplicitSignoutIntent] =
+    useState(false)
   const hasCheckedRef = useRef(false)
   const pendingSignoutCleanupRef = useRef<number | null>(null)
   const pendingUserSwitchCleanupRef = useRef<Promise<void> | null>(null)
@@ -53,6 +59,34 @@ export function AuthCleanupHandler() {
       userId: user?.id,
     }
   }, [isLoaded, isSignedIn, user?.id])
+
+  useEffect(() => {
+    const syncSignoutIntent = () => {
+      setHasExplicitSignoutIntent(hasRecentExplicitSignoutIntent())
+    }
+    const handleSignoutRequested = () => setHasExplicitSignoutIntent(true)
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key === AUTH_SIGNOUT_REQUESTED_AT) {
+        syncSignoutIntent()
+      }
+    }
+
+    syncSignoutIntent()
+    window.addEventListener(
+      AUTH_SIGNOUT_REQUESTED_EVENT,
+      handleSignoutRequested,
+    )
+    window.addEventListener(AUTH_SIGNOUT_CLEARED_EVENT, syncSignoutIntent)
+    window.addEventListener('storage', handleStorage)
+    return () => {
+      window.removeEventListener(
+        AUTH_SIGNOUT_REQUESTED_EVENT,
+        handleSignoutRequested,
+      )
+      window.removeEventListener(AUTH_SIGNOUT_CLEARED_EVENT, syncSignoutIntent)
+      window.removeEventListener('storage', handleStorage)
+    }
+  }, [])
 
   useEffect(() => {
     const handleCrossTabResetFailure = () => {
@@ -180,9 +214,14 @@ export function AuthCleanupHandler() {
       window.dispatchEvent(new Event(AUTH_ACTIVE_USER_CHANGED_EVENT))
     }
 
-    // Check if user just signed out (stored user ID exists but no longer signed in)
+    // Confirm an explicit sign-out completed before clearing local account data.
     const storedUserId = localStorage.getItem(AUTH_ACTIVE_USER_ID)
-    if (!isSignedIn && storedUserId && !hasCheckedRef.current) {
+    if (
+      !isSignedIn &&
+      storedUserId &&
+      hasExplicitSignoutIntent &&
+      !hasCheckedRef.current
+    ) {
       if (pendingSignoutCleanupRef.current === null) {
         pendingSignoutCleanupRef.current = window.setTimeout(() => {
           pendingSignoutCleanupRef.current = null
@@ -220,6 +259,7 @@ export function AuthCleanupHandler() {
     user?.id,
     clearPendingSignoutCleanup,
     cleanupError,
+    hasExplicitSignoutIntent,
     runSignoutCleanup,
   ])
 

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -1,6 +1,8 @@
 import {
   findSelectableModel,
   getAIModels,
+  getCachedAIModels,
+  getCachedSystemPromptAndRules,
   getReasoningHistoryPolicy,
   getResolvedModelContextWindowTokens,
   getSystemPromptAndRules,
@@ -99,6 +101,11 @@ import {
 import { logError } from '@/utils/error-handling'
 import { isProbablyTextFile, isSupportedFile } from '@/utils/file-types'
 import { getNewChatPath, isPlainPrimaryClick } from '@/utils/navigation'
+import {
+  PERFORMANCE_METRICS,
+  recordPerformanceDuration,
+  startPerformanceTimer,
+} from '@/utils/performance-metrics'
 import {
   estimateMessageTokens,
   estimateTokenCount,
@@ -338,6 +345,15 @@ export function ChatInterface({
       )
   }, [toast])
   const { isSignedIn, isLoaded: isAuthLoaded, userId: authUserId } = useAuth()
+  const [authRestorationStartedAt] = useState(startPerformanceTimer)
+  useEffect(() => {
+    if (isAuthLoaded) {
+      recordPerformanceDuration(
+        PERFORMANCE_METRICS.AUTH_RESTORATION,
+        authRestorationStartedAt,
+      )
+    }
+  }, [authRestorationStartedAt, isAuthLoaded])
   // TODO: unflip this
   const canUseCodeExecution = false
   const { user } = useUser()
@@ -528,9 +544,12 @@ export function ChatInterface({
 
   // State for right sidebar
   const [isVerifierSidebarOpen, setIsVerifierSidebarOpen] = useState(false)
+  const [hasMountedVerifierSidebar, setHasMountedVerifierSidebar] =
+    useState(false)
 
   // State for settings modal
   const [isSettingsModalOpen, setIsSettingsModalOpen] = useState(false)
+  const [hasMountedSettingsModal, setHasMountedSettingsModal] = useState(false)
   const [settingsInitialTab, setSettingsInitialTab] = useState<
     SettingsTab | undefined
   >(undefined)
@@ -538,6 +557,7 @@ export function ChatInterface({
 
   // State for share modal
   const [isShareModalOpen, setIsShareModalOpen] = useState(false)
+  const [hasMountedShareModal, setHasMountedShareModal] = useState(false)
 
   // State for cloud sync setup modal
   const [showCloudSyncSetupModal, setShowCloudSyncSetupModal] = useState(false)
@@ -679,6 +699,7 @@ export function ChatInterface({
   const [activePresetId, setActivePresetId] = useState<string | null>(null)
   const [isPromptLibraryModalOpen, setIsPromptLibraryModalOpen] =
     useState(false)
+  const [hasMountedPromptLibrary, setHasMountedPromptLibrary] = useState(false)
   const { getPresetById } = usePromptLibrary()
   const activePreset = getPresetById(activePresetId)
 
@@ -777,7 +798,31 @@ export function ChatInterface({
   // Load models and system prompt immediately in parallel.
   useEffect(() => {
     let cancelled = false
+    const configStartedAt = startPerformanceTimer()
+    let recordedConfigReady = false
+    const recordConfigReady = () => {
+      if (recordedConfigReady) return
+      recordedConfigReady = true
+      recordPerformanceDuration(
+        PERFORMANCE_METRICS.CONFIG_READY,
+        configStartedAt,
+      )
+    }
     const loadInitial = async () => {
+      const cachedPrompt = getCachedSystemPromptAndRules()
+      const cachedModels = getCachedAIModels()
+      if (cachedPrompt) {
+        setSystemPrompt(cachedPrompt.systemPrompt)
+        setRules(cachedPrompt.rules)
+      }
+      if (cachedModels) {
+        setModels(cachedModels)
+      }
+      if (cachedPrompt && cachedModels) {
+        setIsLoadingConfig(false)
+        recordConfigReady()
+      }
+
       try {
         const [promptData, models] = await Promise.all([
           getSystemPromptAndRules(),
@@ -789,6 +834,7 @@ export function ChatInterface({
           setRules(promptData.rules)
           setModels(models)
           setIsLoadingConfig(false)
+          recordConfigReady()
         }
       } catch (error) {
         logError('Failed to load chat configuration', error, {
@@ -797,6 +843,7 @@ export function ChatInterface({
         })
         if (!cancelled) {
           setIsLoadingConfig(false)
+          recordConfigReady()
         }
       }
     }
@@ -1244,6 +1291,7 @@ export function ChatInterface({
   )
 
   const handleOpenPromptLibrary = useCallback(() => {
+    setHasMountedPromptLibrary(true)
     setIsPromptLibraryModalOpen(true)
   }, [])
 
@@ -2097,6 +2145,7 @@ export function ChatInterface({
 
   // Handler for setting verifier sidebar state
   const handleSetVerifierSidebarOpen = (isOpen: boolean) => {
+    if (isOpen) setHasMountedVerifierSidebar(true)
     setIsVerifierSidebarOpen(isOpen)
     if (isOpen) {
       // If window is narrow, close left sidebar when opening right sidebar
@@ -2114,6 +2163,7 @@ export function ChatInterface({
     } else {
       // Open settings and close verifier if open
       setSettingsInitialTab(syncNeedsAttention ? 'cloud-sync' : undefined)
+      setHasMountedSettingsModal(true)
       setIsSettingsModalOpen(true)
       handleSetVerifierSidebarOpen(false)
       setIsAskSidebarOpen(false)
@@ -2127,12 +2177,14 @@ export function ChatInterface({
 
   // Handler for opening share modal
   const handleOpenShareModal = () => {
+    setHasMountedShareModal(true)
     setIsShareModalOpen(true)
   }
 
   // Handler for encryption key button - opens settings modal to cloud-sync tab
   const handleOpenEncryptionKeyModal = () => {
     setSettingsInitialTab('cloud-sync')
+    setHasMountedSettingsModal(true)
     setIsSettingsModalOpen(true)
     handleSetVerifierSidebarOpen(false)
     if (windowWidth < CONSTANTS.SINGLE_SIDEBAR_BREAKPOINT) {
@@ -3534,6 +3586,7 @@ export function ChatInterface({
         }
         onSettingsTabReady={(tab) => {
           setSettingsInitialTab(tab)
+          setHasMountedSettingsModal(true)
           setIsSettingsModalOpen(true)
           handleSetVerifierSidebarOpen(false)
           if (windowWidth < CONSTANTS.SINGLE_SIDEBAR_BREAKPOINT) {
@@ -3920,16 +3973,18 @@ export function ChatInterface({
       </DragProvider>
 
       {/* Right Verifier Sidebar */}
-      <VerifierSidebarLazy
-        isOpen={isVerifierSidebarOpen}
-        setIsOpen={handleSetVerifierSidebarOpen}
-        onVerificationComplete={(success) =>
-          setVerificationStatus(success ? 'verified' : 'failed')
-        }
-        onVerificationUpdate={setVerificationDocument}
-        isDarkMode={isDarkMode}
-        isClient={isClient}
-      />
+      {hasMountedVerifierSidebar && (
+        <VerifierSidebarLazy
+          isOpen={isVerifierSidebarOpen}
+          setIsOpen={handleSetVerifierSidebarOpen}
+          onVerificationComplete={(success) =>
+            setVerificationStatus(success ? 'verified' : 'failed')
+          }
+          onVerificationUpdate={setVerificationDocument}
+          isDarkMode={isDarkMode}
+          isClient={isClient}
+        />
+      )}
 
       {/* Ask Sidebar - ephemeral, context-aware side conversation seeded from
           highlighted text. Discarded on close or on the next "Ask" click. */}
@@ -3965,69 +4020,75 @@ export function ChatInterface({
       />
 
       {/* Share Modal */}
-      <ShareModalLazy
-        isOpen={isShareModalOpen}
-        onClose={() => setIsShareModalOpen(false)}
-        messages={currentChat?.messages || []}
-        isDarkMode={isDarkMode}
-        isSidebarOpen={
-          isSidebarOpen && windowWidth >= CONSTANTS.MOBILE_BREAKPOINT
-        }
-        isRightSidebarOpen={
-          (isVerifierSidebarOpen ||
-            isSettingsModalOpen ||
-            isAskSidebarOpen ||
-            isArtifactSidebarOpen) &&
-          windowWidth >= CONSTANTS.MOBILE_BREAKPOINT
-        }
-        chatTitle={currentChat?.title}
-        chatCreatedAt={currentChat?.createdAt}
-        chatId={currentChat?.id}
-      />
+      {hasMountedShareModal && (
+        <ShareModalLazy
+          isOpen={isShareModalOpen}
+          onClose={() => setIsShareModalOpen(false)}
+          messages={currentChat?.messages || []}
+          isDarkMode={isDarkMode}
+          isSidebarOpen={
+            isSidebarOpen && windowWidth >= CONSTANTS.MOBILE_BREAKPOINT
+          }
+          isRightSidebarOpen={
+            (isVerifierSidebarOpen ||
+              isSettingsModalOpen ||
+              isAskSidebarOpen ||
+              isArtifactSidebarOpen) &&
+            windowWidth >= CONSTANTS.MOBILE_BREAKPOINT
+          }
+          chatTitle={currentChat?.title}
+          chatCreatedAt={currentChat?.createdAt}
+          chatId={currentChat?.id}
+        />
+      )}
 
       {/* Prompt Library Modal */}
-      <PromptLibraryModalLazy
-        isOpen={isPromptLibraryModalOpen}
-        onClose={handleClosePromptLibrary}
-        activePresetId={activePresetId}
-        onSelectPreset={handleSetActivePreset}
-        isSidebarOpen={
-          isSidebarOpen && windowWidth >= CONSTANTS.MOBILE_BREAKPOINT
-        }
-        isRightSidebarOpen={
-          (isVerifierSidebarOpen ||
-            isSettingsModalOpen ||
-            isAskSidebarOpen ||
-            isArtifactSidebarOpen) &&
-          windowWidth >= CONSTANTS.MOBILE_BREAKPOINT
-        }
-      />
+      {hasMountedPromptLibrary && (
+        <PromptLibraryModalLazy
+          isOpen={isPromptLibraryModalOpen}
+          onClose={handleClosePromptLibrary}
+          activePresetId={activePresetId}
+          onSelectPreset={handleSetActivePreset}
+          isSidebarOpen={
+            isSidebarOpen && windowWidth >= CONSTANTS.MOBILE_BREAKPOINT
+          }
+          isRightSidebarOpen={
+            (isVerifierSidebarOpen ||
+              isSettingsModalOpen ||
+              isAskSidebarOpen ||
+              isArtifactSidebarOpen) &&
+            windowWidth >= CONSTANTS.MOBILE_BREAKPOINT
+          }
+        />
+      )}
 
       {/* Settings Modal */}
-      <SettingsModalLazy
-        isOpen={isSettingsModalOpen}
-        setIsOpen={setIsSettingsModalOpen}
-        isDarkMode={isDarkMode}
-        themeMode={themeMode}
-        setThemeMode={setThemeMode}
-        isClient={isClient}
-        defaultSystemPrompt={systemPrompt}
-        onCloudSyncSetupClick={
-          isSignedIn ? handleOpenCloudSyncSetup : undefined
-        }
-        onChatsUpdated={reloadChats}
-        isSignedIn={isSignedIn}
-        isPremium={isPremium}
-        encryptionKey={encryptionKey}
-        passkeyActive={passkeyActive}
-        passkeySetupAvailable={passkeySetupAvailable}
-        passkeyAddDeviceAvailable={passkeyAddDeviceAvailable}
-        onSetupPasskey={setupPasskey}
-        onAddPasskeyToThisDevice={addPasskeyToThisDevice}
-        onRefreshBundleState={refreshBundleState}
-        initialTab={settingsInitialTab}
-        chats={chats}
-      />
+      {hasMountedSettingsModal && (
+        <SettingsModalLazy
+          isOpen={isSettingsModalOpen}
+          setIsOpen={setIsSettingsModalOpen}
+          isDarkMode={isDarkMode}
+          themeMode={themeMode}
+          setThemeMode={setThemeMode}
+          isClient={isClient}
+          defaultSystemPrompt={systemPrompt}
+          onCloudSyncSetupClick={
+            isSignedIn ? handleOpenCloudSyncSetup : undefined
+          }
+          onChatsUpdated={reloadChats}
+          isSignedIn={isSignedIn}
+          isPremium={isPremium}
+          encryptionKey={encryptionKey}
+          passkeyActive={passkeyActive}
+          passkeySetupAvailable={passkeySetupAvailable}
+          passkeyAddDeviceAvailable={passkeyAddDeviceAvailable}
+          onSetupPasskey={setupPasskey}
+          onAddPasskeyToThisDevice={addPasskeyToThisDevice}
+          onRefreshBundleState={refreshBundleState}
+          initialTab={settingsInitialTab}
+          chats={chats}
+        />
+      )}
 
       {/* Main Chat Area - Modified for sliding effect */}
       <div

--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -51,6 +51,10 @@ import { projectCache } from '@/services/storage/project-cache'
 import { sessionChatStorage } from '@/services/storage/session-storage'
 import { attachmentGet } from '@/services/sync-enclave/sync-api'
 import { TINFOIL_COLORS } from '@/theme/colors'
+import {
+  clearExplicitSignoutIntent,
+  requestExplicitSignout,
+} from '@/utils/auth-signout-intent'
 import { base64ToUint8Array } from '@/utils/binary-codec'
 import {
   parseChatGPTConversations,
@@ -1273,9 +1277,11 @@ export function SettingsModal({
   const handleSignOut = useCallback(async () => {
     setIsSigningOut(true)
     showSignoutProgress()
+    requestExplicitSignout()
     try {
       await signOut()
     } catch (error) {
+      clearExplicitSignoutIntent()
       logError('Sign out failed', error, {
         component: 'SettingsModal',
         action: 'handleSignOut',

--- a/src/components/ui/logo-loading.tsx
+++ b/src/components/ui/logo-loading.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import type { AnimationItem } from 'lottie-web'
-import lottie from 'lottie-web'
 import { useEffect, useRef } from 'react'
 
 // Eagerly fetch the animation JSON so it's ready by the time the component mounts
@@ -33,8 +32,8 @@ function LogoAnimation({
 
     let unmounted = false
 
-    animationDataPromise
-      .then((animationData) => {
+    Promise.all([import('lottie-web'), animationDataPromise])
+      .then(([{ default: lottie }, animationData]) => {
         if (!animationData || unmounted) return
         const anim = lottie.loadAnimation({
           container,

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -1,5 +1,9 @@
 import { setGenUIConfig } from '@/components/chat/genui/config'
 import { API_BASE_URL, IS_DEV } from '@/config'
+import {
+  CONFIG_CACHED_MODELS,
+  CONFIG_CACHED_SYSTEM_PROMPT,
+} from '@/constants/storage-keys'
 import { DEV_SIMULATOR_MODEL } from '@/utils/dev-simulator'
 import { logError } from '@/utils/error-handling'
 import {
@@ -333,9 +337,126 @@ const isLocalDevelopment = (): boolean => {
   )
 }
 
+const CONFIG_CACHE_VERSION = 1
+const CONFIG_CACHE_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000
+const CONFIG_REQUEST_TIMEOUT_MS = 10_000
+
+type CachedConfig<T> = {
+  version: number
+  cachedAt: number
+  value: T
+}
+
+type SystemPromptAndRules = {
+  systemPrompt: string
+  rules: string
+}
+
+type CachedSystemPromptAndRules = SystemPromptAndRules & {
+  genUI?: unknown
+}
+
+function readCachedConfig<T>(
+  key: string,
+  validate: (value: unknown) => value is T,
+): T | null {
+  if (typeof window === 'undefined') return null
+  try {
+    const parsed = JSON.parse(localStorage.getItem(key) ?? '') as Partial<
+      CachedConfig<unknown>
+    >
+    if (
+      parsed.version !== CONFIG_CACHE_VERSION ||
+      typeof parsed.cachedAt !== 'number' ||
+      Date.now() - parsed.cachedAt < 0 ||
+      Date.now() - parsed.cachedAt > CONFIG_CACHE_MAX_AGE_MS ||
+      !validate(parsed.value)
+    ) {
+      return null
+    }
+    return parsed.value
+  } catch {
+    return null
+  }
+}
+
+function writeCachedConfig<T>(key: string, value: T): void {
+  try {
+    localStorage.setItem(
+      key,
+      JSON.stringify({
+        version: CONFIG_CACHE_VERSION,
+        cachedAt: Date.now(),
+        value,
+      } satisfies CachedConfig<T>),
+    )
+  } catch {
+    // best-effort
+  }
+}
+
+function isBaseModelArray(value: unknown): value is BaseModel[] {
+  return (
+    Array.isArray(value) &&
+    value.length > 0 &&
+    value.every(
+      (model) =>
+        typeof model === 'object' &&
+        model !== null &&
+        typeof model.modelName === 'string' &&
+        typeof model.name === 'string' &&
+        typeof model.type === 'string',
+    )
+  )
+}
+
+function isSystemPromptAndRules(
+  value: unknown,
+): value is CachedSystemPromptAndRules {
+  const candidate = value as Record<string, unknown> | null
+  return (
+    typeof candidate === 'object' &&
+    candidate !== null &&
+    typeof candidate.systemPrompt === 'string' &&
+    typeof candidate.rules === 'string'
+  )
+}
+
+async function fetchConfig(url: string): Promise<Response> {
+  const controller = new AbortController()
+  const timeout = setTimeout(
+    () => controller.abort(),
+    CONFIG_REQUEST_TIMEOUT_MS,
+  )
+  try {
+    return await fetch(url, { signal: controller.signal })
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+export function getCachedAIModels(): BaseModel[] | null {
+  const models = readCachedConfig(CONFIG_CACHED_MODELS, isBaseModelArray)
+  return models ? rememberModelDisplayNames(models) : null
+}
+
+export function getCachedSystemPromptAndRules(): SystemPromptAndRules | null {
+  const cached = readCachedConfig(
+    CONFIG_CACHED_SYSTEM_PROMPT,
+    isSystemPromptAndRules,
+  )
+  if (!cached) return null
+  applyGenUIConfigFromResponse(cached.genUI)
+  return {
+    systemPrompt: cached.systemPrompt,
+    rules: cached.rules,
+  }
+}
+
 // Fetch models from the API
 export const getAIModels = async (): Promise<BaseModel[]> => {
   const isLocalDev = isLocalDevelopment()
+  const cachedModels = getCachedAIModels()
 
   // In dev mode on localhost, return hardcoded models instead of fetching
   if (IS_DEV && isLocalDev) {
@@ -343,7 +464,7 @@ export const getAIModels = async (): Promise<BaseModel[]> => {
   }
 
   try {
-    const response = await fetch(`${API_BASE_URL}/api/config/models`)
+    const response = await fetchConfig(`${API_BASE_URL}/api/config/models`)
 
     if (!response.ok) {
       throw new Error(`Failed to fetch models: ${response.status}`)
@@ -362,46 +483,57 @@ export const getAIModels = async (): Promise<BaseModel[]> => {
       models.unshift(DEV_SIMULATOR_MODEL)
     }
 
-    return rememberModelDisplayNames(models)
+    const rememberedModels = rememberModelDisplayNames(models)
+    writeCachedConfig(CONFIG_CACHED_MODELS, rememberedModels)
+    return rememberedModels
   } catch (error) {
     logError('Failed to fetch AI models', error, {
       component: 'getAIModels',
     })
-    return []
+    return cachedModels ?? []
   }
 }
 
 // Fetch system prompt and rules from the API
-export const getSystemPromptAndRules = async (): Promise<{
-  systemPrompt: string
-  rules: string
-}> => {
-  try {
-    const url = `${API_BASE_URL}/api/config/system-prompt`
-    const response = await fetch(url)
+export const getSystemPromptAndRules =
+  async (): Promise<SystemPromptAndRules> => {
+    const cachedPrompt = getCachedSystemPromptAndRules()
+    try {
+      const url = `${API_BASE_URL}/api/config/system-prompt`
+      const response = await fetchConfig(url)
 
-    if (!response.ok) {
-      throw new Error(`Failed to fetch system prompt: ${response.status}`)
-    }
+      if (!response.ok) {
+        throw new Error(`Failed to fetch system prompt: ${response.status}`)
+      }
 
-    const data = await response.json()
-    applyGenUIConfigFromResponse(data?.genUI)
-    return {
-      systemPrompt: data.systemPrompt,
-      rules: data.rules,
-    }
-  } catch (error) {
-    logError('Failed to fetch system prompt', error, {
-      component: 'getSystemPromptAndRules',
-    })
-    setGenUIConfig(null)
-    // Return a basic fallback
-    return {
-      systemPrompt: 'You are an intelligent and helpful assistant named Tin.',
-      rules: '',
+      const data = await response.json()
+      const result: CachedSystemPromptAndRules = {
+        systemPrompt: data.systemPrompt,
+        rules: data.rules,
+        genUI: data?.genUI,
+      }
+      if (!isSystemPromptAndRules(result)) {
+        throw new Error('System prompt response is malformed')
+      }
+      applyGenUIConfigFromResponse(result.genUI)
+      writeCachedConfig(CONFIG_CACHED_SYSTEM_PROMPT, result)
+      return result
+    } catch (error) {
+      logError('Failed to fetch system prompt', error, {
+        component: 'getSystemPromptAndRules',
+      })
+      if (!cachedPrompt) {
+        setGenUIConfig(null)
+      }
+      return (
+        cachedPrompt ?? {
+          systemPrompt:
+            'You are an intelligent and helpful assistant named Tin.',
+          rules: '',
+        }
+      )
     }
   }
-}
 
 /**
  * Validates the optional `genUI` block from the system-prompt response and

--- a/src/constants/auth-events.ts
+++ b/src/constants/auth-events.ts
@@ -1,2 +1,5 @@
 export const ACCOUNT_RESET_FAILED_EVENT = 'tinfoil:account-reset-failed'
 export const AUTH_ACTIVE_USER_CHANGED_EVENT = 'tinfoil:active-user-changed'
+export const AUTH_SIGNOUT_REQUESTED_EVENT = 'tinfoil:signout-requested'
+export const AUTH_SIGNOUT_CLEARED_EVENT = 'tinfoil:signout-cleared'
+export const AUTH_SIGNOUT_INTENT_MAX_AGE_MS = 5 * 60 * 1000

--- a/src/constants/storage-keys.ts
+++ b/src/constants/storage-keys.ts
@@ -25,6 +25,11 @@ export const SECRET_CLOUD_KEY_AUTHORIZATION_PREFIX =
 // --- localStorage: Auth ----------------------------------------------------
 export const AUTH_ACTIVE_USER_ID = 'tinfoil-auth-active-user-id'
 export const AUTH_ACCOUNT_RESET_SIGNAL = 'tinfoil-auth-account-reset-signal'
+export const AUTH_SIGNOUT_REQUESTED_AT = 'tinfoil-auth-signout-requested-at'
+
+// --- localStorage: Public app configuration -------------------------------
+export const CONFIG_CACHED_MODELS = 'tinfoil-config-cached-models'
+export const CONFIG_CACHED_SYSTEM_PROMPT = 'tinfoil-config-cached-system-prompt'
 
 // --- localStorage: App settings --------------------------------------------
 export const SETTINGS_CLOUD_SYNC_ENABLED = 'tinfoil-settings-cloud-sync-enabled'

--- a/src/hooks/use-subscription-status.ts
+++ b/src/hooks/use-subscription-status.ts
@@ -1,4 +1,8 @@
-import { SETTINGS_CACHED_SUBSCRIPTION_STATUS } from '@/constants/storage-keys'
+import { AUTH_ACTIVE_USER_CHANGED_EVENT } from '@/constants/auth-events'
+import {
+  AUTH_ACTIVE_USER_ID,
+  SETTINGS_CACHED_SUBSCRIPTION_STATUS,
+} from '@/constants/storage-keys'
 import { useUser } from '@clerk/nextjs'
 import { useEffect, useState } from 'react'
 
@@ -23,6 +27,38 @@ const SUPPORTED_STATUSES = new Set<StripeSubscriptionStatus>([
   'unpaid',
 ])
 const MAX_TIMEOUT_MS = 2_147_483_647
+const SUBSCRIPTION_CACHE_MAX_AGE_MS = 24 * 60 * 60 * 1000
+
+type CachedSubscriptionStatus = {
+  userId: string
+  chat_subscription_active: boolean
+  cachedAt: number
+}
+
+export function readCachedSubscriptionStatus(
+  activeUserId: string | null,
+  now = Date.now(),
+): boolean | null {
+  if (!activeUserId) return null
+
+  try {
+    const raw = localStorage.getItem(SETTINGS_CACHED_SUBSCRIPTION_STATUS)
+    if (!raw) return null
+    const cached = JSON.parse(raw) as Partial<CachedSubscriptionStatus>
+    if (
+      cached.userId !== activeUserId ||
+      typeof cached.chat_subscription_active !== 'boolean' ||
+      typeof cached.cachedAt !== 'number' ||
+      now - cached.cachedAt < 0 ||
+      now - cached.cachedAt > SUBSCRIPTION_CACHE_MAX_AGE_MS
+    ) {
+      return null
+    }
+    return cached.chat_subscription_active
+  } catch {
+    return null
+  }
+}
 
 const isValidStatus = (status: unknown): status is StripeSubscriptionStatus =>
   typeof status === 'string' &&
@@ -68,6 +104,43 @@ export const hasActiveSubscription = (
 export function useSubscriptionStatus() {
   const { user, isLoaded } = useUser()
   const [, setExpirationTick] = useState(0)
+  const [cachedSubscriptionActive, setCachedSubscriptionActive] =
+    useState(false)
+
+  useEffect(() => {
+    const syncCachedSubscription = () => {
+      try {
+        const activeUserId = localStorage.getItem(AUTH_ACTIVE_USER_ID)
+        setCachedSubscriptionActive(
+          readCachedSubscriptionStatus(activeUserId) ?? false,
+        )
+      } catch {
+        setCachedSubscriptionActive(false)
+      }
+    }
+    const handleStorage = (event: StorageEvent) => {
+      if (
+        event.key === AUTH_ACTIVE_USER_ID ||
+        event.key === SETTINGS_CACHED_SUBSCRIPTION_STATUS
+      ) {
+        syncCachedSubscription()
+      }
+    }
+
+    syncCachedSubscription()
+    window.addEventListener(
+      AUTH_ACTIVE_USER_CHANGED_EVENT,
+      syncCachedSubscription,
+    )
+    window.addEventListener('storage', handleStorage)
+    return () => {
+      window.removeEventListener(
+        AUTH_ACTIVE_USER_CHANGED_EVENT,
+        syncCachedSubscription,
+      )
+      window.removeEventListener('storage', handleStorage)
+    }
+  }, [])
 
   const publicMetadata = (user?.publicMetadata ?? {}) as Record<string, unknown>
   const rawChatStatus = publicMetadata['chat_subscription_status']
@@ -97,10 +170,11 @@ export function useSubscriptionStatus() {
     }
   }, [expirationTime])
 
-  const chatSubscriptionActive =
-    isLoaded &&
-    !!user &&
-    hasActiveSubscription(chatStatus, chatExpiration, new Date())
+  const resolvedSubscriptionActive =
+    !!user && hasActiveSubscription(chatStatus, chatExpiration, new Date())
+  const chatSubscriptionActive = isLoaded
+    ? resolvedSubscriptionActive
+    : cachedSubscriptionActive
 
   // Persist subscription status so next page load can use it immediately
   useEffect(() => {
@@ -113,7 +187,9 @@ export function useSubscriptionStatus() {
       localStorage.setItem(
         SETTINGS_CACHED_SUBSCRIPTION_STATUS,
         JSON.stringify({
+          userId: user.id,
           chat_subscription_active: chatSubscriptionActive,
+          cachedAt: Date.now(),
         }),
       )
     } catch {

--- a/src/pages/signin.tsx
+++ b/src/pages/signin.tsx
@@ -5,7 +5,7 @@ import { Button } from '@/components/ui/button'
 import { getClerkErrorMessage } from '@/utils/clerk-errors'
 import { logError } from '@/utils/error-handling'
 import { sanitizeRelativeRedirect } from '@/utils/redirect-url'
-import { useClerk, useSignIn, useSignUp } from '@clerk/nextjs'
+import { useAuth, useClerk, useSignIn, useSignUp } from '@clerk/nextjs'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { useEffect, useRef, useState } from 'react'
@@ -58,6 +58,7 @@ function clerkErrorCode(error: unknown): string | undefined {
 export default function SignInPage() {
   const router = useRouter()
   const clerk = useClerk()
+  const { isLoaded: isAuthLoaded, isSignedIn } = useAuth()
   const { signIn, errors: signInErrors } = useSignIn()
   const { signUp } = useSignUp()
   const [isDarkMode, setIsDarkMode] = useState(false)
@@ -87,6 +88,11 @@ export default function SignInPage() {
   const postAuthRedirectUrl =
     sanitizeRelativeRedirect(router.query.redirect_url) ??
     POST_AUTH_REDIRECT_URL
+
+  useEffect(() => {
+    if (!router.isReady || !isAuthLoaded || !isSignedIn) return
+    void router.replace(postAuthRedirectUrl)
+  }, [isAuthLoaded, isSignedIn, postAuthRedirectUrl, router])
 
   const navigateAfterAuth = async ({
     session,
@@ -470,6 +476,14 @@ export default function SignInPage() {
   }
 
   const isPending = pendingAction !== null
+
+  if (!isAuthLoaded || isSignedIn) {
+    return (
+      <main className="flex min-h-screen items-center justify-center bg-surface-chat-background font-aeonik">
+        <PiSpinner className="h-6 w-6 animate-spin text-content-secondary" />
+      </main>
+    )
+  }
 
   return (
     <main className="flex min-h-screen items-center justify-center bg-surface-chat-background px-6 py-16 font-aeonik">

--- a/src/services/inference/inference-client.ts
+++ b/src/services/inference/inference-client.ts
@@ -13,6 +13,11 @@ import { AUTO_MODEL_OPTIONS_FIELD, AUTO_REQUEST_MODEL } from '@/config/models'
 import { shouldRetryTestFail } from '@/utils/dev-simulator'
 import { logError, logInfo } from '@/utils/error-handling'
 import {
+  PERFORMANCE_METRICS,
+  recordPerformanceDuration,
+  startPerformanceTimer,
+} from '@/utils/performance-metrics'
+import {
   APIConnectionError,
   APIUserAbortError,
   AuthenticationError,
@@ -22,14 +27,14 @@ import type { SessionRecoveryToken } from 'tinfoil'
 import { ChatQueryBuilder } from './chat-query-builder'
 import { chatChunkStreamFromSSE, type ChatChunkStream } from './chat-stream'
 import {
+  acquireRecoverableTinfoilTransport,
   createRecoverableTinfoilClient,
-  createRecoverableTinfoilTransport,
   discardRateLimitSnapshot,
   getRateLimitInfo,
   getTinfoilClient,
   refreshRateLimit,
   resetTinfoilClient,
-  type RecoverableTinfoilTransport,
+  type RecoverableTinfoilTransportLease,
 } from './tinfoil-client'
 
 const CHAT_COMPLETIONS_ENDPOINT = '/v1/chat/completions'
@@ -432,11 +437,17 @@ export async function sendChatStream(
 
   let lastError: unknown = null
   const maxRetries = CONSTANTS.MESSAGE_SEND_MAX_RETRIES
-  let recoverableTransport: RecoverableTinfoilTransport | null = null
+  let recoverableTransportLease: RecoverableTinfoilTransportLease | null = null
+
+  const releaseRecoverableTransport = () => {
+    recoverableTransportLease?.release()
+    recoverableTransportLease = null
+  }
 
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     let recoverySessionId: string | null = null
     if (signal.aborted) {
+      releaseRecoverableTransport()
       throw new DOMException('Aborted', 'AbortError')
     }
 
@@ -451,6 +462,7 @@ export async function sendChatStream(
       const connectionWaitStart = Date.now()
       while (!isOnline() && Date.now() - connectionWaitStart < 10000) {
         if (signal.aborted) {
+          releaseRecoverableTransport()
           throw new DOMException('Aborted', 'AbortError')
         }
         await delay(500)
@@ -509,11 +521,15 @@ export async function sendChatStream(
         }
       }
 
+      const streamStartedAt = startPerformanceTimer()
       let client
       let waitForTokenCapture: (() => Promise<void>) | undefined
       let recoverySessionCleanup: (() => Promise<void>) | undefined
       if (recovery) {
-        recoverableTransport ??= await createRecoverableTinfoilTransport()
+        if (!recoverableTransportLease) {
+          recoverableTransportLease = await acquireRecoverableTinfoilTransport()
+        }
+        const recoverableTransport = recoverableTransportLease.transport
         recoverySessionId = generateRecoverySessionId()
         recovery.onAttemptStarted(recoverySessionId)
         const recoverable = await createRecoverableTinfoilClient(
@@ -542,7 +558,12 @@ export async function sendChatStream(
         requestBody,
         { signal, maxRetries: 0 },
       )
+      recordPerformanceDuration(
+        PERFORMANCE_METRICS.INFERENCE_STREAM_READY,
+        streamStartedAt,
+      )
       if (!waitForTokenCapture || !recoverySessionCleanup) {
+        releaseRecoverableTransport()
         return stream as ChatChunkStream
       }
       const abandonRecovery = recoverySessionCleanup
@@ -565,9 +586,22 @@ export async function sendChatStream(
       void recoveryReady.catch(() => undefined)
       return {
         recoveryReady,
-        abandonRecovery,
-        [Symbol.asyncIterator]: () =>
-          (stream as ChatChunkStream)[Symbol.asyncIterator](),
+        abandonRecovery: async () => {
+          try {
+            await abandonRecovery()
+          } finally {
+            releaseRecoverableTransport()
+          }
+        },
+        async *[Symbol.asyncIterator]() {
+          try {
+            for await (const chunk of stream as ChatChunkStream) {
+              yield chunk
+            }
+          } finally {
+            releaseRecoverableTransport()
+          }
+        },
       }
     } catch (err: unknown) {
       if (recoverySessionId && recovery) {
@@ -591,6 +625,7 @@ export async function sendChatStream(
           anyErr.name === 'AbortError') ||
         anyErr?.name === 'AbortError'
       ) {
+        releaseRecoverableTransport()
         throw err
       }
 
@@ -605,6 +640,7 @@ export async function sendChatStream(
       if (getHttpStatus(err) === 429) {
         const quotaError = await classifyQuotaExhausted429(err)
         if (quotaError) {
+          releaseRecoverableTransport()
           throw quotaError
         }
       }
@@ -644,12 +680,14 @@ export async function sendChatStream(
         },
       })
 
+      releaseRecoverableTransport()
       throw toTerminalChatError(err)
     }
   }
 
   // Fallback: every branch above should already have thrown, but if the
   // retry loop exits without doing so we still need to surface an error.
+  releaseRecoverableTransport()
   throw toTerminalChatError(lastError, maxRetries)
 }
 

--- a/src/services/inference/tinfoil-client.ts
+++ b/src/services/inference/tinfoil-client.ts
@@ -3,6 +3,11 @@ import { API_BASE_URL, DEV_API_KEY, IS_DEV } from '@/config'
 import { AUTH_ACTIVE_USER_ID } from '@/constants/storage-keys'
 import { logError } from '@/utils/error-handling'
 import {
+  PERFORMANCE_METRICS,
+  recordPerformanceDuration,
+  startPerformanceTimer,
+} from '@/utils/performance-metrics'
+import {
   TINFOIL_EVENTS_HEADER,
   TINFOIL_EVENTS_VALUE_CODE_EXECUTION,
   TINFOIL_EVENTS_VALUE_WEB_SEARCH,
@@ -44,6 +49,9 @@ let refreshInFlight: Promise<void> | null = null
 let sessionCacheGeneration = 0
 let initializationInFlight: InitializationTask | null = null
 let cachedVerificationDocument: VerificationDocument | null = null
+const MAX_IDLE_RECOVERABLE_TRANSPORTS = 1
+let idleRecoverableTransports: RecoverableTinfoilTransport[] = []
+let recoverableTransportPoolGeneration = 0
 
 class SessionCacheInvalidatedError extends Error {}
 
@@ -344,15 +352,23 @@ async function fetchSessionTokenForGeneration(
 }
 
 async function fetchSessionToken(signal?: AbortSignal): Promise<string> {
-  while (true) {
-    try {
-      return await fetchSessionTokenForGeneration(
-        sessionCacheGeneration,
-        signal,
-      )
-    } catch (error) {
-      if (!(error instanceof SessionCacheInvalidatedError)) throw error
+  const startedAt = startPerformanceTimer()
+  try {
+    while (true) {
+      try {
+        return await fetchSessionTokenForGeneration(
+          sessionCacheGeneration,
+          signal,
+        )
+      } catch (error) {
+        if (!(error instanceof SessionCacheInvalidatedError)) throw error
+      }
     }
+  } finally {
+    recordPerformanceDuration(
+      PERFORMANCE_METRICS.INFERENCE_SESSION_TOKEN,
+      startedAt,
+    )
   }
 }
 
@@ -453,6 +469,8 @@ export function resetTinfoilClient(): void {
   remainingBeforeRequest = null
   refreshInFlight = null
   cachedVerificationDocument = null
+  idleRecoverableTransports = []
+  recoverableTransportPoolGeneration++
 }
 
 export function invalidateSessionCache(): void {
@@ -490,7 +508,12 @@ async function initClient(
     }
 
     const candidateSecureClient = new SecureClient({})
+    const attestationStartedAt = startPerformanceTimer()
     await waitForSignal(candidateSecureClient.ready(), signal)
+    recordPerformanceDuration(
+      PERFORMANCE_METRICS.INFERENCE_ATTESTATION,
+      attestationStartedAt,
+    )
     return {
       secureClient: candidateSecureClient,
       client: new OpenAI({
@@ -544,6 +567,11 @@ export interface RecoverableTinfoilTransport {
   baseURL: string
 }
 
+export interface RecoverableTinfoilTransportLease {
+  transport: RecoverableTinfoilTransport
+  release: () => void
+}
+
 export function isChatRecoveryAvailable(): boolean {
   return !IS_DEV
 }
@@ -568,8 +596,35 @@ export async function createRecoverableTinfoilTransport(): Promise<RecoverableTi
   }
   const baseURL = new URL('/v1/', controlplaneBaseURL()).toString()
   const dedicatedSecureClient = new SecureClient({ baseURL })
+  const attestationStartedAt = startPerformanceTimer()
   await dedicatedSecureClient.ready()
+  recordPerformanceDuration(
+    PERFORMANCE_METRICS.INFERENCE_ATTESTATION,
+    attestationStartedAt,
+  )
   return { secureClient: dedicatedSecureClient, baseURL }
+}
+
+export async function acquireRecoverableTinfoilTransport(): Promise<RecoverableTinfoilTransportLease> {
+  const generation = recoverableTransportPoolGeneration
+  const transport =
+    idleRecoverableTransports.pop() ??
+    (await createRecoverableTinfoilTransport())
+  let released = false
+
+  return {
+    transport,
+    release: () => {
+      if (released) return
+      released = true
+      if (
+        generation === recoverableTransportPoolGeneration &&
+        idleRecoverableTransports.length < MAX_IDLE_RECOVERABLE_TRANSPORTS
+      ) {
+        idleRecoverableTransports.push(transport)
+      }
+    },
+  }
 }
 
 export async function createRecoverableTinfoilClient(

--- a/src/utils/auth-signout-intent.ts
+++ b/src/utils/auth-signout-intent.ts
@@ -1,0 +1,49 @@
+import {
+  AUTH_SIGNOUT_CLEARED_EVENT,
+  AUTH_SIGNOUT_INTENT_MAX_AGE_MS,
+  AUTH_SIGNOUT_REQUESTED_EVENT,
+} from '@/constants/auth-events'
+import { AUTH_SIGNOUT_REQUESTED_AT } from '@/constants/storage-keys'
+
+export function requestExplicitSignout(): void {
+  try {
+    localStorage.setItem(AUTH_SIGNOUT_REQUESTED_AT, String(Date.now()))
+  } catch {
+    // The same-tab event still lets cleanup proceed when storage is restricted.
+  }
+  window.dispatchEvent(new CustomEvent(AUTH_SIGNOUT_REQUESTED_EVENT))
+}
+
+function removeExplicitSignoutIntent(): void {
+  try {
+    localStorage.removeItem(AUTH_SIGNOUT_REQUESTED_AT)
+  } catch {
+    // best-effort
+  }
+}
+
+export function clearExplicitSignoutIntent(): void {
+  removeExplicitSignoutIntent()
+  window.dispatchEvent(new CustomEvent(AUTH_SIGNOUT_CLEARED_EVENT))
+}
+
+export function hasRecentExplicitSignoutIntent(now = Date.now()): boolean {
+  let requestedAt: number
+  try {
+    requestedAt = Number(localStorage.getItem(AUTH_SIGNOUT_REQUESTED_AT))
+  } catch {
+    return false
+  }
+  const age = now - requestedAt
+  const isRecent =
+    Number.isFinite(requestedAt) &&
+    requestedAt > 0 &&
+    age >= 0 &&
+    age <= AUTH_SIGNOUT_INTENT_MAX_AGE_MS
+
+  if (!isRecent) {
+    removeExplicitSignoutIntent()
+  }
+
+  return isRecent
+}

--- a/src/utils/performance-metrics.ts
+++ b/src/utils/performance-metrics.ts
@@ -1,0 +1,26 @@
+export const PERFORMANCE_METRICS = {
+  AUTH_RESTORATION: 'tinfoil.auth.restoration',
+  CONFIG_READY: 'tinfoil.config.ready',
+  INFERENCE_ATTESTATION: 'tinfoil.inference.attestation',
+  INFERENCE_SESSION_TOKEN: 'tinfoil.inference.session-token',
+  INFERENCE_STREAM_READY: 'tinfoil.inference.stream-ready',
+} as const
+
+export function startPerformanceTimer(): number | null {
+  return typeof performance === 'undefined' ? null : performance.now()
+}
+
+export function recordPerformanceDuration(
+  name: (typeof PERFORMANCE_METRICS)[keyof typeof PERFORMANCE_METRICS],
+  startedAt: number | null,
+): void {
+  if (startedAt === null || typeof performance === 'undefined') return
+  try {
+    performance.measure(name, {
+      start: startedAt,
+      end: performance.now(),
+    })
+  } catch {
+    // best-effort
+  }
+}

--- a/src/utils/signout-cleanup.ts
+++ b/src/utils/signout-cleanup.ts
@@ -3,6 +3,8 @@ import { PINNED_CHAT_IDS_CHANGED_EVENT } from '@/constants/settings-events'
 import {
   AUTH_ACCOUNT_RESET_FAILED,
   AUTH_ACTIVE_USER_ID,
+  CONFIG_CACHED_MODELS,
+  CONFIG_CACHED_SYSTEM_PROMPT,
   SECRET_PASSKEY_BACKED_UP,
   SETTINGS_HAS_SEEN_ONBOARDING,
   USER_ENCRYPTION_KEY,
@@ -108,6 +110,8 @@ async function clearAllUserData(options: ClearUserDataOptions): Promise<void> {
   try {
     const preservedKeys = new Set([
       AUTH_ACTIVE_USER_ID,
+      CONFIG_CACHED_MODELS,
+      CONFIG_CACHED_SYSTEM_PROMPT,
       SETTINGS_HAS_SEEN_ONBOARDING,
       ...(preserveEncryptionKey ? [USER_ENCRYPTION_KEY] : []),
     ])

--- a/tests/components/auth-cleanup-handler.test.tsx
+++ b/tests/components/auth-cleanup-handler.test.tsx
@@ -1,8 +1,13 @@
 import { AuthCleanupHandler } from '@/components/auth-cleanup-handler'
-import { ACCOUNT_RESET_FAILED_EVENT } from '@/constants/auth-events'
+import {
+  ACCOUNT_RESET_FAILED_EVENT,
+  AUTH_SIGNOUT_CLEARED_EVENT,
+  AUTH_SIGNOUT_REQUESTED_EVENT,
+} from '@/constants/auth-events'
 import {
   AUTH_ACCOUNT_RESET_FAILED,
   AUTH_ACTIVE_USER_ID,
+  AUTH_SIGNOUT_REQUESTED_AT,
 } from '@/constants/storage-keys'
 import { act, fireEvent, render, screen } from '@testing-library/react'
 import { createElement } from 'react'
@@ -103,8 +108,24 @@ describe('AuthCleanupHandler', () => {
     expect(mockPerformUserSwitchCleanup).not.toHaveBeenCalled()
   })
 
-  it('clears data after the grace period when still signed out', async () => {
+  it('preserves data when the session expires without explicit sign-out', async () => {
     localStorage.setItem(AUTH_ACTIVE_USER_ID, 'user_123')
+
+    render(createElement(AuthCleanupHandler))
+
+    await act(async () => {
+      vi.advanceTimersByTime(2000)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(mockPerformSignoutCleanup).not.toHaveBeenCalled()
+    expect(window.location.reload).not.toHaveBeenCalled()
+  })
+
+  it('clears data after an explicit sign-out remains signed out', async () => {
+    localStorage.setItem(AUTH_ACTIVE_USER_ID, 'user_123')
+    localStorage.setItem(AUTH_SIGNOUT_REQUESTED_AT, String(Date.now()))
 
     render(createElement(AuthCleanupHandler))
 
@@ -120,6 +141,7 @@ describe('AuthCleanupHandler', () => {
 
   it('keeps cleanup retryable while browser data is still being cleared', async () => {
     localStorage.setItem(AUTH_ACTIVE_USER_ID, 'user_123')
+    localStorage.setItem(AUTH_SIGNOUT_REQUESTED_AT, String(Date.now()))
     mockPerformSignoutCleanup.mockReturnValueOnce(new Promise(() => {}))
 
     render(createElement(AuthCleanupHandler))
@@ -136,6 +158,7 @@ describe('AuthCleanupHandler', () => {
 
   it('does not reload-loop when browser data cleanup fails', async () => {
     localStorage.setItem(AUTH_ACTIVE_USER_ID, 'user_123')
+    localStorage.setItem(AUTH_SIGNOUT_REQUESTED_AT, String(Date.now()))
     mockPerformSignoutCleanup.mockRejectedValueOnce(new Error('reset failed'))
 
     render(createElement(AuthCleanupHandler))
@@ -231,6 +254,7 @@ describe('AuthCleanupHandler', () => {
 
   it('cancels scheduled sign-out cleanup when reset failure is reported', async () => {
     localStorage.setItem(AUTH_ACTIVE_USER_ID, 'user_123')
+    localStorage.setItem(AUTH_SIGNOUT_REQUESTED_AT, String(Date.now()))
     render(createElement(AuthCleanupHandler))
 
     await act(async () => {
@@ -239,6 +263,47 @@ describe('AuthCleanupHandler', () => {
     act(() => {
       window.dispatchEvent(new CustomEvent(ACCOUNT_RESET_FAILED_EVENT))
     })
+    await act(async () => {
+      vi.advanceTimersByTime(2000)
+      await Promise.resolve()
+    })
+
+    expect(mockPerformSignoutCleanup).not.toHaveBeenCalled()
+  })
+
+  it('responds to an explicit sign-out requested after mount', async () => {
+    localStorage.setItem(AUTH_ACTIVE_USER_ID, 'user_123')
+    render(createElement(AuthCleanupHandler))
+
+    act(() => {
+      localStorage.setItem(AUTH_SIGNOUT_REQUESTED_AT, String(Date.now()))
+      window.dispatchEvent(new CustomEvent(AUTH_SIGNOUT_REQUESTED_EVENT))
+    })
+    await act(async () => {
+      vi.advanceTimersByTime(2000)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(mockPerformSignoutCleanup).toHaveBeenCalledTimes(1)
+  })
+
+  it('cancels explicit cleanup when sign-out fails', async () => {
+    localStorage.setItem(AUTH_ACTIVE_USER_ID, 'user_123')
+    authState = { isSignedIn: true, isLoaded: true }
+    userState = { user: { id: 'user_123' } }
+    const { rerender } = render(createElement(AuthCleanupHandler))
+
+    act(() => {
+      localStorage.setItem(AUTH_SIGNOUT_REQUESTED_AT, String(Date.now()))
+      window.dispatchEvent(new CustomEvent(AUTH_SIGNOUT_REQUESTED_EVENT))
+      localStorage.removeItem(AUTH_SIGNOUT_REQUESTED_AT)
+      window.dispatchEvent(new CustomEvent(AUTH_SIGNOUT_CLEARED_EVENT))
+    })
+
+    authState = { isSignedIn: false, isLoaded: true }
+    userState = { user: null }
+    rerender(createElement(AuthCleanupHandler))
     await act(async () => {
       vi.advanceTimersByTime(2000)
       await Promise.resolve()

--- a/tests/config/genui-config-reset.test.ts
+++ b/tests/config/genui-config-reset.test.ts
@@ -1,12 +1,16 @@
 import { getGenUIConfig, setGenUIConfig } from '@/components/chat/genui/config'
 import {
   applyGenUIConfigFromResponse,
+  getAIModels,
+  getCachedAIModels,
+  getCachedSystemPromptAndRules,
   getSystemPromptAndRules,
 } from '@/config/models'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 afterEach(() => {
   setGenUIConfig(null)
+  localStorage.clear()
   vi.unstubAllGlobals()
 })
 
@@ -56,5 +60,66 @@ describe('applyGenUIConfigFromResponse', () => {
       rules: '',
     })
     expect(getGenUIConfig()).toBeNull()
+  })
+
+  it('restores cached configuration while the network refreshes', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          systemPrompt: 'Cached prompt',
+          rules: 'Cached rules',
+          genUI: { header: 'cached', enabledWidgets: ['render_chart'] },
+        }),
+      })
+      .mockRejectedValueOnce(new Error('network down'))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await getSystemPromptAndRules()
+    setGenUIConfig(null)
+
+    expect(getCachedSystemPromptAndRules()).toEqual({
+      systemPrompt: 'Cached prompt',
+      rules: 'Cached rules',
+    })
+    expect(getGenUIConfig()).toEqual({
+      header: 'cached',
+      enabledWidgets: ['render_chart'],
+    })
+
+    await expect(getSystemPromptAndRules()).resolves.toEqual({
+      systemPrompt: 'Cached prompt',
+      rules: 'Cached rules',
+    })
+    expect(getGenUIConfig()).toEqual({
+      header: 'cached',
+      enabledWidgets: ['render_chart'],
+    })
+  })
+
+  it('restores a cached model list after a request failure', async () => {
+    const model = {
+      modelName: 'gpt-oss-120b',
+      image: 'openai.png',
+      name: 'GPT-OSS 120B',
+      nameShort: 'GPT-OSS',
+      description: 'Test model',
+      type: 'chat',
+      chat: true,
+    }
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: vi.fn().mockResolvedValue([model]),
+      })
+      .mockRejectedValueOnce(new Error('network down'))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const fetchedModels = await getAIModels()
+    expect(fetchedModels).toContainEqual(model)
+    expect(getCachedAIModels()).toEqual(fetchedModels)
+    await expect(getAIModels()).resolves.toEqual(fetchedModels)
   })
 })

--- a/tests/hooks/use-subscription-status.test.ts
+++ b/tests/hooks/use-subscription-status.test.ts
@@ -1,5 +1,24 @@
-import { hasActiveSubscription } from '@/hooks/use-subscription-status'
-import { describe, expect, it } from 'vitest'
+import { AUTH_ACTIVE_USER_CHANGED_EVENT } from '@/constants/auth-events'
+import {
+  AUTH_ACTIVE_USER_ID,
+  SETTINGS_CACHED_SUBSCRIPTION_STATUS,
+} from '@/constants/storage-keys'
+import {
+  hasActiveSubscription,
+  readCachedSubscriptionStatus,
+  useSubscriptionStatus,
+} from '@/hooks/use-subscription-status'
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const clerkState = vi.hoisted(() => ({
+  isLoaded: false,
+  user: null as null | { id: string; publicMetadata: Record<string, unknown> },
+}))
+
+vi.mock('@clerk/nextjs', () => ({
+  useUser: () => clerkState,
+}))
 
 describe('hasActiveSubscription', () => {
   const now = new Date('2026-07-23T12:00:00Z')
@@ -30,5 +49,126 @@ describe('hasActiveSubscription', () => {
   it('rejects canceled subscriptions without a future cutoff', () => {
     expect(hasActiveSubscription('canceled', null, now)).toBe(false)
     expect(hasActiveSubscription('canceled', past, now)).toBe(false)
+  })
+})
+
+describe('readCachedSubscriptionStatus', () => {
+  const now = new Date('2026-07-23T12:00:00Z').getTime()
+
+  beforeEach(() => localStorage.clear())
+
+  it('restores a recent cache for the same user', () => {
+    localStorage.setItem(
+      SETTINGS_CACHED_SUBSCRIPTION_STATUS,
+      JSON.stringify({
+        userId: 'user_123',
+        chat_subscription_active: true,
+        cachedAt: now,
+      }),
+    )
+
+    expect(readCachedSubscriptionStatus('user_123', now)).toBe(true)
+  })
+
+  it('rejects another user or an expired cache', () => {
+    localStorage.setItem(
+      SETTINGS_CACHED_SUBSCRIPTION_STATUS,
+      JSON.stringify({
+        userId: 'user_123',
+        chat_subscription_active: true,
+        cachedAt: now - 25 * 60 * 60 * 1000,
+      }),
+    )
+
+    expect(readCachedSubscriptionStatus('user_456', now)).toBeNull()
+    expect(readCachedSubscriptionStatus('user_123', now)).toBeNull()
+  })
+})
+
+describe('useSubscriptionStatus cache synchronization', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    clerkState.isLoaded = false
+    clerkState.user = null
+  })
+
+  afterEach(() => vi.restoreAllMocks())
+
+  it('re-reads cached status when the active user changes', () => {
+    localStorage.setItem(AUTH_ACTIVE_USER_ID, 'user_123')
+    localStorage.setItem(
+      SETTINGS_CACHED_SUBSCRIPTION_STATUS,
+      JSON.stringify({
+        userId: 'user_123',
+        chat_subscription_active: true,
+        cachedAt: Date.now(),
+      }),
+    )
+    const { result } = renderHook(() => useSubscriptionStatus())
+
+    expect(result.current.chat_subscription_active).toBe(true)
+
+    act(() => {
+      localStorage.setItem(AUTH_ACTIVE_USER_ID, 'user_456')
+      window.dispatchEvent(new Event(AUTH_ACTIVE_USER_CHANGED_EVENT))
+    })
+
+    expect(result.current.chat_subscription_active).toBe(false)
+  })
+
+  it('re-reads cached status after cross-tab storage changes', () => {
+    localStorage.setItem(AUTH_ACTIVE_USER_ID, 'user_123')
+    localStorage.setItem(
+      SETTINGS_CACHED_SUBSCRIPTION_STATUS,
+      JSON.stringify({
+        userId: 'user_123',
+        chat_subscription_active: true,
+        cachedAt: Date.now(),
+      }),
+    )
+    const { result } = renderHook(() => useSubscriptionStatus())
+
+    act(() => {
+      localStorage.setItem(
+        SETTINGS_CACHED_SUBSCRIPTION_STATUS,
+        JSON.stringify({
+          userId: 'user_123',
+          chat_subscription_active: false,
+          cachedAt: Date.now(),
+        }),
+      )
+      window.dispatchEvent(
+        new StorageEvent('storage', {
+          key: SETTINGS_CACHED_SUBSCRIPTION_STATUS,
+        }),
+      )
+    })
+    expect(result.current.chat_subscription_active).toBe(false)
+
+    act(() => {
+      localStorage.setItem(AUTH_ACTIVE_USER_ID, 'user_456')
+      localStorage.setItem(
+        SETTINGS_CACHED_SUBSCRIPTION_STATUS,
+        JSON.stringify({
+          userId: 'user_456',
+          chat_subscription_active: true,
+          cachedAt: Date.now(),
+        }),
+      )
+      window.dispatchEvent(
+        new StorageEvent('storage', { key: AUTH_ACTIVE_USER_ID }),
+      )
+    })
+    expect(result.current.chat_subscription_active).toBe(true)
+  })
+
+  it('falls back safely when browser storage is unavailable', () => {
+    vi.spyOn(localStorage, 'getItem').mockImplementation(() => {
+      throw new DOMException('Blocked', 'SecurityError')
+    })
+
+    const { result } = renderHook(() => useSubscriptionStatus())
+
+    expect(result.current.chat_subscription_active).toBe(false)
   })
 })

--- a/tests/pages/signin.test.tsx
+++ b/tests/pages/signin.test.tsx
@@ -34,10 +34,23 @@ const auth = vi.hoisted(() => {
     query: {} as Record<string, string | undefined>,
   }
 
-  return { clerkLoaded: true, signIn, signUp, router, routerPush: vi.fn() }
+  return {
+    clerkLoaded: true,
+    isAuthLoaded: true,
+    isSignedIn: false,
+    signIn,
+    signUp,
+    router,
+    routerPush: vi.fn(),
+    routerReplace: vi.fn(),
+  }
 })
 
 vi.mock('@clerk/nextjs', () => ({
+  useAuth: () => ({
+    isLoaded: auth.isAuthLoaded,
+    isSignedIn: auth.isSignedIn,
+  }),
   useClerk: () => ({ loaded: auth.clerkLoaded }),
   useSignIn: () => ({
     signIn: auth.signIn,
@@ -52,13 +65,19 @@ vi.mock('@clerk/nextjs', () => ({
 }))
 
 vi.mock('next/router', () => ({
-  useRouter: () => ({ push: auth.routerPush, ...auth.router }),
+  useRouter: () => ({
+    push: auth.routerPush,
+    replace: auth.routerReplace,
+    ...auth.router,
+  }),
 }))
 
 describe('SignInPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     auth.clerkLoaded = true
+    auth.isAuthLoaded = true
+    auth.isSignedIn = false
     auth.router.isReady = true
     auth.router.query = {}
     auth.signIn.id = undefined
@@ -107,6 +126,17 @@ describe('SignInPage', () => {
       'text-balance',
       'text-center',
     )
+  })
+
+  it('redirects an already signed-in user to the requested page', async () => {
+    auth.isSignedIn = true
+    auth.router.query = { redirect_url: '/project/example' }
+
+    render(<SignInPage />)
+
+    await waitFor(() => {
+      expect(auth.routerReplace).toHaveBeenCalledWith('/project/example')
+    })
   })
 
   it('clears an abandoned sign-in attempt on a fresh landing', async () => {

--- a/tests/services/inference/inference-client-quota.test.ts
+++ b/tests/services/inference/inference-client-quota.test.ts
@@ -21,7 +21,7 @@ vi.mock('@/components/chat/constants', async () => {
 })
 
 vi.mock('@/services/inference/tinfoil-client', () => ({
-  createRecoverableTinfoilTransport: vi.fn(),
+  acquireRecoverableTinfoilTransport: vi.fn(),
   createRecoverableTinfoilClient: vi.fn(),
   discardRateLimitSnapshot: () => discardRateLimitSnapshot(),
   getRateLimitInfo: () => getRateLimitInfo(),

--- a/tests/services/inference/inference-client-recovery.test.ts
+++ b/tests/services/inference/inference-client-recovery.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const createCompletion = vi.fn()
 const createRecoverableTransport = vi.fn()
+const releaseRecoverableTransport = vi.fn()
 const createRecoverableClient = vi.fn()
 const resetTinfoilClient = vi.fn()
 
@@ -22,7 +23,10 @@ vi.mock('@/components/chat/constants', async () => {
 })
 
 vi.mock('@/services/inference/tinfoil-client', () => ({
-  createRecoverableTinfoilTransport: () => createRecoverableTransport(),
+  acquireRecoverableTinfoilTransport: async () => ({
+    transport: await createRecoverableTransport(),
+    release: releaseRecoverableTransport,
+  }),
   createRecoverableTinfoilClient: (...args: unknown[]) =>
     createRecoverableClient(...args),
   discardRateLimitSnapshot: vi.fn(),
@@ -108,8 +112,14 @@ describe('recoverable inference retries', () => {
     const stream = await send(recovery).promise
     expect(typeof stream[Symbol.asyncIterator]).toBe('function')
     await expect(stream.recoveryReady).resolves.toBeUndefined()
+    const chunks = []
+    for await (const chunk of stream) {
+      chunks.push(chunk)
+    }
+    expect(chunks).toHaveLength(1)
 
     expect(createRecoverableTransport).toHaveBeenCalledOnce()
+    expect(releaseRecoverableTransport).toHaveBeenCalledOnce()
     expect(createRecoverableClient).toHaveBeenCalledTimes(2)
     expect(createCompletion).toHaveBeenCalledTimes(2)
   })
@@ -128,9 +138,15 @@ describe('recoverable inference retries', () => {
 
     const stream = await send().promise
     expect(typeof stream[Symbol.asyncIterator]).toBe('function')
+    const chunks = []
+    for await (const chunk of stream) {
+      chunks.push(chunk)
+    }
+    expect(chunks).toHaveLength(1)
 
     expect(resetTinfoilClient).toHaveBeenCalledOnce()
     expect(createRecoverableTransport).toHaveBeenCalledOnce()
+    expect(releaseRecoverableTransport).toHaveBeenCalledOnce()
     expect(createRecoverableClient).toHaveBeenCalledTimes(2)
   })
 
@@ -189,5 +205,27 @@ describe('recoverable inference retries', () => {
 
     await expect(stream.recoveryReady).rejects.toBe(captureError)
     expect(recovery.onAttemptAbandoned).toHaveBeenCalledOnce()
+  })
+
+  it('releases the transport after an aborted request', async () => {
+    createCompletion.mockRejectedValueOnce(
+      new DOMException('Aborted', 'AbortError'),
+    )
+
+    await expect(send().promise).rejects.toMatchObject({ name: 'AbortError' })
+
+    expect(releaseRecoverableTransport).toHaveBeenCalledOnce()
+  })
+
+  it('releases the transport after a terminal request error', async () => {
+    createCompletion.mockRejectedValueOnce(
+      Object.assign(new Error('invalid request'), { status: 400 }),
+    )
+
+    await expect(send().promise).rejects.toMatchObject({
+      code: 'SERVER_ERROR',
+    })
+
+    expect(releaseRecoverableTransport).toHaveBeenCalledOnce()
   })
 })

--- a/tests/services/inference/inference-client-structured.test.ts
+++ b/tests/services/inference/inference-client-structured.test.ts
@@ -9,11 +9,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const { createMock } = vi.hoisted(() => ({ createMock: vi.fn() }))
 
 vi.mock('@/services/inference/tinfoil-client', () => ({
+  acquireRecoverableTinfoilTransport: vi.fn(),
   getTinfoilClient: vi.fn(async () => ({
     chat: { completions: { create: createMock } },
   })),
   createRecoverableTinfoilClient: vi.fn(),
-  createRecoverableTinfoilTransport: vi.fn(),
   discardRateLimitSnapshot: vi.fn(),
   getRateLimitInfo: vi.fn(),
   refreshRateLimit: vi.fn(),

--- a/tests/services/inference/tinfoil-client-recovery-pool.test.ts
+++ b/tests/services/inference/tinfoil-client-recovery-pool.test.ts
@@ -1,0 +1,68 @@
+import {
+  acquireRecoverableTinfoilTransport,
+  resetTinfoilClient,
+} from '@/services/inference/tinfoil-client'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const sdk = vi.hoisted(() => {
+  const ready = vi.fn(async () => undefined)
+  const instances: unknown[] = []
+
+  class SecureClient {
+    fetch = vi.fn()
+
+    constructor() {
+      instances.push(this)
+    }
+
+    ready() {
+      return ready()
+    }
+  }
+
+  return { instances, ready, SecureClient }
+})
+
+vi.mock('@/config', () => ({
+  API_BASE_URL: 'https://api.example',
+  DEV_API_KEY: '',
+  IS_DEV: false,
+}))
+
+vi.mock('openai', () => ({
+  default: class OpenAI {},
+}))
+
+vi.mock('tinfoil', () => ({
+  AuthenticationError: class AuthenticationError extends Error {},
+  SecureClient: sdk.SecureClient,
+}))
+
+describe('recoverable transport pool', () => {
+  beforeEach(() => {
+    resetTinfoilClient()
+    sdk.instances.length = 0
+    sdk.ready.mockClear()
+  })
+
+  it('reuses a released attested transport', async () => {
+    const first = await acquireRecoverableTinfoilTransport()
+    first.release()
+    const second = await acquireRecoverableTinfoilTransport()
+
+    expect(second.transport).toBe(first.transport)
+    expect(sdk.instances).toHaveLength(1)
+    expect(sdk.ready).toHaveBeenCalledTimes(1)
+    second.release()
+  })
+
+  it('keeps concurrent leases on separate transports', async () => {
+    const first = await acquireRecoverableTinfoilTransport()
+    const second = await acquireRecoverableTinfoilTransport()
+
+    expect(second.transport).not.toBe(first.transport)
+    expect(sdk.instances).toHaveLength(2)
+    first.release()
+    second.release()
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -33,6 +33,7 @@
   ],
   "exclude": [
     "node_modules",
+    "out",
     "vitest.setup.ts",
     "**/*.test.ts",
     "**/*.test.tsx"


### PR DESCRIPTION
## Summary
- preserve returning Premium sessions by limiting destructive cleanup to explicit sign-outs, restoring active sessions, and using a user-scoped entitlement cache
- speed up startup with cached configuration, request timeouts, deferred non-critical UI, and lazy Lottie loading while leaving the existing icon set unchanged
- reuse attested recovery transports between sequential queries and expose local-only Performance API timings for auth, configuration, tokens, attestation, and stream readiness

## Validation
- `npx vitest run` (185 files, 1966 tests)
- `npm run lint`
- `npm run build`