### PR TITLE
fix: correct chat deletion confirmation

### DIFF
--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -121,10 +121,14 @@ const DELETE_ALL_CHATS_CONFIRM_PHRASE = 'delete all chats'
 const DELETE_ALL_PROJECTS_CONFIRM_PHRASE = 'delete all projects'
 
 export function getDeleteAllChatsSuccessDescription(
-  isSignedIn?: boolean,
+  isSignedIn: boolean,
+  cloudDeletionCompleted: boolean,
 ): string {
+  if (cloudDeletionCompleted) {
+    return 'Removed all chats from this device and encrypted cloud storage.'
+  }
   return isSignedIn
-    ? 'Removed all chats from this device and encrypted cloud storage.'
+    ? 'Removed all chats from this device. Encrypted cloud storage was not cleared.'
     : 'Removed all chats from this browser session.'
 }
 
@@ -1802,16 +1806,19 @@ export function SettingsModal({
     setIsDeletingAllChats(true)
     try {
       if (isSignedIn) {
-        await chatStorage.deleteAllChats()
+        const result = await chatStorage.deleteAllChats()
         toast({
           title: 'All chats deleted',
-          description: getDeleteAllChatsSuccessDescription(isSignedIn),
+          description: getDeleteAllChatsSuccessDescription(
+            true,
+            result.cloudDeletionCompleted,
+          ),
         })
       } else {
         sessionChatStorage.clearAll()
         toast({
           title: 'All chats deleted',
-          description: getDeleteAllChatsSuccessDescription(isSignedIn),
+          description: getDeleteAllChatsSuccessDescription(false, false),
         })
       }
 

--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -120,6 +120,15 @@ const DASHBOARD_URL = 'https://dash.tinfoil.sh'
 const DELETE_ALL_CHATS_CONFIRM_PHRASE = 'delete all chats'
 const DELETE_ALL_PROJECTS_CONFIRM_PHRASE = 'delete all projects'
 
+export function getDeleteAllChatsSuccessTitle(
+  isSignedIn: boolean,
+  cloudDeletionCompleted: boolean,
+): string {
+  return isSignedIn && !cloudDeletionCompleted
+    ? 'Chats deleted from this device'
+    : 'All chats deleted'
+}
+
 export function getDeleteAllChatsSuccessDescription(
   isSignedIn: boolean,
   cloudDeletionCompleted: boolean,
@@ -1808,7 +1817,10 @@ export function SettingsModal({
       if (isSignedIn) {
         const result = await chatStorage.deleteAllChats()
         toast({
-          title: 'All chats deleted',
+          title: getDeleteAllChatsSuccessTitle(
+            true,
+            result.cloudDeletionCompleted,
+          ),
           description: getDeleteAllChatsSuccessDescription(
             true,
             result.cloudDeletionCompleted,
@@ -1817,7 +1829,7 @@ export function SettingsModal({
       } else {
         sessionChatStorage.clearAll()
         toast({
-          title: 'All chats deleted',
+          title: getDeleteAllChatsSuccessTitle(false, false),
           description: getDeleteAllChatsSuccessDescription(false, false),
         })
       }

--- a/src/components/chat/settings-modal.tsx
+++ b/src/components/chat/settings-modal.tsx
@@ -120,6 +120,14 @@ const DASHBOARD_URL = 'https://dash.tinfoil.sh'
 const DELETE_ALL_CHATS_CONFIRM_PHRASE = 'delete all chats'
 const DELETE_ALL_PROJECTS_CONFIRM_PHRASE = 'delete all projects'
 
+export function getDeleteAllChatsSuccessDescription(
+  isSignedIn?: boolean,
+): string {
+  return isSignedIn
+    ? 'Removed all chats from this device and encrypted cloud storage.'
+    : 'Removed all chats from this browser session.'
+}
+
 const ScrambleText = ({
   text,
   className,
@@ -1794,18 +1802,16 @@ export function SettingsModal({
     setIsDeletingAllChats(true)
     try {
       if (isSignedIn) {
-        const result = await chatStorage.deleteAllChats()
+        await chatStorage.deleteAllChats()
         toast({
           title: 'All chats deleted',
-          description: result.notificationSent
-            ? 'We will email you a confirmation.'
-            : 'Email confirmation could not be sent.',
+          description: getDeleteAllChatsSuccessDescription(isSignedIn),
         })
       } else {
         sessionChatStorage.clearAll()
         toast({
           title: 'All chats deleted',
-          description: 'Removed all chats from this browser session.',
+          description: getDeleteAllChatsSuccessDescription(isSignedIn),
         })
       }
 

--- a/src/services/cloud/cloud-storage.ts
+++ b/src/services/cloud/cloud-storage.ts
@@ -682,7 +682,6 @@ export class CloudStorageService {
 
   async deleteAllChats(guard?: AccountOperationGuard): Promise<{
     deleted: number
-    notificationSent?: boolean
   }> {
     let deleted = 0
     let cursor: string | undefined
@@ -718,7 +717,6 @@ export class CloudStorageService {
     guard?: AccountOperationGuard,
   ): Promise<{
     deleted: number
-    notificationSent?: boolean
   }> {
     // Single server-side bulk delete: the controlplane removes every chat
     // in the project and writes one tombstone per row, so other devices
@@ -739,9 +737,9 @@ export class CloudStorageService {
       throw new Error(`Failed to delete project chats: ${response.statusText}`)
     }
 
-    const result = await response.json()
+    const result: { deleted: number } = await response.json()
     guard?.assertCurrent()
-    return result
+    return { deleted: result.deleted }
   }
 
   async listChatIdsByProject(

--- a/src/services/storage/chat-storage.ts
+++ b/src/services/storage/chat-storage.ts
@@ -291,6 +291,7 @@ export class ChatStorageService {
   async deleteAllChats(): Promise<{
     localDeleted: number
     cloudDeleted: number
+    cloudDeletionCompleted: boolean
   }> {
     // Capture the guard before any await so the whole operation —
     // ID snapshot, cloud delete, and local wipe — is pinned to the
@@ -311,11 +312,13 @@ export class ChatStorageService {
     // and skip both the tracker update and the local wipe so the user can
     // retry without partial-deletion side effects.
     let cloudDeleted = 0
+    let cloudDeletionCompleted = false
     if (await cloudStorage.isAuthenticated()) {
       try {
         guard.assertCurrent()
         const result = await cloudStorage.deleteAllChats(guard)
         cloudDeleted = result.deleted
+        cloudDeletionCompleted = true
       } catch (error) {
         logError('Failed to bulk-delete cloud chats', error, {
           component: 'ChatStorageService',
@@ -343,7 +346,7 @@ export class ChatStorageService {
       metadata: { localDeleted, cloudDeleted },
     })
 
-    return { localDeleted, cloudDeleted }
+    return { localDeleted, cloudDeleted, cloudDeletionCompleted }
   }
 
   async getAllChats(): Promise<Chat[]> {

--- a/src/services/storage/chat-storage.ts
+++ b/src/services/storage/chat-storage.ts
@@ -291,7 +291,6 @@ export class ChatStorageService {
   async deleteAllChats(): Promise<{
     localDeleted: number
     cloudDeleted: number
-    notificationSent: boolean
   }> {
     // Capture the guard before any await so the whole operation —
     // ID snapshot, cloud delete, and local wipe — is pinned to the
@@ -312,13 +311,11 @@ export class ChatStorageService {
     // and skip both the tracker update and the local wipe so the user can
     // retry without partial-deletion side effects.
     let cloudDeleted = 0
-    let notificationSent = false
     if (await cloudStorage.isAuthenticated()) {
       try {
         guard.assertCurrent()
         const result = await cloudStorage.deleteAllChats(guard)
         cloudDeleted = result.deleted
-        notificationSent = result.notificationSent ?? false
       } catch (error) {
         logError('Failed to bulk-delete cloud chats', error, {
           component: 'ChatStorageService',
@@ -346,7 +343,7 @@ export class ChatStorageService {
       metadata: { localDeleted, cloudDeleted },
     })
 
-    return { localDeleted, cloudDeleted, notificationSent }
+    return { localDeleted, cloudDeleted }
   }
 
   async getAllChats(): Promise<Chat[]> {

--- a/tests/components/chat/settings-modal.test.ts
+++ b/tests/components/chat/settings-modal.test.ts
@@ -1,7 +1,20 @@
-import { getDeleteAllChatsSuccessDescription } from '@/components/chat/settings-modal'
+import {
+  getDeleteAllChatsSuccessDescription,
+  getDeleteAllChatsSuccessTitle,
+} from '@/components/chat/settings-modal'
 import { describe, expect, it } from 'vitest'
 
 describe('settings chat deletion confirmation', () => {
+  it('scopes the title to the device when cloud deletion is incomplete', () => {
+    expect(getDeleteAllChatsSuccessTitle(true, false)).toBe(
+      'Chats deleted from this device',
+    )
+    expect(getDeleteAllChatsSuccessTitle(true, true)).toBe('All chats deleted')
+    expect(getDeleteAllChatsSuccessTitle(false, false)).toBe(
+      'All chats deleted',
+    )
+  })
+
   it('describes completed cloud deletion without claiming an email was sent', () => {
     expect(getDeleteAllChatsSuccessDescription(true, true)).toBe(
       'Removed all chats from this device and encrypted cloud storage.',

--- a/tests/components/chat/settings-modal.test.ts
+++ b/tests/components/chat/settings-modal.test.ts
@@ -1,0 +1,16 @@
+import { getDeleteAllChatsSuccessDescription } from '@/components/chat/settings-modal'
+import { describe, expect, it } from 'vitest'
+
+describe('settings chat deletion confirmation', () => {
+  it('describes signed-in deletion without claiming an email was sent', () => {
+    expect(getDeleteAllChatsSuccessDescription(true)).toBe(
+      'Removed all chats from this device and encrypted cloud storage.',
+    )
+  })
+
+  it('keeps local-only deletion scoped to the browser session', () => {
+    expect(getDeleteAllChatsSuccessDescription(false)).toBe(
+      'Removed all chats from this browser session.',
+    )
+  })
+})

--- a/tests/components/chat/settings-modal.test.ts
+++ b/tests/components/chat/settings-modal.test.ts
@@ -2,14 +2,20 @@ import { getDeleteAllChatsSuccessDescription } from '@/components/chat/settings-
 import { describe, expect, it } from 'vitest'
 
 describe('settings chat deletion confirmation', () => {
-  it('describes signed-in deletion without claiming an email was sent', () => {
-    expect(getDeleteAllChatsSuccessDescription(true)).toBe(
+  it('describes completed cloud deletion without claiming an email was sent', () => {
+    expect(getDeleteAllChatsSuccessDescription(true, true)).toBe(
       'Removed all chats from this device and encrypted cloud storage.',
     )
   })
 
-  it('keeps local-only deletion scoped to the browser session', () => {
-    expect(getDeleteAllChatsSuccessDescription(false)).toBe(
+  it('warns signed-in users when cloud deletion did not complete', () => {
+    expect(getDeleteAllChatsSuccessDescription(true, false)).toBe(
+      'Removed all chats from this device. Encrypted cloud storage was not cleared.',
+    )
+  })
+
+  it('keeps guest deletion scoped to the browser session', () => {
+    expect(getDeleteAllChatsSuccessDescription(false, false)).toBe(
       'Removed all chats from this browser session.',
     )
   })

--- a/tests/services/cloud/cloud-storage.test.ts
+++ b/tests/services/cloud/cloud-storage.test.ts
@@ -12,6 +12,7 @@ const mockGetKeyBytesOrThrow = vi.fn()
 const mockGetAlternativeKeyBytes = vi.fn()
 const mockEnclavePush = vi.fn()
 const mockEnclavePull = vi.fn()
+const mockEnclaveDeleteRow = vi.fn()
 const mockRevisionSnapshot = vi.fn()
 const mockListStatus = vi.fn()
 const mockAttachmentPut = vi.fn()
@@ -42,6 +43,7 @@ vi.mock('@/services/sync-enclave/sync-api', async () => {
     ...actual,
     push: (...args: any[]) => mockEnclavePush(...args),
     pull: (...args: any[]) => mockEnclavePull(...args),
+    deleteRow: (...args: any[]) => mockEnclaveDeleteRow(...args),
     revisionSnapshot: (...args: any[]) => mockRevisionSnapshot(...args),
     listStatus: (...args: any[]) => mockListStatus(...args),
     attachmentPut: (...args: any[]) => mockAttachmentPut(...args),
@@ -72,6 +74,7 @@ describe('CloudStorageService auth readiness', () => {
     mockGetAlternativeKeyBytes.mockReturnValue(TEST_BYTES)
     mockEnclavePush.mockResolvedValue({ ok: true, etag: '1', keyId: 'kid' })
     mockEnclavePull.mockResolvedValue({ items: [] })
+    mockEnclaveDeleteRow.mockResolvedValue(undefined)
     mockRevisionSnapshot.mockResolvedValue({
       items: [],
       snapshot_revision: '0',
@@ -237,6 +240,31 @@ describe('CloudStorageService auth readiness', () => {
     expect(isAuthenticated).toBe(true)
     expect(mockWaitForInit).toHaveBeenCalledWith(3000)
     expect(mockIsAuthenticated).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns only the number of chats deleted from cloud storage', async () => {
+    mockRevisionSnapshot.mockResolvedValueOnce({
+      items: [{ id: 'chat-1' }, { id: 'chat-2' }],
+      snapshot_revision: '2',
+    })
+
+    const result = await new CloudStorageService().deleteAllChats()
+
+    expect(result).toEqual({ deleted: 2 })
+    expect(mockEnclaveDeleteRow).toHaveBeenCalledTimes(2)
+  })
+
+  it('returns only the deleted count for project chat deletion', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ deleted: 2, ignored: true }),
+    } as Response)
+
+    const result = await new CloudStorageService().deleteChatsByProject(
+      'project-1',
+    )
+
+    expect(result).toEqual({ deleted: 2 })
   })
 
   it('marks restore uploads so the enclave can clear stale tombstones', async () => {

--- a/tests/services/storage/chat-storage-pending-save.test.ts
+++ b/tests/services/storage/chat-storage-pending-save.test.ts
@@ -349,7 +349,7 @@ describe('chatStorage pendingSave is not persisted', () => {
     expect(acknowledgePendingDeletesSpy).not.toHaveBeenCalled()
   })
 
-  it('returns only local and cloud deletion counts', async () => {
+  it('reports completed cloud deletion with local and cloud counts', async () => {
     getAllChatIdsSpy.mockResolvedValueOnce(['local-1', 'local-2'])
     deleteAllChatsSpy.mockResolvedValueOnce(2)
     isCloudAuthenticatedSpy.mockResolvedValueOnce(true)
@@ -357,8 +357,23 @@ describe('chatStorage pendingSave is not persisted', () => {
 
     const result = await chatStorage.deleteAllChats()
 
-    expect(result).toEqual({ localDeleted: 2, cloudDeleted: 3 })
+    expect(result).toEqual({
+      localDeleted: 2,
+      cloudDeleted: 3,
+      cloudDeletionCompleted: true,
+    })
     expect(markAsDeletedSpy).toHaveBeenCalledTimes(2)
+  })
+
+  it('reports when cloud deletion is skipped without authentication', async () => {
+    deleteAllChatsSpy.mockResolvedValueOnce(2)
+
+    await expect(chatStorage.deleteAllChats()).resolves.toEqual({
+      localDeleted: 2,
+      cloudDeleted: 0,
+      cloudDeletionCompleted: false,
+    })
+    expect(deleteAllCloudChatsSpy).not.toHaveBeenCalled()
   })
 })
 

--- a/tests/services/storage/chat-storage-pending-save.test.ts
+++ b/tests/services/storage/chat-storage-pending-save.test.ts
@@ -9,6 +9,8 @@ const {
   saveChatSpy,
   getChatSpy,
   getAllChatsSpy,
+  getAllChatIdsSpy,
+  deleteAllChatsSpy,
   backupChatSpy,
   deleteChatsByProjectSpy,
   acknowledgePendingDeletesSpy,
@@ -23,8 +25,11 @@ const {
   deleteChatWithPendingIntentSpy,
   deleteLocalChatSpy,
   deleteFromCloudSpy,
+  deleteAllCloudChatsSpy,
+  isCloudAuthenticatedSpy,
   hasPendingUploadSpy,
   isDeletedSpy,
+  markAsDeletedSpy,
 } = vi.hoisted(() => ({
   saveChatSpy: vi.fn(async (chat: unknown) => ({
     saved: true,
@@ -32,6 +37,8 @@ const {
   })),
   getChatSpy: vi.fn(async () => null as unknown),
   getAllChatsSpy: vi.fn(async () => [] as unknown[]),
+  getAllChatIdsSpy: vi.fn(async () => [] as string[]),
+  deleteAllChatsSpy: vi.fn(async () => 0),
   backupChatSpy: vi.fn(async () => {}),
   deleteChatsByProjectSpy: vi.fn(async () => [] as string[]),
   acknowledgePendingDeletesSpy: vi.fn(async () => {}),
@@ -49,8 +56,11 @@ const {
   deleteChatWithPendingIntentSpy: vi.fn(async () => true),
   deleteLocalChatSpy: vi.fn(async () => {}),
   deleteFromCloudSpy: vi.fn(async () => {}),
+  deleteAllCloudChatsSpy: vi.fn(async () => ({ deleted: 0 })),
+  isCloudAuthenticatedSpy: vi.fn(async () => false),
   hasPendingUploadSpy: vi.fn(() => false),
   isDeletedSpy: vi.fn((_id: unknown) => false),
+  markAsDeletedSpy: vi.fn(),
 }))
 
 vi.mock('@/services/storage/indexed-db', () => ({
@@ -59,6 +69,8 @@ vi.mock('@/services/storage/indexed-db', () => ({
     getChat: getChatSpy,
     saveChat: saveChatSpy,
     getAllChats: getAllChatsSpy,
+    getAllChatIds: getAllChatIdsSpy,
+    deleteAllChats: deleteAllChatsSpy,
     resetChatTimestamps: resetChatTimestampsSpy,
     updateChatLocalOnly: updateChatLocalOnlySpy,
     updateChatProject: updateChatProjectSpy,
@@ -81,6 +93,8 @@ vi.mock('@/services/cloud/cloud-storage', () => ({
   cloudStorage: {
     deleteChatsByProject: deleteRemoteProjectChatsSpy,
     listChatIdsByProject: listChatIdsByProjectSpy,
+    deleteAllChats: deleteAllCloudChatsSpy,
+    isAuthenticated: isCloudAuthenticatedSpy,
   },
 }))
 vi.mock('@/services/sync-enclave/sync-api', () => ({
@@ -94,7 +108,7 @@ vi.mock('@/services/storage/chat-events', () => ({
 }))
 vi.mock('@/services/storage/deleted-chats-tracker', () => ({
   deletedChatsTracker: {
-    markAsDeleted: vi.fn(),
+    markAsDeleted: markAsDeletedSpy,
     isDeleted: isDeletedSpy,
   },
 }))
@@ -124,6 +138,10 @@ describe('chatStorage pendingSave is not persisted', () => {
     listChatIdsByProjectSpy.mockResolvedValue([])
     deleteChatWithPendingIntentSpy.mockResolvedValue(true)
     hasPendingUploadSpy.mockReturnValue(false)
+    getAllChatIdsSpy.mockResolvedValue([])
+    deleteAllChatsSpy.mockResolvedValue(0)
+    deleteAllCloudChatsSpy.mockResolvedValue({ deleted: 0 })
+    isCloudAuthenticatedSpy.mockResolvedValue(false)
     createAccountOperationGuardSpy.mockImplementation(() => {
       const userId = localStorage.getItem(AUTH_ACTIVE_USER_ID)
       const isCurrent = () =>
@@ -329,6 +347,18 @@ describe('chatStorage pendingSave is not persisted', () => {
       'bulk delete unavailable',
     )
     expect(acknowledgePendingDeletesSpy).not.toHaveBeenCalled()
+  })
+
+  it('returns only local and cloud deletion counts', async () => {
+    getAllChatIdsSpy.mockResolvedValueOnce(['local-1', 'local-2'])
+    deleteAllChatsSpy.mockResolvedValueOnce(2)
+    isCloudAuthenticatedSpy.mockResolvedValueOnce(true)
+    deleteAllCloudChatsSpy.mockResolvedValueOnce({ deleted: 3 })
+
+    const result = await chatStorage.deleteAllChats()
+
+    expect(result).toEqual({ localDeleted: 2, cloudDeleted: 3 })
+    expect(markAsDeletedSpy).toHaveBeenCalledTimes(2)
   })
 })
 


### PR DESCRIPTION
## Summary
- remove unused deletion-email result plumbing
- show truthful local/cloud deletion completion copy
- preserve existing deletion behavior

## Testing
- 1,970 unit tests
- typecheck and lint

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes chat deletion confirmation so it no longer claims an email confirmation was sent after deleting all chats.

- Removes unused `notificationSent` plumbing from cloud and chat storage deletion results.
- `deleteAllChats` now reports `cloudDeletionCompleted`, and the confirmation copy tells signed-in users whether encrypted cloud storage was cleared or left untouched; signed-out users see a message scoped to this browser session.
- Deletion behavior is unchanged.

<sup>Written for commit 35adf04f3da5bf742f43f8a9749d2453104c5030. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-webapp/pull/549?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

