### PR TITLE
Make projects available to all cloud sync users

### DIFF
--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -676,7 +676,7 @@ export function ChatInterface({
 
   // Load projects for move to project functionality
   const { projects } = useProjects({
-    autoLoad: isSignedIn && isCloudSyncEnabled() && isPremium,
+    autoLoad: isSignedIn && isCloudSyncEnabled(),
   })
 
   // Reasoning controls — graded effort for models that support it, on/off

--- a/src/components/chat/chat-sidebar.tsx
+++ b/src/components/chat/chat-sidebar.tsx
@@ -44,7 +44,6 @@ import { FaLock } from 'react-icons/fa6'
 import { GoSidebarCollapse, GoSidebarExpand } from 'react-icons/go'
 import { IoChatbubblesOutline } from 'react-icons/io5'
 import {
-  PiFolder,
   PiMicrophone,
   PiNotePencilLight,
   PiPushPin,
@@ -351,7 +350,7 @@ export function ChatSidebar({
     projects,
     loading: projectsLoading,
     refresh: refreshProjects,
-  } = useProjects({ autoLoad: isSignedIn && cloudSyncEnabled && isPremium })
+  } = useProjects({ autoLoad: isSignedIn && cloudSyncEnabled })
 
   const { deleteProject, activeProject } = useProject()
 
@@ -592,11 +591,11 @@ export function ChatSidebar({
 
   // Drives both the Projects section's visibility and the Chats header's
   // sticky offset so the two can never drift apart.
-  const hasPinnedProjectsHeader = Boolean(isSignedIn && isPremium)
+  const hasPinnedProjectsHeader = Boolean(isSignedIn)
 
-  // Heal stale accordion state: a stored Projects=true flag (e.g. from a
-  // premium session) would otherwise leave a signed-out/non-premium user
-  // with no Projects section AND a collapsed chat list — an empty sidebar.
+  // Heal stale accordion state: a stored Projects=true flag would otherwise
+  // leave a signed-out user with no Projects section AND a collapsed chat
+  // list — an empty sidebar.
   useEffect(() => {
     if (isAuthLoaded && !hasPinnedProjectsHeader && isProjectsExpanded) {
       setIsProjectsExpanded(false)
@@ -994,8 +993,8 @@ export function ChatSidebar({
                 </div>
               )}
 
-              {/* Projects button - only for premium users */}
-              {isSignedIn && isPremium && (
+              {/* Projects button - only for signed-in users */}
+              {isSignedIn && (
                 <div className="group relative">
                   <button
                     onClick={() => {
@@ -1182,11 +1181,6 @@ export function ChatSidebar({
                   <div className="flex items-center gap-3 text-xs text-content-secondary">
                     <PiSparkle className="h-4 w-4 flex-shrink-0 text-content-muted" />
                     <span>No daily request limits</span>
-                  </div>
-
-                  <div className="flex items-center gap-3 text-xs text-content-secondary">
-                    <PiFolder className="h-4 w-4 flex-shrink-0 text-content-muted" />
-                    <span>Create projects to chat with files</span>
                   </div>
                 </div>
                 <div className="mt-4">
@@ -1435,7 +1429,7 @@ export function ChatSidebar({
             </section>
           )}
 
-          {/* Projects dropdown - show for premium users. The header and
+          {/* Projects dropdown - show for signed-in users. The header and
               list are direct children of the scroll container (no section
               wrapper) so the sticky header pins to the scroll area itself
               and stays visible for the rest of the scroll. */}
@@ -2374,7 +2368,6 @@ export function ChatSidebar({
                         showMoveToProject={
                           !isSearchActive &&
                           isSignedIn &&
-                          isPremium &&
                           cloudSyncEnabled &&
                           !!onMoveChatToProject
                         }

--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -1606,10 +1606,10 @@ export function SettingsModal({
     const file = e.target.files?.[0]
     if (!file) return
 
-    if (!isPremium) {
+    if (!isSignedIn) {
       toast({
-        title: 'Premium required',
-        description: 'Project import is only available for premium users',
+        title: 'Sign in required',
+        description: 'Sign in to import projects',
         variant: 'destructive',
       })
       e.target.value = ''
@@ -2771,8 +2771,8 @@ ${encryptionKey.replace('key_', '')}
                         </div>
                       </div>
 
-                      {/* Delete all projects (signed-in premium users only) */}
-                      {isSignedIn && isPremium && (
+                      {/* Delete all projects (signed-in users only) */}
+                      {isSignedIn && (
                         <div
                           className={cn(
                             'rounded-lg border border-border-subtle p-4',
@@ -4186,7 +4186,7 @@ ${encryptionKey.replace('key_', '')}
                         accept=".json"
                         onChange={handleImportClaudeProjects}
                         className="hidden"
-                        disabled={isImporting || !isPremium}
+                        disabled={isImporting || !isSignedIn}
                       />
                       <div className="mt-2 flex gap-2">
                         <button
@@ -4211,10 +4211,10 @@ ${encryptionKey.replace('key_', '')}
                           onClick={() =>
                             claudeProjectsFileInputRef.current?.click()
                           }
-                          disabled={isImporting || !isPremium}
+                          disabled={isImporting || !isSignedIn}
                           className={cn(
                             'flex flex-1 items-center justify-center gap-2 rounded-lg border border-border-subtle px-4 py-2.5 text-sm font-medium transition-colors',
-                            isImporting || !isPremium
+                            isImporting || !isSignedIn
                               ? 'cursor-not-allowed opacity-50'
                               : 'hover:bg-surface-chat',
                             isDarkMode
@@ -4224,11 +4224,6 @@ ${encryptionKey.replace('key_', '')}
                         >
                           <ArrowUpTrayIcon className="h-4 w-4" />
                           Projects
-                          {!isPremium && (
-                            <span className="ml-1 rounded-full bg-brand-accent-light/20 px-1.5 py-px text-[10px] font-medium text-brand-accent-light">
-                              Premium
-                            </span>
-                          )}
                         </button>
                       </div>
                     </div>
@@ -4319,8 +4314,8 @@ ${encryptionKey.replace('key_', '')}
                     </div>
                   </div>
 
-                  {/* Export Projects (premium only) */}
-                  {isPremium && (
+                  {/* Export Projects */}
+                  {isSignedIn && (
                     <div className="space-y-3">
                       <h3 className="font-aeonik text-sm font-medium text-content-secondary">
                         Export Projects for Claude

--- a/tests/components/chat/chat-sidebar-project-access.test.tsx
+++ b/tests/components/chat/chat-sidebar-project-access.test.tsx
@@ -1,0 +1,149 @@
+import { ChatSidebar } from '@/components/chat/chat-sidebar'
+import type { Chat } from '@/components/chat/types'
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  auth: {
+    isLoaded: true,
+    isSignedIn: true,
+  },
+  useProjects: vi.fn(),
+}))
+
+vi.mock('@clerk/nextjs', () => ({
+  useAuth: () => mocks.auth,
+  useUser: () => ({ user: { id: 'project-user' } }),
+}))
+
+vi.mock('@/hooks/use-projects', () => ({
+  useProjects: mocks.useProjects,
+}))
+
+vi.mock('@/hooks/use-sync-health', () => ({
+  useSyncHealth: () => ({ gate: { kind: 'ok' }, failedChats: {} }),
+  useSyncHealthAttention: () => false,
+  useSyncFailedChats: () => ({}),
+}))
+
+vi.mock('@/hooks/use-upgrade-to-pro', () => ({
+  useUpgradeToPro: () => ({
+    startUpgrade: vi.fn(),
+    upgradeLoading: false,
+    upgradeError: null,
+  }),
+}))
+
+vi.mock('@/utils/cloud-sync-settings', () => ({
+  CLOUD_SYNC_SETTING_CHANGED_EVENT: 'cloudSyncSettingChanged',
+  hasUserSetLocalOnlyPreference: () => true,
+  isCloudSyncEnabled: () => true,
+  isLocalOnlyModeEnabled: () => false,
+  setCloudSyncEnabled: vi.fn(),
+  setLocalOnlyModeEnabled: vi.fn(),
+}))
+
+vi.mock('@/components/project/project-context', () => ({
+  useProject: () => ({ deleteProject: vi.fn(), activeProject: null }),
+}))
+
+vi.mock('@/hooks/use-cloud-pagination', () => ({
+  useCloudPagination: () => ({
+    hasMore: false,
+    isLoading: false,
+    hasAttempted: false,
+    isInitialized: true,
+    loadMore: vi.fn(),
+  }),
+}))
+
+vi.mock('@/hooks/use-chat-search', () => ({
+  useChatSearch: () => ({
+    available: false,
+    results: [],
+    isSearching: false,
+  }),
+}))
+
+vi.mock('@/components/chat/drag-context', () => ({
+  useDrag: () => ({
+    draggingChatId: null,
+    draggingChatFromProjectId: null,
+    draggingChatSource: null,
+    dropTargetProjectId: null,
+    dropTargetTab: null,
+    isDropTargetChatHistory: false,
+    setDraggingChat: vi.fn(),
+    setDropTargetProject: vi.fn(),
+    setDropTargetTab: vi.fn(),
+    setDropTargetChatHistory: vi.fn(),
+    clearDragState: vi.fn(),
+  }),
+}))
+
+vi.mock('@/components/chat/use-favorite-drop-target', () => ({
+  useFavoriteDropTarget: () => ({
+    isFavoriteDropTarget: false,
+    favoriteDropTargetProps: {},
+  }),
+}))
+
+const currentChat = {
+  id: 'blank-chat',
+  title: 'New chat',
+  messages: [],
+  createdAt: new Date('2026-08-24T00:00:00.000Z'),
+  isBlankChat: true,
+} satisfies Chat
+
+function renderSidebar(isPremium: boolean) {
+  return render(
+    <ChatSidebar
+      isOpen={false}
+      setIsOpen={vi.fn()}
+      chats={[currentChat]}
+      currentChat={currentChat}
+      isDarkMode={false}
+      pixelateSidebarChatTitles={false}
+      createNewChat={vi.fn()}
+      handleChatSelect={vi.fn()}
+      updateChatTitle={vi.fn()}
+      deleteChat={vi.fn()}
+      isClient={true}
+      isPremium={isPremium}
+      onMoveChatToProject={vi.fn()}
+      windowWidth={1280}
+    />,
+  )
+}
+
+describe('ChatSidebar project access', () => {
+  beforeEach(() => {
+    sessionStorage.clear()
+    mocks.auth.isSignedIn = true
+    mocks.useProjects.mockReset().mockReturnValue({
+      projects: [],
+      loading: false,
+      refresh: vi.fn(),
+    })
+  })
+
+  it('makes cloud projects available to signed-in free accounts', () => {
+    renderSidebar(false)
+
+    expect(
+      screen.getAllByRole('button', { name: 'Projects' }),
+    ).not.toHaveLength(0)
+    expect(mocks.useProjects).toHaveBeenCalledWith({ autoLoad: true })
+  })
+
+  it('keeps projects unavailable to signed-out visitors', () => {
+    mocks.auth.isSignedIn = false
+    renderSidebar(false)
+
+    expect(screen.queryAllByRole('button', { name: 'Projects' })).toHaveLength(
+      0,
+    )
+    expect(mocks.useProjects).toHaveBeenCalledWith({ autoLoad: false })
+  })
+})


### PR DESCRIPTION
## Summary
- establish the web app behavior as the source of truth: projects are available to every signed-in account using cloud sync, regardless of subscription tier
- remove premium-only restrictions from project navigation, chat moves, imports, exports, and deletion
- keep project data restricted to authenticated accounts and add regression coverage for free and signed-out users

This resolves the platform discrepancy by defining the behavior that the iOS app should match.

## Testing
- `npm run test:unit -- --run tests/components/chat/chat-sidebar-project-access.test.tsx tests/hooks/use-projects.test.tsx`
- `npx eslint src/components/chat/chat-interface.tsx src/components/chat/chat-sidebar.tsx src/components/chat/settings-modal.tsx tests/components/chat/chat-sidebar-project-access.test.tsx`
- `npx tsc --noEmit -p tsconfig.json`