### PR TITLE
fix: align personalization and language defaults

### DIFF
--- a/src/components/chat/hooks/use-custom-system-prompt.ts
+++ b/src/components/chat/hooks/use-custom-system-prompt.ts
@@ -8,16 +8,15 @@ import {
   USER_PREFS_PROFESSION,
   USER_PREFS_TRAITS,
 } from '@/constants/storage-keys'
+import {
+  isPersonalizationEnabled,
+  type PersonalizationSettings,
+} from '@/utils/personalization-settings'
+import {
+  normalizeResponseLanguage,
+  resolveResponseLanguage,
+} from '@/utils/response-language'
 import { useEffect, useState } from 'react'
-
-type PersonalizationSettings = {
-  nickname: string
-  profession: string
-  traits: string[]
-  additionalContext: string
-  language: string
-  isEnabled: boolean
-}
 
 type UseCustomSystemPromptReturn = {
   effectiveSystemPrompt: string
@@ -48,8 +47,8 @@ export const useCustomSystemPrompt = (
       profession: '',
       traits: [],
       additionalContext: '',
-      language: '',
-      isEnabled: false,
+      language: normalizeResponseLanguage(null),
+      isEnabled: true,
     })
 
   const [isUsingCustomPrompt, setIsUsingCustomPrompt] = useState(false)
@@ -64,8 +63,9 @@ export const useCustomSystemPrompt = (
       const savedContext =
         localStorage.getItem(USER_PREFS_ADDITIONAL_CONTEXT) || ''
       const savedLanguage = localStorage.getItem(USER_PREFS_LANGUAGE)
-      const savedEnabled =
-        localStorage.getItem(USER_PREFS_PERSONALIZATION_ENABLED) === 'true'
+      const savedEnabled = localStorage.getItem(
+        USER_PREFS_PERSONALIZATION_ENABLED,
+      )
 
       let traits: string[] = []
       if (savedTraits) {
@@ -76,7 +76,7 @@ export const useCustomSystemPrompt = (
         }
       }
 
-      const language = savedLanguage || ''
+      const language = normalizeResponseLanguage(savedLanguage)
 
       setPersonalization({
         nickname: savedNickname,
@@ -84,7 +84,7 @@ export const useCustomSystemPrompt = (
         traits,
         additionalContext: savedContext,
         language,
-        isEnabled: savedEnabled,
+        isEnabled: isPersonalizationEnabled(savedEnabled),
       })
 
       // Load custom system prompt settings
@@ -115,21 +115,24 @@ export const useCustomSystemPrompt = (
         language,
         isEnabled,
       } = event.detail
-      setPersonalization({
+      setPersonalization((previous) => ({
         nickname: nickname || '',
         profession: profession || '',
         traits: traits || [],
         additionalContext: additionalContext || '',
-        language: language || personalization.language, // Keep existing language if not provided
-        isEnabled: isEnabled || false,
-      })
+        language:
+          typeof language === 'string'
+            ? normalizeResponseLanguage(language)
+            : previous.language,
+        isEnabled: isEnabled !== false,
+      }))
     }
 
     const handleLanguageChange = (event: CustomEvent) => {
       const { language } = event.detail
       setPersonalization((prev) => ({
         ...prev,
-        language: language || '',
+        language: normalizeResponseLanguage(language),
       }))
     }
 
@@ -166,7 +169,7 @@ export const useCustomSystemPrompt = (
         handleCustomPromptChange as EventListener,
       )
     }
-  }, [personalization.language, defaultSystemPrompt])
+  }, [defaultSystemPrompt])
 
   // Generate the user preferences XML
   const generateUserPreferencesXML = (): string => {
@@ -211,14 +214,11 @@ export const useCustomSystemPrompt = (
 
   // Shared helper to replace placeholders in text
   const replacePlaceholders = (text: string): string => {
-    // Personalization is opt-in: even when fields are filled, nothing
-    // is sent to the model unless the user enabled the toggle.
     const userPreferencesXML = personalization.isEnabled
       ? generateUserPreferencesXML()
       : ''
 
-    // Get the effective language (default to English if not set)
-    const effectiveLanguage = personalization.language.trim() || 'English'
+    const effectiveLanguage = resolveResponseLanguage(personalization.language)
 
     // Extract timezone separately
     const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone

--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -69,6 +69,15 @@ import {
   setLocalOnlyModeEnabled,
 } from '@/utils/cloud-sync-settings'
 import { logError, logInfo, logWarning } from '@/utils/error-handling'
+import {
+  clearPersonalizationDetails,
+  isPersonalizationEnabled,
+} from '@/utils/personalization-settings'
+import {
+  normalizeResponseLanguage,
+  RESPONSE_LANGUAGES,
+  SYSTEM_RESPONSE_LANGUAGE,
+} from '@/utils/response-language'
 import { generateReverseId } from '@/utils/reverse-id'
 import {
   hideSignoutProgress,
@@ -419,9 +428,11 @@ export function SettingsModal({
     traits: string[]
     additionalContext: string
   }>({ nickname: '', profession: '', traits: [], additionalContext: '' })
+  const [showClearPersonalizationConfirm, setShowClearPersonalizationConfirm] =
+    useState(false)
 
   // Language setting (separate from personalization)
-  const [language, setLanguage] = useState<string>('')
+  const [language, setLanguage] = useState<string>(SYSTEM_RESPONSE_LANGUAGE)
 
   // Custom system prompt settings
   const [isUsingCustomPrompt, setIsUsingCustomPrompt] = useState<boolean>(false)
@@ -551,30 +562,6 @@ export function SettingsModal({
     'optimistic',
   ]
 
-  // Available languages for dropdown
-  const availableLanguages = [
-    'English',
-    'Spanish',
-    'French',
-    'German',
-    'Italian',
-    'Portuguese',
-    'Russian',
-    'Japanese',
-    'Korean',
-    'Chinese (Simplified)',
-    'Chinese (Traditional)',
-    'Arabic',
-    'Hindi',
-    'Dutch',
-    'Swedish',
-    'Norwegian',
-    'Danish',
-    'Finnish',
-    'Polish',
-    'Turkish',
-  ]
-
   // Shared function to load settings from localStorage
   const loadSettingsFromStorage = useCallback(() => {
     // Load personalization settings
@@ -604,15 +591,13 @@ export function SettingsModal({
       traits: parsedTraits,
       additionalContext: savedContext ?? '',
     })
-    if (savedUsingPersonalization !== null) {
-      setIsUsingPersonalization(savedUsingPersonalization === 'true')
-    }
+    setIsUsingPersonalization(
+      isPersonalizationEnabled(savedUsingPersonalization),
+    )
 
     // Load language setting
     const savedLanguage = localStorage.getItem(USER_PREFS_LANGUAGE)
-    if (savedLanguage) {
-      setLanguage(savedLanguage)
-    }
+    setLanguage(normalizeResponseLanguage(savedLanguage))
 
     // Load custom system prompt settings
     const savedUsingCustomPrompt = localStorage.getItem(
@@ -669,13 +654,6 @@ export function SettingsModal({
   useEffect(() => {
     if (isClient) {
       loadSettingsFromStorage()
-
-      // Set default language if not already set
-      const savedLanguage = localStorage.getItem(USER_PREFS_LANGUAGE)
-      if (!savedLanguage) {
-        setLanguage('English')
-        localStorage.setItem(USER_PREFS_LANGUAGE, 'English')
-      }
     }
   }, [isClient, loadSettingsFromStorage])
 
@@ -914,32 +892,34 @@ export function SettingsModal({
     }
   }
 
-  const handleResetPersonalization = () => {
-    setNickname('')
-    setProfession('')
-    setSelectedTraits([])
-    setAdditionalContext('')
-    setLanguage('English')
-    setSavedPersonalization({
-      nickname: '',
-      profession: '',
-      traits: [],
-      additionalContext: '',
+  const handleClearPersonalization = () => {
+    const cleared = clearPersonalizationDetails({
+      nickname,
+      profession,
+      traits: selectedTraits,
+      additionalContext,
+      language,
+      isEnabled: isUsingPersonalization,
     })
+    setNickname(cleared.nickname)
+    setProfession(cleared.profession)
+    setSelectedTraits(cleared.traits)
+    setAdditionalContext(cleared.additionalContext)
+    setSavedPersonalization({
+      nickname: cleared.nickname,
+      profession: cleared.profession,
+      traits: cleared.traits,
+      additionalContext: cleared.additionalContext,
+    })
+    setShowClearPersonalizationConfirm(false)
 
     if (isClient) {
-      localStorage.removeItem(USER_PREFS_NICKNAME)
-      localStorage.removeItem(USER_PREFS_PROFESSION)
-      localStorage.removeItem(USER_PREFS_TRAITS)
-      localStorage.removeItem(USER_PREFS_ADDITIONAL_CONTEXT)
-      localStorage.setItem(USER_PREFS_LANGUAGE, 'English')
-      saveLanguageSetting('English')
       savePersonalizationSettings({
-        nickname: '',
-        profession: '',
-        traits: [],
-        additionalContext: '',
-        isEnabled: isUsingPersonalization,
+        nickname: cleared.nickname,
+        profession: cleared.profession,
+        traits: cleared.traits,
+        additionalContext: cleared.additionalContext,
+        isEnabled: cleared.isEnabled,
       })
     }
   }
@@ -2411,7 +2391,10 @@ ${encryptionKey.replace('key_', '')}
                               : 'border-border-subtle bg-surface-sidebar text-content-primary',
                           )}
                         >
-                          {availableLanguages.map((lang) => (
+                          {!RESPONSE_LANGUAGES.some(
+                            (option) => option === language,
+                          ) && <option value={language}>{language}</option>}
+                          {RESPONSE_LANGUAGES.map((lang) => (
                             <option key={lang} value={lang}>
                               {lang}
                             </option>
@@ -2984,18 +2967,50 @@ ${encryptionKey.replace('key_', '')}
                         </div>
                       </div>
 
-                      {/* Reset Button */}
-                      <button
-                        onClick={handleResetPersonalization}
-                        className={cn(
-                          'w-full rounded-lg border px-3 py-1.5 text-sm font-medium transition-colors',
-                          isDarkMode
-                            ? 'border-red-500/30 bg-red-950/20 text-red-400 hover:bg-red-950/40'
-                            : 'border-red-300 bg-red-50 text-red-600 hover:bg-red-100',
-                        )}
-                      >
-                        Reset all fields
-                      </button>
+                      {!showClearPersonalizationConfirm ? (
+                        <button
+                          onClick={() =>
+                            setShowClearPersonalizationConfirm(true)
+                          }
+                          className={cn(
+                            'w-full rounded-lg border px-3 py-1.5 text-sm font-medium transition-colors',
+                            isDarkMode
+                              ? 'border-red-500/30 bg-red-950/20 text-red-400 hover:bg-red-950/40'
+                              : 'border-red-300 bg-red-50 text-red-600 hover:bg-red-100',
+                          )}
+                        >
+                          Clear details
+                        </button>
+                      ) : (
+                        <div className="space-y-2 rounded-lg border border-border-subtle p-3">
+                          <p className="font-aeonik-fono text-xs text-content-muted">
+                            Clear your name, occupation, traits, and additional
+                            context? Your personalization setting and response
+                            language will not change.
+                          </p>
+                          <div className="flex gap-2">
+                            <button
+                              onClick={handleClearPersonalization}
+                              className={cn(
+                                'flex-1 rounded-md px-3 py-1.5 text-sm font-medium text-white',
+                                isDarkMode
+                                  ? 'bg-red-600 hover:bg-red-500'
+                                  : 'bg-red-600 hover:bg-red-700',
+                              )}
+                            >
+                              Clear details
+                            </button>
+                            <button
+                              onClick={() =>
+                                setShowClearPersonalizationConfirm(false)
+                              }
+                              className="flex-1 rounded-md border border-border-subtle px-3 py-1.5 text-sm font-medium text-content-secondary"
+                            >
+                              Cancel
+                            </button>
+                          </div>
+                        </div>
+                      )}
                     </>
                   )}
                 </>

--- a/src/services/cloud/profile-merge.ts
+++ b/src/services/cloud/profile-merge.ts
@@ -41,6 +41,10 @@ const PRESERVE_LOCAL_WHEN_REMOTE_OMITS = new Set<
   (typeof PROFILE_MERGE_FIELDS)[number]
 >(['pixelateSidebarChatTitlesEnabled', 'pinnedChatIds'])
 
+const TREAT_LOCAL_OMISSION_AS_UNEDITED = new Set<
+  (typeof PROFILE_MERGE_FIELDS)[number]
+>(['language', 'isUsingPersonalization'])
+
 // A blob's field clocks are trustworthy only when they were maintained
 // at the row's current server version. If a clock-unaware client wrote
 // since, clockVersion lags the etag and we must not trust the clocks.
@@ -245,7 +249,11 @@ export function mergeProfilesThreeWay(args: {
 
   for (const field of PROFILE_MERGE_FIELDS) {
     const baselineValue = (baseline as Record<string, unknown>)[field]
-    const localValue = (local as Record<string, unknown>)[field]
+    const localHasField = Object.prototype.hasOwnProperty.call(local, field)
+    const localValue =
+      !localHasField && TREAT_LOCAL_OMISSION_AS_UNEDITED.has(field)
+        ? baselineValue
+        : (local as Record<string, unknown>)[field]
     const remoteValue = (remote as Record<string, unknown>)[field]
     const lc = fieldClock(local, field, localTrusted)
     const rc = fieldClock(remote, field, remoteTrusted)

--- a/src/services/cloud/profile-settings-serializer.ts
+++ b/src/services/cloud/profile-settings-serializer.ts
@@ -133,9 +133,10 @@ export function loadLocalSettings(): ProfileData {
     settings.themeMode = savedThemeMode
   }
 
-  settings.language = normalizeResponseLanguage(
-    localStorage.getItem(USER_PREFS_LANGUAGE),
-  )
+  const language = localStorage.getItem(USER_PREFS_LANGUAGE)
+  if (language) {
+    settings.language = normalizeResponseLanguage(language)
+  }
 
   // Personalization
   const nickname = localStorage.getItem(USER_PREFS_NICKNAME)
@@ -159,9 +160,11 @@ export function loadLocalSettings(): ProfileData {
   const isUsingPersonalization = localStorage.getItem(
     USER_PREFS_PERSONALIZATION_ENABLED,
   )
-  settings.isUsingPersonalization = isPersonalizationEnabled(
-    isUsingPersonalization,
-  )
+  if (isUsingPersonalization) {
+    settings.isUsingPersonalization = isPersonalizationEnabled(
+      isUsingPersonalization,
+    )
+  }
 
   // Custom system prompt settings
   const isUsingCustomPrompt = localStorage.getItem(

--- a/src/services/cloud/profile-settings-serializer.ts
+++ b/src/services/cloud/profile-settings-serializer.ts
@@ -31,13 +31,16 @@ import type {
   ProfilePromptPreset,
 } from '@/services/cloud/profile-sync'
 import { logWarning } from '@/utils/error-handling'
+import { isPersonalizationEnabled } from '@/utils/personalization-settings'
+import {
+  normalizeResponseLanguage,
+  SYSTEM_RESPONSE_LANGUAGE,
+} from '@/utils/response-language'
 import {
   loadPinnedChatIds,
   normalizePinnedChatIds,
 } from '../storage/pinned-chats'
 import { ProfileDataSchema } from './schemas'
-
-const DEFAULT_PROFILE_LANGUAGE = 'English'
 
 function safeParsePromptPresets(raw: string | null): ProfilePromptPreset[] {
   if (!raw) return []
@@ -130,10 +133,9 @@ export function loadLocalSettings(): ProfileData {
     settings.themeMode = savedThemeMode
   }
 
-  const language = localStorage.getItem(USER_PREFS_LANGUAGE)
-  if (language) {
-    settings.language = language
-  }
+  settings.language = normalizeResponseLanguage(
+    localStorage.getItem(USER_PREFS_LANGUAGE),
+  )
 
   // Personalization
   const nickname = localStorage.getItem(USER_PREFS_NICKNAME)
@@ -157,9 +159,9 @@ export function loadLocalSettings(): ProfileData {
   const isUsingPersonalization = localStorage.getItem(
     USER_PREFS_PERSONALIZATION_ENABLED,
   )
-  if (isUsingPersonalization) {
-    settings.isUsingPersonalization = isUsingPersonalization === 'true'
-  }
+  settings.isUsingPersonalization = isPersonalizationEnabled(
+    isUsingPersonalization,
+  )
 
   // Custom system prompt settings
   const isUsingCustomPrompt = localStorage.getItem(
@@ -264,12 +266,12 @@ export function loadLocalSettings(): ProfileData {
 export function resetSettingsToLocalDefaults(): ProfileData {
   const defaults: ProfileData = {
     themeMode: 'system',
-    language: DEFAULT_PROFILE_LANGUAGE,
+    language: SYSTEM_RESPONSE_LANGUAGE,
     nickname: '',
     profession: '',
     traits: [],
     additionalContext: '',
-    isUsingPersonalization: false,
+    isUsingPersonalization: true,
     isUsingCustomPrompt: false,
     customSystemPrompt: '',
     customPromptPresets: [],
@@ -585,10 +587,12 @@ export function applySettingsToLocal(settings: ProfileData): void {
           language:
             settings.language ??
             localStorage.getItem(USER_PREFS_LANGUAGE) ??
-            'English',
+            SYSTEM_RESPONSE_LANGUAGE,
           isEnabled:
             settings.isUsingPersonalization ??
-            localStorage.getItem(USER_PREFS_PERSONALIZATION_ENABLED) === 'true',
+            isPersonalizationEnabled(
+              localStorage.getItem(USER_PREFS_PERSONALIZATION_ENABLED),
+            ),
         },
       }),
     )

--- a/src/utils/personalization-settings.ts
+++ b/src/utils/personalization-settings.ts
@@ -1,0 +1,24 @@
+export type PersonalizationSettings = {
+  nickname: string
+  profession: string
+  traits: string[]
+  additionalContext: string
+  language: string
+  isEnabled: boolean
+}
+
+export function isPersonalizationEnabled(value: string | null): boolean {
+  return value !== 'false'
+}
+
+export function clearPersonalizationDetails(
+  settings: PersonalizationSettings,
+): PersonalizationSettings {
+  return {
+    ...settings,
+    nickname: '',
+    profession: '',
+    traits: [],
+    additionalContext: '',
+  }
+}

--- a/src/utils/response-language.ts
+++ b/src/utils/response-language.ts
@@ -1,0 +1,111 @@
+export const SYSTEM_RESPONSE_LANGUAGE = 'System'
+
+export const RESPONSE_LANGUAGES = [
+  SYSTEM_RESPONSE_LANGUAGE,
+  ...[
+    'Afrikaans',
+    'Albanian',
+    'Arabic',
+    'Armenian',
+    'Azerbaijani',
+    'Basque',
+    'Belarusian',
+    'Bengali',
+    'Bosnian',
+    'Bulgarian',
+    'Catalan',
+    'Chinese (Simplified)',
+    'Chinese (Traditional)',
+    'Croatian',
+    'Czech',
+    'Danish',
+    'Dutch',
+    'English',
+    'Estonian',
+    'Filipino',
+    'Finnish',
+    'French',
+    'Galician',
+    'Georgian',
+    'German',
+    'Greek',
+    'Gujarati',
+    'Haitian Creole',
+    'Hebrew',
+    'Hindi',
+    'Hungarian',
+    'Icelandic',
+    'Indonesian',
+    'Irish',
+    'Italian',
+    'Japanese',
+    'Kannada',
+    'Kazakh',
+    'Korean',
+    'Latin',
+    'Latvian',
+    'Lithuanian',
+    'Macedonian',
+    'Malay',
+    'Malayalam',
+    'Maltese',
+    'Marathi',
+    'Mongolian',
+    'Norwegian',
+    'Persian',
+    'Polish',
+    'Portuguese',
+    'Romanian',
+    'Russian',
+    'Serbian',
+    'Slovak',
+    'Slovenian',
+    'Spanish',
+    'Swahili',
+    'Swedish',
+    'Tamil',
+    'Telugu',
+    'Thai',
+    'Turkish',
+    'Ukrainian',
+    'Urdu',
+    'Uzbek',
+    'Vietnamese',
+    'Welsh',
+    'Yiddish',
+  ].sort(),
+] as const
+
+export function normalizeResponseLanguage(
+  language: string | null | undefined,
+): string {
+  return language && language.trim() ? language : SYSTEM_RESPONSE_LANGUAGE
+}
+
+export function resolveResponseLanguage(
+  language: string | null | undefined,
+  locales?: readonly string[],
+): string {
+  const normalized = normalizeResponseLanguage(language)
+  if (normalized !== SYSTEM_RESPONSE_LANGUAGE) return normalized
+
+  const browserLocales =
+    locales ??
+    (typeof navigator === 'undefined'
+      ? []
+      : [...navigator.languages, navigator.language])
+  const locale = browserLocales.find((candidate) => candidate.trim())
+  if (!locale) return 'English'
+
+  try {
+    const canonicalLocale = Intl.getCanonicalLocales(
+      locale.replace('_', '-'),
+    )[0]
+    return (
+      new Intl.DisplayNames(['en'], { type: 'language' }).of(canonicalLocale) ??
+      'English'
+    )
+  } catch {
+    return 'English'
+  }
+}

--- a/tests/components/chat/use-custom-system-prompt.test.tsx
+++ b/tests/components/chat/use-custom-system-prompt.test.tsx
@@ -1,0 +1,53 @@
+import { useCustomSystemPrompt } from '@/components/chat/hooks/use-custom-system-prompt'
+import {
+  USER_PREFS_NICKNAME,
+  USER_PREFS_PERSONALIZATION_ENABLED,
+} from '@/constants/storage-keys'
+import { renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+const prompt = 'Preferences: {USER_PREFERENCES}\nLanguage: {LANGUAGE}'
+
+describe('useCustomSystemPrompt personalization', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    localStorage.setItem(USER_PREFS_NICKNAME, 'Ada')
+  })
+
+  it('includes details when the enabled flag is missing', async () => {
+    const { result } = renderHook(() => useCustomSystemPrompt(prompt))
+
+    await waitFor(() =>
+      expect(result.current.effectiveSystemPrompt).toContain(
+        '<nickname>Ada</nickname>',
+      ),
+    )
+    expect(result.current.isUsingPersonalization).toBe(true)
+  })
+
+  it('includes details when explicitly enabled', async () => {
+    localStorage.setItem(USER_PREFS_PERSONALIZATION_ENABLED, 'true')
+    const { result } = renderHook(() => useCustomSystemPrompt(prompt))
+
+    await waitFor(() =>
+      expect(result.current.effectiveSystemPrompt).toContain(
+        '<nickname>Ada</nickname>',
+      ),
+    )
+  })
+
+  it('suppresses all details when explicitly disabled', async () => {
+    localStorage.setItem(USER_PREFS_PERSONALIZATION_ENABLED, 'false')
+    const { result } = renderHook(() => useCustomSystemPrompt(prompt))
+
+    await waitFor(() =>
+      expect(result.current.effectiveSystemPrompt).not.toContain(
+        '<nickname>Ada</nickname>',
+      ),
+    )
+    expect(result.current.effectiveSystemPrompt).not.toContain(
+      '<user_preferences>',
+    )
+    expect(result.current.isUsingPersonalization).toBe(false)
+  })
+})

--- a/tests/services/cloud/profile-merge.test.ts
+++ b/tests/services/cloud/profile-merge.test.ts
@@ -519,6 +519,34 @@ describe('mergeProfilesThreeWay', () => {
     expect(result.conflicts).toEqual([])
   })
 
+  it('retains baseline preferences when migrated local keys are absent', () => {
+    const result = mergeProfilesThreeWay({
+      baseline: { language: 'Spanish', isUsingPersonalization: false },
+      local: {},
+      remote: {
+        language: 'Spanish',
+        isUsingPersonalization: false,
+        version: 2,
+      },
+    })
+
+    expect(result.merged.language).toBe('Spanish')
+    expect(result.merged.isUsingPersonalization).toBe(false)
+    expect(result.conflicts).toEqual([])
+  })
+
+  it('adopts remote preference updates when migrated local keys are absent', () => {
+    const result = mergeProfilesThreeWay({
+      baseline: { language: 'Spanish', isUsingPersonalization: true },
+      local: {},
+      remote: { language: 'French', isUsingPersonalization: false, version: 2 },
+    })
+
+    expect(result.merged.language).toBe('French')
+    expect(result.merged.isUsingPersonalization).toBe(false)
+    expect(result.conflicts).toEqual([])
+  })
+
   it('combines independent edits from both devices', () => {
     const result = mergeProfilesThreeWay({
       baseline: { nickname: 'Ada', profession: 'Engineer' },

--- a/tests/services/cloud/profile-settings-serializer.test.ts
+++ b/tests/services/cloud/profile-settings-serializer.test.ts
@@ -12,6 +12,7 @@ import {
   USER_PREFS_CUSTOM_PROMPT_PRESETS,
   USER_PREFS_CUSTOM_SYSTEM_PROMPT,
   USER_PREFS_FAVORITE_PROMPT_PRESETS,
+  USER_PREFS_LANGUAGE,
   USER_PREFS_NICKNAME,
   USER_PREFS_PERSONALIZATION_ENABLED,
   USER_PREFS_PINNED_CHAT_IDS,
@@ -46,6 +47,22 @@ describe('profile-settings-serializer', () => {
       customSystemPrompt: '',
       isUsingPersonalization: false,
     })
+  })
+
+  it('uses shared defaults when language and personalization are missing', () => {
+    expect(loadLocalSettings()).toMatchObject({
+      language: 'System',
+      isUsingPersonalization: true,
+    })
+  })
+
+  it('preserves explicit and unknown response languages through storage', () => {
+    localStorage.setItem(USER_PREFS_LANGUAGE, 'Klingon')
+    expect(loadLocalSettings().language).toBe('Klingon')
+
+    applySettingsToLocal({ language: 'Elvish' })
+    expect(localStorage.getItem(USER_PREFS_LANGUAGE)).toBe('Elvish')
+    expect(loadLocalSettings().language).toBe('Elvish')
   })
 
   it('round-trips pins while preserving absent and explicit-clear semantics', () => {
@@ -92,6 +109,23 @@ describe('profile-settings-serializer', () => {
     expect(localStorage.getItem(USER_PREFS_PERSONALIZATION_ENABLED)).toBe(
       'true',
     )
+  })
+
+  it('retains saved details when personalization is disabled', () => {
+    localStorage.setItem(USER_PREFS_NICKNAME, 'Alice')
+    localStorage.setItem(USER_PREFS_PROFESSION, 'Dev')
+    localStorage.setItem(USER_PREFS_TRAITS, JSON.stringify(['concise']))
+    localStorage.setItem(USER_PREFS_ADDITIONAL_CONTEXT, 'context')
+
+    applySettingsToLocal({ isUsingPersonalization: false })
+
+    expect(loadLocalSettings()).toMatchObject({
+      nickname: 'Alice',
+      profession: 'Dev',
+      traits: ['concise'],
+      additionalContext: 'context',
+      isUsingPersonalization: false,
+    })
   })
 
   it('clears explicitly emptied personalization fields', () => {

--- a/tests/services/cloud/profile-settings-serializer.test.ts
+++ b/tests/services/cloud/profile-settings-serializer.test.ts
@@ -49,11 +49,9 @@ describe('profile-settings-serializer', () => {
     })
   })
 
-  it('uses shared defaults when language and personalization are missing', () => {
-    expect(loadLocalSettings()).toMatchObject({
-      language: 'System',
-      isUsingPersonalization: true,
-    })
+  it('preserves absent language and personalization as unedited fields', () => {
+    expect(loadLocalSettings().language).toBeUndefined()
+    expect(loadLocalSettings().isUsingPersonalization).toBeUndefined()
   })
 
   it('preserves explicit and unknown response languages through storage', () => {

--- a/tests/utils/personalization-settings.test.ts
+++ b/tests/utils/personalization-settings.test.ts
@@ -1,0 +1,36 @@
+import {
+  clearPersonalizationDetails,
+  isPersonalizationEnabled,
+} from '@/utils/personalization-settings'
+import { describe, expect, it } from 'vitest'
+
+describe('personalization settings', () => {
+  it('defaults missing and enabled flags to on', () => {
+    expect(isPersonalizationEnabled(null)).toBe(true)
+    expect(isPersonalizationEnabled('true')).toBe(true)
+  })
+
+  it('treats only explicit false as off', () => {
+    expect(isPersonalizationEnabled('false')).toBe(false)
+  })
+
+  it('clears details without changing the toggle or language', () => {
+    expect(
+      clearPersonalizationDetails({
+        nickname: 'Ada',
+        profession: 'Engineer',
+        traits: ['direct'],
+        additionalContext: 'Use examples',
+        language: 'Welsh',
+        isEnabled: false,
+      }),
+    ).toEqual({
+      nickname: '',
+      profession: '',
+      traits: [],
+      additionalContext: '',
+      language: 'Welsh',
+      isEnabled: false,
+    })
+  })
+})

--- a/tests/utils/response-language.test.ts
+++ b/tests/utils/response-language.test.ts
@@ -1,0 +1,34 @@
+import {
+  normalizeResponseLanguage,
+  resolveResponseLanguage,
+  RESPONSE_LANGUAGES,
+  SYSTEM_RESPONSE_LANGUAGE,
+} from '@/utils/response-language'
+import { describe, expect, it } from 'vitest'
+
+describe('response language', () => {
+  it('defaults missing and empty values to System', () => {
+    expect(normalizeResponseLanguage(null)).toBe(SYSTEM_RESPONSE_LANGUAGE)
+    expect(normalizeResponseLanguage('')).toBe(SYSTEM_RESPONSE_LANGUAGE)
+  })
+
+  it('resolves System from the preferred browser locale', () => {
+    expect(resolveResponseLanguage('System', ['fr-CA', 'en-US'])).toBe(
+      'Canadian French',
+    )
+    expect(resolveResponseLanguage('System', ['ja-JP'])).not.toBe('System')
+  })
+
+  it('preserves known and unknown explicit values', () => {
+    expect(resolveResponseLanguage('Spanish', ['fr-CA'])).toBe('Spanish')
+    expect(resolveResponseLanguage('Klingon', ['fr-CA'])).toBe('Klingon')
+    expect(normalizeResponseLanguage('  Klingon  ')).toBe('  Klingon  ')
+  })
+
+  it('matches the current iOS language choices', () => {
+    expect(RESPONSE_LANGUAGES).toContain('System')
+    expect(RESPONSE_LANGUAGES).toContain('Afrikaans')
+    expect(RESPONSE_LANGUAGES).toContain('Yiddish')
+    expect(RESPONSE_LANGUAGES).toHaveLength(71)
+  })
+})


### PR DESCRIPTION
## Summary
- make missing Personalize responses settings default on while respecting explicit off
- retain saved details while disabled and clear only personalization fields
- add System response language and resolve it from the browser locale
- preserve explicit and unknown synced language values

## Testing
- 1,979 unit tests
- typecheck and lint

## Related
Coordinate with the iOS personalization/language PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns personalization and response language defaults so missing settings behave predictably while explicit user choices stay intact.

- Personalization defaults to enabled when the flag is missing; only an explicit `false` disables it.
- Adds a "System" response language that resolves from the browser locale instead of defaulting to English.
- Profile sync treats absent language and personalization settings as unedited, so remote updates win without conflicts and previously saved details survive re-syncs.
- Sync retains saved details while personalization is disabled and round-trips explicit or unknown language values; only missing or empty local values become "System".
- The clear details action now wipes only name, occupation, traits, and context, leaving the toggle and language untouched.
- Coordinates with the iOS personalization/language PR.

<sup>Written for commit 60f187130695adfbc5889f4f4e99aa1ea1135280. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/547?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

